### PR TITLE
ci: add advance-deploy-env caller workflow

### DIFF
--- a/.github/workflows/advance-deploy-env.yml
+++ b/.github/workflows/advance-deploy-env.yml
@@ -1,0 +1,14 @@
+name: Advance deploy env
+
+# Calls the reusable workflow in tracebloc/.github.
+# When this branch (develop/staging/master/main) receives a merge,
+# updates each contained PR's Deploy environment field on the engineer kanban.
+
+on:
+  push:
+    branches: [develop, staging, master, main]
+
+jobs:
+  advance:
+    uses: tracebloc/.github/.github/workflows/advance-deploy-env.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a 9-line caller workflow that triggers the org-wide reusable workflow [`tracebloc/.github/.github/workflows/advance-deploy-env.yml`](https://github.com/tracebloc/.github/blob/main/.github/workflows/advance-deploy-env.yml) on push to `develop`/`staging`/`master`/`main`.

## What changes after merge

Every PR merged into one of those branches will auto-update its card on the [engineer kanban](https://github.com/orgs/tracebloc/projects/2):

- merge to `develop` → `Deploy environment = dev`
- merge to `staging` → `Deploy environment = staging`
- merge to `master`/`main` → `Deploy environment = prod` AND `Status = Done`

No effect on PRs not on the kanban (those are auto-skipped).

## Why a caller pattern

Same as the kanban auto-add workflow we shipped earlier — keep the logic in one place (`tracebloc/.github`), each repo just calls it. If we change the rules later, one file edit propagates everywhere.

## Test plan

- [ ] After merge: open a small test PR, merge it to `develop`, verify the kanban card flips `Deploy environment = dev`
- [ ] On next `develop → main` release: verify the same PR's card flips to `Status = Done`, `Deploy environment = prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)