### PR TITLE
feat(#45): release official ingestor image to GHCR with cosign signing and SBOM

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,4 +21,7 @@ var/
 .git
 .gitignore
 README.md
-*.md 
+*.md
+# setup.py reads Readme.md for long_description — must be in the build
+# context so the wheel build (Dockerfile #45) succeeds.
+!Readme.md 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -95,11 +95,20 @@ jobs:
         # of bug above: if anyone refactors `tags:` and accidentally breaks
         # the value source, we fail loudly here instead of letting the build
         # succeed with nothing pushed.
+        #
+        # REF goes through the env: block, not inline `${{ … }}` in the run
+        # script. inputs.ref is user-controllable on workflow_dispatch, and
+        # inline interpolation would let a crafted value (e.g.
+        # `$(malicious command)`) execute inside the double-quoted echo.
+        # env-block values are passed via the environment and read by the
+        # shell at runtime — no substitution risk. Matches the pattern the
+        # release-notes step below uses for TAG / IMAGE / DIGEST / TAGS.
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
+          REF: ${{ inputs.ref || github.ref_name }}
         run: |
           if [ -z "${TAGS//[[:space:]]/}" ]; then
-            echo "::error::docker/metadata-action produced no tags for ref '${{ inputs.ref || github.ref_name }}'. Aborting before the build silently pushes nothing." >&2
+            echo "::error::docker/metadata-action produced no tags for ref '${REF}'. Aborting before the build silently pushes nothing." >&2
             exit 1
           fi
           echo "Tags to publish:"

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -68,10 +68,19 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # Tag strategy: semver only. No :latest — downstream must pick a
           # specific major or minor and accept the upgrade window explicitly.
+          #
+          # The explicit `value=` is load-bearing for workflow_dispatch: by
+          # default docker/metadata-action reads github.ref, which on a
+          # workflow_dispatch event points at the *default branch* rather
+          # than the tag the user typed into `inputs.ref`. Without `value=`,
+          # the semver patterns produce zero tags, the build silently pushes
+          # nothing, and the cosign loop signs nothing. Pinning to
+          # `inputs.ref || github.ref_name` makes both trigger paths produce
+          # the same three tags from the same semver source.
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ inputs.ref || github.ref_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.ref || github.ref_name }}
+            type=semver,pattern={{major}},value=${{ inputs.ref || github.ref_name }}
           flavor: |
             latest=false
           labels: |
@@ -80,6 +89,21 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.licenses=Apache-2.0
             org.opencontainers.image.vendor=tracebloc
+
+      - name: Verify tags were produced
+        # Defense-in-depth against the workflow_dispatch / github.ref class
+        # of bug above: if anyone refactors `tags:` and accidentally breaks
+        # the value source, we fail loudly here instead of letting the build
+        # succeed with nothing pushed.
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          if [ -z "${TAGS//[[:space:]]/}" ]; then
+            echo "::error::docker/metadata-action produced no tags for ref '${{ inputs.ref || github.ref_name }}'. Aborting before the build silently pushes nothing." >&2
+            exit 1
+          fi
+          echo "Tags to publish:"
+          printf '  %s\n' "$TAGS"
 
       - name: Build and push image
         id: build

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,164 @@
+# Build, sign, and publish the official ingestor image to GHCR.
+#
+# Triggered by pushing a vX.Y.Z tag (or manually via workflow_dispatch).
+# Produces:
+#   - ghcr.io/tracebloc/ingestor:X.Y.Z, :X.Y, :X (deliberately no :latest per #45)
+#   - Cosign keyless signature on the image digest (Sigstore Rekor)
+#   - SBOM + SLSA provenance attached as OCI attestations (buildkit-native)
+#   - GitHub Release updated with the image digest for downstream pinning
+#
+# Downstream consumers pin by digest, not tag. The Helm subchart (client#86)
+# pulls the digest from the release notes and bakes it into its values.
+#
+# Verification:
+#   cosign verify ghcr.io/tracebloc/ingestor@<digest> \
+#     --certificate-identity-regexp \
+#       'https://github.com/tracebloc/data-ingestors/.github/workflows/release-image.yml@.*' \
+#     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+name: Release image
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag to build (e.g. v0.3.0). Must already exist on origin.'
+        required: true
+        type: string
+
+permissions:
+  contents: write     # update release notes with the digest
+  packages: write     # push to GHCR
+  id-token: write     # cosign keyless OIDC + buildkit attestations
+  attestations: write # SBOM + provenance attestations
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tracebloc/ingestor
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          # cosign + buildkit reproducibility benefit from full history.
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Tag strategy: semver only. No :latest — downstream must pick a
+          # specific major or minor and accept the upgrade window explicitly.
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          flavor: |
+            latest=false
+          labels: |
+            org.opencontainers.image.title=tracebloc-ingestor
+            org.opencontainers.image.description=Official tracebloc data-ingestor image (declarative YAML-driven, signed)
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=tracebloc
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # SLSA provenance + SBOM as OCI attestations, attached at the image
+          # index level. Extractable with `docker buildx imagetools inspect`.
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.4.0'
+
+      - name: Sign image (keyless OIDC)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          # Sign each tag's digest separately so `cosign verify <tag>` works
+          # for all three (X.Y.Z, X.Y, X). All point to the same digest, so
+          # this is cheap.
+          echo "$TAGS" | while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "::group::Signing $tag@$DIGEST"
+            cosign sign --yes "$tag@$DIGEST"
+            echo "::endgroup::"
+          done
+
+      - name: Update release notes with digest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.ref || github.ref_name }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          # Indent each pushed tag two spaces for the markdown bullet list.
+          tag_list=$(echo "$TAGS" | sed 's/^/- `/; s/$/`/')
+
+          notes=$(cat <<EOF
+          ## Image
+
+          \`\`\`
+          ${IMAGE}@${DIGEST}
+          \`\`\`
+
+          ### Tags pushed
+
+          ${tag_list}
+
+          ### Verify signature
+
+          \`\`\`
+          cosign verify ${IMAGE}@${DIGEST} \\
+            --certificate-identity-regexp 'https://github.com/${{ github.repository }}/.github/workflows/release-image.yml@.*' \\
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+          \`\`\`
+
+          ### Inspect SBOM / provenance
+
+          \`\`\`
+          docker buildx imagetools inspect ${IMAGE}@${DIGEST} --format '{{ json .SBOM }}'
+          docker buildx imagetools inspect ${IMAGE}@${DIGEST} --format '{{ json .Provenance }}'
+          \`\`\`
+          EOF
+          )
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Updating existing release $TAG"
+            gh release edit "$TAG" --notes "$notes"
+          else
+            echo "Creating new release $TAG"
+            gh release create "$TAG" --title "$TAG" --notes "$notes"
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,51 @@
-# Use Python 3.11 as base image
-FROM python:3.11
+# syntax=docker/dockerfile:1.7
+#
+# Official tracebloc data-ingestor image (#45).
+#
+# The image entrypoint is the declarative `tracebloc-ingest` console script
+# registered by setup.py (#44). The Helm subchart (client#86) mounts the
+# customer's ingest.yaml at the path pointed to by INGEST_CONFIG. No customer
+# Python script lives in the image; no customer-built Dockerfile is needed.
 
-# Set working directory
+# ---- Builder: produce a wheel from the source in this repo so the image
+#       ships the exact code being released (not whatever's on PyPI). ----
+FROM python:3.11-slim AS builder
+WORKDIR /build
+
+COPY setup.py requirements.txt Readme.md ./
+COPY tracebloc_ingestor/ tracebloc_ingestor/
+
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+ && pip wheel --no-deps --wheel-dir /wheels .
+
+# ---- Runtime ----
+FROM python:3.11-slim
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y netcat-traditional
+# Runtime deps:
+#   netcat-traditional — docker-entrypoint.sh uses `nc -z` to wait for MySQL.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends netcat-traditional \
+ && rm -rf /var/lib/apt/lists/*
 
-# Install data ingestor package
-RUN pip install tracebloc_ingestor
+# Install dependencies first (cacheable layer), then the wheel built above.
+# Using --no-deps on the wheel avoids re-resolving against PyPI; deps come
+# from requirements.txt so the resolution is reproducible at release time.
+COPY requirements.txt /tmp/requirements.txt
+COPY --from=builder /wheels/*.whl /tmp/
+RUN pip install --no-cache-dir -r /tmp/requirements.txt \
+ && pip install --no-cache-dir --no-deps /tmp/*.whl \
+ && rm /tmp/*.whl /tmp/requirements.txt
 
-# Copy the user's chosen ingestor (rename a template to ./ingestor.py before building) # train/test switch
-COPY ingestor.py /app/ingestor.py
-
-
-# Set environment variables
-ENV PYTHONPATH=/app
-# Disable GPU/CUDA usage
 ENV CUDA_VISIBLE_DEVICES=-1
 ENV TF_CPP_MIN_LOG_LEVEL=2
 
-# Create an entrypoint script
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# Set the entrypoint
-ENTRYPOINT ["docker-entrypoint.sh"] 
+# Run as non-root. The process needs read access to /custom/ (processor
+# scripts mounted via ConfigMap by client#86) and write access to whatever
+# PVC the Helm chart mounts at the configured DEST_PATH.
+USER nobody
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,31 @@
-#!/bin/bash
+#!/bin/sh
+# Wait for MySQL, then hand off to the YAML-driven entrypoint registered by
+# setup.py (`tracebloc-ingest`, defined in #44). The Helm subchart (client#86)
+# mounts ingest.yaml and sets INGEST_CONFIG to its path; this script does not
+# need to know about that — it just exec's the console script.
 
-# Wait for MySQL to be ready
-echo "Waiting for MySQL to be ready..."
-while ! nc -z $MYSQL_HOST 3306; do
+set -e
+
+if [ -z "$MYSQL_HOST" ]; then
+  echo "ERROR: MYSQL_HOST must be set (the tracebloc client provides this)" >&2
+  exit 64
+fi
+
+# Bound the MySQL wait so a misconfigured client surfaces a clear failure
+# instead of hanging the Job indefinitely.
+WAIT_SECONDS="${MYSQL_WAIT_SECONDS:-120}"
+echo "Waiting up to ${WAIT_SECONDS}s for MySQL at ${MYSQL_HOST}:3306..."
+i=0
+until nc -z "$MYSQL_HOST" 3306; do
+  i=$((i + 1))
+  if [ "$i" -ge "$WAIT_SECONDS" ]; then
+    echo "ERROR: MySQL not reachable at ${MYSQL_HOST}:3306 after ${WAIT_SECONDS}s" >&2
+    exit 65
+  fi
   sleep 1
 done
-echo "MySQL is ready!"
+echo "MySQL is ready."
 
-# Run the CSV ingestor
-python ingestor.py "$@" # train/test switch
+# exec so the Python process becomes PID 1 and Kubernetes signal handling
+# (SIGTERM on Pod deletion, etc.) reaches the application directly.
+exec tracebloc-ingest "$@"


### PR DESCRIPTION
**Draft — depends on #69 (#44) merging first. Once #44 is on develop, I'll rebase this branch and mark ready for review. Until then the diff includes #44's commits.**

Closes #45

## Summary

Replaces the per-customer Python script + Dockerfile pattern with one official image, semver-tagged, signed, and consumed by digest. Customers no longer build their own ingestor container — the Helm subchart ([client#86](https://github.com/tracebloc/client/issues/86)) pulls a digest-pinned image from this workflow's output.

## What's in this PR (the #45-specific files)

- **`.github/workflows/release-image.yml`** (new, ~140 lines): triggered on `v*.*.*` tags or `workflow_dispatch`. Builds for `ghcr.io/tracebloc/ingestor`, tags with `:X.Y.Z` / `:X.Y` / `:X` (deliberately no `:latest`). Buildkit attaches SLSA provenance and SBOM as OCI attestations at the index level. Cosign keyless-signs the digest via GitHub Actions OIDC. The release notes are updated with the digest + verification command.
- **`Dockerfile`** (rewritten): multi-stage build. Builder produces a wheel from this repo's source (the image ships the exact code being released, not whatever's currently on PyPI). Runtime installs the wheel + deps onto `python:3.11-slim`. Drops the `COPY ingestor.py` pattern — no customer script lives in the image. Runs as `nobody`.
- **`docker-entrypoint.sh`** (updated): keeps the MySQL wait but bounds it (`MYSQL_WAIT_SECONDS`, default 120s) so a misconfigured client surfaces a clear failure instead of hanging the Job. `exec tracebloc-ingest "$@"` at the end — the Python process becomes PID 1 so Kubernetes signal handling reaches the app directly.
- **`.dockerignore`** (one-line fix): un-exclude `Readme.md` since `setup.py` reads it for `long_description` during wheel build.

## Acceptance criteria status

| Criterion | Status |
|---|---|
| `v0.3.0` tag → signed `ghcr.io/tracebloc/ingestor:0.3.0` with SBOM | ✅ workflow does this — needs first real tag to confirm end-to-end |
| `cosign verify` succeeds with `--certificate-identity ...` | ✅ keyless OIDC signing; verify command included in release notes |
| Image runs an example YAML from #44 with `BACKEND_TOKEN` env | ⚠️ requires #44 merged + a real cluster — flagged for post-merge validation |
| No PAT or other secret embedded in the image | ✅ wheel built from local source; no `git+https://<token>@...` pattern; secrets scan of the layers should confirm |

## Local verification done

```
docker build -t tracebloc-ingestor-test:dev .   # succeeds (~85s on a clean cache)
docker run --rm --entrypoint /bin/sh tracebloc-ingestor-test:dev -c "id"
# uid=65534(nobody) gid=65534(nogroup) groups=65534(nogroup)
docker run --rm --entrypoint /bin/sh tracebloc-ingestor-test:dev -c "which tracebloc-ingest"
# /usr/local/bin/tracebloc-ingest
docker run --rm tracebloc-ingestor-test:dev      # (with INGEST_CONFIG unset)
# ERROR: MYSQL_HOST must be set ... (entrypoint exits 64, no hang)
```

Image is 597 MB. That's mostly the python:3.11-slim base + pinned ML deps (pandas/numpy/Pillow); not a tight optimization target since pulls happen rarely and cluster-internal.

## Design choices worth flagging

1. **No `:latest` tag.** Acceptance criteria says so. Downstream consumers must pick `:X.Y.Z` or `:X.Y` explicitly. The Helm subchart pins by digest anyway.
2. **Wheel built from local source, not PyPI.** Image ships exactly what's released. Prevents drift between the Python package and the image at the same tag.
3. **Buildkit-native attestations (SBOM + provenance), not separate `anchore/sbom-action`.** Simpler workflow, native OCI attachment, inspectable with `docker buildx imagetools inspect`. If the team prefers a separate SPDX/CycloneDX file artifact attached to the GitHub Release as well, I can add that as a follow-up.
4. **Cosign keyless signing**, not key-based. No secrets to rotate; trust anchor is the GitHub Actions OIDC identity of *this* workflow on *this* repo. The verify command in the release notes pins both.
5. **Bounded MySQL wait (default 120s).** The existing entrypoint waited forever. With the YAML-driven flow you'd rather see a fast-fail Job failure than a stuck Pod.

## What I deliberately didn't include

- **No image-build dry-run on PRs.** Could add `release-image.yml`'s `pull_request` trigger with `push: false` to surface Dockerfile breakage early. Worth it as a follow-up; not in the #45 acceptance criteria.
- **No automatic version bump.** The workflow consumes whatever tag you push (`v0.3.0`, `v1.0.0-rc1`, etc.). The release-tagging cadence is a separate team decision; standardizing it (with e.g. release-please) is out of scope.
- **No SBOM file artifact on the GitHub Release.** The SBOM is attached to the OCI image; that's what the ticket asked for. Inline release-notes SBOM is a follow-up if customers want it.

## Test plan

After #44 merges and this PR is rebased:

- [ ] Push a `v0.3.0-rc1` tag → workflow runs end-to-end
- [ ] `docker buildx imagetools inspect ghcr.io/tracebloc/ingestor:0.3.0-rc1` shows SBOM + provenance
- [ ] `cosign verify ...` succeeds with the workflow identity from the release notes
- [ ] Pull the image into a test cluster, point at an example YAML from `examples/yaml/`, confirm end-to-end ingestion
- [ ] No secrets visible in `docker history` / layer scan

## Depends on / unblocks

- **Depends on:** #44 (the `tracebloc-ingest` console script — needs to be on develop before this can merge cleanly)
- **Unblocks:** [client#86](https://github.com/tracebloc/client/issues/86) (Helm subchart can now pin this image by digest), [#46](https://github.com/tracebloc/data-ingestors/issues/46) (docs/migration guide can point at concrete tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new release workflow that builds/signs/publishes container images and rewrites the Docker build/entrypoint path, which could impact release integrity and runtime startup behavior if misconfigured.
> 
> **Overview**
> Adds a new `release-image.yml` workflow that, on `v*.*.*` tags (or manual dispatch), builds and pushes `ghcr.io/tracebloc/ingestor` with semver tags (no `latest`), attaches SBOM + SLSA provenance, signs the digest via keyless cosign, and writes the resulting digest/verification commands into the GitHub Release notes.
> 
> Reworks the `Dockerfile` into a multi-stage build that wheels the local source (instead of installing from PyPI), installs deps from `requirements.txt`, runs as `nobody`, and updates `.dockerignore` to include `Readme.md` so the wheel build succeeds.
> 
> Updates `docker-entrypoint.sh` to be `sh`-based, fail fast if `MYSQL_HOST` is unset, bound the MySQL wait via `MYSQL_WAIT_SECONDS`, and `exec tracebloc-ingest` so the app runs as PID 1 for proper signal handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4081d9f9f02a2a0cf71aa4135f36109e86d2e74e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->