### PR TITLE
fix(ingestor): strip label columns from schema metadata sent to backend

### DIFF
--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -133,10 +133,6 @@ class BaseIngestor(ABC):
                 f"server-side UUIDs instead.{RESET}"
             )
         
-        # Add schema to file_options for validators if not already present
-        if schema and "schema" not in self.file_options:
-            self.file_options["schema"] = schema
-
         # Remove label_column, annotation_column, and unique_id_column from schema
         # These are handled separately and should not be ingested as regular columns
         table_schema = schema.copy()
@@ -146,6 +142,15 @@ class BaseIngestor(ABC):
             del table_schema[self.annotation_column]
         if self.unique_id_column and self.unique_id_column in table_schema:
             del table_schema[self.unique_id_column]
+
+        # Add cleaned schema to file_options for validators / downstream metadata.
+        # Always overwrite so a schema passed in by the template (which may still
+        # contain the label/annotation/unique_id columns) is sanitized before
+        # being sent to the backend as part of meta_data.
+        if schema:
+            self.file_options["schema"] = table_schema
+            if "number_of_columns" in self.file_options:
+                self.file_options["number_of_columns"] = len(table_schema)
 
         # Ensure table exists
         self.table = self.database.create_table(table_name, table_schema)


### PR DESCRIPTION
Cherry-pick of [#85](https://github.com/tracebloc/data-ingestors/pull/85) (merged to `develop` as 10a4b69) onto `master`.

## Summary
- Sanitize `file_options["schema"]` (the metadata forwarded to the backend) by removing `label_column`, `annotation_column`, and `unique_id_column` — using the same cleaned `table_schema` used to create the DB table.
- Recompute `file_options["number_of_columns"]` after cleanup so the count stays consistent with the sanitized schema.

## Test plan
- [ ] Run an ingestion where `label_column` is set to a column present in `schema`; verify the global metadata payload no longer contains that column under `meta_data.schema`.
- [ ] Same check for `annotation_column` and `unique_id_column`.
- [ ] Confirm `number_of_columns` (when present) equals `len(meta_data.schema)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that sanitizes `file_options` schema and column counts; main risk is downstream consumers relying on the previously unsanitized schema/`number_of_columns` values.
> 
> **Overview**
> Ensures the schema metadata forwarded via `file_options` is **sanitized** before being sent to the backend by always overwriting `file_options["schema"]` with the cleaned `table_schema` (with `label_column`, `annotation_column`, and `unique_id_column` removed).
> 
> Keeps metadata consistent by recomputing `file_options["number_of_columns"]` (when present) based on the cleaned schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917a4394b38aa819fb1f8a1e74f385b9bf1ac4ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->