### PR TITLE
fix(#101): allow rerun when destination dir is empty leftover

### DIFF
--- a/tests/test_duplicate_validator.py
+++ b/tests/test_duplicate_validator.py
@@ -1,0 +1,58 @@
+"""Regression tests for #101: DuplicateValidator must allow reruns
+when the destination dir was left behind empty by a previous aborted
+ingestion.
+
+Before the fix, *any* existing destination directory failed validation,
+forcing customers to ``kubectl exec`` and ``rm -rf`` on the shared PVC
+between attempts. After the fix, an empty leftover dir passes with a
+warning; a populated dir still fails.
+"""
+
+import os
+
+from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
+
+
+def test_missing_destination_passes(tmp_path):
+    """Happy path: destination doesn't exist yet."""
+    dest = tmp_path / "fresh_table"
+    validator = DuplicateValidator(dest_path=str(dest))
+
+    result = validator.validate(data=None)
+
+    assert result.is_valid
+    assert result.errors == []
+    assert result.metadata["directory_exists"] is False
+
+
+def test_empty_destination_passes_with_warning(tmp_path):
+    """An empty leftover dir (previous run aborted before any data
+    landed) is reused, with a warning. This is the #101 case."""
+    dest = tmp_path / "leftover_empty_table"
+    dest.mkdir()
+    assert os.listdir(dest) == []
+    validator = DuplicateValidator(dest_path=str(dest))
+
+    result = validator.validate(data=None)
+
+    assert result.is_valid, f"unexpected errors: {result.errors}"
+    assert result.errors == []
+    assert any("empty" in w for w in result.warnings), result.warnings
+    assert result.metadata["directory_exists"] is True
+    assert result.metadata["directory_empty"] is True
+
+
+def test_non_empty_destination_fails(tmp_path):
+    """Populated destination is still treated as a real collision — we
+    must not clobber an existing dataset."""
+    dest = tmp_path / "populated_table"
+    dest.mkdir()
+    (dest / "row_0.png").write_bytes(b"not-actually-a-png")
+    validator = DuplicateValidator(dest_path=str(dest))
+
+    result = validator.validate(data=None)
+
+    assert not result.is_valid
+    assert any("already exists" in e for e in result.errors), result.errors
+    assert result.metadata["directory_exists"] is True
+    assert result.metadata["directory_empty"] is False

--- a/tracebloc_ingestor/validators/duplicate_validator.py
+++ b/tracebloc_ingestor/validators/duplicate_validator.py
@@ -62,9 +62,21 @@ class DuplicateValidator(BaseValidator):
             metadata["directory_exists"] = directory_exists
 
             if directory_exists:
-                errors.append(
-                    f"Destination directory '{self.dest_path}' already exists"
-                )
+                # An empty directory typically means a previous ingestion
+                # attempt aborted before any data landed. Reusing it is
+                # safe and lets customers rerun without manual PVC cleanup.
+                # A populated directory is treated as a real collision.
+                is_empty = self._is_directory_empty()
+                metadata["directory_empty"] = is_empty
+                if is_empty:
+                    warnings.append(
+                        f"Destination directory '{self.dest_path}' exists but "
+                        "is empty (likely from a previous failed run); reusing."
+                    )
+                else:
+                    errors.append(
+                        f"Destination directory '{self.dest_path}' already exists"
+                    )
 
             # Check if parent directory exists (for creating the destination)
             parent_dir = Path(self.dest_path).parent
@@ -101,6 +113,18 @@ class DuplicateValidator(BaseValidator):
             return dest_path.exists() and dest_path.is_dir()
         except Exception as e:
             logger.error(f"Error checking directory existence: {str(e)}")
+            return False
+
+    def _is_directory_empty(self) -> bool:
+        """Return True iff dest_path is an empty directory.
+
+        Returns False on any error so the validator falls back to the
+        existing "fail loudly" behavior rather than masking a real issue.
+        """
+        try:
+            return not any(Path(self.dest_path).iterdir())
+        except Exception as e:
+            logger.error(f"Error checking if directory is empty: {str(e)}")
             return False
 
     def _create_directory_if_needed(self) -> bool:


### PR DESCRIPTION
## Summary

- Closes [#101](https://github.com/tracebloc/data-ingestors/issues/101).
- `DuplicateValidator` now accepts an existing-but-empty destination directory (with a warning) instead of hard-failing. A populated destination still fails — that's the real "would clobber an existing dataset" case.
- Adds `tests/test_duplicate_validator.py` covering missing / empty / populated cases.

## Context

Observed on cluster on 2026-05-19: a previous ingestion attempt failed mid-`file_transfer` (separate bug, already fixed) and left an empty `/data/shared/<table_name>/` on the shared PVC. The next retry — same `ingest.yaml`, fixed image — failed at the validator step:

```
ValueError: Duplicate Validator Validator failed:
Destination directory '/data/shared/sample_cats_dogs_train' already exists
```

The customer-facing workarounds (manual `kubectl exec` + `rm -rf` on the PVC, or renaming the table for every retry) are both painful and undocumented. Empty-dir reuse is the minimum fix.

## Behavior change

| State | Before | After |
| --- | --- | --- |
| Dest dir missing | pass | pass (unchanged) |
| Dest dir exists, empty | fail | **pass with warning** |
| Dest dir exists, populated | fail | fail (unchanged) |

## Test plan

- [x] `pytest tests/test_duplicate_validator.py -v` — 3 passed
- [x] Full `pytest` — 160 passed; one pre-existing failure in `test_template_equivalence.py::test_every_existing_template_has_a_case` about `masked_language_modeling` is unrelated to this change (reproduces on master HEAD without my diff applied).
- [ ] Manual cluster verification: rerun a `sample_cats_dogs_train` ingest after leaving an empty destination dir behind; validator emits the warning and proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validation behavior around existing destination directories; incorrect emptiness detection could allow unintended reuse, though populated directories still fail.
> 
> **Overview**
> Fixes #101 by changing `DuplicateValidator` to **permit reruns when the destination directory already exists but is empty**, emitting a warning and recording `directory_empty` in metadata; non-empty directories still error as before.
> 
> Adds regression tests covering missing destination, empty leftover directory (passes with warning), and populated destination (fails).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c38f101a1ef865ff1d5b1f7ead38ec7399a8326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->