### PR TITLE
docs: document Pod Security Standards (restricted) overrides

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -79,6 +79,46 @@ The Job needs these environment variables (set in [`ingestor-job.yaml`](ingestor
 | `TITLE` | *(optional)* Human-readable dataset name |
 | `LOG_LEVEL` | *(optional)* `INFO`, `WARNING`, `ERROR` |
 
+### Running under Pod Security Standards (`restricted`)
+
+If the namespace you're deploying into enforces the [`restricted`](https://kubernetes.io/docs/concepts/security/pod-security-standards/) Pod Security Standard (OpenShift, hardened clusters, many managed-Kubernetes namespaces), the stock [`Dockerfile`](Dockerfile) and [`ingestor-job.yaml`](ingestor-job.yaml) won't admit. Two changes are needed.
+
+Check first:
+
+```bash
+kubectl get ns <namespace> -o jsonpath='{.metadata.labels}' | jq
+```
+
+Look for `pod-security.kubernetes.io/enforce: restricted`. If absent, the stock files admit fine and you can skip this section.
+
+**1. `Dockerfile` — drop root.** Append before `ENTRYPOINT`:
+
+```dockerfile
+# OpenShift-compatible: grant group write via GID 0
+RUN chgrp -R 0 /app && chmod -R g=u /app
+USER 1001
+```
+
+**2. `ingestor-job.yaml` — add a hardened `securityContext`.** Both pod-level and container-level:
+
+```yaml
+spec:
+  template:
+    spec:
+      securityContext:                    # pod-level
+        runAsNonRoot: true
+        runAsUser: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: api
+        # ... existing container spec ...
+        securityContext:                  # container-level
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+```
+
 ## Writing a custom ingestor
 
 For data that doesn't fit a template, subclass `BaseIngestor`:


### PR DESCRIPTION
## Summary
Follow-up to #54 / #55. Adds a sub-section under the Quickstart deploy step covering what to change when the target namespace enforces the [`restricted`](https://kubernetes.io/docs/concepts/security/pod-security-standards/) Pod Security Standard.

- How to check whether a namespace enforces `restricted` (`kubectl get ns ... -o jsonpath='{.metadata.labels}'`).
- Dockerfile changes: `chgrp -R 0 /app && chmod -R g=u /app` + `USER 1001` (same OpenShift-compatible pattern client-runtime already uses).
- `ingestor-job.yaml` changes: pod-level + container-level `securityContext` (`runAsNonRoot`, `runAsUser: 1001`, `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`, `capabilities.drop: ["ALL"]`).

Closes #56

## Test plan
- [ ] Skim rendered README on the PR diff
- [ ] Apply both diffs to a real Dockerfile + ingestor-job.yaml and deploy into a namespace labeled `pod-security.kubernetes.io/enforce: restricted` — confirm the Job admits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change with no runtime or dependency modifications.
> 
> **Overview**
> Adds a new README section for deploying the Kubernetes Job into namespaces enforcing the Pod Security Standards `restricted` profile.
> 
> Documents how to detect enforcement via namespace labels and lists the required hardening steps: running the image as non-root (with OpenShift-compatible `/app` permissions) and adding pod/container `securityContext` settings (e.g., `runAsNonRoot`, `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`, dropping capabilities).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3ae98bc2b0c3a7aaf0be987634653f4d5801011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->