### PR TITLE
refactor: use `extension` option key for text use case

### DIFF
--- a/templates/text_classification/text_classification.py
+++ b/templates/text_classification/text_classification.py
@@ -24,7 +24,7 @@ setup_logging(config)
 logger = logging.getLogger(__name__)
 
 # Text specific options including CSV options
-text_options = {"allowed_extension": FileExtension.TXT}  # Allowed text file extensions
+text_options = {"extension": FileExtension.TXT}  # Allowed text file extensions
 
 # CSV specific options
 csv_options = {

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -164,7 +164,7 @@ def text_transfer(record: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, 
 
     Args:
         record: Dictionary containing filename and other record data
-        options: Dictionary containing transfer options like allowed_extension
+        options: Dictionary containing transfer options like extension
 
     Returns:
         Updated record dictionary
@@ -175,7 +175,7 @@ def text_transfer(record: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, 
     try:
         # Get the filename from the record
         filename = record.get("filename")
-        extension = options.get("allowed_extension")
+        extension = options.get("extension")
         if not filename:
             logger.error(f"{RED}No filename found in record{RESET}")
             return record

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -47,10 +47,11 @@ def map_validators(
         validators = []
 
         # Add text file validator
-        allowed_extension = options.get("allowed_extension", FileExtension.TXT)
-
         validators.append(
-            FileTypeValidator(allowed_extension=allowed_extension, path="texts"),
+            FileTypeValidator(
+                allowed_extension=options.get("extension", FileExtension.TXT),
+                path="texts",
+            ),
         )
 
         # Add data validator if schema is provided


### PR DESCRIPTION
## Summary
- Rename text_options key from `allowed_extension` to `extension` so image, object-detection, and text use cases share the same option name
- Update `validators_mapping.py` and `file_transfer.text_transfer` to read the new key
- `.xml` stays hardcoded for object-detection annotations; tabular use cases remain unchanged (no extension option needed)

## Test plan
- [ ] Run text_classification template end-to-end and confirm `FileTypeValidator` and `text_transfer` pick up the extension
- [ ] Run image_classification / object_detection templates to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-complexity refactor, but it changes a configuration key (`allowed_extension` -> `extension`) that could break existing text-classification ingestion runs if callers aren’t updated.
> 
> **Overview**
> Standardizes the text-classification file option from `allowed_extension` to `extension` to align with other task types.
> 
> Updates the text classification template plus `text_transfer` and the TEXT_CLASSIFICATION branch of `map_validators` so both file copying and `FileTypeValidator` pull the extension from the new key (defaulting to `FileExtension.TXT` if absent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5cdf1d17a289b54b0f26856a4ca8b1028770664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->