### PR TITLE
fix: align tabular_classification and time_series_forecasting templates with their sample CSVs

### DIFF
--- a/templates/tabular_classification/README.md
+++ b/templates/tabular_classification/README.md
@@ -60,5 +60,5 @@ The template includes sample data with:
 ## Notes
 
 - The `schema` dict defines feature columns only — do **not** include the label column in it.
-- ⚠️ **Known mismatch:** the template script currently sets `label_column="name"`, but the sample CSV has a `label` column and no `name` column. Update `label_column` to `"label"` (or to your CSV's actual target column) before running against this sample data.
+- If you replace the sample CSV with your own data, update `label_column` to match your CSV's target column.
 - The framework validates the number of CSV columns against the schema length plus the label column.

--- a/templates/tabular_classification/tabular_classification.py
+++ b/templates/tabular_classification/tabular_classification.py
@@ -56,7 +56,7 @@ def main():
             category=TaskCategory.TABULAR_CLASSIFICATION,
             csv_options=csv_options,
             file_options={"number_of_columns": len(schema)},
-            label_column="name",
+            label_column="label",
             intent=Intent.TRAIN,  # Is the data for training or testing
         )
 

--- a/templates/time_series_forecasting/README.md
+++ b/templates/time_series_forecasting/README.md
@@ -15,7 +15,7 @@ time_series_forecasting/
 
 ### CSV File
 The sample CSV contains the following columns:
-- `date`: ISO date (YYYY-MM-DD)
+- `timestamp`: ISO date (YYYY-MM-DD) — required column for time series ingestion
 - `day_of_week`, `month`, `day_of_month`, `week_of_year`, `is_weekend`: Calendar features (INT)
 - `lag_1`: Previous timestep's value (FLOAT; blank for the first row)
 - `moving_avg_7`: 7-day moving average (FLOAT; blank until enough history accumulates)
@@ -54,5 +54,6 @@ The template includes sample data with:
 ## Notes
 
 - The `schema` dict defines feature columns only. The label column is supplied via `label_column`.
+- A column named `timestamp` is required for time series ingestion — keep this name even if you replace the sample CSV with your own data.
 - If you replace the sample CSV with your own data, update the `schema` dict and `label_column` in the script to match your CSV's columns.
 - Time series ingestion treats each row as a timestep; ensure your CSV is sorted chronologically.

--- a/templates/time_series_forecasting/README.md
+++ b/templates/time_series_forecasting/README.md
@@ -54,5 +54,5 @@ The template includes sample data with:
 ## Notes
 
 - The `schema` dict defines feature columns only. The label column is supplied via `label_column`.
-- ⚠️ **Known mismatch:** the template script's `schema` (`timestamp`, `eq_count`, `avg_magnitude`, `median_magnitude`, `dayofweek`, `is_weekend`, `dayofyear`, `month`, `sin_dayofyear`, `cos_dayofyear`) and `label_column="max_magnitude"` describe a different dataset (earthquake magnitudes) than the bundled sample CSV (daily values with calendar features). Update the `schema` and `label_column` in the script to match whichever dataset you actually run against.
+- If you replace the sample CSV with your own data, update the `schema` dict and `label_column` in the script to match your CSV's columns.
 - Time series ingestion treats each row as a timestep; ensure your CSV is sorted chronologically.

--- a/templates/time_series_forecasting/time_series_forecasting.py
+++ b/templates/time_series_forecasting/time_series_forecasting.py
@@ -29,7 +29,7 @@ def main():
         # Schema definition for time series data
         # Schema should contain feature columns only (excluding the target/label column)
         schema = {
-            "date": "TIMESTAMP",
+            "timestamp": "TIMESTAMP",
             "day_of_week": "INT",
             "month": "INT",
             "day_of_month": "INT",

--- a/templates/time_series_forecasting/time_series_forecasting.py
+++ b/templates/time_series_forecasting/time_series_forecasting.py
@@ -29,16 +29,14 @@ def main():
         # Schema definition for time series data
         # Schema should contain feature columns only (excluding the target/label column)
         schema = {
-            "timestamp": "TIMESTAMP",
-            "eq_count": "INT",
-            "avg_magnitude": "FLOAT",
-            "median_magnitude": "FLOAT",
-            "dayofweek": "INT",
-            "is_weekend": "INT",
-            "dayofyear": "INT",
+            "date": "TIMESTAMP",
+            "day_of_week": "INT",
             "month": "INT",
-            "sin_dayofyear": "FLOAT",
-            "cos_dayofyear": "FLOAT",
+            "day_of_month": "INT",
+            "week_of_year": "INT",
+            "is_weekend": "INT",
+            "lag_1": "FLOAT",
+            "moving_avg_7": "FLOAT",
         }
 
         # CSV specific options
@@ -63,7 +61,7 @@ def main():
             category=TaskCategory.TIME_SERIES_FORECASTING,
             csv_options=csv_options,
             file_options={"number_of_columns": len(schema)},
-            label_column="max_magnitude",
+            label_column="value",
             intent=Intent.TRAIN,  # Is the data for training or testing
         )
 

--- a/templates/time_series_forecasting/time_series_forecasting_sample_in_csv_format.csv
+++ b/templates/time_series_forecasting/time_series_forecasting_sample_in_csv_format.csv
@@ -1,4 +1,4 @@
-date,day_of_week,month,day_of_month,week_of_year,is_weekend,lag_1,moving_avg_7,value
+timestamp,day_of_week,month,day_of_month,week_of_year,is_weekend,lag_1,moving_avg_7,value
 2023-10-01,7,10,1,40,1,,,125.50
 2023-10-02,1,10,2,40,0,125.50,,132.30
 2023-10-03,2,10,3,40,0,132.30,,128.75


### PR DESCRIPTION
## Summary

Two templates shipped `.py` scripts that didn't match their bundled sample CSVs — running either template against its own sample data would error out before producing any output. Discovered while writing per-template READMEs in [#74](https://github.com/tracebloc/data-ingestors/pull/74), which documented the mismatches with "⚠️ Known mismatch" callouts so users knew to adjust the script. This PR fixes the underlying scripts and softens those (now-stale) README callouts to generic guidance.

### `tabular_classification.py`

```diff
-            label_column="name",
+            label_column="label",
```

The sample CSV has a `label` column and no `name` column.

### `time_series_forecasting.py`

Replace the script's earthquake-magnitudes schema with the daily-value schema that the bundled CSV actually contains:

```diff
 schema = {
-    "timestamp": "TIMESTAMP",
-    "eq_count": "INT",
-    "avg_magnitude": "FLOAT",
-    "median_magnitude": "FLOAT",
-    "dayofweek": "INT",
-    "is_weekend": "INT",
-    "dayofyear": "INT",
-    "month": "INT",
-    "sin_dayofyear": "FLOAT",
-    "cos_dayofyear": "FLOAT",
+    "date": "TIMESTAMP",
+    "day_of_week": "INT",
+    "month": "INT",
+    "day_of_month": "INT",
+    "week_of_year": "INT",
+    "is_weekend": "INT",
+    "lag_1": "FLOAT",
+    "moving_avg_7": "FLOAT",
 }
…
-label_column="max_magnitude",
+label_column="value",
```

This is option **(a)** from the ticket — update the script to match the existing sample CSV. Lowest-effort fix; the bundled CSV is already a reasonable daily-value forecasting dataset.

### READMEs

The "⚠️ Known mismatch" callouts added in #74 are softened to generic guidance:

```diff
-- ⚠️ **Known mismatch:** the template script currently sets `label_column="name"`, but the sample CSV has a `label` column...
+- If you replace the sample CSV with your own data, update `label_column` to match your CSV's target column.
```

Same shape for the time_series_forecasting README.

Closes #75

## Test plan

- [ ] `python templates/tabular_classification/tabular_classification.py` runs against the sample CSV without schema/label errors
- [ ] `python templates/time_series_forecasting/time_series_forecasting.py` runs against the sample CSV without schema/label errors
- [ ] Visual review of the softened README "Notes" sections in both templates

## Out of scope

The ticket's acceptance criteria suggested "a quick audit of the 4 other templates that ship sample CSVs to make sure none have a similar mismatch." I audited those during the README work for #74 (`tabular_regression`, `text_classification`, `time_to_event_prediction`, and the three image-based templates) — all consistent. No further mismatches found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to template sample scripts/docs to correct schema/label configuration so they run against bundled CSVs; no core library or security-sensitive logic is modified.
> 
> **Overview**
> Fixes template/runtime mismatches so the bundled examples run cleanly against their own sample CSVs.
> 
> Updates `tabular_classification.py` to use `label_column="label"` (matching the sample data) and adjusts the README notes accordingly.
> 
> Replaces the time-series template’s schema/target to match the provided daily-forecasting CSV: updates `time_series_forecasting.py` feature `schema`, sets `label_column="value"`, renames the sample CSV’s first column to `timestamp`, and softens the README “known mismatch” text into general guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 144639a52bc08db25343bb0d009bfabe71a8524a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->