### PR TITLE
feat: add masked language modeling ingestor template

### DIFF
--- a/examples/yaml/masked_language_modeling.yaml
+++ b/examples/yaml/masked_language_modeling.yaml
@@ -1,0 +1,10 @@
+# Masked language modeling: CSV manifest + .txt sidecar files (one per sequence).
+# Self-supervised — no label column required.
+# `sequences:` directory holds space-separated token sequences from graph random walks.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: primekg_mlm_train
+intent: train
+category: masked_language_modeling
+csv: /data/labels_file.csv
+sequences: /data/sequences/

--- a/templates/masked_language_modeling/README.md
+++ b/templates/masked_language_modeling/README.md
@@ -1,0 +1,91 @@
+# Masked Language Modeling Data Ingestion Template
+
+This template demonstrates how to ingest pre-tokenized text sequences for masked language modeling (MLM) into a database using the tracebloc_ingestor framework.
+
+## Directory Structure
+
+```
+masked_language_modeling/
+├── masked_language_modeling.py   # Main ingestion script
+├── README.md                     # This file
+└── data/
+    ├── sequences/                # Text files (.txt), one per sequence
+    │   ├── seq_0000001.txt
+    │   ├── seq_0000002.txt
+    │   ├── seq_0000003.txt
+    │   ├── seq_0000004.txt
+    │   └── seq_0000005.txt
+    └── labels_file_sample.csv    # CSV manifest mapping filenames to extensions
+```
+
+## Data Format
+
+### Text Files
+- Supported extension: `.txt`
+- One space-separated token sequence per file, placed in `data/sequences/`
+- Each sequence is typically a random walk over a knowledge graph (e.g. PrimeKG)
+- Example: `"Lepirudin indication Huntington phenotype_present Chorea"`
+
+### CSV Labels File
+MLM is **self-supervised** — no label column is needed. The CSV contains:
+- `filename`: Base name of the text file, without extension (e.g. `seq_0000001`)
+- `extension`: File extension as a quoted string (e.g. `'.txt'`)
+
+## Preprocessing
+
+The text sequences are generated from a knowledge graph using the preprocessing scripts in the `tracebloc-client` repo:
+
+```bash
+# Step 1: Download and reformat PrimeKG
+python prep_primekg.py --output-dir ./primekg_data
+
+# Step 2: Generate random walk corpus
+python graph_to_corpus.py \
+    --nodes primekg_data/nodes.csv \
+    --edges primekg_data/edges.csv \
+    --output-dir ./output \
+    --walk-length 5 \
+    --walks-per-node 30 \
+    --seed 42
+```
+
+This produces the `labels_file.csv` + `sequences/` directory consumed by this ingestor.
+
+## Usage
+
+1. Place your `.txt` sequence files in `data/sequences/`
+2. Update `labels_file_sample.csv` with one row per sequence file
+3. Configure environment variables (see below)
+4. Run the ingestion script:
+
+```bash
+python masked_language_modeling.py
+```
+
+## Configuration
+
+The script uses the following configuration:
+- **Extension**: TXT - Expected text file extension
+- **Chunk Size**: 100 - Batch size for CSV reading
+- **Encoding**: utf-8
+- **Category**: MASKED_LANGUAGE_MODELING
+- **Data Format**: TEXT
+- **Intent**: TRAIN (change to `Intent.TEST` for evaluation data)
+- **Label column**: None (self-supervised)
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TABLE_NAME` | Target database table | Required |
+| `LABEL_FILE` | Path to CSV manifest | Required |
+| `SRC_PATH` | Path to sequences directory | Required |
+| `BATCH_SIZE` | Ingestion batch size | 4000 |
+| `BACKEND_TOKEN` | Auth token for API | Required |
+| `CLIENT_ENV` | Environment (local/dev/stg/prod) | prod |
+
+## Notes
+
+- The `filename` column does **not** include the extension — that's supplied separately via the `extension` column.
+- No `label` column is needed because MLM training is self-supervised (masking is applied on-the-fly by the training client).
+- A `tokenizer.json` file should be placed alongside the data on the dataset path. The MLM client will load it automatically. See the preprocessing scripts for tokenizer generation.

--- a/templates/masked_language_modeling/data/labels_file_sample.csv
+++ b/templates/masked_language_modeling/data/labels_file_sample.csv
@@ -1,0 +1,6 @@
+filename,extension
+seq_0000001,'.txt'
+seq_0000002,'.txt'
+seq_0000003,'.txt'
+seq_0000004,'.txt'
+seq_0000005,'.txt'

--- a/templates/masked_language_modeling/data/sequences/seq_0000001.txt
+++ b/templates/masked_language_modeling/data/sequences/seq_0000001.txt
@@ -1,0 +1,1 @@
+Lepirudin indication Huntington phenotype_present Chorea associated_with Dystonia

--- a/templates/masked_language_modeling/data/sequences/seq_0000002.txt
+++ b/templates/masked_language_modeling/data/sequences/seq_0000002.txt
@@ -1,0 +1,1 @@
+Soliris target TP53 associated_with Breast_cancer contraindication Methotrexate

--- a/templates/masked_language_modeling/data/sequences/seq_0000003.txt
+++ b/templates/masked_language_modeling/data/sequences/seq_0000003.txt
@@ -1,0 +1,1 @@
+BRCA1 ppi RAD51 expression_present Breast_tissue interacts_with ESR1

--- a/templates/masked_language_modeling/data/sequences/seq_0000004.txt
+++ b/templates/masked_language_modeling/data/sequences/seq_0000004.txt
@@ -1,0 +1,1 @@
+Aspirin indication Headache parent-child Pain phenotype_present Fever

--- a/templates/masked_language_modeling/data/sequences/seq_0000005.txt
+++ b/templates/masked_language_modeling/data/sequences/seq_0000005.txt
@@ -1,0 +1,1 @@
+EGFR target Gefitinib associated_with Lung_cancer expression_present Lung

--- a/templates/masked_language_modeling/masked_language_modeling.py
+++ b/templates/masked_language_modeling/masked_language_modeling.py
@@ -1,0 +1,89 @@
+"""Masked Language Modeling Data Ingestion Example.
+
+This example demonstrates how to ingest pre-tokenized text sequences for
+masked language modeling (MLM) into a database and optionally send metadata
+to the tracebloc API.
+
+MLM is self-supervised — no label column is needed.  Each row in the CSV
+maps to a .txt file containing a space-separated token sequence (e.g. a
+random walk over a knowledge graph).  The MLM client applies masking
+on-the-fly during training.
+"""
+
+import logging
+import os
+from typing import Dict, Any
+
+from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor.utils.logging import setup_logging
+from tracebloc_ingestor.utils.constants import (
+    TaskCategory,
+    Intent,
+    DataFormat,
+    FileExtension,
+)
+
+# Initialize config and configure logging
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+
+# Text file options
+text_options = {"extension": FileExtension.TXT}
+
+# CSV specific options
+csv_options = {
+    "chunk_size": 100,
+    "delimiter": ",",
+    "quotechar": '"',
+    "escapechar": "\\",
+    "on_bad_lines": "warn",
+    "encoding": "utf-8",
+}
+
+
+def main():
+    """Run the masked language modeling ingestion example."""
+    try:
+        # Initialize components
+        database = Database(config)
+        api_client = APIClient(config)
+
+        # Create ingestor for MLM data
+        # No label_column — MLM is self-supervised
+        ingestor = CSVIngestor(
+            database=database,
+            api_client=api_client,
+            table_name=config.TABLE_NAME,
+            data_format=DataFormat.TEXT,
+            category=TaskCategory.MASKED_LANGUAGE_MODELING,
+            csv_options=csv_options,
+            file_options=text_options,
+            intent=Intent.TRAIN,
+        )
+
+        # Ingest data with validation
+        logger.info("Starting masked language modeling ingestion with data validation...")
+        with ingestor:
+            failed_records = ingestor.ingest(
+                config.LABEL_FILE, batch_size=config.BATCH_SIZE
+            )
+            if failed_records:
+                logger.warning(f"Failed to process {len(failed_records)} records")
+                for record in failed_records:
+                    logger.warning(
+                        f"Failed record: {record.get('filename', 'Unknown')}"
+                    )
+                    logger.warning(
+                        f"Error details: {record.get('error', 'Unknown error')}"
+                    )
+            else:
+                logger.info("All records processed successfully")
+
+    except Exception as e:
+        logger.error(f"Ingestion failed: {str(e)}")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -60,6 +60,10 @@ TIME_TO_EVENT_CATEGORIES: FrozenSet[str] = frozenset({
     TaskCategory.TIME_TO_EVENT_PREDICTION,
 })
 
+MLM_CATEGORIES: FrozenSet[str] = frozenset({
+    TaskCategory.MASKED_LANGUAGE_MODELING,
+})
+
 # Categories where the label is a numeric prediction target rather than
 # class metadata. The schema requires `label.policy` for these so the raw
 # value never ships to the central backend by default.
@@ -105,6 +109,10 @@ DEFAULT_TEXT_FILE_OPTIONS: Dict[str, Any] = {
     "extension": ".txt",
 }
 
+DEFAULT_MLM_FILE_OPTIONS: Dict[str, Any] = {
+    "extension": ".txt",
+}
+
 
 # ---------------------------------------------------------------------------
 # Resolved configuration — what the entrypoint actually consumes.
@@ -137,6 +145,7 @@ class ResolvedConfig:
     annotations: Optional[str] = None
     masks: Optional[str] = None
     texts: Optional[str] = None
+    sequences: Optional[str] = None
 
     # ----- Tabular / time-series -----
     schema: Dict[str, str] = field(default_factory=dict)
@@ -203,7 +212,7 @@ def resolve(config: Dict[str, Any]) -> ResolvedConfig:
     # 2. Sidecar directories — set whatever the customer specified; the
     #    schema's conditional `if/then` already enforced that the right ones
     #    are present for each category.
-    for key in ("images", "annotations", "masks", "texts"):
+    for key in ("images", "annotations", "masks", "texts", "sequences"):
         if key in config:
             setattr(resolved, key, config[key])
 
@@ -287,6 +296,8 @@ def _data_format_for(category: str) -> str:
         or category in TIME_TO_EVENT_CATEGORIES
     ):
         return DataFormat.TABULAR
+    if category in MLM_CATEGORIES:
+        return DataFormat.TEXT
     raise ValueError(
         f"Unknown category {category!r}; cannot derive data_format. "
         "If this is a new category, add it to the relevant CATEGORY set "
@@ -306,6 +317,8 @@ def _default_file_options_for(category: str) -> Dict[str, Any]:
         return dict(DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[category])
     if category in TEXT_CATEGORIES:
         return dict(DEFAULT_TEXT_FILE_OPTIONS)
+    if category in MLM_CATEGORIES:
+        return dict(DEFAULT_MLM_FILE_OPTIONS)
     # Tabular / time-series categories don't carry file_options.
     return {}
 
@@ -322,4 +335,6 @@ __all__ = [
     "DEFAULT_CSV_OPTIONS",
     "DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY",
     "DEFAULT_TEXT_FILE_OPTIONS",
+    "MLM_CATEGORIES",
+    "DEFAULT_MLM_FILE_OPTIONS",
 ]

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -217,7 +217,8 @@ def _set_legacy_env_vars(resolved: ResolvedConfig) -> None:
     """
     src_path = None
     src_path_source = (
-        resolved.images or resolved.texts or resolved.masks or resolved.annotations
+        resolved.images or resolved.texts or resolved.masks
+        or resolved.annotations or resolved.sequences
     )
     if src_path_source:
         src_path = os.path.dirname(src_path_source.rstrip("/"))

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -35,7 +35,8 @@
         "tabular_classification",
         "tabular_regression",
         "time_series_forecasting",
-        "time_to_event_prediction"
+        "time_to_event_prediction",
+        "masked_language_modeling"
       ],
       "description": "Task category. Drives convention defaults: validators, data_format, default columns, default file extensions, default validator set."
     },
@@ -86,6 +87,12 @@
       "type": "string",
       "minLength": 1,
       "description": "Directory holding text files referenced by the labels CSV. Required for text_classification."
+    },
+
+    "sequences": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Directory holding sequence text files (.txt). Required for masked_language_modeling."
     },
 
     "label": {
@@ -299,6 +306,14 @@
         "required": ["category"]
       },
       "then": { "required": ["texts"] }
+    },
+    {
+      "description": "masked_language_modeling requires `sequences`.",
+      "if": {
+        "properties": { "category": { "const": "masked_language_modeling" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["sequences"] }
     },
     {
       "description": "tabular and time-series categories require `schema`.",

--- a/tracebloc_ingestor/utils/constants.py
+++ b/tracebloc_ingestor/utils/constants.py
@@ -45,6 +45,7 @@ class TaskCategory:
     TIME_TO_EVENT_PREDICTION = "time_to_event_prediction"
     SEMANTIC_SEGMENTATION = "semantic_segmentation"
     INSTANCE_SEGMENTATION = "instance_segmentation"
+    MASKED_LANGUAGE_MODELING = "masked_language_modeling"
 
     @classmethod
     def get_all_categories(cls) -> list[str]:
@@ -65,6 +66,7 @@ class TaskCategory:
             cls.TIME_TO_EVENT_PREDICTION,
             cls.SEMANTIC_SEGMENTATION,
             cls.INSTANCE_SEGMENTATION,
+            cls.MASKED_LANGUAGE_MODELING,
         ]
 
     @classmethod

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -138,5 +138,24 @@ def map_validators(
             DuplicateValidator(),
         ]
         return validators
+    elif task_category == TaskCategory.MASKED_LANGUAGE_MODELING:
+        validators = []
+
+        # Validate text file extensions
+        validators.append(
+            FileTypeValidator(
+                allowed_extension=options.get("extension", FileExtension.TXT),
+                path="sequences",
+            ),
+        )
+
+        # Add data validator if schema is provided
+        if options.get("schema"):
+            validators.append(DataValidator(schema=options["schema"]))
+
+        validators.append(TableNameValidator())
+        validators.append(DuplicateValidator())
+
+        return validators
     else:
         return []

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -13,6 +13,7 @@ from tracebloc_ingestor.validators.time_before_today_validator import TimeBefore
 from tracebloc_ingestor.validators.numeric_columns_validator import NumericColumnsValidator
 from tracebloc_ingestor.validators.keypoint_annotation_validator import KeypointAnnotationValidator
 from tracebloc_ingestor.validators.keypoint_visibility_validator import KeypointVisibilityValidator
+from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
 from tracebloc_ingestor.utils.constants import TaskCategory, FileExtension
 
 
@@ -148,6 +149,9 @@ def map_validators(
                 path="sequences",
             ),
         )
+
+        # Validate tokenizer.json has required special tokens ([MASK], [PAD])
+        validators.append(TokenizerValidator())
 
         # Add data validator if schema is provided
         if options.get("schema"):

--- a/tracebloc_ingestor/validators/__init__.py
+++ b/tracebloc_ingestor/validators/__init__.py
@@ -19,6 +19,7 @@ from .time_ordered_validator import TimeOrderedValidator
 from .time_before_today_validator import TimeBeforeTodayValidator
 from .keypoint_annotation_validator import KeypointAnnotationValidator
 from .keypoint_visibility_validator import KeypointVisibilityValidator
+from .tokenizer_validator import TokenizerValidator
 
 __all__ = [
     "BaseValidator",
@@ -35,4 +36,5 @@ __all__ = [
     "TimeBeforeTodayValidator",
     "KeypointAnnotationValidator",
     "KeypointVisibilityValidator",
+    "TokenizerValidator",
 ]

--- a/tracebloc_ingestor/validators/tokenizer_validator.py
+++ b/tracebloc_ingestor/validators/tokenizer_validator.py
@@ -1,0 +1,149 @@
+"""Tokenizer Validator Module.
+
+Validates that a tokenizer.json file exists alongside the data and contains
+the required special tokens ([MASK] and [PAD]) for masked language modeling.
+Without these tokens the training client will fail with an embedding
+out-of-bounds IndexError.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from .base import BaseValidator, ValidationResult
+from ..config import Config
+from ..utils.logging import setup_logging
+
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+
+class TokenizerValidator(BaseValidator):
+    """Validator for tokenizer.json special-token requirements.
+
+    Ensures that a tokenizer.json file exists at the configured data path
+    and that its vocabulary includes all required special tokens.  For MLM
+    the mandatory tokens are [MASK] (used to create training targets) and
+    [PAD] (used to pad variable-length sequences in a batch).
+
+    Attributes:
+        required_tokens: Set of token strings that must appear in the vocab.
+    """
+
+    def __init__(
+        self,
+        required_tokens: tuple = ("[MASK]", "[PAD]"),
+        name: str = "Tokenizer Validator",
+    ):
+        super().__init__(name)
+        self.required_tokens = set(required_tokens)
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        """Validate tokenizer.json at the configured source path.
+
+        Args:
+            data: Unused (path is read from config.SRC_PATH).
+            **kwargs: Additional validation parameters.
+
+        Returns:
+            ValidationResult with status and error details.
+        """
+        try:
+            tokenizer_path = Path(config.SRC_PATH) / "tokenizer.json"
+
+            if not tokenizer_path.exists():
+                return self._create_result(
+                    is_valid=False,
+                    errors=[
+                        f"tokenizer.json not found at {tokenizer_path}. "
+                        "MLM training requires a tokenizer.json file alongside "
+                        "the sequence data."
+                    ],
+                    metadata={"path_checked": str(tokenizer_path)},
+                )
+
+            with open(tokenizer_path, "r", encoding="utf-8") as f:
+                tokenizer_data = json.load(f)
+
+            vocab = self._extract_vocab(tokenizer_data)
+            if vocab is None:
+                return self._create_result(
+                    is_valid=False,
+                    errors=[
+                        "Could not extract vocabulary from tokenizer.json. "
+                        "Expected a 'model.vocab' mapping or an 'added_tokens' list."
+                    ],
+                    metadata={"path_checked": str(tokenizer_path)},
+                )
+
+            missing = sorted(self.required_tokens - vocab)
+            if missing:
+                return self._create_result(
+                    is_valid=False,
+                    errors=[
+                        f"Tokenizer is missing required special tokens: "
+                        f"{', '.join(missing)}. "
+                        f"Without these tokens, training will fail with an "
+                        f"embedding out-of-bounds error. "
+                        f"Re-train or update the tokenizer to include them."
+                    ],
+                    metadata={
+                        "path_checked": str(tokenizer_path),
+                        "missing_tokens": missing,
+                        "required_tokens": sorted(self.required_tokens),
+                    },
+                )
+
+            return self._create_result(
+                is_valid=True,
+                metadata={
+                    "path_checked": str(tokenizer_path),
+                    "required_tokens": sorted(self.required_tokens),
+                    "vocab_size": len(vocab),
+                },
+            )
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse tokenizer.json: {e}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"tokenizer.json is not valid JSON: {e}"],
+            )
+        except Exception as e:
+            logger.error(f"Tokenizer validation error: {e}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Tokenizer validation error: {str(e)}"],
+            )
+
+    @staticmethod
+    def _extract_vocab(tokenizer_data: dict):
+        """Extract the set of token strings from a HuggingFace tokenizer JSON.
+
+        Checks both ``model.vocab`` (WordLevel / WordPiece / BPE) and
+        ``added_tokens`` (special tokens added after training).
+
+        Returns:
+            Set of token strings, or None if the structure is unrecognised.
+        """
+        tokens = set()
+
+        # model.vocab — the main vocabulary mapping
+        model = tokenizer_data.get("model", {})
+        vocab = model.get("vocab")
+        if isinstance(vocab, dict):
+            tokens.update(vocab.keys())
+
+        # added_tokens — special tokens registered separately
+        added_tokens = tokenizer_data.get("added_tokens", [])
+        if isinstance(added_tokens, list):
+            for entry in added_tokens:
+                if isinstance(entry, dict) and "content" in entry:
+                    tokens.update([entry["content"]])
+                elif isinstance(entry, str):
+                    tokens.add(entry)
+
+        return tokens if tokens else None

--- a/tracebloc_ingestor/validators/tokenizer_validator.py
+++ b/tracebloc_ingestor/validators/tokenizer_validator.py
@@ -132,10 +132,16 @@ class TokenizerValidator(BaseValidator):
         tokens = set()
 
         # model.vocab — the main vocabulary mapping
+        # WordLevel/WordPiece/BPE store vocab as {token: id} dict.
+        # Unigram stores vocab as [[token, score], ...] list.
         model = tokenizer_data.get("model", {})
         vocab = model.get("vocab")
         if isinstance(vocab, dict):
             tokens.update(vocab.keys())
+        elif isinstance(vocab, list):
+            for entry in vocab:
+                if isinstance(entry, (list, tuple)) and len(entry) >= 1:
+                    tokens.add(str(entry[0]))
 
         # added_tokens — special tokens registered separately
         added_tokens = tokenizer_data.get("added_tokens", [])


### PR DESCRIPTION
## Summary
- Add `MASKED_LANGUAGE_MODELING` to `TaskCategory` constants and `get_all_categories()`
- Add MLM validator mapping in `validators_mapping.py` — validates `.txt` file extensions in `sequences/` directory, plus table name and duplicate checks
- Create `templates/masked_language_modeling/` with full ingestion script, README, and 5 sample PrimeKG-style random walk sequences
- Add `examples/yaml/masked_language_modeling.yaml` for CLI-based ingestion

### Key difference from text_classification
MLM is **self-supervised** — no `label_column` is needed. The CSV manifest only contains `filename` and `extension` columns. Masking is applied on-the-fly by the training client during training.

### Data format
```
data/
├── labels_file.csv           filename, extension
├── sequences/
│     seq_0000001.txt         "Lepirudin indication Huntington phenotype_present Chorea"
│     seq_0000002.txt         "Soliris target TP53 associated_with Breast_cancer"
└── tokenizer.json            (placed on dataset path, not ingested)
```

### Files changed
| File | Change |
|------|--------|
| `tracebloc_ingestor/utils/constants.py` | Add `MASKED_LANGUAGE_MODELING` to `TaskCategory` |
| `tracebloc_ingestor/utils/validators_mapping.py` | Add MLM validator chain |
| `templates/masked_language_modeling/` | New template with script, README, sample data |
| `examples/yaml/masked_language_modeling.yaml` | New YAML config example |

## Test plan
- [ ] Verify `TaskCategory.is_valid_category("masked_language_modeling")` returns `True`
- [ ] Verify `map_validators(TaskCategory.MASKED_LANGUAGE_MODELING, ...)` returns correct validator chain
- [ ] Run `masked_language_modeling.py` template against sample data
- [ ] Verify ingested records have correct `filename`, `extension`, and no label column errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new ingestion category that changes CLI schema validation, convention resolution, and validator selection, which could affect YAML-driven runs if misconfigured. Main risk is around sidecar path resolution (`sequences`/`SRC_PATH`) and the new `TokenizerValidator` failing datasets missing `tokenizer.json` or required tokens.
> 
> **Overview**
> Adds first-class **masked language modeling (MLM)** ingestion support across the declarative YAML/CLI path.
> 
> The PR extends `TaskCategory`, the ingest JSON schema, and CLI conventions to recognize `category: masked_language_modeling`, require a `sequences` sidecar directory, derive `SRC_PATH` from it, and default MLM to `DataFormat.TEXT` with `.txt` file options.
> 
> It wires in an MLM-specific validator chain (including a new `TokenizerValidator` that enforces presence of `tokenizer.json` with `[MASK]`/`[PAD]`) and adds a complete `templates/masked_language_modeling/` example plus an `examples/yaml/masked_language_modeling.yaml` config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e774ec1b29a4513af9a5fbc813494d371190045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->