### PR TITLE
fix(keypoint): persist Visibility column and avoid duplicate mask lookup

### DIFF
--- a/templates/keypoint_detection/keypoint_detection.py
+++ b/templates/keypoint_detection/keypoint_detection.py
@@ -61,6 +61,11 @@ def main():
         database = Database(config)
         api_client = APIClient(config)
 
+        # Visibility is kept in the schema so it survives process_record's
+        # schema-based filtering and is persisted alongside the annotation;
+        # without it the column is validated and then silently dropped.
+        schema = {"Visibility": "TEXT"}
+
         # Create ingestor for keypoint detection data with validators
         ingestor = CSVIngestor(
             database=database,
@@ -68,6 +73,7 @@ def main():
             table_name=config.TABLE_NAME,
             data_format=DataFormat.IMAGE,
             category=TaskCategory.KEYPOINT_DETECTION,
+            schema=schema,
             csv_options=csv_options,
             file_options=file_options,
             label_column="image_label",

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -221,25 +221,21 @@ def _find_mask_src(mask_id: str):
     return None, None, mask_name
 
 
-def mask_transfer(record: Dict[str, Any]) -> Dict[str, Any]:
-    """Transfer mask files for semantic segmentation tasks.
+def mask_transfer(
+    record: Dict[str, Any],
+    mask_src_path: str,
+    mask_ext: str,
+    mask_name: str,
+) -> Dict[str, Any]:
+    """Copy a pre-resolved mask file from SRC_PATH/masks/ to DEST_PATH/.
 
-    Copies mask from SRC_PATH/masks/ to DEST_PATH/.
-    Searches for the mask with common image extensions (.jpg, .jpeg, .png).
+    The caller is responsible for locating the mask via `_find_mask_src` and
+    passing the resolved path; this keeps the filesystem lookup to a single
+    call per record.
     """
     os.makedirs(config.DEST_PATH, exist_ok=True)
 
     try:
-        mask_id = record.get("mask_id")
-        if not mask_id:
-            logger.error(f"{RED}No mask_id found in record{RESET}")
-            return record
-
-        mask_src_path, mask_ext, mask_name = _find_mask_src(mask_id)
-        if mask_src_path is None:
-            logger.error(f"{RED}Source mask not found: {mask_name} in {config.SRC_PATH}/masks/{RESET}")
-            return record
-
         mask_dest_path = os.path.join(config.DEST_PATH, f"{mask_name}{mask_ext}")
         _copy_file_with_retry(mask_src_path, mask_dest_path)
 
@@ -280,14 +276,14 @@ def map_file_transfer(
         if not mask_id:
             logger.error(f"{RED}No mask_id found in record{RESET}")
             return None
-        mask_src_path, _, mask_name = _find_mask_src(mask_id)
+        mask_src_path, mask_ext, mask_name = _find_mask_src(mask_id)
         if mask_src_path is None:
             logger.error(
                 f"{RED}Source mask not found: {mask_name} in {config.SRC_PATH}/masks/ — skipping record{RESET}"
             )
             return None
         record = image_transfer(record, options)
-        record = mask_transfer(record)
+        record = mask_transfer(record, mask_src_path, mask_ext, mask_name)
         return record
     elif task_category == TaskCategory.KEYPOINT_DETECTION:
         result = image_transfer(record, options)


### PR DESCRIPTION
## Summary
Addresses both Cursor Bugbot findings on [#79](https://github.com/tracebloc/data-ingestors/pull/79).

- **Keypoint `Visibility` was silently dropped during ingestion.** `KeypointVisibilityValidator` checks the column, but `BaseIngestor.process_record` only keeps keys present in `self.schema` — and `Visibility` was neither in the schema nor mapped as a special column. Adds `Visibility` back to the keypoint template's schema so it persists alongside the annotation.
- **Duplicate filesystem lookup in semantic-segmentation transfer.** The `SEMANTIC_SEGMENTATION` branch of `map_file_transfer` called `_find_mask_src` to validate existence, then `mask_transfer` ran the same search again. Refactored `mask_transfer` to take the pre-resolved `(src_path, ext, name)` so the lookup happens once per record. Only caller updated accordingly.

## Test plan
- [ ] Run the keypoint detection template end-to-end and confirm `Visibility` is present in the destination table
- [ ] Run the semantic segmentation template and confirm masks still copy correctly (single `_find_mask_src` call per record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized changes to ingestion templates and semantic-segmentation file copy flow; main risk is minor behavior change in what columns/files are persisted per record.
> 
> **Overview**
> Fixes keypoint-detection ingestion so the `Visibility` field is included in the ingestor schema and therefore survives schema-based record filtering and is stored with the annotation.
> 
> Refactors semantic-segmentation mask transfer so `_find_mask_src` is called once per record and the resolved `(mask_src_path, mask_ext, mask_name)` is passed into `mask_transfer`, avoiding a second filesystem search while preserving the “skip record if mask missing” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a92f3bd4b7518110fe00a163859b737173927dfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->