### PR TITLE
docs: refresh Readme.md with quickstart, env vars, and template links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,9 +2,7 @@
 
 # Data Ingestors 📊
 
-Get your data into the [tracebloc](https://tracebloc.io/) training environment — validated, clean, and ready for model evaluation.
-
-These pipelines handle the full data preparation workflow: validation, preprocessing, and secure transfer into your Kubernetes cluster. A metadata representation syncs to the tracebloc web app so you can manage datasets visually. Your raw data never leaves your infrastructure.
+Move your data into the [tracebloc](https://tracebloc.io/) training environment — validated, clean, and ready for model evaluation. **Your raw data never leaves your infrastructure.**
 
 ## How it works
 
@@ -12,47 +10,100 @@ These pipelines handle the full data preparation workflow: validation, preproces
 Your raw data
      │
      ▼
-┌─────────────────┐     ┌──────────────────────────────────┐
-│  Data ingestor   │────►│  Your Kubernetes cluster          │
-│                  │     │                                   │
-│  Validates       │     │  Validated dataset                │
-│  Preprocesses    │     │  (ready for training)             │
-│  Transfers       │     │                                   │
-└─────────────────┘     └──────────────┬────────────────────┘
-                                       │
-                              Metadata only
-                                       │
-                                       ▼
-                        ┌──────────────────────────┐
-                        │  tracebloc web app        │
-                        │  (dataset management UI)  │
-                        └──────────────────────────┘
+┌──────────────────┐     ┌──────────────────────────────────┐
+│  Data ingestor   │────►│  Your Kubernetes cluster         │
+│                  │     │                                  │
+│  Validates       │     │  Validated dataset               │
+│  Preprocesses    │     │  (ready for training)            │
+│  Transfers       │     │                                  │
+└──────────────────┘     └──────────────┬───────────────────┘
+                                        │
+                               Metadata only
+                                        │
+                                        ▼
+                         ┌──────────────────────────┐
+                         │  tracebloc web app       │
+                         │  (dataset management UI) │
+                         └──────────────────────────┘
 ```
 
-Data stays on your infrastructure. Only metadata (structure, schema, statistics) syncs to the web app for dataset management and vendor guidance.
+Only metadata (schema, statistics, structure) syncs to the web app. Raw data stays put.
 
 ## Supported data types
 
-| Type | Examples |
+| Type | Templates |
 |---|---|
-| **Image** | Classification, detection, segmentation datasets |
-| **Text / NLP** | Document classification, sentiment, named entities |
-| **Tabular** | Structured CSV data, feature tables |
-| **Time series** | Sequential measurements, forecasting datasets |
+| **Image** | [`image_classification`](templates/image_classification), [`object_detection`](templates/object_detection) |
+| **Text / NLP** | [`text_classification`](templates/text_classification) |
+| **Tabular** | [`tabular_classification`](templates/tabular_classification), [`tabular_regression`](templates/tabular_regression) |
+| **Time series** | [`time_series_forecasting`](templates/time_series_forecasting), [`time_to_event_prediction`](templates/time_to_event_prediction) |
 
-## Install
+Each template is a runnable starting point — copy it, point it at your data, ship it.
+
+## Quickstart
+
+### 1. Install
 
 ```bash
 pip install tracebloc-ingestor
 ```
+
+### 2. Pick a template
+
+```bash
+cp templates/image_classification/ingestor.py .
+```
+
+Each template builds on the same primitives — `BaseIngestor`, `CSVIngestor`, validators — and overrides the parts that vary by data type.
+
+### 3. Deploy as a Kubernetes Job
+
+The ingestor runs *inside* your cluster, next to a tracebloc client. The provided [`Dockerfile`](Dockerfile) and [`ingestor-job.yaml`](ingestor-job.yaml) are the canonical pattern:
+
+```bash
+docker build -t <your-registry>/<image-name>:latest .
+docker push <your-registry>/<image-name>:latest
+kubectl apply -f ingestor-job.yaml
+```
+
+The Job needs these environment variables (set in [`ingestor-job.yaml`](ingestor-job.yaml)):
+
+| Variable | What it is |
+|---|---|
+| `CLIENT_ID`, `CLIENT_PASSWORD` | Tracebloc client credentials |
+| `CLIENT_PVC` | PVC name shared with the client (must match `values.yaml`) |
+| `MYSQL_HOST` | Hostname of the client's MySQL service |
+| `SRC_PATH` | Where your raw data is mounted in the ingestor pod |
+| `LABEL_FILE` | Path to labels (e.g. `Xy_train.csv`) |
+| `TABLE_NAME` | Destination table name in the client database |
+| `TITLE` | *(optional)* Human-readable dataset name |
+| `LOG_LEVEL` | *(optional)* `INFO`, `WARNING`, `ERROR` |
+
+## Writing a custom ingestor
+
+For data that doesn't fit a template, subclass `BaseIngestor`:
+
+```python
+from tracebloc_ingestor import BaseIngestor, FileTypeValidator
+
+class MyIngestor(BaseIngestor):
+    validators = [FileTypeValidator(allowed=[".parquet"])]
+
+    def transform(self, record):
+        # your preprocessing
+        return record
+
+if __name__ == "__main__":
+    MyIngestor().ingest()
+```
+
+The package exports `BaseIngestor`, `CSVIngestor`, `JSONIngestor`, plus validators (`FileTypeValidator`, `ImageResolutionValidator`, `TableNameValidator`) and the `Database` / `APIClient` helpers. See [`examples/`](examples) for working scripts.
 
 ## Prerequisites
 
 - Python 3.8+
 - A [tracebloc account](https://ai.tracebloc.io/signup) with an active use case
 - A running [tracebloc client](https://github.com/tracebloc/client) on your infrastructure
-
-For step-by-step data preparation instructions → [Prepare Data guide](https://docs.tracebloc.io/create-use-case/prepare-dataset)
 
 ## Links
 


### PR DESCRIPTION
## Summary
- Adds a three-step Quickstart (install → pick template → kubectl apply) so new users can ship an ingestor without spelunking through `Dockerfile` + `ingestor-job.yaml`.
- Documents the env vars the Job expects (`CLIENT_ID`, `CLIENT_PASSWORD`, `CLIENT_PVC`, `MYSQL_HOST`, `SRC_PATH`, `LABEL_FILE`, `TABLE_NAME`, `TITLE`, `LOG_LEVEL`).
- Links the Supported data types table cells to their `templates/<use-case>/` directories — previously templates were effectively undiscoverable from the README.
- Adds a short custom-ingestor code example using `BaseIngestor` to surface that this is a Python library, not just a CLI.
- Preserves the existing tone, badge row, architecture diagram, and privacy positioning.

Closes #54

## Test plan
- [ ] Skim rendered README on the PR diff
- [ ] Click each `templates/*` link in the Supported data types table — confirm all resolve
- [ ] Confirm Quickstart commands run end-to-end against a dev cluster

## Out of scope (separate follow-ups)
- Version mismatch: `setup.py:15` (`0.2.10`) vs `tracebloc_ingestor/__init__.py:20` (`0.1.0`)
- License classifier in `setup.py:29` says MIT; `LICENSE` file is Apache 2.0
- `Dockerfile:13` `COPY templates/csv_ingestor.py` — that path no longer exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that don’t affect runtime behavior. Main risk is inaccurate instructions/links causing user confusion.
> 
> **Overview**
> Refreshes `Readme.md` to make onboarding actionable: adds a **Quickstart** (install → copy a template → build/push/apply a Kubernetes Job) and documents the required Job environment variables.
> 
> Updates the supported data types section to link directly to runnable `templates/*` directories, and adds a short example for writing a custom ingestor by subclassing `BaseIngestor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 418d80681657579bbb5c414902bd4cf3fef7a19a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->