### PR TITLE
fix(semantic-seg): pre-verify image source so atomicity holds

### DIFF
--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -75,19 +75,20 @@ def _has_extension(filename: str) -> bool:
     return False
 
 
-def _find_image_src(filename: str, extension: str):
-    """Resolve the source path for an image in SRC_PATH/images/.
+def _find_src(subdirectory: str, filename: str, extension: str):
+    """Resolve a source file in `SRC_PATH/<subdirectory>/`.
 
     Returns (src_path, filename_with_ext) on success, or
-    (None, filename_with_ext) if the file does not exist. Centralising the
-    path/extension resolution keeps pre-checks (e.g. the atomic
-    SEMANTIC_SEGMENTATION branch in `map_file_transfer`) consistent with
-    what `image_transfer` actually copies.
+    (None, filename_with_ext) if the file does not exist. Centralising
+    the path/extension resolution keeps atomic pre-checks (e.g. the
+    OBJECT_DETECTION and SEMANTIC_SEGMENTATION branches in
+    `map_file_transfer`) consistent with what the corresponding
+    `*_transfer` function actually copies.
     """
     filename_with_ext = (
         filename if _has_extension(filename) else f"{filename}{extension}"
     )
-    candidate = os.path.join(config.SRC_PATH, "images", filename_with_ext)
+    candidate = os.path.join(config.SRC_PATH, subdirectory, filename_with_ext)
     if os.path.exists(candidate):
         return candidate, filename_with_ext
     return None, filename_with_ext
@@ -101,10 +102,10 @@ def image_transfer(
 ) -> Dict[str, Any]:
     """Copy an image from SRC_PATH/images/ to DEST_PATH/.
 
-    Callers that have already resolved the source via `_find_image_src`
-    (e.g. atomic multi-file branches that need to pre-check existence)
-    can pass `src_path` and `filename_with_ext` to skip the lookup; in
-    that mode no filesystem stat happens here.
+    Callers that have already resolved the source via `_find_src` (e.g.
+    atomic multi-file branches that need to pre-check existence) can
+    pass `src_path` and `filename_with_ext` to skip the lookup; in that
+    mode no filesystem stat happens here.
     """
     # Create destination directory if it doesn't exist
     os.makedirs(config.DEST_PATH, exist_ok=True)
@@ -118,7 +119,7 @@ def image_transfer(
             return record
 
         if src_path is None:
-            src_path, filename_with_ext = _find_image_src(filename, extension)
+            src_path, filename_with_ext = _find_src("images", filename, extension)
             if src_path is None:
                 logger.error(
                     f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', filename_with_ext)}{RESET}"
@@ -147,24 +148,6 @@ filename: file_name.png (or any other extension) file_name.xml
 """
 
 
-def _find_annotation_src(filename: str, extension: str):
-    """Resolve the source path for an annotation in SRC_PATH/annotations/.
-
-    Returns (src_path, filename_with_ext) on success, or
-    (None, filename_with_ext) if the file does not exist. Mirrors
-    `_find_image_src` / `_find_mask_src` so atomic pre-checks (e.g.
-    OBJECT_DETECTION) cannot drift from what `annotation_transfer` looks
-    for.
-    """
-    filename_with_ext = (
-        filename if _has_extension(filename) else f"{filename}{extension}"
-    )
-    candidate = os.path.join(config.SRC_PATH, "annotations", filename_with_ext)
-    if os.path.exists(candidate):
-        return candidate, filename_with_ext
-    return None, filename_with_ext
-
-
 def annotation_transfer(
     record: Dict[str, Any],
     options: Dict[str, Any],
@@ -174,9 +157,9 @@ def annotation_transfer(
 ) -> Dict[str, Any]:
     """Copy an annotation file from SRC_PATH/annotations/ to DEST_PATH/.
 
-    Callers that have already resolved the source via
-    `_find_annotation_src` can pass `src_path` and `filename_with_ext`
-    to skip the lookup; in that mode no filesystem stat happens here.
+    Callers that have already resolved the source via `_find_src` can
+    pass `src_path` and `filename_with_ext` to skip the lookup; in that
+    mode no filesystem stat happens here.
     """
     # Create destination directory if it doesn't exist
     os.makedirs(config.DEST_PATH, exist_ok=True)
@@ -189,7 +172,9 @@ def annotation_transfer(
             return record
 
         if src_path is None:
-            src_path, filename_with_ext = _find_annotation_src(filename, extension)
+            src_path, filename_with_ext = _find_src(
+                "annotations", filename, extension
+            )
             if src_path is None:
                 logger.error(
                     f"{RED}Source file not found: {os.path.join(config.SRC_PATH, 'annotations', filename_with_ext)}{RESET}"
@@ -320,16 +305,16 @@ def map_file_transfer(
         if not filename:
             logger.error(f"{RED}No filename found in record{RESET}")
             return None
-        image_src_path, image_filename = _find_image_src(
-            filename, options.get("extension")
+        image_src_path, image_filename = _find_src(
+            "images", filename, options.get("extension")
         )
         if image_src_path is None:
             logger.error(
                 f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', image_filename)} — skipping record{RESET}"
             )
             return None
-        annotation_src_path, annotation_filename = _find_annotation_src(
-            filename, ".xml"
+        annotation_src_path, annotation_filename = _find_src(
+            "annotations", filename, ".xml"
         )
         if annotation_src_path is None:
             logger.error(
@@ -349,15 +334,15 @@ def map_file_transfer(
         # before either copy, since image_transfer returns the record (not
         # None) when the source image is missing — without this pre-check
         # a missing image would still let mask_transfer leave an orphan
-        # mask on disk. Both sides resolve their source via shared helpers
-        # (_find_image_src / _find_mask_src) so the pre-check stays in
-        # lockstep with what the copy functions actually look for.
+        # mask on disk. Both sides resolve their source via shared
+        # helpers (`_find_src` / `_find_mask_src`) so the pre-check stays
+        # in lockstep with what the copy functions actually look for.
         filename = record.get("filename")
         if not filename:
             logger.error(f"{RED}No filename found in record{RESET}")
             return None
-        image_src_path, image_filename = _find_image_src(
-            filename, options.get("extension")
+        image_src_path, image_filename = _find_src(
+            "images", filename, options.get("extension")
         )
         if image_src_path is None:
             logger.error(

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -270,8 +270,26 @@ def map_file_transfer(
         result = text_transfer(record, options)
         return result
     elif task_category == TaskCategory.SEMANTIC_SEGMENTATION:
-        # Atomic: only copy image+mask together. If the mask is missing,
-        # skip the record entirely so we don't leave an orphan image on disk.
+        # Atomic: only copy image+mask together. Pre-verify both sources
+        # before either copy, since image_transfer returns the record (not
+        # None) when the source image is missing — without this pre-check
+        # a missing image would still let mask_transfer leave an orphan
+        # mask on disk.
+        filename = record.get("filename")
+        if not filename:
+            logger.error(f"{RED}No filename found in record{RESET}")
+            return None
+        extension = options.get("extension")
+        image_filename = (
+            filename if _has_extension(filename) else f"{filename}{extension}"
+        )
+        image_src_path = os.path.join(config.SRC_PATH, "images", image_filename)
+        if not os.path.exists(image_src_path):
+            logger.error(
+                f"{RED}Source image not found: {image_src_path} — skipping record{RESET}"
+            )
+            return None
+
         mask_id = record.get("mask_id")
         if not mask_id:
             logger.error(f"{RED}No mask_id found in record{RESET}")

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -75,6 +75,24 @@ def _has_extension(filename: str) -> bool:
     return False
 
 
+def _find_image_src(filename: str, extension: str):
+    """Resolve the source path for an image in SRC_PATH/images/.
+
+    Returns (src_path, filename_with_ext) on success, or
+    (None, filename_with_ext) if the file does not exist. Centralising the
+    path/extension resolution keeps pre-checks (e.g. the atomic
+    SEMANTIC_SEGMENTATION branch in `map_file_transfer`) consistent with
+    what `image_transfer` actually copies.
+    """
+    filename_with_ext = (
+        filename if _has_extension(filename) else f"{filename}{extension}"
+    )
+    candidate = os.path.join(config.SRC_PATH, "images", filename_with_ext)
+    if os.path.exists(candidate):
+        return candidate, filename_with_ext
+    return None, filename_with_ext
+
+
 def image_transfer(record: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, Any]:
     # Create destination directory if it doesn't exist
     os.makedirs(config.DEST_PATH, exist_ok=True)
@@ -87,16 +105,11 @@ def image_transfer(record: Dict[str, Any], options: Dict[str, Any]) -> Dict[str,
             logger.error(f"{RED}No filename found in record{RESET}")
             return record
 
-        # Add extension to filename if it doesn't have one
-        if not _has_extension(filename):
-            filename_with_ext = f"{filename}{extension}"
-        else:
-            filename_with_ext = filename
-
-        # Process the image
-        image_src_path = os.path.join(config.SRC_PATH, "images", filename_with_ext)
-        if not os.path.exists(image_src_path):
-            logger.error(f"{RED}Source image not found: {image_src_path}{RESET}")
+        image_src_path, filename_with_ext = _find_image_src(filename, extension)
+        if image_src_path is None:
+            logger.error(
+                f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', filename_with_ext)}{RESET}"
+            )
             return record
 
         # Save the resized image
@@ -274,19 +287,19 @@ def map_file_transfer(
         # before either copy, since image_transfer returns the record (not
         # None) when the source image is missing — without this pre-check
         # a missing image would still let mask_transfer leave an orphan
-        # mask on disk.
+        # mask on disk. Both sides resolve their source via shared helpers
+        # (_find_image_src / _find_mask_src) so the pre-check stays in
+        # lockstep with what the copy functions actually look for.
         filename = record.get("filename")
         if not filename:
             logger.error(f"{RED}No filename found in record{RESET}")
             return None
-        extension = options.get("extension")
-        image_filename = (
-            filename if _has_extension(filename) else f"{filename}{extension}"
+        image_src_path, image_filename = _find_image_src(
+            filename, options.get("extension")
         )
-        image_src_path = os.path.join(config.SRC_PATH, "images", image_filename)
-        if not os.path.exists(image_src_path):
+        if image_src_path is None:
             logger.error(
-                f"{RED}Source image not found: {image_src_path} — skipping record{RESET}"
+                f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', image_filename)} — skipping record{RESET}"
             )
             return None
 

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -93,7 +93,19 @@ def _find_image_src(filename: str, extension: str):
     return None, filename_with_ext
 
 
-def image_transfer(record: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, Any]:
+def image_transfer(
+    record: Dict[str, Any],
+    options: Dict[str, Any],
+    src_path: str = None,
+    filename_with_ext: str = None,
+) -> Dict[str, Any]:
+    """Copy an image from SRC_PATH/images/ to DEST_PATH/.
+
+    Callers that have already resolved the source via `_find_image_src`
+    (e.g. atomic multi-file branches that need to pre-check existence)
+    can pass `src_path` and `filename_with_ext` to skip the lookup; in
+    that mode no filesystem stat happens here.
+    """
     # Create destination directory if it doesn't exist
     os.makedirs(config.DEST_PATH, exist_ok=True)
 
@@ -105,17 +117,18 @@ def image_transfer(record: Dict[str, Any], options: Dict[str, Any]) -> Dict[str,
             logger.error(f"{RED}No filename found in record{RESET}")
             return record
 
-        image_src_path, filename_with_ext = _find_image_src(filename, extension)
-        if image_src_path is None:
-            logger.error(
-                f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', filename_with_ext)}{RESET}"
-            )
-            return record
+        if src_path is None:
+            src_path, filename_with_ext = _find_image_src(filename, extension)
+            if src_path is None:
+                logger.error(
+                    f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', filename_with_ext)}{RESET}"
+                )
+                return record
 
         # Save the resized image
         image_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)
         # Copy file with retry logic
-        _copy_file_with_retry(image_src_path, image_dest_path)
+        _copy_file_with_retry(src_path, image_dest_path)
 
         record["filename"] = os.path.splitext(filename_with_ext)[0]
         record["extension"] = extension
@@ -134,36 +147,59 @@ filename: file_name.png (or any other extension) file_name.xml
 """
 
 
+def _find_annotation_src(filename: str, extension: str):
+    """Resolve the source path for an annotation in SRC_PATH/annotations/.
+
+    Returns (src_path, filename_with_ext) on success, or
+    (None, filename_with_ext) if the file does not exist. Mirrors
+    `_find_image_src` / `_find_mask_src` so atomic pre-checks (e.g.
+    OBJECT_DETECTION) cannot drift from what `annotation_transfer` looks
+    for.
+    """
+    filename_with_ext = (
+        filename if _has_extension(filename) else f"{filename}{extension}"
+    )
+    candidate = os.path.join(config.SRC_PATH, "annotations", filename_with_ext)
+    if os.path.exists(candidate):
+        return candidate, filename_with_ext
+    return None, filename_with_ext
+
+
 def annotation_transfer(
-    record: Dict[str, Any], options: Dict[str, Any], extension: str
+    record: Dict[str, Any],
+    options: Dict[str, Any],
+    extension: str,
+    src_path: str = None,
+    filename_with_ext: str = None,
 ) -> Dict[str, Any]:
+    """Copy an annotation file from SRC_PATH/annotations/ to DEST_PATH/.
+
+    Callers that have already resolved the source via
+    `_find_annotation_src` can pass `src_path` and `filename_with_ext`
+    to skip the lookup; in that mode no filesystem stat happens here.
+    """
     # Create destination directory if it doesn't exist
     os.makedirs(config.DEST_PATH, exist_ok=True)
 
     try:
         # Get the filename from the record
         filename = record.get("filename")
-        extension = extension
         if not filename:
             logger.error(f"{RED}No filename found in record{RESET}")
             return record
 
-        # Add extension to filename if it doesn't have one
-        if not _has_extension(filename):
-            filename_with_ext = f"{filename}{extension}"
-        else:
-            filename_with_ext = filename
-
-        # Process the image
-        file_src_path = os.path.join(config.SRC_PATH, "annotations", filename_with_ext)
-        if not os.path.exists(file_src_path):
-            logger.error(f"{RED}Source file not found: {file_src_path}{RESET}")
-            return record
+        if src_path is None:
+            src_path, filename_with_ext = _find_annotation_src(filename, extension)
+            if src_path is None:
+                logger.error(
+                    f"{RED}Source file not found: {os.path.join(config.SRC_PATH, 'annotations', filename_with_ext)}{RESET}"
+                )
+                return record
 
         # Save the file
         file_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)
         # Copy file with retry logic
-        _copy_file_with_retry(file_src_path, file_dest_path)
+        _copy_file_with_retry(src_path, file_dest_path)
 
         logger.info(f"{GREEN}Successfully copied file: {filename}{RESET}")
         return record
@@ -276,8 +312,34 @@ def map_file_transfer(
         result = image_transfer(record, options)
         return result
     elif task_category == TaskCategory.OBJECT_DETECTION:
-        record = image_transfer(record, options)
-        result = annotation_transfer(record, options, ".xml")
+        # Atomic: only copy image+annotation together. Pre-verify both
+        # sources so a missing image (image_transfer returns the record,
+        # not None, on missing source) doesn't let annotation_transfer
+        # leave an orphan annotation on disk — and vice versa.
+        filename = record.get("filename")
+        if not filename:
+            logger.error(f"{RED}No filename found in record{RESET}")
+            return None
+        image_src_path, image_filename = _find_image_src(
+            filename, options.get("extension")
+        )
+        if image_src_path is None:
+            logger.error(
+                f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', image_filename)} — skipping record{RESET}"
+            )
+            return None
+        annotation_src_path, annotation_filename = _find_annotation_src(
+            filename, ".xml"
+        )
+        if annotation_src_path is None:
+            logger.error(
+                f"{RED}Source annotation not found: {os.path.join(config.SRC_PATH, 'annotations', annotation_filename)} — skipping record{RESET}"
+            )
+            return None
+        record = image_transfer(record, options, image_src_path, image_filename)
+        result = annotation_transfer(
+            record, options, ".xml", annotation_src_path, annotation_filename
+        )
         return result
     elif task_category == TaskCategory.TEXT_CLASSIFICATION:
         result = text_transfer(record, options)
@@ -313,7 +375,7 @@ def map_file_transfer(
                 f"{RED}Source mask not found: {mask_name} in {config.SRC_PATH}/masks/ — skipping record{RESET}"
             )
             return None
-        record = image_transfer(record, options)
+        record = image_transfer(record, options, image_src_path, image_filename)
         record = mask_transfer(record, mask_src_path, mask_ext, mask_name)
         return record
     elif task_category == TaskCategory.KEYPOINT_DETECTION:


### PR DESCRIPTION
## Summary

Third of the bugbot findings on [#79](https://github.com/tracebloc/data-ingestors/pull/79). The other two were addressed in #80; this one was flagged on commit `e1f95a6` and remained open.

The `SEMANTIC_SEGMENTATION` branch of `map_file_transfer` claimed to be atomic — only copy image + mask together — but `image_transfer` returns the record (not `None`) when the source image is missing. So a missing image still let `mask_transfer` run, leaving an orphan mask on disk.

Pre-resolve and stat the image path before either copy. If the image source is missing, return `None` so `BaseIngestor.ingest` skips the record. Mirrors the existing pre-check for the mask source.

## Type of change
- [x] Bug fix

## Test plan
- [x] Manual review of the SEMANTIC_SEGMENTATION branch flow
- [ ] Run an ingestion against a record with a missing image — expect the record to be skipped with `Source image not found …` and no mask copied to `DEST_PATH`
- [ ] Run an ingestion against a record with a missing mask — expect skip with no image copied (existing behavior, unchanged)

## Related
Ref [#79](https://github.com/tracebloc/data-ingestors/pull/79) — bugbot comment [#discussion_r3233186700](https://github.com/tracebloc/data-ingestors/pull/79#discussion_r3233186700).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-file transfer behavior for `OBJECT_DETECTION` and `SEMANTIC_SEGMENTATION` to pre-check sources and skip records on missing files, which could alter ingestion outcomes and on-disk artifacts.
> 
> **Overview**
> Fixes atomicity for multi-file ingestion so related files are only copied together.
> 
> Introduces `_find_src` and updates `image_transfer`/`annotation_transfer` to accept pre-resolved `src_path`/`filename_with_ext`, then updates `map_file_transfer` to pre-verify existence of both sources for `OBJECT_DETECTION` (image + XML) and `SEMANTIC_SEGMENTATION` (image + mask) and return `None` to skip the record when any required source is missing (preventing orphan files in `DEST_PATH`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f017e7560b61c66cd71ff41852a4808f341ed9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->