### PR TITLE
docs: drop "active use case" from prereqs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -142,7 +142,7 @@ The package exports `BaseIngestor`, `CSVIngestor`, `JSONIngestor`, plus validato
 ## Prerequisites
 
 - Python 3.8+
-- A [tracebloc account](https://ai.tracebloc.io/signup) with an active use case
+- A [tracebloc account](https://ai.tracebloc.io/signup)
 - A running [tracebloc client](https://github.com/tracebloc/client) on your infrastructure
 
 ## Links


### PR DESCRIPTION
## Summary

- Removes the misleading "with an active use case" wording from the prereq bullet in [Readme.md](Readme.md).

A use case can only be created **after** data has been ingested — the platform needs the dataset's real schema and stats to define one. The prior wording sent newcomers to the web app to create a use case before they had a dataset, which is impossible. They'd get stuck before ever installing this package.

The full end-to-end quickstart that walks the corrected journey (sign up → install client → ingest → create use case → run experiments) belongs to #46 once its blockers (#44, #45, [tracebloc/client#86](https://github.com/tracebloc/client/issues/86)) clear next sprint. This PR is just the one-line correction.

Closes #64

## Test plan

- [ ] Visual review of the updated Prerequisites section in [Readme.md](Readme.md)
- [ ] Confirm no other doc/template still asserts a use case must exist before ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that clarifies prerequisites without affecting runtime behavior.
> 
> **Overview**
> Updates `Readme.md` prerequisites to remove the requirement that a tracebloc account have an *active use case*, leaving signup as the only account-related prerequisite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d547470efc60be63f5da8509e4b8108797a8b941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->