### PR TITLE
Pin numeric USER in Dockerfile for K8s admission compat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,12 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 # Run as non-root. The process needs read access to /custom/ (processor
 # scripts mounted via ConfigMap by client#86) and write access to whatever
 # PVC the Helm chart mounts at the configured DEST_PATH.
-USER nobody
+#
+# Numeric UID (not the `nobody` name) is required so Pods with
+# securityContext.runAsNonRoot: true admit on clusters that enforce the
+# restricted Pod Security Standard — the kubelet can only verify
+# non-root at admission time when the image USER is numeric. 65534 is
+# the `nobody` UID on Debian/Ubuntu/Alpine.
+USER 65534
 
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- Change `USER nobody` → `USER 65534` in the runtime stage of the Dockerfile so the image admits on clusters that enforce `securityContext.runAsNonRoot: true`. The kubelet can only verify non-root at admission time when the image USER is **numeric**; a name lands the Pod in `CreateContainerConfigError` with "container has runAsNonRoot and image has non-numeric user (nobody), cannot verify user is non-root".
- 65534 is the `nobody` UID on Debian (the `python:3.11-slim` base), Ubuntu, and Alpine — so the effective process identity is unchanged.

## Context
Hit during a real-cluster test today. The chart-rendered Job is already unblocked by a runtime-side workaround in [`tracebloc/client-runtime`](https://github.com/tracebloc/client-runtime) (`submit_ingestion_run.py :: build_job_spec` now sets `run_as_user=65534` on the PodSecurityContext explicitly). But any external consumer pulling `ghcr.io/tracebloc/ingestor` and running it under their own Pod spec with `runAsNonRoot: true` still hits the same admission failure — fixing the Dockerfile is the right defense-in-depth.

Related: #56 documented the PSS `restricted` Pod-spec workaround; this PR closes the gap at the image level so downstream consumers don't have to.

Tracking issue: #91.

## Release target
Ships in the next ingestor release — **v0.3.0-rc2** or **v0.3.0** final. After merge + release, bump `images.ingestor.digest` default in [`tracebloc/client`](https://github.com/tracebloc/client) `client/values.yaml` to the new digest.

## Test plan
- [ ] CI green (build, lint, tests).
- [ ] Local sanity: `docker build -t tb-ingestor-test . && docker run --rm --entrypoint id tb-ingestor-test` returns `uid=65534`.
- [ ] In-cluster: deploy a Pod from the new image with `runAsNonRoot: true` and no `runAsUser` override — Pod admits and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new release pipeline that builds/pushes/signs images and introduces a new YAML-configured CLI path that changes how ingestion is launched and how regression labels are sent (bucketed), which could affect runtime behavior if misconfigured.
> 
> **Overview**
> **Adds an official, reproducible container release path**: introduces a `release-image.yml` GitHub Action that builds with Buildx, pushes semver tags (no `latest`), signs with keyless cosign, attaches SBOM/provenance attestations, and writes the image digest into GitHub release notes.
> 
> **Reworks the Docker image to ship repo code and run safely on locked-down clusters**: switches to a multi-stage wheel build/install, updates `.dockerignore` to include `Readme.md`, hardens `docker-entrypoint.sh` (bounded MySQL wait + `exec tracebloc-ingest`), and runs the runtime stage as numeric non-root `USER 65534` for Kubernetes `runAsNonRoot` admission.
> 
> **Introduces declarative `ingest.yaml` support end-to-end**: adds `tracebloc-ingest` console script (`cli/run.py`) that loads `INGEST_CONFIG`, validates against new bundled JSON schema (`schema/ingest.v1.json`), resolves convention defaults (`cli/conventions.py`), bridges legacy env vars / patches `file_transfer.config`, and dispatches to `CSVIngestor`/`JSONIngestor` (with warnings for deferred `spec.processors`/`spec.validators`/`spec.sidecars`).
> 
> **Adds label bucketing for regression-class tasks**: introduces `utils/label_policy.py` and plumbs `label_policy` through `BaseIngestor`/`CSVIngestor`/`JSONIngestor` so labels can be hashed into buckets before sending, plus updates schema/file_options sanitization.
> 
> **Adds extensive tests and examples**: new `examples/yaml/*.yaml` for categories and comprehensive pytest coverage for schema validation, conventions resolution, entrypoint behavior, and label-policy wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75806bdb7986cff7dc4569e0c3ddac9831b29ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->