### PR TITLE
fix(semantic-seg): atomic image+mask transfer, skip record on missing mask

### DIFF
--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -207,6 +207,20 @@ def text_transfer(record: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, 
         raise ValueError(f"{RED}Error processing text file: {str(e)}{RESET}")
 
 
+def _find_mask_src(mask_id: str):
+    """Locate a mask file in SRC_PATH/masks/, trying common image extensions.
+
+    Returns (src_path, extension, mask_name) on success, or (None, None, mask_name)
+    if no matching file is found.
+    """
+    mask_name = mask_id.split(".")[0] if "." in mask_id else mask_id
+    for ext in [".png", ".jpg", ".jpeg"]:
+        candidate = os.path.join(config.SRC_PATH, "masks", f"{mask_name}{ext}")
+        if os.path.exists(candidate):
+            return candidate, ext, mask_name
+    return None, None, mask_name
+
+
 def mask_transfer(record: Dict[str, Any]) -> Dict[str, Any]:
     """Transfer mask files for semantic segmentation tasks.
 
@@ -221,19 +235,7 @@ def mask_transfer(record: Dict[str, Any]) -> Dict[str, Any]:
             logger.error(f"{RED}No mask_id found in record{RESET}")
             return record
 
-        # Strip extension if present
-        mask_name = mask_id.split(".")[0] if "." in mask_id else mask_id
-
-        # Search for mask file with common extensions
-        mask_src_path = None
-        mask_ext = None
-        for ext in [".png", ".jpg", ".jpeg"]:
-            candidate = os.path.join(config.SRC_PATH, "masks", f"{mask_name}{ext}")
-            if os.path.exists(candidate):
-                mask_src_path = candidate
-                mask_ext = ext
-                break
-
+        mask_src_path, mask_ext, mask_name = _find_mask_src(mask_id)
         if mask_src_path is None:
             logger.error(f"{RED}Source mask not found: {mask_name} in {config.SRC_PATH}/masks/{RESET}")
             return record
@@ -272,6 +274,18 @@ def map_file_transfer(
         result = text_transfer(record, options)
         return result
     elif task_category == TaskCategory.SEMANTIC_SEGMENTATION:
+        # Atomic: only copy image+mask together. If the mask is missing,
+        # skip the record entirely so we don't leave an orphan image on disk.
+        mask_id = record.get("mask_id")
+        if not mask_id:
+            logger.error(f"{RED}No mask_id found in record{RESET}")
+            return None
+        mask_src_path, _, mask_name = _find_mask_src(mask_id)
+        if mask_src_path is None:
+            logger.error(
+                f"{RED}Source mask not found: {mask_name} in {config.SRC_PATH}/masks/ — skipping record{RESET}"
+            )
+            return None
         record = image_transfer(record, options)
         record = mask_transfer(record)
         return record


### PR DESCRIPTION
## Summary
- In `SEMANTIC_SEGMENTATION` file transfer, the image was copied first and the mask second. If the mask file was missing, `mask_transfer` only logged an error and returned the record unchanged, so the image landed in `DEST_PATH` and the record still got inserted into the DB without its mask.
- Now pre-validate the mask source (presence of `mask_id` + a matching `.png/.jpg/.jpeg` file under `SRC_PATH/masks/`) before any copy. If validation fails, return `None` so the ingestor's existing skip path (`base.py:385`) increments `skipped_records` and no orphan image is written.
- Extracted `_find_mask_src()` helper and reused it from `mask_transfer()`.

## Test plan
- [ ] Run the semantic_segmentation template against a dataset with a row whose `mask_id` has no corresponding file in `SRC_PATH/masks/` — verify the row is skipped, no image is copied to `DEST_PATH`, and `skipped_records` increments.
- [ ] Run against a row with a missing/blank `mask_id` — verify same skip behavior.
- [ ] Run against a fully valid dataset — verify both image and mask land in `DEST_PATH` and the record is inserted as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ingestion behavior for semantic-segmentation records by returning `None` to trigger the skip path, which can affect record counts and downstream expectations. Risk is limited to mask/image transfer logic and improves consistency by preventing partial writes.
> 
> **Overview**
> **Semantic segmentation transfers are now atomic.** Before copying anything, the transfer path now validates that `mask_id` is present and that a corresponding mask file exists under `SRC_PATH/masks/`; if not, it returns `None` so the ingestor skips the record.
> 
> Mask file lookup logic was deduplicated into a new `_find_mask_src()` helper, which is reused by both `mask_transfer()` and the `SEMANTIC_SEGMENTATION` branch in `map_file_transfer()` to prevent orphan images when masks are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96f4154cc08f9f9664155fdb96ee069e25efa114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->