### PR TITLE
Updates Dockerfile and ingestor-job.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Python 3.11 as base image
-FROM --platform=linux/amd64 python:3.11
+FROM python:3.11
 
 # Set working directory
 WORKDIR /app

--- a/ingestor-job.yaml
+++ b/ingestor-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: api
-        image: moritz000/csv-templates-ingestor-claims-train:latest # train/test switch
+        image: <docker-user>/<image-name>:latest # train/test switch
         imagePullPolicy: Always
         volumeMounts:
           - name: shared-volume
@@ -22,7 +22,7 @@ spec:
         - name: CLIENT_PVC
           value: "client-pvc"
         - name: MYSQL_HOST
-          value: "mysql"
+          value: "mysql-client"
         - name: SRC_PATH
           value: "/data" # Source folder path whithin the data ingestor
         - name: LABEL_FILE
@@ -35,8 +35,6 @@ spec:
           value: "WARNING"
       imagePullSecrets:
       - name: regcred
-      nodeSelector:
-        type: system
       volumes:
         - name: shared-volume
           persistentVolumeClaim:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes container build targeting (removes `--platform` pin) and modifies Kubernetes Job runtime settings (image reference, MySQL host, and scheduling), which can break deployments if cluster/registry assumptions differ.
> 
> **Overview**
> Makes the Docker build more portable by removing the `--platform=linux/amd64` pin from the `Dockerfile` base image.
> 
> Updates `ingestor-job.yaml` to use a placeholder image (`<docker-user>/<image-name>:latest`), switch `MYSQL_HOST` to `mysql-client`, and drop the previous `nodeSelector` constraint so the Job can schedule without requiring `type: system` nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb4e51587a028822bc0dfc8b534c9ce81b3171b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->