### PR TITLE
docs: drop "active use case" from prereqs (develop)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,7 +49,7 @@ pip install tracebloc-ingestor
 ## Prerequisites
 
 - Python 3.8+
-- A [tracebloc account](https://ai.tracebloc.io/signup) with an active use case
+- A [tracebloc account](https://ai.tracebloc.io/signup)
 - A running [tracebloc client](https://github.com/tracebloc/client) on your infrastructure
 
 For step-by-step data preparation instructions → [Prepare Data guide](https://docs.tracebloc.io/create-use-case/prepare-dataset)


### PR DESCRIPTION
## Summary

- Same one-line fix as #65 (which targets `master`), applied to `develop` so the bug isn't re-introduced when develop next merges to master.

A use case can only be created **after** data has been ingested — the platform needs the dataset's real schema and stats to define one. The prior wording sent newcomers to the web app to create a use case before they had a dataset, which is impossible.

The full quickstart that walks the corrected journey lands under #46 once its blockers clear next sprint.

Refs #64 (the umbrella issue is closed by #65 on master)

## Test plan

- [ ] Visual review of the updated Prerequisites section in [Readme.md](Readme.md)
- [ ] Land alongside #65 so master and develop converge on the corrected wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts onboarding wording; no code or runtime behavior is affected.
> 
> **Overview**
> Updates `Readme.md` prerequisites to remove the requirement for an "active use case" from the tracebloc account, aligning the setup steps with the actual ingestion-first workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37154950c88e88f69f4ec83605e17dc66406b3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->