### PR TITLE
fix(csv_ingestor): stop clobbering cleaned schema in file_options

### DIFF
--- a/tests/test_csv_file_options.py
+++ b/tests/test_csv_file_options.py
@@ -1,0 +1,69 @@
+"""Regression tests for #93: CSVIngestor must not clobber the cleaned
+``file_options["schema"]`` that ``BaseIngestor.__init__`` injects.
+
+Before the fix, ``CSVIngestor.__init__`` re-assigned
+``self.file_options = file_options or {}`` after ``super().__init__``.
+On the new YAML path with tabular/time-series categories the caller
+passes ``file_options={}``, so the subclass replaced the dict base had
+populated with a fresh empty dict — the cleaned schema (and
+``number_of_columns``) were silently dropped before they reached
+``map_validators`` and the metadata API call.
+"""
+
+from unittest.mock import MagicMock
+
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+
+
+def _make_ingestor(schema, file_options, label_column=None):
+    """Build a CSVIngestor with mock DB/API so ``BaseIngestor.__init__``
+    runs end-to-end (including ``database.create_table``)."""
+    database = MagicMock()
+    api_client = MagicMock()
+    return CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name="t",
+        schema=schema,
+        file_options=file_options,
+        label_column=label_column,
+    )
+
+
+def test_yaml_path_empty_file_options_keeps_cleaned_schema():
+    """YAML path: caller passes file_options={}. The cleaned schema base
+    injects must survive subclass init."""
+    schema = {"feature_a": "str", "feature_b": "int", "label": "str"}
+    ing = _make_ingestor(schema=schema, file_options={}, label_column="label")
+
+    assert "schema" in ing.file_options, (
+        "subclass init wiped the schema base injected"
+    )
+    assert ing.file_options["schema"] == {"feature_a": "str", "feature_b": "int"}
+
+
+def test_template_path_existing_file_options_sanitized_and_resized():
+    """Old template path: caller passes file_options with its own schema
+    and ``number_of_columns``. Base must overwrite ``schema`` with the
+    cleaned version and update ``number_of_columns`` to match."""
+    schema = {"feature_a": "str", "feature_b": "int", "label": "str"}
+    file_options = {
+        "schema": schema,  # not yet cleaned — includes label_column
+        "number_of_columns": 3,
+        "custom_flag": True,  # unrelated keys must be preserved
+    }
+    ing = _make_ingestor(
+        schema=schema, file_options=file_options, label_column="label"
+    )
+
+    assert ing.file_options["schema"] == {"feature_a": "str", "feature_b": "int"}
+    assert ing.file_options["number_of_columns"] == 2
+    assert ing.file_options["custom_flag"] is True
+
+
+def test_file_options_none_keeps_cleaned_schema():
+    """Defensive: caller passes file_options=None (the default)."""
+    schema = {"feature_a": "str", "label": "str"}
+    ing = _make_ingestor(schema=schema, file_options=None, label_column="label")
+
+    assert ing.file_options["schema"] == {"feature_a": "str"}

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -89,7 +89,6 @@ class CSVIngestor(BaseIngestor):
             label_policy=label_policy,
         )
         self.csv_options = csv_options or {}
-        self.file_options = file_options or {}
 
     def _validate_csv(self, df: pd.DataFrame) -> None:
         """Validate CSV data against schema using pandas functionality.


### PR DESCRIPTION
Closes #93. Caught by Cursor Bugbot during review of [#92](https://github.com/tracebloc/data-ingestors/pull/92) (the comment was attached to the wrong PR's diff because of a base-branch mistake on my end — the underlying bug is real and lives on `develop` today).

## Summary
- Delete the redundant `self.file_options = file_options or {}` line in [`CSVIngestor.__init__`](https://github.com/tracebloc/data-ingestors/blob/develop/tracebloc_ingestor/ingestors/csv_ingestor.py#L92). `BaseIngestor.__init__` already initialises `self.file_options` *and* injects the cleaned schema; the subclass reassignment was at best redundant and at worst destructive.
- Add `tests/test_csv_file_options.py` covering all three caller shapes.

## The bug
`BaseIngestor.__init__` strips `label_column`, `annotation_column`, and `unique_id_column` from the schema and stores the cleaned version on `self.file_options["schema"]` — `map_validators` and `send_global_meta_meta` both depend on it.

`CSVIngestor.__init__` then ran `self.file_options = file_options or {}` after `super().__init__`. On the **new YAML path** for tabular and time-series categories the caller passes `file_options={}`, so `file_options or {}` evaluated to a *fresh* empty dict — the cleaned schema was silently dropped before any validator or metadata code saw it:

- `map_validators` received empty options → `DataValidator`, `TimeFormatValidator`, `NumericColumnsValidator` setup was skipped.
- `send_global_meta_meta` sent empty metadata to the backend.

Pre-YAML templates were unaffected because `file_options` was truthy, so `file_options or {}` was `file_options` and the schema happened to survive.

`JSONIngestor` doesn't reassign `self.file_options`, so it was never affected.

## Test plan
- [ ] **Local pytest run needed** — I couldn't run the new tests in the dev sandbox (no installed runtime deps; the repo doesn't have a CI workflow that runs `pytest`). Please run `pytest tests/test_csv_file_options.py -v` locally before merging.
- [ ] Spot-check on a tabular YAML config: run the new ingestor entrypoint with `examples/yaml/tabular_classification.yaml`, confirm `CSVIngestor.file_options["schema"]` is populated and the validators are set up.
- [ ] Spot-check on a legacy template that passes `file_options={"schema": ..., "number_of_columns": N}` — confirm the cleaned schema replaces the original and `number_of_columns` is rewritten to the cleaned count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes initialization of `CSVIngestor.file_options`, which affects downstream validator setup and metadata sent to the backend; small surface area but impacts ingestion correctness for YAML-driven configs.
> 
> **Overview**
> Prevents `CSVIngestor.__init__` from reassigning `self.file_options` after `super().__init__`, preserving the cleaned `file_options["schema"]` (and updated `number_of_columns`) that `BaseIngestor` injects for validators and metadata.
> 
> Adds regression tests covering `file_options={}` (YAML path), template-style `file_options` with an existing schema/`number_of_columns`, and `file_options=None`, ensuring the cleaned schema is retained and unrelated options are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7133e6c94c54ab0f5f022a15f02dd442c0b5158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->