### PR TITLE
path issue

### DIFF
--- a/tracebloc_ingestor/validators/file_validator.py
+++ b/tracebloc_ingestor/validators/file_validator.py
@@ -76,7 +76,7 @@ class FileTypeValidator(BaseValidator):
             ValidationResult containing validation status and messages
         """
         try:
-            data = f"{path}/{self.path}"
+            data = f"{config.SRC_PATH}/{self.path}"
             recursive = kwargs.get("recursive", True)
             ignore_hidden = kwargs.get("ignore_hidden", True)
 

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -83,7 +83,7 @@ class ImageResolutionValidator(BaseValidator):
             ValidationResult containing validation status and messages
         """
         try:
-            data = f"{path}/images"
+            data = f"{config.SRC_PATH}/images"
             if not PIL_AVAILABLE:
                 return self._create_result(
                     is_valid=False,

--- a/tracebloc_ingestor/validators/xml_validator.py
+++ b/tracebloc_ingestor/validators/xml_validator.py
@@ -83,9 +83,9 @@ class PascalVOCXMLValidator(BaseValidator):
         try:
             recursive = kwargs.get("recursive", True)
             ignore_hidden = kwargs.get("ignore_hidden", True)
-
+    
             # Get list of XML files to validate
-            files_to_validate = self._get_xml_files(data, recursive, ignore_hidden)
+            files_to_validate = self._get_xml_files(config.SRC_PATH, recursive, ignore_hidden)
 
             if not files_to_validate:
                 return self._create_result(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core validator input resolution to always use `config.SRC_PATH`, which may break callers that expect `validate(path)` to operate on an arbitrary provided directory. Low code churn, but behavior change affects all file/image/XML validation runs.
> 
> **Overview**
> Updates the dataset validators to **build their validation target paths from `config.SRC_PATH`** instead of the `path`/`data` argument passed into `validate()`.
> 
> `FileTypeValidator` and `ImageResolutionValidator` now always validate under `SRC_PATH` (plus their respective subdirectories), and `PascalVOCXMLValidator` now enumerates XML files starting from `SRC_PATH`, standardizing path handling across validators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b0f6b287052700efb1f6ef605a84b57689d5a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->