### PR TITLE
Copy tokenizer.json to training pod for MLM datasets

### DIFF
--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -360,6 +360,22 @@ def map_file_transfer(
         return result
     elif task_category == TaskCategory.MASKED_LANGUAGE_MODELING:
         result = text_transfer(record, options, src_subdir="sequences")
+        # Copy tokenizer.json once (if provided by the user).
+        # The client's MLM strategy looks for tokenizer.json at
+        # DEST_PATH/tokenizer.json to use the user's custom tokenizer
+        # instead of falling back to bert-base-uncased.  Without this
+        # copy the tokenizer vocab_size may mismatch the model's
+        # nn.Embedding, causing CUDA device-side assert at training.
+        tokenizer_src = os.path.join(config.SRC_PATH, "tokenizer.json")
+        tokenizer_dest = os.path.join(config.DEST_PATH, "tokenizer.json")
+        if (
+            os.path.isfile(tokenizer_src)
+            and not os.path.exists(tokenizer_dest)
+        ):
+            _copy_file_with_retry(tokenizer_src, tokenizer_dest)
+            logger.info(
+                f"{GREEN}Copied tokenizer.json to {config.DEST_PATH}{RESET}"
+            )
         return result
     elif task_category == TaskCategory.SEMANTIC_SEGMENTATION:
         # Atomic: only copy image+mask together. Pre-verify both sources


### PR DESCRIPTION
## Summary

- The data ingestor validates `tokenizer.json` during ingestion (checks for `[MASK]` and `[PAD]` tokens) but never copies it to `DEST_PATH` (`/data/shared/<table_name>/`)
- The client's MLM strategy looks for `tokenizer.json` at the dataset path — when it's missing, it falls back to `bert-base-uncased` (vocab_size=30,522)
- Non-HF model-zoo models may have smaller vocab_size (e.g. 30,000), causing token IDs from the bert tokenizer to exceed the model's `nn.Embedding` bounds
- This triggers a CUDA device-side assert with a misleading async traceback that points at an unrelated line, making it extremely hard to diagnose

## Fix

Copy `tokenizer.json` from `SRC_PATH/` to `DEST_PATH/` during MLM file transfer, if the file exists. This is a one-time copy (skipped if already present at destination). If no `tokenizer.json` is provided, behavior is unchanged — the client falls back to HF tokenizer as before.

## Files changed

- `tracebloc_ingestor/file_transfer.py` — `map_file_transfer()`: added tokenizer.json copy in the `MASKED_LANGUAGE_MODELING` branch

## Test plan

- [ ] Run MLM ingestion with tokenizer.json in SRC_PATH — verify it's copied to DEST_PATH
- [ ] Run MLM ingestion without tokenizer.json — verify no error, .txt files still copied normally
- [ ] Confirm client training pod picks up the copied tokenizer.json (logs should show `MLM tokenizer source=LOCAL`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a guarded, one-time file copy during MLM ingestion; main risk is unexpected overwrite/permission issues when writing to `DEST_PATH`, mitigated by skipping if already present.
> 
> **Overview**
> For `TaskCategory.MASKED_LANGUAGE_MODELING`, ingestion now **copies a user-provided `tokenizer.json`** from `SRC_PATH` to `DEST_PATH` (one-time, skipped if already present) alongside the existing sequence text transfer.
> 
> This ensures the training pod can pick up the dataset’s custom tokenizer instead of falling back to a default tokenizer that may cause vocab/model embedding mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32888e19275033763c24a194c9cfa677ca71dde2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->