### PR TITLE
feat(#82): recognize REQUESTS_PROXY_URL in Config.API_ENDPOINT

### DIFF
--- a/tests/test_api_client_auth.py
+++ b/tests/test_api_client_auth.py
@@ -39,7 +39,7 @@ def _make_config(**overrides) -> Config:
         BACKEND_TOKEN="test-token-abc",
         CLIENT_USERNAME=None,
         CLIENT_PASSWORD=None,
-        EDGE_ENV="prod",
+        CLIENT_ENV="prod",
     )
     defaults.update(overrides)
     return Config(**defaults)
@@ -164,7 +164,7 @@ class TestLocalModeBypassesValidation:
     def test_local_mode_skips_validation(self):
         # No backend auth — validate() must still pass under local mode.
         config = _make_config(
-            EDGE_ENV="local",
+            CLIENT_ENV="local",
             BACKEND_TOKEN=None,
             CLIENT_USERNAME=None,
             CLIENT_PASSWORD=None,
@@ -175,7 +175,7 @@ class TestLocalModeBypassesValidation:
 
     def test_local_mode_uses_mock_token(self):
         config = _make_config(
-            EDGE_ENV="local",
+            CLIENT_ENV="local",
             BACKEND_TOKEN=None,
             CLIENT_USERNAME=None,
             CLIENT_PASSWORD=None,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,53 @@
+"""Tests for ``Config.API_ENDPOINT`` resolution.
+
+The cluster routes all backend traffic through ``requests-proxy-service:8888``
+(per tracebloc/client#118-120 and tracebloc/client-runtime#33). When
+``REQUESTS_PROXY_URL`` is set in the pod's env, the ingestor picks it up
+directly rather than relying on the Helm chart to remap it onto a
+``CLIENT_ENV`` value. These tests pin both the new precedence and the
+preserved fallback behavior.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def _reload_config():
+    """Reload the config module so class-body env reads pick up monkeypatched
+    values. ``Config`` dataclass defaults are evaluated once at class
+    definition time; changing env after import has no effect without a reload.
+    """
+    from tracebloc_ingestor import config as cfg_module
+    return importlib.reload(cfg_module)
+
+
+def test_api_endpoint_uses_requests_proxy_url_when_set(monkeypatch):
+    """``REQUESTS_PROXY_URL`` wins over the ``CLIENT_ENV → API_ENDPOINTS`` map."""
+    monkeypatch.setenv("REQUESTS_PROXY_URL", "http://requests-proxy-service:8888")
+    monkeypatch.setenv("CLIENT_ENV", "prod")  # would otherwise pick api.tracebloc.io
+
+    cfg_module = _reload_config()
+    assert cfg_module.Config().API_ENDPOINT == "http://requests-proxy-service:8888"
+
+
+def test_api_endpoint_falls_back_to_client_env_when_proxy_unset(monkeypatch):
+    """Existing ``CLIENT_ENV`` behavior is preserved when ``REQUESTS_PROXY_URL`` is unset."""
+    monkeypatch.delenv("REQUESTS_PROXY_URL", raising=False)
+    monkeypatch.setenv("CLIENT_ENV", "stg")
+
+    cfg_module = _reload_config()
+    assert cfg_module.Config().API_ENDPOINT == "https://stg-api.tracebloc.io"
+
+
+def test_api_endpoint_treats_empty_proxy_url_as_unset(monkeypatch):
+    """An empty ``REQUESTS_PROXY_URL`` falls back rather than producing an empty endpoint.
+
+    Guards against the Helm chart accidentally injecting ``REQUESTS_PROXY_URL=""``
+    (e.g. from a defaulted value template) and silently breaking outbound calls.
+    """
+    monkeypatch.setenv("REQUESTS_PROXY_URL", "")
+    monkeypatch.setenv("CLIENT_ENV", "prod")
+
+    cfg_module = _reload_config()
+    assert cfg_module.Config().API_ENDPOINT == "https://api.tracebloc.io"

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -34,7 +34,7 @@ class LoggingRetry(Retry):
 class APIClient:
     def __init__(self, config: Config):
         # Fail fast on missing creds before any network or session setup.
-        # `validate()` is a no-op when EDGE_ENV == "local".
+        # `validate()` is a no-op when CLIENT_ENV == "local".
         config.validate()
 
         self.config = config
@@ -46,7 +46,7 @@ class APIClient:
         #      training-pod pattern via jobs-manager)
         #   3. CLIENT_ID + CLIENT_PASSWORD → fall back to /api-token-auth/
         #      (deprecated; kept for one minor version while callers migrate)
-        if config.EDGE_ENV == "local":
+        if config.CLIENT_ENV == "local":
             self.token = "mock_token"
             logger.info("Skipping API authentication for local mode")
         elif config.BACKEND_TOKEN:
@@ -122,7 +122,7 @@ class APIClient:
             bool: True if successful, False otherwise
         """
         # Skip API calls in local mode
-        if self.config.EDGE_ENV == "local":
+        if self.config.CLIENT_ENV == "local":
             logger.info(f"Mock: Would send {len(records)} records to API")
             return True
 
@@ -182,7 +182,7 @@ class APIClient:
             bool: True if successful, False otherwise
         """
         # Skip API calls in local mode
-        if self.config.EDGE_ENV == "local":
+        if self.config.CLIENT_ENV == "local":
             logger.info(f"Mock: Would send schema for {table_name}")
             return True
 
@@ -240,7 +240,7 @@ class APIClient:
             bool: True if successful, False otherwise
         """
         # Skip API calls in local mode
-        if self.config.EDGE_ENV == "local":
+        if self.config.CLIENT_ENV == "local":
             logger.info(f"Mock: Would generate edge labels for {table_name}")
             return True
 
@@ -286,7 +286,7 @@ class APIClient:
             bool: True if successful, False otherwise
         """
         # Skip API calls in local mode
-        if self.config.EDGE_ENV == "local":
+        if self.config.CLIENT_ENV == "local":
             logger.info(f"Mock: Would prepare dataset {category}")
             return True
 
@@ -343,7 +343,7 @@ class APIClient:
             requests.exceptions.RequestException: If the API request fails
         """
         # Skip API calls in local mode
-        if self.config.EDGE_ENV == "local":
+        if self.config.CLIENT_ENV == "local":
             logger.info(f"Mock: Would create dataset {category}")
             return {"id": "mock_dataset_id", "title": "Mock Dataset"}
 

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -35,10 +35,10 @@ class Config:
     # jobs-manager-deployment.yaml does (per tracebloc/client#118-120 and
     # tracebloc/client-runtime#33). Saves the chart from remapping a name the rest of
     # the cluster uses with a different one. An empty value falls back to CLIENT_ENV.
-    EDGE_ENV: str = os.getenv("CLIENT_ENV", "prod")
+    CLIENT_ENV: str = os.getenv("CLIENT_ENV", "prod")
     API_ENDPOINT: str = (
         os.getenv("REQUESTS_PROXY_URL")
-        or API_ENDPOINTS.get(EDGE_ENV, API_ENDPOINTS["dev"])
+        or API_ENDPOINTS.get(CLIENT_ENV, API_ENDPOINTS["dev"])
     )
 
     # ===== Auth =====
@@ -92,7 +92,7 @@ class Config:
             ValueError: with a single, comma-joined list of missing vars,
                 including a hint about ``CLIENT_ENV=local``.
         """
-        if self.EDGE_ENV == "local":
+        if self.CLIENT_ENV == "local":
             return
 
         missing = []

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -28,9 +28,18 @@ class Config:
     }
     STORAGE_PATH = "/data/shared"
 
-    # Get environment and set appropriate API endpoint, default to prod
+    # Get environment and set appropriate API endpoint, default to prod.
+    # REQUESTS_PROXY_URL — when set, takes precedence over the CLIENT_ENV → API_ENDPOINTS
+    # mapping. Set inside the cluster by the Helm subchart (tracebloc/client#86) so the
+    # ingestor routes backend traffic through requests-proxy-service:8888 the same way
+    # jobs-manager-deployment.yaml does (per tracebloc/client#118-120 and
+    # tracebloc/client-runtime#33). Saves the chart from remapping a name the rest of
+    # the cluster uses with a different one. An empty value falls back to CLIENT_ENV.
     EDGE_ENV: str = os.getenv("CLIENT_ENV", "prod")
-    API_ENDPOINT: str = API_ENDPOINTS.get(EDGE_ENV, API_ENDPOINTS["dev"])
+    API_ENDPOINT: str = (
+        os.getenv("REQUESTS_PROXY_URL")
+        or API_ENDPOINTS.get(EDGE_ENV, API_ENDPOINTS["dev"])
+    )
 
     # ===== Auth =====
     # Preferred: pre-minted token from upstream (e.g. jobs-manager), passed via env.


### PR DESCRIPTION
## Summary

Take `REQUESTS_PROXY_URL` directly when set, falling back to the existing `CLIENT_ENV → API_ENDPOINTS` mapping otherwise. Makes the ingestor a peer of `jobs-manager` in how it picks up cluster-internal networking.

```diff
-API_ENDPOINT: str = API_ENDPOINTS.get(EDGE_ENV, API_ENDPOINTS["dev"])
+API_ENDPOINT: str = (
+    os.getenv("REQUESTS_PROXY_URL")
+    or API_ENDPOINTS.get(EDGE_ENV, API_ENDPOINTS["dev"])
+)
```

## Why

After [tracebloc/client#118-120](https://github.com/tracebloc/client/pull/118) and [tracebloc/client-runtime#33](https://github.com/tracebloc/client-runtime/pull/33), all cluster workloads route backend traffic through `requests-proxy-service:8888`. `jobs-manager-deployment.yaml` already injects `REQUESTS_PROXY_URL`; when [client#86](https://github.com/tracebloc/client/issues/86) lands the Helm subchart, the natural pattern is for the ingestor pod to receive the same env var name. Taking it here saves the chart from remapping to a `CLIENT_ENV` value.

## Behavior

| `REQUESTS_PROXY_URL` | `CLIENT_ENV` | Resulting `API_ENDPOINT` |
|---|---|---|
| `http://requests-proxy-service:8888` | (any) | `http://requests-proxy-service:8888` |
| unset | `prod` (default) | `https://api.tracebloc.io` |
| unset | `stg` | `https://stg-api.tracebloc.io` |
| `""` (empty) | `prod` | `https://api.tracebloc.io` (treats empty as unset — guards against accidentally-defaulted Helm template) |

No behavior change for existing customers (fallback path unchanged).

## Test plan

- `tests/test_config.py` pins all three cases above.
- Full suite: 143 passed (3 new + 140 existing).

Closes #82

## Refs

- Surfaced during cross-repo review at the end of [#77](https://github.com/tracebloc/data-ingestors/pull/77).
- Companion to [tracebloc/client#118-120](https://github.com/tracebloc/client/pull/118) and [tracebloc/client-runtime#33](https://github.com/tracebloc/client-runtime/pull/33).
- The chart-side env injection lives in [client#86](https://github.com/tracebloc/client/issues/86) (separate ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `Config.API_ENDPOINT` is derived, which can redirect all outbound API traffic when `REQUESTS_PROXY_URL` is set (including handling of empty values). Risk is limited by a clear fallback to the existing `CLIENT_ENV` mapping and added unit tests covering the precedence rules.
> 
> **Overview**
> Updates `Config.API_ENDPOINT` resolution to **prefer `REQUESTS_PROXY_URL` when set** (treating `""` as unset) and otherwise fall back to the existing `CLIENT_ENV`→`API_ENDPOINTS` mapping.
> 
> Renames the internal env field from `EDGE_ENV` to `CLIENT_ENV` throughout `Config`, `APIClient`, and auth/local-mode tests, and adds `tests/test_config.py` to pin the new endpoint precedence and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eafb661b200980e4a06cb80c5b9e486cb61cda01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->