### PR TITLE
fix(ingestor): strip label columns from schema metadata sent to backend

### DIFF
--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -133,10 +133,6 @@ class BaseIngestor(ABC):
                 f"server-side UUIDs instead.{RESET}"
             )
         
-        # Add schema to file_options for validators if not already present
-        if schema and "schema" not in self.file_options:
-            self.file_options["schema"] = schema
-
         # Remove label_column, annotation_column, and unique_id_column from schema
         # These are handled separately and should not be ingested as regular columns
         table_schema = schema.copy()
@@ -146,6 +142,13 @@ class BaseIngestor(ABC):
             del table_schema[self.annotation_column]
         if self.unique_id_column and self.unique_id_column in table_schema:
             del table_schema[self.unique_id_column]
+
+        # Add cleaned schema to file_options for validators / downstream metadata.
+        # Always overwrite so a schema passed in by the template (which may still
+        # contain the label/annotation/unique_id columns) is sanitized before
+        # being sent to the backend as part of meta_data.
+        if schema:
+            self.file_options["schema"] = table_schema
 
         # Ensure table exists
         self.table = self.database.create_table(table_name, table_schema)


### PR DESCRIPTION
## Summary
- `send_global_meta_meta` sends `file_options` as `meta_data`. Its `schema` entry could still include the `label_column`, `annotation_column`, or `unique_id_column` — either because base inserted the raw schema, or because a template (e.g. `time_to_event_prediction`) passed the full schema in `file_options` directly.
- Sanitize `file_options["schema"]` with the same cleaned `table_schema` used to create the DB table, so columns acting as labels are not forwarded to the backend.

## Test plan
- [ ] Run an ingestion where `label_column` is set to a column present in `schema`; verify the global metadata payload no longer contains that column under `meta_data.schema`.
- [ ] Same check for `annotation_column` and `unique_id_column`.
- [ ] Confirm validators that read `file_options["schema"]` (DataValidator, NumericColumnsValidator, TimeFormatValidator) still behave correctly with the cleaned schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `meta_data.schema` payload sent to the API and could affect validators or downstream consumers that relied on the unsanitized schema contents.
> 
> **Overview**
> Prevents label-related columns from leaking into schema metadata by always overwriting `file_options["schema"]` with the cleaned `table_schema` (with `label_column`, `annotation_column`, and `unique_id_column` removed).
> 
> This ensures validators and `send_global_meta_meta` receive the sanitized schema even when a template provided a full schema in `file_options`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6176a45f0a88739e2e27434212d3c4a40a44df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->