### PR TITLE
Fix MLM ingestor skipping file transfer to cluster storage

### DIFF
--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -193,12 +193,19 @@ def annotation_transfer(
         raise ValueError(f"{RED}Error processing binary file: {str(e)}{RESET}")
 
 
-def text_transfer(record: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, Any]:
-    """Transfer text files for text classification tasks.
+def text_transfer(
+    record: Dict[str, Any],
+    options: Dict[str, Any],
+    src_subdir: str = "texts",
+) -> Dict[str, Any]:
+    """Transfer text files for text-based tasks.
 
     Args:
         record: Dictionary containing filename and other record data
         options: Dictionary containing transfer options like extension
+        src_subdir: Subdirectory under SRC_PATH where source files live
+                    (``"texts"`` for text classification,
+                     ``"sequences"`` for masked language modeling)
 
     Returns:
         Updated record dictionary
@@ -221,7 +228,7 @@ def text_transfer(record: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, 
             filename_with_ext = filename
 
         # Process the text file
-        text_src_path = os.path.join(config.SRC_PATH, "texts", filename_with_ext)
+        text_src_path = os.path.join(config.SRC_PATH, src_subdir, filename_with_ext)
         if not os.path.exists(text_src_path):
             logger.error(f"{RED}Source text file not found: {text_src_path}{RESET}")
             return record
@@ -328,6 +335,9 @@ def map_file_transfer(
         return result
     elif task_category == TaskCategory.TEXT_CLASSIFICATION:
         result = text_transfer(record, options)
+        return result
+    elif task_category == TaskCategory.MASKED_LANGUAGE_MODELING:
+        result = text_transfer(record, options, src_subdir="sequences")
         return result
     elif task_category == TaskCategory.SEMANTIC_SEGMENTATION:
         # Atomic: only copy image+mask together. Pre-verify both sources

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -400,6 +400,7 @@ class BaseIngestor(ABC):
                                 TaskCategory.TEXT_CLASSIFICATION,
                                 TaskCategory.SEMANTIC_SEGMENTATION,
                                 TaskCategory.KEYPOINT_DETECTION,
+                                TaskCategory.MASKED_LANGUAGE_MODELING,
                             ]:
                                 processed_record = map_file_transfer(
                                     self.category, processed_record, self.file_options


### PR DESCRIPTION
## Summary

- **Bug:** The `masked_language_modeling` category was missing from the file transfer routing, so sequence `.txt` files were never copied from `SRC_PATH/sequences/` to `DEST_PATH/{TABLE_NAME}/`. Records were inserted into MySQL and sent to the backend API, but the actual text files were missing from the shared volume — making the dataset unusable for training.
- **Fix:** Add `MASKED_LANGUAGE_MODELING` to the file transfer category list in `base.py` and `file_transfer.py`, routing through `text_transfer()` with `src_subdir="sequences"` (MLM stores files in `sequences/` not `texts/`)
- **Backwards compatible:** `text_transfer()` now accepts an optional `src_subdir` param, defaulting to `"texts"` so existing text classification behavior is unchanged

## Files changed

- `tracebloc_ingestor/ingestors/base.py` — added `MASKED_LANGUAGE_MODELING` to file transfer category gate
- `tracebloc_ingestor/file_transfer.py` — added `src_subdir` param to `text_transfer()`, added MLM case to `map_file_transfer()`

## Test plan

- [x] All 141 existing tests pass
- [ ] Deploy MLM ingestor with PrimeKG dataset and verify files appear in `DEST_PATH/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes ingestion-time file transfer routing and the source subdirectory used for text copies, which can affect whether records are skipped or files land in the correct shared volume path.
> 
> **Overview**
> Ensures `MASKED_LANGUAGE_MODELING` records perform file transfer during ingestion, preventing datasets from being created without their underlying `.txt` files.
> 
> `text_transfer()` now accepts a `src_subdir` (defaulting to `"texts"`) and `map_file_transfer()` routes MLM through `src_subdir="sequences"`, while `BaseIngestor.ingest()` includes MLM in the categories that trigger `map_file_transfer()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1fbf7d3d9f5e37580fac93eab17b5d55fc6d06e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->