### PR TITLE
fix(#99): surface file_transfer failures in ingestion summary

### DIFF
--- a/tests/test_file_transfer_summary.py
+++ b/tests/test_file_transfer_summary.py
@@ -169,6 +169,59 @@ def test_banner_drops_celebration_on_file_transfer_failure():
     assert "576" in out  # the failure count appears in the banner
 
 
+def test_banner_total_does_not_double_count_file_transfer(capsys):
+    """Bugbot caught this: when every record fails file_transfer, the
+    failure count must be 576, NOT 1152. The bug was summing
+    file_transfer_failures alongside (total_records - api_sent_records),
+    but file-transfer failures never reach the API so they were counted
+    in both terms.
+
+    The failure channels are mutually exclusive per record:
+        file_transfer_failures  — never reached DB
+        failed_records          — DB failures; never reached API
+        api_only_failures       — inserted to DB but didn't ship
+    """
+    s = _summary(
+        total_records=576,
+        processed_records=576,
+        inserted_records=0,
+        api_sent_records=0,
+        file_transfer_failures=576,
+    )
+    out = _capture_summary(s)
+
+    # The "Failed to Send to API" line previously read 576 here too —
+    # double-counting the same records. Should be 0: nothing was
+    # inserted, so nothing was eligible for the API ship step.
+    assert "❌ Failed to Send to API:" in out
+    api_line = next(
+        line for line in out.splitlines() if "Failed to Send to API" in line
+    )
+    # ANSI color codes wrap the count, so check the digits don't include 576.
+    assert "576" not in api_line
+    assert ">0<" in api_line.replace("\x1b[91m", ">").replace("\x1b[0m", "<")
+
+    # The banner total appears only once and equals the unique failures.
+    assert "1,152" not in out
+    assert "1152" not in out
+
+
+def test_banner_total_correct_with_mixed_failure_modes():
+    """Sanity check: the three failure channels add up cleanly when all
+    three are non-zero."""
+    s = _summary(
+        total_records=100,
+        processed_records=95,  # 5 generic skips (not failures)
+        inserted_records=80,   # 15 DB failures
+        api_sent_records=70,   # 10 API-only failures
+        failed_records=15,
+        file_transfer_failures=5,
+    )
+    # Expected unique failure count: 5 (file) + 15 (DB) + 10 (API) = 30.
+    out = _capture_summary(s)
+    assert "30 failure" in out
+
+
 def test_banner_shows_file_transfer_failures_line():
     s = _summary(file_transfer_failures=3, total_records=13, processed_records=10)
     out = _capture_summary(s)
@@ -213,7 +266,11 @@ def test_ingest_counts_file_transfer_failures_separately(monkeypatch):
       * NOT increment ``inserted_records`` / ``api_sent_records`` for the
         failed records,
       * increment ``file_transfer_failures`` (NOT ``skipped_records``),
-      * append the failures to the returned list so cli.run.main exits 1.
+      * append the failures to the returned list so cli.run.main exits 1,
+      * tick the tqdm progress bar for each failed record so an
+        all-transfer-failure run doesn't leave the bar stuck at 0/N
+        (bugbot regression — the `continue` previously skipped
+        ``pbar.update``).
     """
     records = [{"filename": f"row{i}", "extension": ".jpeg"} for i in range(5)]
 
@@ -222,6 +279,22 @@ def test_ingest_counts_file_transfer_failures_separately(monkeypatch):
         "tracebloc_ingestor.ingestors.base.map_file_transfer",
         lambda category, record, options: None,
     )
+
+    # Replace tqdm with a stub that records update() calls so we can
+    # assert the progress bar actually advances.
+    pbar_updates: list[int] = []
+
+    class _FakePbar:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def update(self, n):
+            pbar_updates.append(n)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("tracebloc_ingestor.ingestors.base.tqdm", _FakePbar)
 
     captured = _Recorder()
     monkeypatch.setattr(BaseIngestor, "_log_summary", captured)
@@ -264,3 +337,7 @@ def test_ingest_counts_file_transfer_failures_separately(monkeypatch):
     # K8s job marker was Succeeded.
     assert len(failed) == 5
     assert all(f["error"] == "file_transfer_failed" for f in failed)
+
+    # Bugbot regression: the file-transfer skip branch must advance the
+    # progress bar. Sum of ticks must reach total_records (5).
+    assert sum(pbar_updates) == 5

--- a/tests/test_file_transfer_summary.py
+++ b/tests/test_file_transfer_summary.py
@@ -1,0 +1,266 @@
+"""Regression tests for issue #99 — the silent file_transfer failure
+pattern.
+
+Before the fix, ``image_transfer`` / ``annotation_transfer`` /
+``text_transfer`` returned the record unchanged when their source file
+was missing, so ``map_file_transfer`` returned a truthy record and
+``BaseIngestor.ingest`` happily wrote the row to the DB and pushed it to
+the API. The summary's "Inserted to Database" / "Sent to API" counters
+both incremented, and the customer-facing banner reported
+``🎉 Ingestion completed successfully!`` with 100% success — even though
+zero image files reached the destination directory.
+
+These tests pin three things:
+
+1. The single-file transfer functions return ``None`` on missing source.
+2. ``BaseIngestor.ingest`` increments ``file_transfer_failures`` (NOT
+   ``skipped_records``) for those records and surfaces them in the
+   ``failed_records`` list it returns to the CLI.
+3. ``IngestionSummary.has_failures`` is True whenever any non-trivial
+   failure occurred, so the "completed successfully" banner is gated
+   correctly.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tracebloc_ingestor import file_transfer
+from tracebloc_ingestor.ingestors.base import BaseIngestor, IngestionSummary
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+# ---------------------------------------------------------------------------
+# Unit: single-file transfer functions return None on missing source
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_dirs(tmp_path, monkeypatch):
+    """Point file_transfer's module-level Config at empty tmp dirs so any
+    transfer attempt resolves to a non-existent source.
+
+    Config exposes SRC_PATH as a lazy env-backed property and DEST_PATH
+    as a derived property (``STORAGE_PATH / TABLE_NAME``), so the
+    supported override path is env vars + a STORAGE_PATH override on
+    the module-level Config instance."""
+    src = tmp_path / "src"
+    storage = tmp_path / "storage"
+    src.mkdir()
+    storage.mkdir()
+    monkeypatch.setenv("SRC_PATH", str(src))
+    monkeypatch.setenv("TABLE_NAME", "test_table")
+    # STORAGE_PATH is a plain class attr (not env-driven), so override
+    # the live module-level Config snapshot directly.
+    monkeypatch.setattr(file_transfer.config, "STORAGE_PATH", str(storage))
+    return src, storage
+
+
+def test_image_transfer_returns_none_when_source_missing(isolated_dirs, caplog):
+    """Pre-fix: this returned the record (truthy), letting the DB write
+    proceed despite zero bytes landing on disk. Now: returns None and
+    the caller in BaseIngestor.ingest treats it as a file-transfer skip."""
+    record = {"filename": "does-not-exist", "data_id": "abc"}
+    with caplog.at_level(logging.ERROR):
+        result = file_transfer.image_transfer(record, {"extension": ".jpeg"})
+    assert result is None
+    assert any("Source image not found" in r.message for r in caplog.records)
+
+
+def test_text_transfer_returns_none_when_source_missing(isolated_dirs, caplog):
+    record = {"filename": "missing-doc", "data_id": "abc"}
+    with caplog.at_level(logging.ERROR):
+        result = file_transfer.text_transfer(record, {"extension": ".txt"})
+    assert result is None
+    assert any("Source text file not found" in r.message for r in caplog.records)
+
+
+def test_annotation_transfer_returns_none_when_source_missing(isolated_dirs, caplog):
+    record = {"filename": "missing", "data_id": "abc"}
+    with caplog.at_level(logging.ERROR):
+        result = file_transfer.annotation_transfer(record, {}, ".xml")
+    assert result is None
+    assert any("Source file not found" in r.message for r in caplog.records)
+
+
+def test_image_transfer_returns_none_when_filename_missing(isolated_dirs):
+    """A record arriving without a filename can never have its file
+    transferred — return None so the caller drops it rather than writing
+    a half-record to the DB."""
+    assert file_transfer.image_transfer({}, {"extension": ".jpeg"}) is None
+
+
+# ---------------------------------------------------------------------------
+# Unit: IngestionSummary.has_failures + banner gating
+# ---------------------------------------------------------------------------
+
+
+def _summary(**overrides) -> IngestionSummary:
+    base = dict(
+        ingestor_id="t",
+        total_records=10,
+        processed_records=10,
+        inserted_records=10,
+        api_sent_records=10,
+        failed_records=0,
+        skipped_records=0,
+        file_transfer_failures=0,
+    )
+    base.update(overrides)
+    return IngestionSummary(**base)
+
+
+def test_has_failures_false_on_clean_run():
+    assert _summary().has_failures is False
+
+
+def test_has_failures_true_when_file_transfer_failed():
+    """The headline regression: even if DB+API both reported all 10
+    records as successful, a single file-transfer failure must flip
+    has_failures so the banner can't say 'completed successfully'."""
+    s = _summary(file_transfer_failures=1, total_records=11, processed_records=10)
+    assert s.has_failures is True
+
+
+def test_has_failures_true_when_inserted_less_than_total():
+    assert _summary(inserted_records=9).has_failures is True
+
+
+def test_has_failures_true_when_api_short_of_inserted():
+    assert _summary(api_sent_records=9).has_failures is True
+
+
+def test_has_failures_true_when_db_failed():
+    assert _summary(failed_records=1).has_failures is True
+
+
+# ---------------------------------------------------------------------------
+# Behavior: _log_summary swaps the banner when failures are present
+# ---------------------------------------------------------------------------
+
+
+def _capture_summary(summary: IngestionSummary) -> str:
+    # _log_summary only reads `summary`, so we can call it on a bare
+    # MagicMock that satisfies the bound-method signature.
+    ingestor = MagicMock(spec=BaseIngestor)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        BaseIngestor._log_summary(ingestor, summary)
+    return buf.getvalue()
+
+
+def test_banner_drops_celebration_on_file_transfer_failure():
+    s = _summary(
+        total_records=576,
+        processed_records=576,
+        inserted_records=0,
+        api_sent_records=0,
+        file_transfer_failures=576,
+    )
+    out = _capture_summary(s)
+    assert "🎉 Ingestion completed successfully!" not in out
+    assert "completed with" in out
+    assert "576" in out  # the failure count appears in the banner
+
+
+def test_banner_shows_file_transfer_failures_line():
+    s = _summary(file_transfer_failures=3, total_records=13, processed_records=10)
+    out = _capture_summary(s)
+    assert "File Transfer Failures" in out
+    assert "3" in out
+
+
+def test_banner_celebrates_only_on_truly_clean_run():
+    out = _capture_summary(_summary())
+    assert "🎉 Ingestion completed successfully!" in out
+
+
+# ---------------------------------------------------------------------------
+# Integration-ish: BaseIngestor.ingest plumbs file_transfer failures
+# through to the caller (so cli.run.main exits non-zero) and the summary
+# attributes them to the new counter.
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Captures the IngestionSummary that _log_summary is called with.
+
+    Installed via ``monkeypatch.setattr(BaseIngestor, "_log_summary", ...)``,
+    which stores the _Recorder instance as a class attribute. Because
+    _Recorder doesn't implement ``__get__``, instance access returns the
+    recorder itself (no descriptor binding), so ``self._log_summary(s)``
+    inside ``ingest()`` reduces to ``recorder(s)`` — hence the single
+    ``summary`` argument on ``__call__``.
+    """
+
+    def __init__(self):
+        self.summary: IngestionSummary | None = None
+
+    def __call__(self, summary):
+        self.summary = summary
+
+
+def test_ingest_counts_file_transfer_failures_separately(monkeypatch):
+    """End-to-end mocked: image_transfer is forced to return None on every
+    record. After the fix, the ingestor should:
+
+      * NOT increment ``inserted_records`` / ``api_sent_records`` for the
+        failed records,
+      * increment ``file_transfer_failures`` (NOT ``skipped_records``),
+      * append the failures to the returned list so cli.run.main exits 1.
+    """
+    records = [{"filename": f"row{i}", "extension": ".jpeg"} for i in range(5)]
+
+    # Force every map_file_transfer call to fail.
+    monkeypatch.setattr(
+        "tracebloc_ingestor.ingestors.base.map_file_transfer",
+        lambda category, record, options: None,
+    )
+
+    captured = _Recorder()
+    monkeypatch.setattr(BaseIngestor, "_log_summary", captured)
+
+    # Patch out the API meta calls so we reach the summary block.
+    mock_api = MagicMock()
+    mock_api.send_generate_edge_label_meta.return_value = True
+    mock_api.send_global_meta_meta.return_value = True
+    mock_api.prepare_dataset.return_value = True
+
+    mock_db = MagicMock()
+    mock_db.create_table.return_value = MagicMock()
+    mock_db.get_table_schema.return_value = {}
+    mock_db.insert_batch.return_value = ([], [])
+
+    with patch.object(BaseIngestor, "__abstractmethods__", set()):
+        ingestor = BaseIngestor(
+            database=mock_db,
+            api_client=mock_api,
+            table_name="t",
+            schema={"filename": "VARCHAR(255)"},
+            category=TaskCategory.IMAGE_CLASSIFICATION,
+            intent="train",  # required for process_record to succeed
+        )
+        ingestor.read_data = lambda source: iter(records)
+        ingestor._count_records = lambda source: len(records)
+        ingestor.validate_data = lambda source: True
+
+        failed = ingestor.ingest("fake-source", batch_size=10)
+
+    assert captured.summary is not None, "summary was never logged"
+    assert captured.summary.file_transfer_failures == 5
+    assert captured.summary.skipped_records == 0  # NOT counted as generic skip
+    assert captured.summary.inserted_records == 0
+    assert captured.summary.api_sent_records == 0
+    assert captured.summary.has_failures is True
+
+    # The CLI exit-code path: cli.run.main returns 1 when this list is
+    # non-empty. Without the fix, a 100%-failed run returned [] and the
+    # K8s job marker was Succeeded.
+    assert len(failed) == 5
+    assert all(f["error"] == "file_transfer_failed" for f in failed)

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -7,7 +7,7 @@ supporting both binary data and file-based image processing.
 
 import logging
 import os
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 import shutil
 import time
 
@@ -99,13 +99,19 @@ def image_transfer(
     options: Dict[str, Any],
     src_path: str = None,
     filename_with_ext: str = None,
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """Copy an image from SRC_PATH/images/ to DEST_PATH/.
 
     Callers that have already resolved the source via `_find_src` (e.g.
     atomic multi-file branches that need to pre-check existence) can
     pass `src_path` and `filename_with_ext` to skip the lookup; in that
     mode no filesystem stat happens here.
+
+    Returns ``None`` if the source file cannot be located or the record
+    is missing a filename. The caller in ``BaseIngestor.ingest`` treats
+    ``None`` as a file-transfer skip — see issue #99 (silent data-loss
+    pattern: returning the record on a missing source let the DB/API
+    write succeed and falsely report 100% success).
     """
     # Create destination directory if it doesn't exist
     os.makedirs(config.DEST_PATH, exist_ok=True)
@@ -116,7 +122,7 @@ def image_transfer(
         extension = options.get("extension")
         if not filename:
             logger.error(f"{RED}No filename found in record{RESET}")
-            return record
+            return None
 
         if src_path is None:
             src_path, filename_with_ext = _find_src("images", filename, extension)
@@ -124,7 +130,7 @@ def image_transfer(
                 logger.error(
                     f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', filename_with_ext)}{RESET}"
                 )
-                return record
+                return None
 
         # Save the resized image
         image_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)
@@ -154,12 +160,14 @@ def annotation_transfer(
     extension: str,
     src_path: str = None,
     filename_with_ext: str = None,
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """Copy an annotation file from SRC_PATH/annotations/ to DEST_PATH/.
 
     Callers that have already resolved the source via `_find_src` can
     pass `src_path` and `filename_with_ext` to skip the lookup; in that
     mode no filesystem stat happens here.
+
+    Returns ``None`` on missing source (see issue #99).
     """
     # Create destination directory if it doesn't exist
     os.makedirs(config.DEST_PATH, exist_ok=True)
@@ -169,7 +177,7 @@ def annotation_transfer(
         filename = record.get("filename")
         if not filename:
             logger.error(f"{RED}No filename found in record{RESET}")
-            return record
+            return None
 
         if src_path is None:
             src_path, filename_with_ext = _find_src(
@@ -179,7 +187,7 @@ def annotation_transfer(
                 logger.error(
                     f"{RED}Source file not found: {os.path.join(config.SRC_PATH, 'annotations', filename_with_ext)}{RESET}"
                 )
-                return record
+                return None
 
         # Save the file
         file_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)
@@ -197,7 +205,7 @@ def text_transfer(
     record: Dict[str, Any],
     options: Dict[str, Any],
     src_subdir: str = "texts",
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """Transfer text files for text-based tasks.
 
     Args:
@@ -208,7 +216,7 @@ def text_transfer(
                      ``"sequences"`` for masked language modeling)
 
     Returns:
-        Updated record dictionary
+        Updated record dictionary, or ``None`` on missing source (see issue #99).
     """
     # Create destination directory if it doesn't exist
     os.makedirs(config.DEST_PATH, exist_ok=True)
@@ -219,7 +227,7 @@ def text_transfer(
         extension = options.get("extension")
         if not filename:
             logger.error(f"{RED}No filename found in record{RESET}")
-            return record
+            return None
 
         # Add extension to filename if it doesn't have one
         if not _has_extension(filename):
@@ -231,7 +239,7 @@ def text_transfer(
         text_src_path = os.path.join(config.SRC_PATH, src_subdir, filename_with_ext)
         if not os.path.exists(text_src_path):
             logger.error(f"{RED}Source text file not found: {text_src_path}{RESET}")
-            return record
+            return None
 
         # Save the text file
         text_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -451,6 +451,12 @@ class BaseIngestor(ABC):
                                             "error": "file_transfer_failed",
                                         }
                                     )
+                                    # Advance the progress bar so an
+                                    # all-transfer-failure run doesn't leave
+                                    # tqdm stuck at 0/N — without this the
+                                    # `continue` skips the batch update that
+                                    # would normally tick the bar.
+                                    pbar.update(1)
                                     continue
 
                             batch.append(processed_record)
@@ -645,8 +651,15 @@ class BaseIngestor(ABC):
         print(
             f"{BOLD}❌ Failed DB Insertion:{RESET}     {RED}{summary.failed_records:,}{RESET}"
         )
+        # Only count records that made it to a DB insert but didn't ship
+        # to the API. Using `total_records - api_sent_records` would also
+        # include file-transfer failures and DB failures (which never had
+        # a chance to ship), giving an inflated, double-counted total.
+        api_only_failures = max(
+            0, summary.inserted_records - summary.api_sent_records
+        )
         print(
-            f"{BOLD}❌ Failed to Send to API:{RESET}   {RED}{(summary.total_records - summary.api_sent_records):,}{RESET}"
+            f"{BOLD}❌ Failed to Send to API:{RESET}   {RED}{api_only_failures:,}{RESET}"
         )
         print(f"{CYAN}{'─'*60}{RESET}")
 
@@ -663,12 +676,15 @@ class BaseIngestor(ABC):
         # Status banner. Any non-trivial failure (DB, API, or file-transfer)
         # disqualifies the "completed successfully" message — a customer
         # seeing 🎉 should be able to trust that no record was silently
-        # dropped. The total-failure count is summed across all failure
-        # channels so the operator can grep logs by the same number.
+        # dropped. The three failure channels are mutually exclusive per
+        # record (file-transfer failures never reach DB; DB failures never
+        # reach API; api_only_failures are records that hit DB but didn't
+        # ship), so summing them gives a clean unique count instead of
+        # the double-count `total_records - api_sent_records` would produce.
         total_failures = (
             summary.failed_records
             + summary.file_transfer_failures
-            + max(0, summary.total_records - summary.api_sent_records)
+            + api_only_failures
         )
         if not summary.has_failures:
             status_msg = "🎉 Ingestion completed successfully!"

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -40,7 +40,13 @@ class IngestionSummary(NamedTuple):
         inserted_records: Number of records inserted into database
         api_sent_records: Number of records sent to API
         failed_records: Number of records that failed processing
-        skipped_records: Number of records that were skipped
+        skipped_records: Number of records that were skipped for non-file
+            reasons (e.g. missing label / invalid intent / processing error)
+        file_transfer_failures: Number of records whose source file (image,
+            annotation, mask, text) was missing or unreadable, so the
+            record was dropped before the DB / API write. Tracked
+            separately from ``skipped_records`` so operators can
+            distinguish data-loss from validation skips (issue #99).
     """
 
     ingestor_id: str
@@ -50,6 +56,21 @@ class IngestionSummary(NamedTuple):
     api_sent_records: int
     failed_records: int
     skipped_records: int
+    file_transfer_failures: int = 0
+
+    @property
+    def has_failures(self) -> bool:
+        """True if any non-trivial failure occurred — DB insert short of
+        total, API short of inserted, file-transfer skipped any record,
+        or processing errored. Used to gate the "completed successfully"
+        banner so customers can't mistake a partial run for a clean one.
+        """
+        return (
+            self.failed_records > 0
+            or self.file_transfer_failures > 0
+            or self.inserted_records < self.total_records
+            or self.api_sent_records < self.inserted_records
+        )
 
 
 class BaseIngestor(ABC):
@@ -376,6 +397,7 @@ class BaseIngestor(ABC):
             "api_sent_records": 0,
             "failed_records": 0,
             "skipped_records": 0,
+            "file_transfer_failures": 0,
         }
 
         # Try to get total count for progress bar
@@ -405,11 +427,29 @@ class BaseIngestor(ABC):
                                 processed_record = map_file_transfer(
                                     self.category, processed_record, self.file_options
                                 )
-                                # Skip record if file transfer failed
+                                # Skip record if file transfer failed. Tracked as
+                                # `file_transfer_failures` (not `skipped_records`)
+                                # so the summary can flag the silent-data-loss
+                                # pattern from issue #99 — a missing source
+                                # would otherwise let the DB / API write succeed
+                                # and falsely report 100% success.
                                 if processed_record is None:
-                                    stats["skipped_records"] += 1
+                                    stats["file_transfer_failures"] += 1
+                                    filename = record.get("filename", "Unknown")
                                     logger.warning(
-                                        f"Skipping record due to file transfer failure: {record.get('filename', 'Unknown')}"
+                                        f"Skipping record due to file transfer failure: {filename}"
+                                    )
+                                    # Also surface the failure to the caller
+                                    # so cli.run.main exits non-zero — without
+                                    # this, a 100%-failed run would still
+                                    # return [] and the K8s job marker would
+                                    # be `Succeeded` (the silent-data-loss
+                                    # pattern from #99).
+                                    failed_records.append(
+                                        {
+                                            "record": record,
+                                            "error": "file_transfer_failed",
+                                        }
                                     )
                                     continue
 
@@ -547,16 +587,31 @@ class BaseIngestor(ABC):
             raise
 
     def _log_summary(self, summary: IngestionSummary):
-        """Log ingestion summary in a clear, formatted way with enhanced visual appeal"""
+        """Log ingestion summary in a clear, formatted way with enhanced visual appeal.
 
-        # Calculate success rate
+        A "success" here means the record was inserted to the DB, sent to
+        the API, AND its sidecar file (image / annotation / mask / text)
+        was copied to the destination. Records whose source file was
+        missing are subtracted from the success count even if the DB
+        row landed — see issue #99 for the silent-data-loss pattern that
+        motivated this.
+        """
+
+        # A successful record requires DB insert AND API send AND, where
+        # applicable, a successful file transfer. File-transfer failures
+        # short-circuit before the DB write (they're skipped from the
+        # batch), so subtracting them from total_records gives the
+        # denominator's effective ceiling. Use inserted_records (the
+        # actual durable outcome) as the numerator.
         success_rate = 0
         if summary.total_records > 0:
             success_rate = (summary.inserted_records / summary.total_records) * 100
 
         # Determine overall status color
         status_color = (
-            GREEN if success_rate >= 90 else YELLOW if success_rate >= 70 else RED
+            GREEN if success_rate >= 90 and not summary.has_failures
+            else YELLOW if success_rate >= 70
+            else RED
         )
 
         print(f"\n{CYAN}{'═'*60}{RESET}")
@@ -581,6 +636,12 @@ class BaseIngestor(ABC):
         print(
             f"{BOLD}⏭️  Skipped Records:{RESET}        {YELLOW}{summary.skipped_records:,}{RESET}"
         )
+        file_transfer_color = (
+            RED if summary.file_transfer_failures > 0 else GREEN
+        )
+        print(
+            f"{BOLD}📁 File Transfer Failures:{RESET}  {file_transfer_color}{summary.file_transfer_failures:,}{RESET}"
+        )
         print(
             f"{BOLD}❌ Failed DB Insertion:{RESET}     {RED}{summary.failed_records:,}{RESET}"
         )
@@ -599,15 +660,33 @@ class BaseIngestor(ABC):
                 f"{BOLD}📊 Success Rate:{RESET} [{status_color}{bar}{RESET}] {status_color}{success_rate:.1f}%{RESET}"
             )
 
-        # Status message
-        if success_rate >= 95:
+        # Status banner. Any non-trivial failure (DB, API, or file-transfer)
+        # disqualifies the "completed successfully" message — a customer
+        # seeing 🎉 should be able to trust that no record was silently
+        # dropped. The total-failure count is summed across all failure
+        # channels so the operator can grep logs by the same number.
+        total_failures = (
+            summary.failed_records
+            + summary.file_transfer_failures
+            + max(0, summary.total_records - summary.api_sent_records)
+        )
+        if not summary.has_failures:
             status_msg = "🎉 Ingestion completed successfully!"
         elif success_rate >= 80:
-            status_msg = "👍 Most records processed successfully."
+            status_msg = (
+                f"⚠️  Ingestion completed with {total_failures:,} failure(s), "
+                "see logs."
+            )
         elif success_rate >= 60:
-            status_msg = "⚠️  Some records failed to process."
+            status_msg = (
+                f"⚠️  Ingestion completed with {total_failures:,} failure(s); "
+                "many records failed to process — see logs."
+            )
         else:
-            status_msg = "❌ Critical! Many records failed to process."
+            status_msg = (
+                f"❌ Critical! Ingestion completed with {total_failures:,} "
+                "failure(s); most records failed — see logs."
+            )
 
         print(f"{CYAN}{'─'*60}{RESET}")
         print(f"{BOLD}{status_color}{status_msg}{RESET}")


### PR DESCRIPTION
Closes #99.

## Summary

- `image_transfer` / `annotation_transfer` / `text_transfer` returned the record unchanged when their source file was missing, so `map_file_transfer` returned a truthy value and the DB + API write paths happily completed despite zero bytes landing on disk. The summary's counters tracked DB + API only, so a 100%-failed run still printed `🎉 Ingestion completed successfully!` at 100% success rate — silent data loss from a customer perspective.
- Single-file transfer functions now return `None` on missing source / missing filename. `BaseIngestor.ingest` increments a new `file_transfer_failures` counter (separate from the generic `skipped_records` so operators can tell data-loss skips from validation skips) and appends the record to the `failed_records` list returned to the CLI.
- `IngestionSummary` gains `file_transfer_failures` and a `has_failures` property. `_log_summary` shows the new counter and gates the banner: any non-trivial failure (DB, API, or file-transfer) prints `⚠️ Ingestion completed with N failures, see logs.` instead of the celebration.
- `cli.run.main` already exits non-zero when `ingest()` returns a non-empty failed list, so the K8s job marker now reflects file-transfer failures automatically.

## Repro before the fix

6-image cats/dogs sample expanded to 576 CSV rows. A bug in `_has_extension` (already fixed in a separate PR) caused every image path to resolve to `cat1.jpeg.jpeg`. The cluster run logged 576 `Source image not found` errors but still printed:

```
📈 Total Records Found:     576
✅ Successfully Processed:  576
💾 Inserted to Database:    576
🚀 Sent to API:             576
🎉 Ingestion completed successfully!
📊 Success Rate: 100.0%
```

## Test plan

- [x] `pytest tests/test_file_transfer_summary.py` — 13 new cases pass.
- [x] Full `pytest` run — 170 passed; the single failure (`test_every_existing_template_has_a_case` for `masked_language_modeling`) is pre-existing and unrelated.
- [ ] Smoke test in a real cluster with a corrupted source dir (e.g. delete `images/` before running) — expect non-zero exit code, `📁 File Transfer Failures: 576`, and the no-celebration banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ingestion control-flow and reporting: missing source files now drop records, increment a new failure counter, and cause non-zero CLI outcomes; this can change job success criteria and downstream counts.
> 
> **Overview**
> Prevents silent ingestion success when source files are missing by making `image_transfer`/`annotation_transfer`/`text_transfer` return `None` on missing filename/source and having `BaseIngestor.ingest` count these as `file_transfer_failures` (and return them in `failed_records`).
> 
> Enhances `IngestionSummary` with `file_transfer_failures` and `has_failures`, updates `_log_summary` to display the new counter, avoid double-counting “Failed to Send to API” (now `inserted_records - api_sent_records`), and gate the 🎉 banner on *any* failure.
> 
> Adds regression tests covering transfer `None` semantics, ingest plumbing (including tqdm updates), and banner/failure-count correctness (issue #99).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d13f3282c6f6c4dd3e26ec2b151b031786b9d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->