### PR TITLE
Add release-time smoke test for ingestor image

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -29,6 +29,10 @@ jobs:
         run: |
           pip install dist/*.tar.gz
 
-      - name: Run basic import test
+      - name: Smoke-test installed sdist
+        # Sdists go through MANIFEST.in, a different packaging code path
+        # from the wheel's package_data. The v0.3.0-rc1 schema-missing bug
+        # surfaced here too. _load_schema() reads schema/ingest.v1.json
+        # from site-packages and fails fast if the file wasn't installed.
         run: |
-          python -c "import tracebloc_ingestor"
+          python -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -28,9 +28,13 @@ jobs:
         run: |
           pip install dist/*.tar.gz
 
-      - name: Run basic import test
+      - name: Smoke-test installed sdist
+        # Sdists go through MANIFEST.in, a different packaging code path
+        # from the wheel's package_data. The v0.3.0-rc1 schema-missing bug
+        # surfaced here too. _load_schema() reads schema/ingest.v1.json
+        # from site-packages and fails fast if the file wasn't installed.
         run: |
-          python -c "import tracebloc_ingestor"
+          python -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
 
       - name: Publish to GitHub Packages
         run: |

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -129,6 +129,38 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Smoke-test built image
+        # Runs against the digest produced by `Build and push image`, BEFORE
+        # cosign signing or release-notes update — so a packaging regression
+        # aborts the workflow with no signed image and no published release.
+        #
+        # First command: import _load_schema() and read it. Catches the
+        # v0.3.0-rc1 regression where tracebloc_ingestor/schema/ was missing
+        # from site-packages because the directory had no __init__.py and
+        # find_packages() silently dropped it.
+        #
+        # Second command: invoke the tracebloc-ingest console script. The
+        # CLI has no --help; main() expects INGEST_CONFIG and exits with a
+        # friendly message when it's absent. We run with no args, accept
+        # the non-zero exit, and grep for that message — which proves:
+        # console_scripts metadata was installed, the wrapper resolves
+        # `tracebloc_ingestor.cli.run:main`, and main() runs far enough to
+        # print its first error. A missing wrapper or import-time failure
+        # produces a different output and fails the grep.
+        #
+        # IMAGE/DIGEST go through the env: block (same security stance as
+        # the release-notes step) to keep ${{ ... }} out of inline shell.
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          docker run --rm "${IMAGE}@${DIGEST}" \
+            python -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
+          output=$(docker run --rm "${IMAGE}@${DIGEST}" tracebloc-ingest 2>&1 || true)
+          echo "$output"
+          echo "$output" | grep -q "INGEST_CONFIG"
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
         with:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -150,14 +150,22 @@ jobs:
         #
         # IMAGE/DIGEST go through the env: block (same security stance as
         # the release-notes step) to keep ${{ ... }} out of inline shell.
+        #
+        # --entrypoint is load-bearing: the image's ENTRYPOINT is
+        # docker-entrypoint.sh, which exits 64 immediately if MYSQL_HOST
+        # is unset — before the shell ever reaches `exec tracebloc-ingest`.
+        # We're not testing the MySQL-wait wrapper here, we're testing the
+        # Python package; overriding the entrypoint lets the smoke probes
+        # run without standing up a MySQL sidecar for what should be a
+        # ~5-second sanity check.
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
-          docker run --rm "${IMAGE}@${DIGEST}" \
-            python -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
-          output=$(docker run --rm "${IMAGE}@${DIGEST}" tracebloc-ingest 2>&1 || true)
+          docker run --rm --entrypoint python "${IMAGE}@${DIGEST}" \
+            -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
+          output=$(docker run --rm --entrypoint tracebloc-ingest "${IMAGE}@${DIGEST}" 2>&1 || true)
           echo "$output"
           echo "$output" | grep -q "INGEST_CONFIG"
 


### PR DESCRIPTION
## Summary

- Adds a smoke-test step to `release-image.yml` that runs against the built image digest *before* cosign signing or release-notes update, so a packaging regression aborts the workflow cleanly with nothing signed or published.
- Augments `publish-master.yml` and `publish-dev.yml` to exercise the same schema-load path against the installed sdist (MANIFEST.in code path), where the v0.3.0-rc1 bug also surfaced.

Closes #95. Companion to the packaging fix landing in a separate PR.

## Background

v0.3.0-rc1 of `ghcr.io/tracebloc/ingestor` published without `tracebloc_ingestor/schema/ingest.v1.json` inside the image. Root cause was `setup.py`: the `schema/` directory had no `__init__.py`, so `find_packages()` didn't pick it up as a subpackage and the `package_data` declaration was a silent no-op. The image passed `docker build`, cosign, and SBOM steps before crashing on first customer use:

```
FileNotFoundError: [Errno 2] No such file or directory:
'/usr/local/lib/python3.11/site-packages/tracebloc_ingestor/schema/ingest.v1.json'
```

## What the smoke test checks

Two probes, both running inside the freshly-built image against `${{ steps.build.outputs.digest }}`:

1. `python -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"` — exercises the exact path that crashed in v0.3.0-rc1.
2. `tracebloc-ingest` invoked with no args, output grepped for `INGEST_CONFIG` — proves the console-script wrapper resolves and `main()` imports cleanly.

### Note on the second probe

The original ticket described it as `tracebloc-ingest --help`. The CLI doesn't implement `--help`: `main()` reads `INGEST_CONFIG` from env and exits with a friendly error when it's absent — so `tracebloc-ingest --help` would fail on a perfectly good image. The implemented form runs `tracebloc-ingest` bare, accepts the non-zero exit, and greps for the expected `INGEST_CONFIG` message. Same intent (catch broken entrypoints), just adjusted to fit the CLI's actual surface. Happy to swap in a real `--help` handler in a follow-up if preferred.

## Sdist coverage

Sdists hit MANIFEST.in instead of `package_data`. `publish-master.yml` and `publish-dev.yml` previously ran `import tracebloc_ingestor` after install — that succeeds even with the schema file missing, since the top-level package import doesn't touch it. Replaced with `_load_schema()` so the sdist code path gets the same coverage.

## Test plan

- [ ] Push a temp tag to a fork or scratch ref and confirm `Smoke-test built image` runs after build and before cosign in the release workflow.
- [ ] Confirm that with the packaging fix in place, both smoke commands pass.
- [ ] Locally: `git revert` the packaging fix on a scratch branch, rebuild the image, re-run the smoke step manually — first command should fail with `FileNotFoundError` and abort the workflow.
- [ ] Push to `develop` after merge and confirm `publish-dev.yml` runs the new sdist smoke step and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release/publish GitHub Actions workflows and adds new gating smoke tests that can block package/image publishing if they are flaky or assumptions about runtime/entrypoints change.
> 
> **Overview**
> Adds release-time smoke testing to catch packaging regressions before artifacts are signed/published.
> 
> `publish-dev.yml` and `publish-master.yml` replace the basic `import tracebloc_ingestor` check with an sdist smoke test that calls `tracebloc_ingestor.cli.run:_load_schema()` to verify required schema files were included in the installed source distribution.
> 
> `release-image.yml` now runs two probes against the freshly built image digest (before cosign/release notes): load the schema via `_load_schema()`, and execute `tracebloc-ingest` (overriding the image entrypoint) and assert the expected `INGEST_CONFIG` error text to confirm the console script is present and imports cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604097e97ccda6b8c0c59acd1925ac12f11eb273. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->