### PR TITLE
docs: add per-template READMEs for the 6 templates missing one

### DIFF
--- a/templates/image_classification/README.md
+++ b/templates/image_classification/README.md
@@ -1,0 +1,67 @@
+# Image Classification Data Ingestion Template
+
+This template demonstrates how to ingest image classification data with images and a CSV labels file into a database using the tracebloc_ingestor framework.
+
+## Directory Structure
+
+```
+image_classification/
+├── image_classification.py     # Main ingestion script
+├── README.md                   # This file
+└── data/
+    ├── images/                 # Source image files
+    │   ├── cat1.jpeg
+    │   ├── cat2.jpeg
+    │   ├── cat3.jpeg
+    │   ├── dog1.jpeg
+    │   ├── dog2.jpeg
+    │   └── dog3.jpeg
+    └── labels_file_sample.csv  # CSV mapping each image to its class label
+```
+
+## Data Format
+
+### Images
+- Supported formats: PNG, JPEG, JPG
+- Images should be placed in the `data/images/` directory
+- Each image must have a corresponding row in the CSV file
+
+### CSV Labels File
+The CSV contains the following columns:
+- `filename`: Image filename with extension, e.g. `cat1.jpeg`
+- `label`: Class label for the image, e.g. `cat`, `dog`
+
+## Usage
+
+1. Place your images in the `data/images/` directory
+2. Update `labels_file_sample.csv` with your `(filename, label)` pairs
+3. Configure the ingestion parameters in `image_classification.py`
+4. Run the ingestion script:
+
+```bash
+python image_classification.py
+```
+
+## Configuration
+
+The script uses the following configuration:
+- **Target Size**: (512, 512) - Images will be resized to this dimension (height = width)
+- **Extension**: JPG - Expected image file extension (jpeg, jpg, and png are also accepted)
+- **Chunk Size**: 1000 - Number of records to process in each batch
+- **Category**: IMAGE_CLASSIFICATION
+- **Data Format**: IMAGE
+- **Intent**: TEST (change to `Intent.TRAIN` for training data)
+- **Label column**: `label`
+
+## Sample Data
+
+The template includes sample data with:
+- 6 images (3 cats, 3 dogs)
+- 2 classes: `cat`, `dog`
+- A CSV with 6 `(filename, label)` rows
+
+## Notes
+
+- The framework validates each image's extension and resizes it to the target size during processing
+- Image files are copied to the destination directory; raw data stays on your cluster
+- The `intent` field in the script defaults to `Intent.TEST` — set it to `Intent.TRAIN` for training data

--- a/templates/tabular_classification/README.md
+++ b/templates/tabular_classification/README.md
@@ -1,0 +1,64 @@
+# Tabular Classification Data Ingestion Template
+
+This template demonstrates how to ingest tabular classification data from a CSV file into a database using the tracebloc_ingestor framework.
+
+## Directory Structure
+
+```
+tabular_classification/
+├── tabular_classification.py                          # Main ingestion script
+├── tabular_classification_sample_in_csv_format.csv    # Sample data
+└── README.md                                          # This file
+```
+
+## Data Format
+
+### CSV File
+The sample CSV contains the following columns:
+- `id`: Unique row identifier
+- `feature_00`, `feature_01`, `feature_02`: Numerical feature columns (FLOAT)
+- `label`: Class label (e.g. `0` or `1`)
+
+The script defines a schema for **feature columns only**. The label column is configured separately via `label_column`:
+
+```python
+schema = {
+    "feature_00": "FLOAT",
+    "feature_01": "FLOAT",
+    "feature_02": "FLOAT",
+}
+```
+
+## Usage
+
+1. Replace `tabular_classification_sample_in_csv_format.csv` with your data, or set `LABEL_FILE` to point at your CSV
+2. Update the `schema` dict in `tabular_classification.py` to match your feature columns
+3. Set `label_column` to the name of your target column in the CSV
+4. Run the ingestion script:
+
+```bash
+python tabular_classification.py
+```
+
+## Configuration
+
+The script uses the following configuration:
+- **Chunk Size**: 1000 - Number of records to process in each batch
+- **Encoding**: utf-8
+- **NA values**: `""`, `"NA"`, `"NULL"`, `"None"` are treated as missing
+- **Category**: TABULAR_CLASSIFICATION
+- **Data Format**: TABULAR
+- **Intent**: TRAIN (change to `Intent.TEST` for evaluation data)
+
+## Sample Data
+
+The template includes sample data with:
+- 3 numerical features (`feature_00`, `feature_01`, `feature_02`)
+- 1 binary label column (`label`)
+- Multiple rows of synthetic data
+
+## Notes
+
+- The `schema` dict defines feature columns only — do **not** include the label column in it.
+- ⚠️ **Known mismatch:** the template script currently sets `label_column="name"`, but the sample CSV has a `label` column and no `name` column. Update `label_column` to `"label"` (or to your CSV's actual target column) before running against this sample data.
+- The framework validates the number of CSV columns against the schema length plus the label column.

--- a/templates/tabular_regression/README.md
+++ b/templates/tabular_regression/README.md
@@ -1,0 +1,66 @@
+# Tabular Regression Data Ingestion Template
+
+This template demonstrates how to ingest tabular regression data from a CSV file into a database using the tracebloc_ingestor framework.
+
+## Directory Structure
+
+```
+tabular_regression/
+├── tabular_regression.py                              # Main ingestion script
+├── tabular_regression_sample_in_csv_format.csv        # Sample data
+└── README.md                                          # This file
+```
+
+## Data Format
+
+### CSV File
+The sample CSV contains the following columns:
+- `id`: Unique row identifier
+- `square_feet`: Floor area in square feet (FLOAT)
+- `bedrooms`: Number of bedrooms (INT)
+- `age`: Age of the property in years (INT)
+- `price`: Sale price — the regression target (FLOAT)
+
+The script defines a schema for **feature columns only**. The label column is configured separately via `label_column`:
+
+```python
+schema = {
+    "square_feet": "FLOAT",
+    "bedrooms": "INT",
+    "age": "INT",
+}
+```
+
+## Usage
+
+1. Replace `tabular_regression_sample_in_csv_format.csv` with your data, or set `LABEL_FILE` to point at your CSV
+2. Update the `schema` dict in `tabular_regression.py` to match your feature columns
+3. Set `label_column` to the name of your continuous target column
+4. Run the ingestion script:
+
+```bash
+python tabular_regression.py
+```
+
+## Configuration
+
+The script uses the following configuration:
+- **Chunk Size**: 1000 - Number of records to process in each batch
+- **Encoding**: utf-8
+- **NA values**: `""`, `"NA"`, `"NULL"`, `"None"` are treated as missing
+- **Category**: TABULAR_REGRESSION
+- **Data Format**: TABULAR
+- **Intent**: TRAIN (change to `Intent.TEST` for evaluation data)
+- **Label column**: `price`
+
+## Sample Data
+
+The template includes sample data with:
+- 3 feature columns (`square_feet`, `bedrooms`, `age`)
+- 1 continuous target (`price`)
+- Synthetic housing-price rows
+
+## Notes
+
+- The `schema` dict defines feature columns only. The label column (`price`) is supplied via `label_column`, not via the schema.
+- The framework validates the number of CSV columns against the schema length plus the label column.

--- a/templates/text_classification/README.md
+++ b/templates/text_classification/README.md
@@ -1,0 +1,66 @@
+# Text Classification Data Ingestion Template
+
+This template demonstrates how to ingest text classification data with `.txt` files and a CSV labels file into a database using the tracebloc_ingestor framework.
+
+## Directory Structure
+
+```
+text_classification/
+├── text_classification.py      # Main ingestion script
+├── README.md                   # This file
+└── data/
+    ├── texts/                  # Source text files
+    │   ├── sample1.txt
+    │   ├── sample2.txt
+    │   ├── sample3.txt
+    │   ├── sample4.txt
+    │   └── sample5.txt
+    └── labels_file_sample.csv  # CSV mapping each text file to its class label
+```
+
+## Data Format
+
+### Text Files
+- Supported extension: `.txt`
+- One document per file, placed in `data/texts/`
+- Each text file must have a corresponding row in the CSV
+
+### CSV Labels File
+The CSV contains the following columns:
+- `filename`: Base name of the text file, without extension (e.g. `sample1`)
+- `extension`: File extension as a quoted string (e.g. `'.txt'`)
+- `label`: Class label (e.g. `positive`, `negative`, `neutral`)
+
+## Usage
+
+1. Place your `.txt` documents in `data/texts/`
+2. Update `labels_file_sample.csv` with one row per document
+3. Configure the ingestion parameters in `text_classification.py`
+4. Run the ingestion script:
+
+```bash
+python text_classification.py
+```
+
+## Configuration
+
+The script uses the following configuration:
+- **Extension**: TXT - Expected text file extension
+- **Chunk Size**: 100 - Smaller batches to accommodate text processing
+- **Encoding**: utf-8
+- **Category**: TEXT_CLASSIFICATION
+- **Data Format**: TEXT
+- **Intent**: TRAIN (change to `Intent.TEST` for evaluation data)
+- **Label column**: `label`
+
+## Sample Data
+
+The template includes sample data with:
+- 5 text files (`sample1.txt` through `sample5.txt`)
+- 3 sentiment classes: `positive`, `negative`, `neutral`
+- Product-review-style text content
+
+## Notes
+
+- The `filename` column does **not** include the extension — that's supplied separately via the `extension` column.
+- Text files are read with utf-8 encoding by default.

--- a/templates/time_series_forecasting/README.md
+++ b/templates/time_series_forecasting/README.md
@@ -1,0 +1,58 @@
+# Time Series Forecasting Data Ingestion Template
+
+This template demonstrates how to ingest time series forecasting data from a CSV file into a database using the tracebloc_ingestor framework.
+
+## Directory Structure
+
+```
+time_series_forecasting/
+├── time_series_forecasting.py                              # Main ingestion script
+├── time_series_forecasting_sample_in_csv_format.csv        # Sample data
+└── README.md                                               # This file
+```
+
+## Data Format
+
+### CSV File
+The sample CSV contains the following columns:
+- `date`: ISO date (YYYY-MM-DD)
+- `day_of_week`, `month`, `day_of_month`, `week_of_year`, `is_weekend`: Calendar features (INT)
+- `lag_1`: Previous timestep's value (FLOAT; blank for the first row)
+- `moving_avg_7`: 7-day moving average (FLOAT; blank until enough history accumulates)
+- `value`: The forecasting target (FLOAT)
+
+The script defines a schema for **feature columns only**. The label column is configured separately via `label_column`.
+
+## Usage
+
+1. Replace `time_series_forecasting_sample_in_csv_format.csv` with your data, or set `LABEL_FILE` to point at your CSV
+2. Update the `schema` dict in `time_series_forecasting.py` to match your feature columns
+3. Set `label_column` to the name of your target column
+4. Run the ingestion script:
+
+```bash
+python time_series_forecasting.py
+```
+
+## Configuration
+
+The script uses the following configuration:
+- **Chunk Size**: 1000 - Number of records to process in each batch
+- **Encoding**: utf-8
+- **NA values**: `""`, `"NA"`, `"NULL"`, `"None"` are treated as missing
+- **Category**: TIME_SERIES_FORECASTING
+- **Data Format**: TABULAR
+- **Intent**: TRAIN
+
+## Sample Data
+
+The template includes sample data with:
+- Daily timestamps starting from 2023-10-01
+- Calendar features + lag and moving-average features
+- A `value` column as the forecasting target
+
+## Notes
+
+- The `schema` dict defines feature columns only. The label column is supplied via `label_column`.
+- ⚠️ **Known mismatch:** the template script's `schema` (`timestamp`, `eq_count`, `avg_magnitude`, `median_magnitude`, `dayofweek`, `is_weekend`, `dayofyear`, `month`, `sin_dayofyear`, `cos_dayofyear`) and `label_column="max_magnitude"` describe a different dataset (earthquake magnitudes) than the bundled sample CSV (daily values with calendar features). Update the `schema` and `label_column` in the script to match whichever dataset you actually run against.
+- Time series ingestion treats each row as a timestep; ensure your CSV is sorted chronologically.

--- a/templates/time_to_event_prediction/README.md
+++ b/templates/time_to_event_prediction/README.md
@@ -1,0 +1,77 @@
+# Time-to-Event Prediction Data Ingestion Template
+
+This template demonstrates how to ingest time-to-event (survival analysis) data from a CSV file into a database using the tracebloc_ingestor framework.
+
+## Directory Structure
+
+```
+time_to_event_prediction/
+├── time_to_event_prediction.py                              # Main ingestion script
+├── time_to_event_prediction_sample_in_csv_format.csv        # Sample data
+└── README.md                                                # This file
+```
+
+## Data Format
+
+### CSV File
+The sample CSV contains a heart-failure clinical dataset with the following columns:
+- `age`: Patient age (FLOAT)
+- `anaemia`: Decrease of red blood cells or hemoglobin (0 or 1)
+- `creatinine_phosphokinase`: Level of CPK enzyme in the blood (FLOAT)
+- `diabetes`: If the patient has diabetes (0 or 1)
+- `ejection_fraction`: Percentage of blood leaving the heart at each contraction (FLOAT)
+- `high_blood_pressure`: If the patient has hypertension (0 or 1)
+- `platelets`: Platelets in the blood (FLOAT)
+- `serum_creatinine`: Level of serum creatinine in the blood (FLOAT)
+- `serum_sodium`: Level of serum sodium in the blood (FLOAT)
+- `sex`: Woman (0) or man (1)
+- `smoking`: If the patient smokes or not (0 or 1)
+- `time`: Follow-up period in days (INT) — the **time column** for survival analysis
+- `DEATH_EVENT`: If the patient died during follow-up (0 or 1) — the **event column**
+
+The script declares a schema covering the feature columns (including `time`) and configures both the time and event columns:
+
+```python
+file_options = {
+    "number_of_columns": len(schema),
+    "schema": schema,
+    "time_column": "time",     # follow-up duration
+}
+label_column = "DEATH_EVENT"   # the event indicator
+```
+
+## Usage
+
+1. Replace the sample CSV with your data, or set `LABEL_FILE` to point at your CSV
+2. Update the `schema` dict in `time_to_event_prediction.py` to match your feature columns
+3. Confirm `time_column` and `label_column` match your CSV's time and event column names
+4. Run the ingestion script:
+
+```bash
+python time_to_event_prediction.py
+```
+
+## Configuration
+
+The script uses the following configuration:
+- **Chunk Size**: 1000 - Number of records to process in each batch
+- **Encoding**: utf-8
+- **NA values**: `""`, `"NA"`, `"NULL"`, `"None"` are treated as missing
+- **Category**: TIME_TO_EVENT_PREDICTION
+- **Data Format**: TABULAR
+- **Intent**: TRAIN
+- **Time column**: `time` (follow-up duration in days)
+- **Label column**: `DEATH_EVENT` (the event indicator)
+
+## Sample Data
+
+The template includes sample data with:
+- 12 feature columns (clinical measurements)
+- 1 time column (`time`)
+- 1 event column (`DEATH_EVENT`)
+- Heart-failure clinical records
+
+## Notes
+
+- The `schema` dict includes the time column (`time`) — from the schema's perspective it's a regular feature column. Only the event column (`DEATH_EVENT`) is excluded from the schema and supplied via `label_column`.
+- The framework uses `time_column` and `label_column` together: each row contributes a `(time, event)` pair to the survival data.


### PR DESCRIPTION
## Summary

Three templates ([`object_detection`](templates/object_detection/README.md), [`keypoint_detection`](templates/keypoint_detection/README.md), [`semantic_segmentation`](templates/semantic_segmentation/README.md)) already had per-template READMEs; six did not. A newcomer who picked one of those six had to reverse-engineer the data layout, label-file format, and configuration constants from the `.py` source.

Adds one README per template, matching the existing style:
- [`image_classification/README.md`](templates/image_classification/README.md)
- [`tabular_classification/README.md`](templates/tabular_classification/README.md)
- [`tabular_regression/README.md`](templates/tabular_regression/README.md)
- [`text_classification/README.md`](templates/text_classification/README.md)
- [`time_series_forecasting/README.md`](templates/time_series_forecasting/README.md)
- [`time_to_event_prediction/README.md`](templates/time_to_event_prediction/README.md)

Each README covers: directory structure, CSV column docs, usage steps, configuration constants, sample data description, and notes.

Templates remain in the repo for one minor version after #46's YAML/subchart migration per that ticket's deprecation plan, so this is useful current-flow guidance — not throwaway work.

Closes #73

## Found during this work — separate ticket recommended

Two templates have inconsistencies between their `.py` script and their bundled sample CSV. The READMEs document the **sample CSV** (what the user actually sees) and flag each mismatch with a "⚠️ Known mismatch" callout so users know to adjust the script before running. The underlying fixes belong in a separate ticket:

1. **`tabular_classification.py`** sets `label_column="name"` but the sample CSV has a `label` column (no `name`). One-line fix.
2. **`time_series_forecasting.py`** declares a `schema` of `timestamp, eq_count, avg_magnitude, …` and `label_column="max_magnitude"` — an earthquake-magnitude dataset — while the bundled sample CSV is a daily-value dataset (`date, day_of_week, lag_1, value, …`). Whole-schema mismatch.

Happy to open a follow-up ticket for these if you want.

## Test plan

- [ ] Render-check each README on GitHub (table of contents, code fences, tree blocks)
- [ ] Confirm column descriptions match each sample CSV exactly
- [ ] Confirm Configuration constants match each `.py` script exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds documentation files and does not change runtime code paths; the only potential issue is inaccurate docs confusing users.
> 
> **Overview**
> Adds per-template `README.md` documentation for six ingestion templates (`image_classification`, `text_classification`, `tabular_classification`, `tabular_regression`, `time_series_forecasting`, `time_to_event_prediction`), covering expected directory layout, label/CSV formats, usage steps, and key configuration knobs.
> 
> Also calls out **known mismatches** between some template scripts and the bundled sample CSVs (notably `tabular_classification`’s `label_column` and `time_series_forecasting`’s schema/label expectations) so users know to adjust before running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd97dbe0e87b74b91595718676b189eb9034ba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->