### PR TITLE
chore: lift python_requires to 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.11",
     install_requires=requirements,
 )


### PR DESCRIPTION
## Summary

The Dockerfile is `FROM python:3.11`; the published package's `setup.py` was still declaring `python_requires=">=3.8"`. Lifting the floor so pip refuses installs on incompatible interpreters instead of silently producing a broken environment.

Part of the org-wide Python version alignment. Companion PRs in `backend`, `averaging-service`, `tracebloc-client`, `tracebloc-py-package`.

## Risk

Any downstream consumer of `tracebloc_ingestor` on Python <3.11 will fail to install after the next release. Confirm internal consumers (Helm subchart in tracebloc-client) all use 3.11 images.

## Test plan

- [ ] CI green
- [ ] Confirm `tracebloc-ingest` entrypoint still launches inside the 3.11 base image

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk (metadata-only), but it will break installation for any downstream users still on Python <3.11.
> 
> **Overview**
> Updates packaging metadata in `setup.py` to raise `python_requires` from `>=3.8` to `>=3.11`, ensuring pip refuses installs on unsupported Python versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9313b91119db9047d85a220453efbdb1baf310e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->