### PR TITLE
refactor(#97): make Config lazy and drop laptop-path defaults

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="tracebloc_ingestor",
-    version="0.2.10",
+    version="0.3.0",
     author="Tracebloc",
     author_email="support@tracebloc.com",
     description="A flexible data ingestion library for various file formats",

--- a/tests/test_api_client_auth.py
+++ b/tests/test_api_client_auth.py
@@ -33,7 +33,7 @@ def _make_config(**overrides) -> Config:
     Default: a valid prod-like config with BACKEND_TOKEN set so ``validate()``
     passes; tests override only the auth fields they care about. DB creds are
     not part of the validation surface (they're bundled-MySQL conventions),
-    so they're left at their dataclass defaults here.
+    so they're left to their env/property defaults here.
     """
     defaults = dict(
         BACKEND_TOKEN="test-token-abc",

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -370,23 +370,25 @@ def test_legacy_env_vars_set_before_config_construction(
     assert captured_env["SRC_PATH"] == "/data"
 
 
-def test_file_transfer_config_patched_in_place(clean_env, mock_runtime, monkeypatch):
+def test_file_transfer_config_reads_env_lazily(clean_env, mock_runtime, monkeypatch):
     """``file_transfer`` holds a module-level ``config = Config()`` captured
-    at import time, before the entrypoint runs. Because ``Config`` is a
-    dataclass whose ``os.getenv`` defaults are evaluated at class-definition
-    time, neither setting env vars nor re-instantiating ``Config()`` would
-    reach that captured instance. The bridge must mutate it in place."""
+    at import time, before the entrypoint runs. ``Config``'s env-driven
+    fields are lazy properties, so the bridge just needs to set env vars
+    — the captured instance reads them on next access.
+
+    This test pre-sets env to a stale value, runs the entrypoint (which
+    must overwrite env from the resolved YAML), and verifies the captured
+    ``file_transfer.config`` reflects the post-main env."""
     monkeypatch.setenv(
         "INGEST_CONFIG", str(EXAMPLES_DIR / "image_classification.yaml")
     )
 
     from tracebloc_ingestor import file_transfer
 
-    # Poison the captured config with values the entrypoint should overwrite.
-    monkeypatch.setattr(file_transfer.config, "TABLE_NAME", "STALE_TABLE")
-    monkeypatch.setattr(file_transfer.config, "LABEL_FILE", "/stale/labels.csv")
-    monkeypatch.setattr(file_transfer.config, "SRC_PATH", "/stale/src")
-    monkeypatch.setattr(file_transfer.config, "DEST_PATH", "/stale/dest")
+    # Pre-poison env so the entrypoint has to overwrite it.
+    monkeypatch.setenv("TABLE_NAME", "STALE_TABLE")
+    monkeypatch.setenv("LABEL_FILE", "/stale/labels.csv")
+    monkeypatch.setenv("SRC_PATH", "/stale/src")
     storage_path = file_transfer.config.STORAGE_PATH
 
     from tracebloc_ingestor.cli.run import main
@@ -395,7 +397,8 @@ def test_file_transfer_config_patched_in_place(clean_env, mock_runtime, monkeypa
     assert file_transfer.config.TABLE_NAME == "chest_xrays_train"
     assert file_transfer.config.LABEL_FILE == "/data/labels.csv"
     assert file_transfer.config.SRC_PATH == "/data"
-    # DEST_PATH is STORAGE_PATH/<table> — file_transfer joins onto it.
+    # DEST_PATH is derived from STORAGE_PATH/<table> via property — no
+    # in-place patching needed.
     assert file_transfer.config.DEST_PATH == os.path.join(storage_path, "chest_xrays_train")
 
 

--- a/tests/test_config_lazy.py
+++ b/tests/test_config_lazy.py
@@ -1,0 +1,139 @@
+"""Lock in ``Config``'s lazy-property contract.
+
+The bug this protects against (see #97): validators import
+``config = Config()`` at module top-level. When ``Config`` was a
+``@dataclass`` with ``os.getenv`` defaults, those fields were frozen at
+class-definition time, long before the declarative entrypoint set
+``SRC_PATH`` / ``TABLE_NAME`` / ``LABEL_FILE`` from the resolved YAML.
+Customers hit ``Path does not exist`` against a laptop-default path
+nobody had set.
+
+These tests verify:
+  - env set before ``Config()`` flows through (baseline).
+  - env mutated *after* ``Config()`` flows through (the regression).
+  - validators that captured ``config = Config()`` at import time observe
+    later env mutations (the cluster bug).
+  - ``Config(SRC_PATH=...)`` overrides env (test ergonomics).
+  - Laptop-path defaults are gone — unset env returns empty string / None.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.config import Config
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Strip the env vars these tests read/write."""
+    for var in (
+        "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
+        "BACKEND_TOKEN", "CLIENT_ID", "CLIENT_PASSWORD",
+        "CLIENT_ENV", "LOG_LEVEL", "BATCH_SIZE",
+        "MYSQL_HOST", "MYSQL_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_env_set_before_construction_flows_through(clean_env, monkeypatch):
+    monkeypatch.setenv("SRC_PATH", "/data/cats-dogs/images")
+    monkeypatch.setenv("TABLE_NAME", "cats_dogs_train")
+    monkeypatch.setenv("LABEL_FILE", "/data/cats-dogs/labels.csv")
+
+    config = Config()
+
+    assert config.SRC_PATH == "/data/cats-dogs/images"
+    assert config.TABLE_NAME == "cats_dogs_train"
+    assert config.LABEL_FILE == "/data/cats-dogs/labels.csv"
+    assert config.DEST_PATH == "/data/shared/cats_dogs_train"
+
+
+def test_env_mutation_after_construction_flows_through(clean_env, monkeypatch):
+    """The exact bug from the cluster: a validator imports ``config = Config()``,
+    the entrypoint sets ``SRC_PATH`` later, and the validator must see the
+    new value."""
+    config = Config()
+    assert config.SRC_PATH == ""  # no env, no laptop default
+
+    monkeypatch.setenv("SRC_PATH", "/data/customer/images")
+    assert config.SRC_PATH == "/data/customer/images"
+
+    monkeypatch.setenv("SRC_PATH", "/data/customer/v2/images")
+    assert config.SRC_PATH == "/data/customer/v2/images"
+
+
+def test_module_level_validator_config_picks_up_env_change(clean_env, monkeypatch):
+    """Validators capture ``config = Config()`` at module import. After the
+    entrypoint sets env, ``file_validator.config.SRC_PATH`` must reflect
+    the new value — that's the cluster bug repro."""
+    from tracebloc_ingestor.validators import file_validator
+
+    monkeypatch.setenv("SRC_PATH", "/data/shared/sample-image-classification")
+    assert file_validator.config.SRC_PATH == "/data/shared/sample-image-classification"
+
+    monkeypatch.setenv("SRC_PATH", "/data/shared/other-customer")
+    assert file_validator.config.SRC_PATH == "/data/shared/other-customer"
+
+
+def test_instance_override_wins_over_env(clean_env, monkeypatch):
+    monkeypatch.setenv("BACKEND_TOKEN", "from-env")
+    monkeypatch.setenv("SRC_PATH", "/from/env")
+
+    config = Config(BACKEND_TOKEN="from-override", SRC_PATH="/from/override")
+
+    assert config.BACKEND_TOKEN == "from-override"
+    assert config.SRC_PATH == "/from/override"
+
+
+def test_explicit_none_override_suppresses_env(clean_env, monkeypatch):
+    """Tests pass ``BACKEND_TOKEN=None`` to *disable* the token path even
+    when env has one set. Sentinel-based override-lookup distinguishes
+    'absent' from 'explicit None'."""
+    monkeypatch.setenv("BACKEND_TOKEN", "leaked-from-env")
+
+    config = Config(BACKEND_TOKEN=None)
+    assert config.BACKEND_TOKEN is None
+
+
+def test_unknown_override_kwarg_raises(clean_env):
+    with pytest.raises(TypeError) as exc:
+        Config(NOT_A_REAL_FIELD="x")
+    assert "NOT_A_REAL_FIELD" in str(exc.value)
+
+
+def test_laptop_path_defaults_are_gone(clean_env):
+    """The pre-refactor defaults pointed at ``~/Downloads/data-ingestors/...``,
+    which silently scanned a developer laptop dir on customer clusters."""
+    config = Config()
+    assert config.SRC_PATH == ""
+    assert config.LABEL_FILE == ""
+    assert config.TABLE_NAME == ""
+    assert config.TITLE is None
+
+    # And no stray "Downloads" anywhere — be paranoid about regressions
+    # where someone reintroduces a laptop path.
+    assert "Downloads" not in (config.SRC_PATH or "")
+    assert "Downloads" not in (config.LABEL_FILE or "")
+
+
+def test_dest_path_follows_table_name(clean_env, monkeypatch):
+    monkeypatch.setenv("TABLE_NAME", "first_table")
+    config = Config()
+    assert config.DEST_PATH == "/data/shared/first_table"
+
+    monkeypatch.setenv("TABLE_NAME", "second_table")
+    assert config.DEST_PATH == "/data/shared/second_table"
+
+
+def test_api_endpoint_follows_edge_env(clean_env, monkeypatch):
+    config = Config()
+    assert config.EDGE_ENV == "prod"
+    assert config.API_ENDPOINT == "https://api.tracebloc.io"
+
+    monkeypatch.setenv("CLIENT_ENV", "stg")
+    assert config.EDGE_ENV == "stg"
+    assert config.API_ENDPOINT == "https://stg-api.tracebloc.io"
+
+    monkeypatch.setenv("CLIENT_ENV", "local")
+    assert config.API_ENDPOINT == "http://localhost:8000"

--- a/tests/test_config_lazy.py
+++ b/tests/test_config_lazy.py
@@ -102,6 +102,26 @@ def test_unknown_override_kwarg_raises(clean_env):
     assert "NOT_A_REAL_FIELD" in str(exc.value)
 
 
+@pytest.mark.parametrize("field", ["DB_PORT", "BATCH_SIZE"])
+def test_numeric_override_rejects_none_at_construction(clean_env, field):
+    """``None`` is a valid suppression for nullable fields (BACKEND_TOKEN
+    etc.) but is nonsensical for numeric ones whose properties do
+    ``int(...)``. The constructor must reject this with a helpful message
+    rather than deferring to a ``TypeError: int() argument must be a
+    string ...`` on first property access."""
+    with pytest.raises(TypeError) as exc:
+        Config(**{field: None})
+    msg = str(exc.value)
+    assert field in msg
+    assert "None" in msg
+
+
+@pytest.mark.parametrize("field,value", [("DB_PORT", 3307), ("BATCH_SIZE", "8000")])
+def test_numeric_override_accepts_ints_and_str_ints(clean_env, field, value):
+    config = Config(**{field: value})
+    assert getattr(config, field) == int(value)
+
+
 def test_laptop_path_defaults_are_gone(clean_env):
     """The pre-refactor defaults pointed at ``~/Downloads/data-ingestors/...``,
     which silently scanned a developer laptop dir on customer clusters."""

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -17,7 +17,7 @@ from .validators import (
     TableNameValidator,
 )
 
-__version__ = "0.2.10"
+__version__ = "0.3.0"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -197,17 +197,12 @@ def _set_legacy_env_vars(resolved: ResolvedConfig) -> None:
     """Bridge the resolved YAML config into the legacy env-var path layer
     in ``file_transfer.py``.
 
-    The ingestor's path-resolution layer was built around env vars
-    (``SRC_PATH``, ``TABLE_NAME``, ``LABEL_FILE``). Refactoring it to take
-    paths as parameters is a follow-up; for v1 we bridge in two steps:
-
-    1. Set the env vars so any downstream code that reads them lazily
-       picks up the resolved values.
-    2. Patch ``file_transfer.config`` (a module-level ``Config()`` instance
-       captured at import time, before this function runs) in place. The
-       ``Config`` dataclass evaluates its ``os.getenv`` defaults once when
-       the class body executes, so neither step (1) alone nor a fresh
-       ``Config()`` call would reach the already-constructed instance.
+    The path-resolution layer reads ``SRC_PATH`` / ``TABLE_NAME`` /
+    ``LABEL_FILE`` via :class:`Config`, whose env-driven fields are now
+    lazy properties — they read ``os.environ`` on access. So this
+    function just needs to set the env vars; module-level
+    ``config = Config()`` snapshots scattered across validators and
+    ingestors all pick up the new values at their next attribute read.
 
     ``SRC_PATH`` is derived from whichever sidecar directory is set, since
     ``file_transfer.py`` joins ``SRC_PATH/<subfolder>/<filename>`` for each
@@ -226,19 +221,6 @@ def _set_legacy_env_vars(resolved: ResolvedConfig) -> None:
     os.environ["LABEL_FILE"] = resolved.source_path
     if src_path:
         os.environ["SRC_PATH"] = src_path
-
-    # Patch the already-constructed file_transfer.config in place. Its
-    # fields were frozen with stale env values at import time (long before
-    # we got here), and Config's dataclass defaults are evaluated at
-    # class-definition time, so re-instantiating wouldn't help either.
-    from .. import file_transfer
-    file_transfer.config.TABLE_NAME = resolved.table_name
-    file_transfer.config.LABEL_FILE = resolved.source_path
-    file_transfer.config.DEST_PATH = os.path.join(
-        file_transfer.config.STORAGE_PATH, resolved.table_name
-    )
-    if src_path:
-        file_transfer.config.SRC_PATH = src_path
 
 
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -1,69 +1,171 @@
-from typing import Dict, Any, Optional
+"""Lazy, env-driven configuration.
+
+Every env-driven field is a ``@property`` that reads ``os.environ`` on
+access. Module-level ``config = Config()`` snapshots in validators and
+ingestors stay valid even when env vars are set after those modules
+import — e.g. the declarative entrypoint (``cli/run.py:main``) resolves
+``ingest.yaml`` into env vars *after* the validator modules have already
+imported.
+
+Tests inject pinpoint values via ``Config(FIELD=value)``; instance
+overrides win over env. Production callers pass no kwargs.
+"""
+
+from typing import Any, Dict, Optional
 import os
-from dataclasses import dataclass
+
 from .utils.constants import LogLevel
 
 
-@dataclass
+# Sentinel signalling \"caller did not pass this field as an override\".
+# Distinguishes the absent case from an explicit ``Field=None``, which
+# tests use to *suppress* a value (e.g. ``BACKEND_TOKEN=None``).
+_MISSING = object()
+
+
 class Config:
-    # ===== Database =====
-    # The cluster-internal MySQL is bundled by the tracebloc client and ships
-    # with these credentials baked into its image. They never vary per customer,
-    # are not exposed outside the cluster, and are connection conventions rather
-    # than secrets. Override via env only if you've replaced the bundled MySQL.
-    DB_HOST: str = os.getenv("MYSQL_HOST", "localhost")
-    DB_PORT: int = int(os.getenv("MYSQL_PORT", "3306"))
-    DB_USER: str = os.getenv("DB_USER", "edgeuser")
-    DB_PASSWORD: str = os.getenv("DB_PASSWORD", "Edg9@Tr@ce")
-    DB_NAME: str = os.getenv("DB_NAME", "training_test_datasets")
-
-    BATCH_SIZE: int = int(os.getenv("BATCH_SIZE", "4000"))
-
-    # Define API endpoints for different environments
-    API_ENDPOINTS = {
+    # ===== Cluster-safe class-level constants (not env-driven) =====
+    API_ENDPOINTS: Dict[str, str] = {
         "dev": "https://dev-api.tracebloc.io",
         "stg": "https://stg-api.tracebloc.io",
         "prod": "https://api.tracebloc.io",
-        "local": "http://localhost:8000",  # Add local endpoint
+        "local": "http://localhost:8000",
     }
-    STORAGE_PATH = "/data/shared"
+    STORAGE_PATH: str = "/data/shared"
 
-    # Get environment and set appropriate API endpoint, default to prod
-    EDGE_ENV: str = os.getenv("CLIENT_ENV", "prod")
-    API_ENDPOINT: str = API_ENDPOINTS.get(EDGE_ENV, API_ENDPOINTS["dev"])
+    # Whitelist of valid override keys. A typo at the call site raises
+    # immediately rather than silently no-op'ing.
+    _ENV_FIELDS = frozenset({
+        "DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
+        "BATCH_SIZE",
+        "EDGE_ENV",
+        "BACKEND_TOKEN", "CLIENT_USERNAME", "CLIENT_PASSWORD",
+        "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
+        "LOG_LEVEL",
+    })
+
+    def __init__(self, **overrides: Any) -> None:
+        unknown = set(overrides) - self._ENV_FIELDS
+        if unknown:
+            raise TypeError(
+                f"Config got unexpected keyword arguments: {sorted(unknown)}"
+            )
+        self._overrides: Dict[str, Any] = dict(overrides)
+
+    def _override(self, name: str, default: Any = _MISSING) -> Any:
+        """Return the per-instance override for ``name`` if one was passed,
+        otherwise ``default`` (sentinel by default — callers branch on it)."""
+        if name in self._overrides:
+            return self._overrides[name]
+        return default
+
+    # ===== Database =====
+    # Cluster-internal MySQL ships with these credentials baked into its
+    # image; they're connection conventions, not secrets. Override via env
+    # only if you've replaced the bundled MySQL.
+    @property
+    def DB_HOST(self) -> str:
+        ov = self._override("DB_HOST")
+        return ov if ov is not _MISSING else os.environ.get("MYSQL_HOST", "localhost")
+
+    @property
+    def DB_PORT(self) -> int:
+        ov = self._override("DB_PORT")
+        raw = ov if ov is not _MISSING else os.environ.get("MYSQL_PORT", "3306")
+        return int(raw)
+
+    @property
+    def DB_USER(self) -> str:
+        ov = self._override("DB_USER")
+        return ov if ov is not _MISSING else os.environ.get("DB_USER", "edgeuser")
+
+    @property
+    def DB_PASSWORD(self) -> str:
+        ov = self._override("DB_PASSWORD")
+        return ov if ov is not _MISSING else os.environ.get("DB_PASSWORD", "Edg9@Tr@ce")
+
+    @property
+    def DB_NAME(self) -> str:
+        ov = self._override("DB_NAME")
+        return ov if ov is not _MISSING else os.environ.get("DB_NAME", "training_test_datasets")
+
+    @property
+    def BATCH_SIZE(self) -> int:
+        ov = self._override("BATCH_SIZE")
+        raw = ov if ov is not _MISSING else os.environ.get("BATCH_SIZE", "4000")
+        return int(raw)
+
+    # ===== API =====
+    @property
+    def EDGE_ENV(self) -> str:
+        ov = self._override("EDGE_ENV")
+        return ov if ov is not _MISSING else os.environ.get("CLIENT_ENV", "prod")
+
+    @property
+    def API_ENDPOINT(self) -> str:
+        return self.API_ENDPOINTS.get(self.EDGE_ENV, self.API_ENDPOINTS["dev"])
 
     # ===== Auth =====
-    # Preferred: pre-minted token from upstream (e.g. jobs-manager), passed via env.
-    # Mirrors the training-pod pattern; no long-lived credentials in the pod.
-    BACKEND_TOKEN: Optional[str] = os.getenv("BACKEND_TOKEN")
+    # Preferred: pre-minted token from upstream (e.g. jobs-manager) via env.
+    @property
+    def BACKEND_TOKEN(self) -> Optional[str]:
+        ov = self._override("BACKEND_TOKEN")
+        return ov if ov is not _MISSING else os.environ.get("BACKEND_TOKEN")
 
-    # Fallback: username/password. Deprecated — kept for one minor version while
-    # callers migrate to BACKEND_TOKEN, then removed in a follow-up.
-    CLIENT_USERNAME: Optional[str] = os.getenv("CLIENT_ID")
-    CLIENT_PASSWORD: Optional[str] = os.getenv("CLIENT_PASSWORD")
+    # Fallback: username/password. Deprecated — kept for one minor version
+    # while callers migrate to BACKEND_TOKEN, then removed in a follow-up.
+    @property
+    def CLIENT_USERNAME(self) -> Optional[str]:
+        ov = self._override("CLIENT_USERNAME")
+        return ov if ov is not _MISSING else os.environ.get("CLIENT_ID")
 
-    SRC_PATH: str = os.getenv(
-        "SRC_PATH",
-        "~/Downloads/data-ingestors/data/crowd_monitoring/dataset_voc_512_mini/train",
-    )  # path to the source data
-    DEST_PATH: str = os.path.join(
-        STORAGE_PATH, os.getenv("TABLE_NAME", "image_ingestor_train")
-    )  # path to the destination data with table name
-    LABEL_FILE: str = os.getenv(
-        "LABEL_FILE",
-        "~/Downloads/data-ingestors/data/crowd_monitoring/dataset_voc_512_mini/train/labels_file.csv",
-    )
-    TABLE_NAME: str = os.getenv("TABLE_NAME", "image_classification_ingestor_train2")
-    TITLE: str = os.getenv("TITLE", "DELETE-Object detection training data")
+    @property
+    def CLIENT_PASSWORD(self) -> Optional[str]:
+        ov = self._override("CLIENT_PASSWORD")
+        return ov if ov is not _MISSING else os.environ.get("CLIENT_PASSWORD")
 
-    # Logging configuration
-    LOG_LEVEL: int = LogLevel.get_level_code(os.getenv("LOG_LEVEL", "WARNING"))
+    # ===== Paths =====
+    # No laptop-path defaults: in production, the declarative entrypoint
+    # (cli/run.py:main) sets these from the resolved ingest.yaml. Empty
+    # string fails loudly in path operations rather than silently scanning
+    # a developer-laptop directory.
+    @property
+    def SRC_PATH(self) -> str:
+        ov = self._override("SRC_PATH")
+        return ov if ov is not _MISSING else os.environ.get("SRC_PATH", "")
+
+    @property
+    def LABEL_FILE(self) -> str:
+        ov = self._override("LABEL_FILE")
+        return ov if ov is not _MISSING else os.environ.get("LABEL_FILE", "")
+
+    @property
+    def TABLE_NAME(self) -> str:
+        ov = self._override("TABLE_NAME")
+        return ov if ov is not _MISSING else os.environ.get("TABLE_NAME", "")
+
+    @property
+    def DEST_PATH(self) -> str:
+        return os.path.join(self.STORAGE_PATH, self.TABLE_NAME)
+
+    @property
+    def TITLE(self) -> Optional[str]:
+        ov = self._override("TITLE")
+        return ov if ov is not _MISSING else os.environ.get("TITLE")
+
+    # ===== Logging =====
+    @property
+    def LOG_LEVEL(self) -> int:
+        ov = self._override("LOG_LEVEL")
+        if ov is not _MISSING:
+            return ov if isinstance(ov, int) else LogLevel.get_level_code(ov)
+        return LogLevel.get_level_code(os.environ.get("LOG_LEVEL", "WARNING"))
 
     def validate(self) -> None:
         """Fail fast on missing backend authentication.
 
         Called explicitly by ``APIClient.__init__`` (the boot moment for a
-        real run) rather than from ``__post_init__`` so that incidental
+        real run) rather than from ``__init__`` so that incidental
         module-level ``Config()`` instantiations elsewhere in the package
         don't blow up at import time.
 
@@ -72,12 +174,13 @@ class Config:
           - ``CLIENT_ID`` + ``CLIENT_PASSWORD`` (deprecated fallback).
 
         Database credentials are intentionally **not** validated here: the
-        bundled MySQL container ships with fixed credentials that the ingestor
-        defaults match. They're a connection convention, not a secret, and
-        forcing customers to set them in env vars adds friction with no
-        security benefit.
+        bundled MySQL container ships with fixed credentials that the
+        ingestor defaults match. They're a connection convention, not a
+        secret, and forcing customers to set them in env vars adds friction
+        with no security benefit.
 
-        Set ``CLIENT_ENV=local`` to bypass for development against a mock backend.
+        Set ``CLIENT_ENV=local`` to bypass for development against a mock
+        backend.
 
         Raises:
             ValueError: with a single, comma-joined list of missing vars,
@@ -88,7 +191,6 @@ class Config:
 
         missing = []
 
-        # Backend auth: either pre-minted token, or the deprecated cred pair.
         has_token = bool(self.BACKEND_TOKEN)
         has_creds = bool(self.CLIENT_USERNAME and self.CLIENT_PASSWORD)
         if not has_token and not has_creds:

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -44,12 +44,25 @@ class Config:
         "LOG_LEVEL",
     })
 
+    # Numeric fields whose properties unconditionally coerce via ``int(...)``.
+    # ``Config(FIELD=None)`` works for nullable fields (BACKEND_TOKEN etc.)
+    # but is nonsensical here — reject at construction with a clear message
+    # rather than letting ``int(None)`` blow up later at property access.
+    _NUMERIC_FIELDS = frozenset({"DB_PORT", "BATCH_SIZE"})
+
     def __init__(self, **overrides: Any) -> None:
         unknown = set(overrides) - self._ENV_FIELDS
         if unknown:
             raise TypeError(
                 f"Config got unexpected keyword arguments: {sorted(unknown)}"
             )
+        for field in self._NUMERIC_FIELDS & set(overrides):
+            if overrides[field] is None:
+                raise TypeError(
+                    f"Config({field}=None) is invalid: {field} is numeric "
+                    "and cannot be suppressed via None. Omit the kwarg to "
+                    "fall back to env / default."
+                )
         self._overrides: Dict[str, Any] = dict(overrides)
 
     def _override(self, name: str, default: Any = _MISSING) -> Any:


### PR DESCRIPTION
Closes #97.

## Summary

- Convert `Config` from `@dataclass` to a plain class with `@property` for every env-driven field, so reads consult `os.environ` on access.
- `__init__(**overrides)` keeps the test-injection surface (`Config(BACKEND_TOKEN=...)`) working; instance overrides win over env. A sentinel lookup distinguishes "absent" from explicit `None`, so `Config(BACKEND_TOKEN=None)` suppresses an env-set token (the existing auth-test behaviour).
- Drop the in-place `file_transfer.config` patching from `cli/run.py:_set_legacy_env_vars` — lazy properties pick up env changes at access time, so the bridge is just env writes.
- Remove laptop-path defaults: `SRC_PATH` / `LABEL_FILE` / `TABLE_NAME` default to `""`; `TITLE` to `None`. A misconfigured pod fails loudly in path operations rather than silently scanning `~/Downloads/data-ingestors/...`.
- Version bumps `0.2.10` → `0.3.0` (internal rewrite, surface API preserved).

## Why

Cluster bug, 2026-05-19. Customer `ingest.yaml`:

```yaml
images: /data/shared/sample-image-classification/images/
```

`FileTypeValidator.validate()` reads `f"{config.SRC_PATH}/{self.path}"`, where `file_validator.config.SRC_PATH` was still the laptop default baked into the `@dataclass` at class-definition time — nobody had set that value. The validator failed against a path the customer never picked.

The pre-existing workaround in `_set_legacy_env_vars` only patched `file_transfer.config` in place; the 14 validator modules each held their own captured `config = Config()` and never got the resolved value.

Lazy properties fix the class of bug structurally: any future module that adds `config = Config()` at top-level cannot regress because no value is captured at instantiation.

## Test plan

- [x] `pytest` — full suite, 149/149 passing locally (8 new lazy-Config tests + existing tests, including the rewritten `test_file_transfer_config_reads_env_lazily`).
- [x] New `tests/test_config_lazy.py` covers: env-before-construction, env-mutation-after-construction (the regression), module-level validator-config picks up env change, instance override wins, explicit `None` suppresses env, unknown kwargs raise, laptop-path defaults gone, `DEST_PATH` follows `TABLE_NAME`, `API_ENDPOINT` follows `EDGE_ENV`.
- [ ] **Cluster smoke**: re-run the cats-dogs ingestion end-to-end on a pod built from this branch and confirm the validators see the resolved `SRC_PATH` without the legacy in-place patches.

## Notes for reviewer

- `_set_legacy_env_vars` keeps the SRC_PATH derivation (parent-of-images) since `file_transfer.py` still joins `SRC_PATH/<subdir>/<filename>`. Refactoring `file_transfer.py` to take paths as parameters remains a follow-up (deferred from #44).
- `Config.validate()` is unchanged; the validation surface (BACKEND_TOKEN required in non-local envs) still applies.
- The deprecated `CLIENT_ID` / `CLIENT_PASSWORD` fallback is preserved verbatim — removing it is a separate concern from this refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core configuration resolution (env/property semantics) and the CLI env-bridging path; misconfigurations or unexpected env/override interactions could affect ingestion/validation at runtime.
> 
> **Overview**
> **Makes `Config` lazy and cluster-safe.** `Config` is refactored from a `@dataclass` into a property-based class that reads `os.environ` on access, adds explicit per-instance overrides (including *explicit `None` suppression*), validates override keys, and drops laptop-path defaults for `SRC_PATH`/`LABEL_FILE`/`TABLE_NAME` (now defaulting to empty/None).
> 
> **Simplifies the CLI legacy bridge.** `cli/run.py:_set_legacy_env_vars` now only writes env vars and no longer mutates `file_transfer.config` in place, relying on the new lazy properties to pick up post-import env changes; tests are updated and expanded (`tests/test_config_lazy.py`) to lock in this behavior. Version is bumped `0.2.10` → `0.3.0` in `setup.py` and `__init__`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 319704d3635263acb6f8b20e4c0f676d6a8abda8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->