### PR TITLE
Sync develop → master for v0.3.0 release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,4 +21,7 @@ var/
 .git
 .gitignore
 README.md
-*.md 
+*.md
+# setup.py reads Readme.md for long_description — must be in the build
+# context so the wheel build (Dockerfile #45) succeeds.
+!Readme.md 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,197 @@
+# Build, sign, and publish the official ingestor image to GHCR.
+#
+# Triggered by pushing a vX.Y.Z tag (or manually via workflow_dispatch).
+# Produces:
+#   - ghcr.io/tracebloc/ingestor:X.Y.Z, :X.Y, :X (deliberately no :latest per #45)
+#   - Cosign keyless signature on the image digest (Sigstore Rekor)
+#   - SBOM + SLSA provenance attached as OCI attestations (buildkit-native)
+#   - GitHub Release updated with the image digest for downstream pinning
+#
+# Downstream consumers pin by digest, not tag. The Helm subchart (client#86)
+# pulls the digest from the release notes and bakes it into its values.
+#
+# Verification:
+#   cosign verify ghcr.io/tracebloc/ingestor@<digest> \
+#     --certificate-identity-regexp \
+#       'https://github.com/tracebloc/data-ingestors/.github/workflows/release-image.yml@.*' \
+#     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+name: Release image
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag to build (e.g. v0.3.0). Must already exist on origin.'
+        required: true
+        type: string
+
+permissions:
+  contents: write     # update release notes with the digest
+  packages: write     # push to GHCR
+  id-token: write     # cosign keyless OIDC + buildkit attestations
+  attestations: write # SBOM + provenance attestations
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tracebloc/ingestor
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          # cosign + buildkit reproducibility benefit from full history.
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Tag strategy: semver only. No :latest — downstream must pick a
+          # specific major or minor and accept the upgrade window explicitly.
+          #
+          # The explicit `value=` is load-bearing for workflow_dispatch: by
+          # default docker/metadata-action reads github.ref, which on a
+          # workflow_dispatch event points at the *default branch* rather
+          # than the tag the user typed into `inputs.ref`. Without `value=`,
+          # the semver patterns produce zero tags, the build silently pushes
+          # nothing, and the cosign loop signs nothing. Pinning to
+          # `inputs.ref || github.ref_name` makes both trigger paths produce
+          # the same three tags from the same semver source.
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.ref || github.ref_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.ref || github.ref_name }}
+            type=semver,pattern={{major}},value=${{ inputs.ref || github.ref_name }}
+          flavor: |
+            latest=false
+          labels: |
+            org.opencontainers.image.title=tracebloc-ingestor
+            org.opencontainers.image.description=Official tracebloc data-ingestor image (declarative YAML-driven, signed)
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=tracebloc
+
+      - name: Verify tags were produced
+        # Defense-in-depth against the workflow_dispatch / github.ref class
+        # of bug above: if anyone refactors `tags:` and accidentally breaks
+        # the value source, we fail loudly here instead of letting the build
+        # succeed with nothing pushed.
+        #
+        # REF goes through the env: block, not inline `${{ … }}` in the run
+        # script. inputs.ref is user-controllable on workflow_dispatch, and
+        # inline interpolation would let a crafted value (e.g.
+        # `$(malicious command)`) execute inside the double-quoted echo.
+        # env-block values are passed via the environment and read by the
+        # shell at runtime — no substitution risk. Matches the pattern the
+        # release-notes step below uses for TAG / IMAGE / DIGEST / TAGS.
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          REF: ${{ inputs.ref || github.ref_name }}
+        run: |
+          if [ -z "${TAGS//[[:space:]]/}" ]; then
+            echo "::error::docker/metadata-action produced no tags for ref '${REF}'. Aborting before the build silently pushes nothing." >&2
+            exit 1
+          fi
+          echo "Tags to publish:"
+          printf '  %s\n' "$TAGS"
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # SLSA provenance + SBOM as OCI attestations, attached at the image
+          # index level. Extractable with `docker buildx imagetools inspect`.
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.4.0'
+
+      - name: Sign image (keyless OIDC)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          # Sign each tag's digest separately so `cosign verify <tag>` works
+          # for all three (X.Y.Z, X.Y, X). All point to the same digest, so
+          # this is cheap.
+          echo "$TAGS" | while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "::group::Signing $tag@$DIGEST"
+            cosign sign --yes "$tag@$DIGEST"
+            echo "::endgroup::"
+          done
+
+      - name: Update release notes with digest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.ref || github.ref_name }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          # Indent each pushed tag two spaces for the markdown bullet list.
+          tag_list=$(echo "$TAGS" | sed 's/^/- `/; s/$/`/')
+
+          notes=$(cat <<EOF
+          ## Image
+
+          \`\`\`
+          ${IMAGE}@${DIGEST}
+          \`\`\`
+
+          ### Tags pushed
+
+          ${tag_list}
+
+          ### Verify signature
+
+          \`\`\`
+          cosign verify ${IMAGE}@${DIGEST} \\
+            --certificate-identity-regexp 'https://github.com/${{ github.repository }}/.github/workflows/release-image.yml@.*' \\
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+          \`\`\`
+
+          ### Inspect SBOM / provenance
+
+          \`\`\`
+          docker buildx imagetools inspect ${IMAGE}@${DIGEST} --format '{{ json .SBOM }}'
+          docker buildx imagetools inspect ${IMAGE}@${DIGEST} --format '{{ json .Provenance }}'
+          \`\`\`
+          EOF
+          )
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Updating existing release $TAG"
+            gh release edit "$TAG" --notes "$notes"
+          else
+            echo "Creating new release $TAG"
+            gh release create "$TAG" --title "$TAG" --notes "$notes"
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,12 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 # Run as non-root. The process needs read access to /custom/ (processor
 # scripts mounted via ConfigMap by client#86) and write access to whatever
 # PVC the Helm chart mounts at the configured DEST_PATH.
-USER nobody
+#
+# Numeric UID (not the `nobody` name) is required so Pods with
+# securityContext.runAsNonRoot: true admit on clusters that enforce the
+# restricted Pod Security Standard — the kubelet can only verify
+# non-root at admission time when the image USER is numeric. 65534 is
+# the `nobody` UID on Debian/Ubuntu/Alpine.
+USER 65534
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,51 @@
-# Use Python 3.11 as base image
-FROM python:3.11
+# syntax=docker/dockerfile:1.7
+#
+# Official tracebloc data-ingestor image (#45).
+#
+# The image entrypoint is the declarative `tracebloc-ingest` console script
+# registered by setup.py (#44). The Helm subchart (client#86) mounts the
+# customer's ingest.yaml at the path pointed to by INGEST_CONFIG. No customer
+# Python script lives in the image; no customer-built Dockerfile is needed.
 
-# Set working directory
+# ---- Builder: produce a wheel from the source in this repo so the image
+#       ships the exact code being released (not whatever's on PyPI). ----
+FROM python:3.11-slim AS builder
+WORKDIR /build
+
+COPY setup.py requirements.txt Readme.md ./
+COPY tracebloc_ingestor/ tracebloc_ingestor/
+
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+ && pip wheel --no-deps --wheel-dir /wheels .
+
+# ---- Runtime ----
+FROM python:3.11-slim
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y netcat-traditional
+# Runtime deps:
+#   netcat-traditional — docker-entrypoint.sh uses `nc -z` to wait for MySQL.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends netcat-traditional \
+ && rm -rf /var/lib/apt/lists/*
 
-# Install data ingestor package
-RUN pip install tracebloc_ingestor
+# Install dependencies first (cacheable layer), then the wheel built above.
+# Using --no-deps on the wheel avoids re-resolving against PyPI; deps come
+# from requirements.txt so the resolution is reproducible at release time.
+COPY requirements.txt /tmp/requirements.txt
+COPY --from=builder /wheels/*.whl /tmp/
+RUN pip install --no-cache-dir -r /tmp/requirements.txt \
+ && pip install --no-cache-dir --no-deps /tmp/*.whl \
+ && rm /tmp/*.whl /tmp/requirements.txt
 
-# Copy the user's chosen ingestor (rename a template to ./ingestor.py before building) # train/test switch
-COPY ingestor.py /app/ingestor.py
-
-
-# Set environment variables
-ENV PYTHONPATH=/app
-# Disable GPU/CUDA usage
 ENV CUDA_VISIBLE_DEVICES=-1
 ENV TF_CPP_MIN_LOG_LEVEL=2
 
-# Create an entrypoint script
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# Set the entrypoint
-ENTRYPOINT ["docker-entrypoint.sh"] 
+# Run as non-root. The process needs read access to /custom/ (processor
+# scripts mounted via ConfigMap by client#86) and write access to whatever
+# PVC the Helm chart mounts at the configured DEST_PATH.
+USER nobody
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,10 @@
 include Readme.md
 include requirements.txt
-include LICENSE 
+include LICENSE
+# Bundle the v1 ingest schema with the sdist. The wheel picks it up via
+# setup.py's package_data once schema/__init__.py exists, but sdists go
+# through MANIFEST.in — without this line a source distribution would
+# be missing the schema and any consumer building from sdist (some
+# air-gapped pip installs do this) would hit the same FileNotFoundError
+# the wheel bug surfaced in cluster testing.
+recursive-include tracebloc_ingestor/schema *.json

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,31 @@
-#!/bin/bash
+#!/bin/sh
+# Wait for MySQL, then hand off to the YAML-driven entrypoint registered by
+# setup.py (`tracebloc-ingest`, defined in #44). The Helm subchart (client#86)
+# mounts ingest.yaml and sets INGEST_CONFIG to its path; this script does not
+# need to know about that — it just exec's the console script.
 
-# Wait for MySQL to be ready
-echo "Waiting for MySQL to be ready..."
-while ! nc -z $MYSQL_HOST 3306; do
+set -e
+
+if [ -z "$MYSQL_HOST" ]; then
+  echo "ERROR: MYSQL_HOST must be set (the tracebloc client provides this)" >&2
+  exit 64
+fi
+
+# Bound the MySQL wait so a misconfigured client surfaces a clear failure
+# instead of hanging the Job indefinitely.
+WAIT_SECONDS="${MYSQL_WAIT_SECONDS:-120}"
+echo "Waiting up to ${WAIT_SECONDS}s for MySQL at ${MYSQL_HOST}:3306..."
+i=0
+until nc -z "$MYSQL_HOST" 3306; do
+  i=$((i + 1))
+  if [ "$i" -ge "$WAIT_SECONDS" ]; then
+    echo "ERROR: MySQL not reachable at ${MYSQL_HOST}:3306 after ${WAIT_SECONDS}s" >&2
+    exit 65
+  fi
   sleep 1
 done
-echo "MySQL is ready!"
+echo "MySQL is ready."
 
-# Run the CSV ingestor
-python ingestor.py "$@" # train/test switch
+# exec so the Python process becomes PID 1 and Kubernetes signal handling
+# (SIGTERM on Pod deletion, etc.) reaches the application directly.
+exec tracebloc-ingest "$@"

--- a/examples/yaml/custom_processor.yaml
+++ b/examples/yaml/custom_processor.yaml
@@ -1,0 +1,33 @@
+# Custom processor escape hatch: when convention defaults aren't enough,
+# customers can plug in a `BaseProcessor` subclass *without* building their
+# own Docker image.
+#
+# How it lands in the cluster:
+#   - The Helm subchart (client#86) takes the script body as a chart value.
+#   - The chart writes a ConfigMap holding the script.
+#   - The ingestor pod mounts the ConfigMap at /custom/.
+#   - The official image dynamically imports the file, instantiates the named
+#     class with `args`, and applies it to every record before persistence.
+#
+# Example use case below: a healthcare dataset where one column holds
+# AES-encrypted PHI that must be decrypted in the cluster before the schema
+# validator runs. The decryption logic lives in the customer's own script.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: phi_records_train
+intent: train
+category: tabular_classification
+csv: /data/records.csv
+schema:
+  patient_id: VARCHAR(255)
+  age: INT
+  encrypted_diagnosis: VARCHAR(1024)
+  outcome: VARCHAR(64)
+label: outcome
+spec:
+  processors:
+    - script: /custom/decrypt.py
+      class: AESDecryptor
+      args:
+        column: encrypted_diagnosis
+        key_secret: phi-key

--- a/examples/yaml/image_classification.yaml
+++ b/examples/yaml/image_classification.yaml
@@ -1,0 +1,15 @@
+# The dominant case: 8 lines, no `spec` block needed.
+# `category: image_classification` implies:
+#   - data_format: image
+#   - default file_options: target_size [512, 512], extension .jpg
+#   - default validators: [FileTypeValidator(images), ImageResolutionValidator,
+#                         TableNameValidator, DuplicateValidator]
+#   - default columns: image_id (data_id source), label (the column you set below)
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: chest_xrays_train
+intent: train
+category: image_classification
+csv: /data/labels.csv
+images: /data/images/
+label: image_label

--- a/examples/yaml/keypoint_detection.yaml
+++ b/examples/yaml/keypoint_detection.yaml
@@ -1,0 +1,10 @@
+# Keypoint detection: image + per-image keypoint coordinates carried in the CSV.
+# Same validator surface as image_classification (no XML, no masks).
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: pose_train
+intent: train
+category: keypoint_detection
+csv: /data/labels.csv
+images: /data/images/
+label: image_label

--- a/examples/yaml/masked_language_modeling.yaml
+++ b/examples/yaml/masked_language_modeling.yaml
@@ -1,0 +1,10 @@
+# Masked language modeling: CSV manifest + .txt sidecar files (one per sequence).
+# Self-supervised — no label column required.
+# `sequences:` directory holds space-separated token sequences from graph random walks.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: primekg_mlm_train
+intent: train
+category: masked_language_modeling
+csv: /data/labels_file.csv
+sequences: /data/sequences/

--- a/examples/yaml/object_detection.yaml
+++ b/examples/yaml/object_detection.yaml
@@ -1,0 +1,12 @@
+# Object detection: image + Pascal VOC XML annotations.
+# `category: object_detection` implies validators include PascalVOCXMLValidator
+# and a separate FileTypeValidator(.xml) for the annotations directory.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: visdrone_train
+intent: train
+category: object_detection
+csv: /data/labels.csv
+images: /data/images/
+annotations: /data/annotations/
+label: image_label

--- a/examples/yaml/semantic_segmentation.yaml
+++ b/examples/yaml/semantic_segmentation.yaml
@@ -1,0 +1,12 @@
+# Semantic segmentation: image + per-image PNG mask.
+# `masks:` directory is convention-mapped one-mask-per-image; the mask file
+# extension is forced to .png by the default validator set.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: tumors_train
+intent: train
+category: semantic_segmentation
+csv: /data/labels.csv
+images: /data/images/
+masks: /data/masks/
+label: image_label

--- a/examples/yaml/tabular_classification.yaml
+++ b/examples/yaml/tabular_classification.yaml
@@ -1,0 +1,15 @@
+# Tabular classification: CSV only, no sidecar files.
+# `schema:` types every column; DataValidator enforces them on read.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: churn_train
+intent: train
+category: tabular_classification
+csv: /data/customers.csv
+schema:
+  age: INT
+  tenure_months: INT
+  monthly_charge: FLOAT
+  contract_type: VARCHAR(64)
+  churned: VARCHAR(8)
+label: churned

--- a/examples/yaml/tabular_regression.yaml
+++ b/examples/yaml/tabular_regression.yaml
@@ -1,0 +1,19 @@
+# Tabular regression: a regression-class task, so `label.policy` is REQUIRED.
+# `bucket` bins the target value before the central backend ever sees it,
+# preventing raw target leakage. `passthrough` is allowed but only after the
+# customer has cleared compliance — schema validation does not enforce this.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: house_prices_train
+intent: train
+category: tabular_regression
+csv: /data/houses.csv
+schema:
+  square_feet: FLOAT
+  bedrooms: INT
+  bathrooms: FLOAT
+  age_years: INT
+  price: FLOAT
+label:
+  column: price
+  policy: bucket

--- a/examples/yaml/text_classification.yaml
+++ b/examples/yaml/text_classification.yaml
@@ -1,0 +1,14 @@
+# Text classification: CSV + .txt sidecar files (one per row, named by text_id).
+# `texts:` directory is convention-mapped; default extension is .txt.
+# `schema:` is required so DataValidator can typecheck the CSV columns.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: support_tickets_train
+intent: train
+category: text_classification
+csv: /data/labels.csv
+texts: /data/texts/
+schema:
+  text_id: VARCHAR(255)
+  label: VARCHAR(64)
+label: label

--- a/examples/yaml/time_series_forecasting.yaml
+++ b/examples/yaml/time_series_forecasting.yaml
@@ -1,0 +1,18 @@
+# Time-series forecasting: regression-class task, so `label.policy` is REQUIRED.
+# `schema:` must include a `timestamp` column (any case) — the framework
+# detects it via TimeFormatValidator and uses it for ordering.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: energy_demand_train
+intent: train
+category: time_series_forecasting
+csv: /data/demand.csv
+schema:
+  timestamp: VARCHAR(64)
+  region: VARCHAR(32)
+  temperature_c: FLOAT
+  is_holiday: INT
+  demand_mw: FLOAT
+label:
+  column: demand_mw
+  policy: bucket

--- a/examples/yaml/time_to_event_prediction.yaml
+++ b/examples/yaml/time_to_event_prediction.yaml
@@ -1,0 +1,19 @@
+# Time-to-event (survival) prediction: regression-class task, so `label.policy`
+# is REQUIRED. `time_column` names the column TimeToEventValidator treats as
+# the event-time field; falls back to `time` if unset.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: customer_churn_survival_train
+intent: train
+category: time_to_event_prediction
+csv: /data/survival.csv
+time_column: tenure_days
+schema:
+  customer_id: VARCHAR(64)
+  tenure_days: INT
+  plan_tier: VARCHAR(32)
+  monthly_spend: FLOAT
+  churned: INT
+label:
+  column: churned
+  policy: bucket

--- a/ingestor-job.yaml
+++ b/ingestor-job.yaml
@@ -25,9 +25,9 @@ spec:
         # Backend auth — deprecated fallback (slated for removal one minor
         # version after BACKEND_TOKEN support is wired up via client#86).
         - name: CLIENT_ID
-          value: "08ec78b9-871c-4fe1-8414-6a0ab3d268e3"
+          value: "<repalce_with_client_id>"
         - name: CLIENT_PASSWORD
-          value: "2unfcsowu4fh!8Uxz23fj"
+          value: "<replace_with_client_pass>"
         - name: CLIENT_PVC
           value: "client-pvc"
         - name: MYSQL_HOST

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,10 @@ Pillow>=10.0.0
 # CSV/JSON handling
 pandas>=2.0.0
 
+# YAML config + JSON Schema validation (for the declarative ingest.yaml flow)
+PyYAML>=6.0
+jsonschema>=4.0.0
+
 # Logging and monitoring
 python-json-logger>=2.0.0
 

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,18 @@ setup(
     packages=find_packages(),
     package_data={
         "": ["Readme.md"],
+        "tracebloc_ingestor.schema": ["*.json"],
     },
     include_package_data=True,
+    entry_points={
+        # Registered as the official image's entrypoint (Ticket #45). The Helm
+        # subchart (Ticket client#86) sets INGEST_CONFIG to the path of the
+        # mounted ingest.yaml; this console script reads it, validates against
+        # schema/ingest.v1.json, and dispatches to the right ingestor.
+        "console_scripts": [
+            "tracebloc-ingest = tracebloc_ingestor.cli.run:main",
+        ],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="tracebloc_ingestor",
-    version="0.2.10",
+    version="0.3.0",
     author="Tracebloc",
     author_email="support@tracebloc.com",
     description="A flexible data ingestion library for various file formats",

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.11",
     install_requires=requirements,
 )

--- a/templates/masked_language_modeling/README.md
+++ b/templates/masked_language_modeling/README.md
@@ -1,0 +1,91 @@
+# Masked Language Modeling Data Ingestion Template
+
+This template demonstrates how to ingest pre-tokenized text sequences for masked language modeling (MLM) into a database using the tracebloc_ingestor framework.
+
+## Directory Structure
+
+```
+masked_language_modeling/
+├── masked_language_modeling.py   # Main ingestion script
+├── README.md                     # This file
+└── data/
+    ├── sequences/                # Text files (.txt), one per sequence
+    │   ├── seq_0000001.txt
+    │   ├── seq_0000002.txt
+    │   ├── seq_0000003.txt
+    │   ├── seq_0000004.txt
+    │   └── seq_0000005.txt
+    └── labels_file_sample.csv    # CSV manifest mapping filenames to extensions
+```
+
+## Data Format
+
+### Text Files
+- Supported extension: `.txt`
+- One space-separated token sequence per file, placed in `data/sequences/`
+- Each sequence is typically a random walk over a knowledge graph (e.g. PrimeKG)
+- Example: `"Lepirudin indication Huntington phenotype_present Chorea"`
+
+### CSV Labels File
+MLM is **self-supervised** — no label column is needed. The CSV contains:
+- `filename`: Base name of the text file, without extension (e.g. `seq_0000001`)
+- `extension`: File extension as a quoted string (e.g. `'.txt'`)
+
+## Preprocessing
+
+The text sequences are generated from a knowledge graph using the preprocessing scripts in the `tracebloc-client` repo:
+
+```bash
+# Step 1: Download and reformat PrimeKG
+python prep_primekg.py --output-dir ./primekg_data
+
+# Step 2: Generate random walk corpus
+python graph_to_corpus.py \
+    --nodes primekg_data/nodes.csv \
+    --edges primekg_data/edges.csv \
+    --output-dir ./output \
+    --walk-length 5 \
+    --walks-per-node 30 \
+    --seed 42
+```
+
+This produces the `labels_file.csv` + `sequences/` directory consumed by this ingestor.
+
+## Usage
+
+1. Place your `.txt` sequence files in `data/sequences/`
+2. Update `labels_file_sample.csv` with one row per sequence file
+3. Configure environment variables (see below)
+4. Run the ingestion script:
+
+```bash
+python masked_language_modeling.py
+```
+
+## Configuration
+
+The script uses the following configuration:
+- **Extension**: TXT - Expected text file extension
+- **Chunk Size**: 100 - Batch size for CSV reading
+- **Encoding**: utf-8
+- **Category**: MASKED_LANGUAGE_MODELING
+- **Data Format**: TEXT
+- **Intent**: TRAIN (change to `Intent.TEST` for evaluation data)
+- **Label column**: None (self-supervised)
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TABLE_NAME` | Target database table | Required |
+| `LABEL_FILE` | Path to CSV manifest | Required |
+| `SRC_PATH` | Path to sequences directory | Required |
+| `BATCH_SIZE` | Ingestion batch size | 4000 |
+| `BACKEND_TOKEN` | Auth token for API | Required |
+| `CLIENT_ENV` | Environment (local/dev/stg/prod) | prod |
+
+## Notes
+
+- The `filename` column does **not** include the extension — that's supplied separately via the `extension` column.
+- No `label` column is needed because MLM training is self-supervised (masking is applied on-the-fly by the training client).
+- A `tokenizer.json` file should be placed alongside the data on the dataset path. The MLM client will load it automatically. See the preprocessing scripts for tokenizer generation.

--- a/templates/masked_language_modeling/data/labels_file_sample.csv
+++ b/templates/masked_language_modeling/data/labels_file_sample.csv
@@ -1,0 +1,6 @@
+filename,extension
+seq_0000001,'.txt'
+seq_0000002,'.txt'
+seq_0000003,'.txt'
+seq_0000004,'.txt'
+seq_0000005,'.txt'

--- a/templates/masked_language_modeling/data/sequences/seq_0000001.txt
+++ b/templates/masked_language_modeling/data/sequences/seq_0000001.txt
@@ -1,0 +1,1 @@
+Lepirudin indication Huntington phenotype_present Chorea associated_with Dystonia

--- a/templates/masked_language_modeling/data/sequences/seq_0000002.txt
+++ b/templates/masked_language_modeling/data/sequences/seq_0000002.txt
@@ -1,0 +1,1 @@
+Soliris target TP53 associated_with Breast_cancer contraindication Methotrexate

--- a/templates/masked_language_modeling/data/sequences/seq_0000003.txt
+++ b/templates/masked_language_modeling/data/sequences/seq_0000003.txt
@@ -1,0 +1,1 @@
+BRCA1 ppi RAD51 expression_present Breast_tissue interacts_with ESR1

--- a/templates/masked_language_modeling/data/sequences/seq_0000004.txt
+++ b/templates/masked_language_modeling/data/sequences/seq_0000004.txt
@@ -1,0 +1,1 @@
+Aspirin indication Headache parent-child Pain phenotype_present Fever

--- a/templates/masked_language_modeling/data/sequences/seq_0000005.txt
+++ b/templates/masked_language_modeling/data/sequences/seq_0000005.txt
@@ -1,0 +1,1 @@
+EGFR target Gefitinib associated_with Lung_cancer expression_present Lung

--- a/templates/masked_language_modeling/masked_language_modeling.py
+++ b/templates/masked_language_modeling/masked_language_modeling.py
@@ -1,0 +1,89 @@
+"""Masked Language Modeling Data Ingestion Example.
+
+This example demonstrates how to ingest pre-tokenized text sequences for
+masked language modeling (MLM) into a database and optionally send metadata
+to the tracebloc API.
+
+MLM is self-supervised — no label column is needed.  Each row in the CSV
+maps to a .txt file containing a space-separated token sequence (e.g. a
+random walk over a knowledge graph).  The MLM client applies masking
+on-the-fly during training.
+"""
+
+import logging
+import os
+from typing import Dict, Any
+
+from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor.utils.logging import setup_logging
+from tracebloc_ingestor.utils.constants import (
+    TaskCategory,
+    Intent,
+    DataFormat,
+    FileExtension,
+)
+
+# Initialize config and configure logging
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+
+# Text file options
+text_options = {"extension": FileExtension.TXT}
+
+# CSV specific options
+csv_options = {
+    "chunk_size": 100,
+    "delimiter": ",",
+    "quotechar": '"',
+    "escapechar": "\\",
+    "on_bad_lines": "warn",
+    "encoding": "utf-8",
+}
+
+
+def main():
+    """Run the masked language modeling ingestion example."""
+    try:
+        # Initialize components
+        database = Database(config)
+        api_client = APIClient(config)
+
+        # Create ingestor for MLM data
+        # No label_column — MLM is self-supervised
+        ingestor = CSVIngestor(
+            database=database,
+            api_client=api_client,
+            table_name=config.TABLE_NAME,
+            data_format=DataFormat.TEXT,
+            category=TaskCategory.MASKED_LANGUAGE_MODELING,
+            csv_options=csv_options,
+            file_options=text_options,
+            intent=Intent.TRAIN,
+        )
+
+        # Ingest data with validation
+        logger.info("Starting masked language modeling ingestion with data validation...")
+        with ingestor:
+            failed_records = ingestor.ingest(
+                config.LABEL_FILE, batch_size=config.BATCH_SIZE
+            )
+            if failed_records:
+                logger.warning(f"Failed to process {len(failed_records)} records")
+                for record in failed_records:
+                    logger.warning(
+                        f"Failed record: {record.get('filename', 'Unknown')}"
+                    )
+                    logger.warning(
+                        f"Error details: {record.get('error', 'Unknown error')}"
+                    )
+            else:
+                logger.info("All records processed successfully")
+
+    except Exception as e:
+        logger.error(f"Ingestion failed: {str(e)}")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api_client_auth.py
+++ b/tests/test_api_client_auth.py
@@ -33,7 +33,7 @@ def _make_config(**overrides) -> Config:
     Default: a valid prod-like config with BACKEND_TOKEN set so ``validate()``
     passes; tests override only the auth fields they care about. DB creds are
     not part of the validation surface (they're bundled-MySQL conventions),
-    so they're left at their dataclass defaults here.
+    so they're left to their env/property defaults here.
     """
     defaults = dict(
         BACKEND_TOKEN="test-token-abc",

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -1,0 +1,416 @@
+"""End-to-end-but-mocked tests for the ``tracebloc-ingest`` entrypoint.
+
+These tests exercise the full ``main()`` flow without spinning up MySQL or
+hitting the network. ``Database`` and ``APIClient`` are patched at the
+``cli.run`` import boundary so they construct cleanly without env vars.
+
+Coverage:
+
+- INGEST_CONFIG missing / pointing at a non-existent file → exit 2 with a
+  clear stderr message and no DB / network calls.
+- Malformed YAML → same.
+- Schema validation failure → exit 2, message lists every error by
+  json-pointer path, no DB / network calls.
+- Happy path (CSV) → constructs ``CSVIngestor`` with the resolved kwargs,
+  calls ``ingest()`` exactly once with the right path, exits 0.
+- Happy path (JSON) → constructs ``JSONIngestor`` instead.
+- ``spec.processors[]`` triggers the deferred-feature warning and the
+  rest of the run continues.
+- Legacy env vars (``SRC_PATH``, ``TABLE_NAME``, ``LABEL_FILE``) are set
+  from the resolved config before ``Config()`` is constructed, so the
+  framework's existing path-resolution layer keeps working unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples" / "yaml"
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Strip all the env vars the entrypoint reads / writes so each test
+    starts from a known state. Use ``monkeypatch.setenv`` from inside the
+    test for anything it actually wants to set."""
+    for var in (
+        "INGEST_CONFIG",
+        "SRC_PATH",
+        "TABLE_NAME",
+        "LABEL_FILE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def mock_runtime():
+    """Patch the heavy runtime — Database, APIClient, and Config — at the
+    cli.run import boundary. Returns the mock objects so tests can assert
+    on calls."""
+    with patch("tracebloc_ingestor.cli.run.Config") as mock_config_cls, \
+         patch("tracebloc_ingestor.cli.run.Database") as mock_db_cls, \
+         patch("tracebloc_ingestor.cli.run.APIClient") as mock_api_cls, \
+         patch("tracebloc_ingestor.cli.run.CSVIngestor") as mock_csv_cls, \
+         patch("tracebloc_ingestor.cli.run.JSONIngestor") as mock_json_cls, \
+         patch("tracebloc_ingestor.cli.run.setup_logging") as mock_setup_logging:
+        mock_config = MagicMock()
+        mock_config.BATCH_SIZE = 4000
+        mock_config_cls.return_value = mock_config
+
+        # Both ingestor classes share the same context-manager + ingest()
+        # surface; tests just inspect which one was constructed.
+        for cls_mock in (mock_csv_cls, mock_json_cls):
+            instance = MagicMock()
+            instance.__enter__ = MagicMock(return_value=instance)
+            instance.__exit__ = MagicMock(return_value=False)
+            instance.ingest = MagicMock(return_value=[])  # no failed records
+            cls_mock.return_value = instance
+
+        yield {
+            "Config": mock_config_cls,
+            "Database": mock_db_cls,
+            "APIClient": mock_api_cls,
+            "CSVIngestor": mock_csv_cls,
+            "JSONIngestor": mock_json_cls,
+            "setup_logging": mock_setup_logging,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Failure modes — must fail fast, no DB / network calls.
+# ---------------------------------------------------------------------------
+
+def test_missing_ingest_config_fails_fast(clean_env, mock_runtime, capsys):
+    from tracebloc_ingestor.cli.run import main
+    rc = main()
+    assert rc == 2
+    assert "INGEST_CONFIG" in capsys.readouterr().err
+    mock_runtime["Database"].assert_not_called()
+    mock_runtime["APIClient"].assert_not_called()
+
+
+def test_nonexistent_ingest_config_fails_fast(clean_env, mock_runtime, monkeypatch, capsys):
+    monkeypatch.setenv("INGEST_CONFIG", "/nope/does/not/exist.yaml")
+    from tracebloc_ingestor.cli.run import main
+    rc = main()
+    assert rc == 2
+    assert "does not exist" in capsys.readouterr().err
+    mock_runtime["Database"].assert_not_called()
+
+
+def test_malformed_yaml_fails_fast(clean_env, mock_runtime, monkeypatch, capsys, tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("apiVersion: tracebloc.io/v1\n  kind: ::: invalid", encoding="utf-8")
+    monkeypatch.setenv("INGEST_CONFIG", str(bad))
+
+    from tracebloc_ingestor.cli.run import main
+    rc = main()
+    assert rc == 2
+    assert "not valid YAML" in capsys.readouterr().err
+    mock_runtime["Database"].assert_not_called()
+
+
+def test_schema_violation_fails_fast(clean_env, mock_runtime, monkeypatch, capsys, tmp_path):
+    """A config that passes YAML parsing but fails schema validation must
+    exit before any DB/network call, listing the failures."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        # Missing `table`, `csv`, `images`, `label` — schema must reject.
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: image_classification\n"
+        "intent: train\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(bad))
+
+    from tracebloc_ingestor.cli.run import main
+    rc = main()
+
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "validation failed" in err
+    # Should mention at least one of the missing fields.
+    assert "table" in err or "csv" in err or "images" in err or "label" in err
+    mock_runtime["Database"].assert_not_called()
+    mock_runtime["APIClient"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Happy path — CSV
+# ---------------------------------------------------------------------------
+
+def test_csv_happy_path(clean_env, mock_runtime, monkeypatch):
+    monkeypatch.setenv(
+        "INGEST_CONFIG", str(EXAMPLES_DIR / "image_classification.yaml")
+    )
+
+    from tracebloc_ingestor.cli.run import main
+    rc = main()
+
+    assert rc == 0
+    # CSVIngestor was constructed; JSONIngestor was not.
+    assert mock_runtime["CSVIngestor"].call_count == 1
+    assert mock_runtime["JSONIngestor"].call_count == 0
+
+    # ingest() called exactly once with the source path from the YAML.
+    csv_instance = mock_runtime["CSVIngestor"].return_value
+    csv_instance.ingest.assert_called_once()
+    args, kwargs = csv_instance.ingest.call_args
+    assert args[0] == "/data/labels.csv"
+    assert kwargs.get("batch_size") == 4000
+
+
+def test_csv_kwargs_match_resolved_config(clean_env, mock_runtime, monkeypatch):
+    monkeypatch.setenv(
+        "INGEST_CONFIG", str(EXAMPLES_DIR / "image_classification.yaml")
+    )
+    from tracebloc_ingestor.cli.run import main
+    main()
+
+    _, kwargs = mock_runtime["CSVIngestor"].call_args
+    assert kwargs["table_name"] == "chest_xrays_train"
+    assert kwargs["intent"] == "train"
+    assert kwargs["category"] == "image_classification"
+    assert kwargs["data_format"] == "image"
+    assert kwargs["label_column"] == "image_label"
+    assert kwargs["unique_id_column"] is None  # UUID generation, the default
+    # File / CSV options carry the conventional defaults.
+    assert kwargs["file_options"]["target_size"] == [512, 512]
+    assert kwargs["file_options"]["extension"] == ".jpg"
+    assert kwargs["csv_options"]["chunk_size"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# Happy path — JSON
+# ---------------------------------------------------------------------------
+
+def test_json_happy_path(clean_env, mock_runtime, monkeypatch, tmp_path):
+    """No JSON example ships in examples/yaml/; build one inline."""
+    cfg = tmp_path / "json_config.yaml"
+    cfg.write_text(
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: tabular_classification\n"
+        "table: events_train\n"
+        "intent: train\n"
+        "json: /data/events.json\n"
+        "schema:\n"
+        "  event_type: VARCHAR(64)\n"
+        "  outcome: VARCHAR(8)\n"
+        "label: outcome\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(cfg))
+
+    from tracebloc_ingestor.cli.run import main
+    rc = main()
+
+    assert rc == 0
+    assert mock_runtime["CSVIngestor"].call_count == 0
+    assert mock_runtime["JSONIngestor"].call_count == 1
+    json_instance = mock_runtime["JSONIngestor"].return_value
+    json_instance.ingest.assert_called_once_with("/data/events.json", batch_size=4000)
+
+
+def test_json_receives_file_options_for_time_to_event(
+    clean_env, mock_runtime, monkeypatch, tmp_path
+):
+    """JSON source + time_to_event_prediction must propagate `time_column`
+    via file_options so map_validators picks up the right TimeToEventValidator
+    config. Regression guard for the dispatch-layer drop."""
+    cfg = tmp_path / "tte.yaml"
+    cfg.write_text(
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: time_to_event_prediction\n"
+        "table: tte_train\n"
+        "intent: train\n"
+        "json: /data/events.json\n"
+        "time_column: event_time\n"
+        "schema:\n"
+        "  event_time: DATETIME\n"
+        "  duration: FLOAT\n"
+        "label:\n"
+        "  column: duration\n"
+        "  policy: bucket\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(cfg))
+
+    from tracebloc_ingestor.cli.run import main
+    main()
+
+    _, kwargs = mock_runtime["JSONIngestor"].call_args
+    assert kwargs["file_options"]["time_column"] == "event_time"
+
+
+# ---------------------------------------------------------------------------
+# Deferred-feature warning for processors
+# ---------------------------------------------------------------------------
+
+def test_processors_trigger_warning_but_run_continues(
+    clean_env, mock_runtime, monkeypatch, caplog
+):
+    monkeypatch.setenv(
+        "INGEST_CONFIG", str(EXAMPLES_DIR / "custom_processor.yaml")
+    )
+    with caplog.at_level(logging.WARNING, logger="tracebloc_ingestor.cli.run"):
+        from tracebloc_ingestor.cli.run import main
+        rc = main()
+
+    assert rc == 0
+    # Run continued (CSVIngestor was constructed and ingest() was called).
+    assert mock_runtime["CSVIngestor"].call_count == 1
+    # But the warning fired.
+    assert any(
+        "spec.processors" in r.message and "client#86" in r.message
+        for r in caplog.records
+    )
+
+
+def test_validators_override_triggers_warning(
+    clean_env, mock_runtime, monkeypatch, caplog, tmp_path
+):
+    """spec.validators is schema-accepted but the runtime path isn't built
+    yet — the entrypoint must warn instead of silently dropping it."""
+    cfg = tmp_path / "ingest.yaml"
+    cfg.write_text(
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: image_classification\n"
+        "table: t\n"
+        "intent: train\n"
+        "csv: /data/labels.csv\n"
+        "images: /data/images/\n"
+        "label: image_label\n"
+        "spec:\n"
+        "  validators: [FileTypeValidator, TableNameValidator]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(cfg))
+
+    with caplog.at_level(logging.WARNING, logger="tracebloc_ingestor.cli.run"):
+        from tracebloc_ingestor.cli.run import main
+        rc = main()
+
+    assert rc == 0
+    assert mock_runtime["CSVIngestor"].call_count == 1
+    assert any("spec.validators" in r.message for r in caplog.records)
+
+
+def test_sidecars_triggers_warning(
+    clean_env, mock_runtime, monkeypatch, caplog, tmp_path
+):
+    """spec.sidecars is schema-accepted but the runtime path isn't built
+    yet — the entrypoint must warn instead of silently dropping it."""
+    cfg = tmp_path / "ingest.yaml"
+    cfg.write_text(
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: image_classification\n"
+        "table: t\n"
+        "intent: train\n"
+        "csv: /data/labels.csv\n"
+        "images: /data/images/\n"
+        "label: image_label\n"
+        "spec:\n"
+        "  sidecars:\n"
+        "    - {column: filename, source: /other/images/}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(cfg))
+
+    with caplog.at_level(logging.WARNING, logger="tracebloc_ingestor.cli.run"):
+        from tracebloc_ingestor.cli.run import main
+        rc = main()
+
+    assert rc == 0
+    assert mock_runtime["CSVIngestor"].call_count == 1
+    assert any("spec.sidecars" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Legacy env-var bridge
+# ---------------------------------------------------------------------------
+
+def test_legacy_env_vars_set_before_config_construction(
+    clean_env, mock_runtime, monkeypatch
+):
+    """The entrypoint must set SRC_PATH / TABLE_NAME / LABEL_FILE so any
+    downstream code that reads env lazily picks them up."""
+    monkeypatch.setenv(
+        "INGEST_CONFIG", str(EXAMPLES_DIR / "image_classification.yaml")
+    )
+
+    # Capture env state at the moment Config() is invoked.
+    captured_env = {}
+    def _capture_env(*args, **kwargs):
+        captured_env["TABLE_NAME"] = os.environ.get("TABLE_NAME")
+        captured_env["LABEL_FILE"] = os.environ.get("LABEL_FILE")
+        captured_env["SRC_PATH"] = os.environ.get("SRC_PATH")
+        return mock_runtime["Config"].return_value
+
+    mock_runtime["Config"].side_effect = _capture_env
+
+    from tracebloc_ingestor.cli.run import main
+    main()
+
+    assert captured_env["TABLE_NAME"] == "chest_xrays_train"
+    assert captured_env["LABEL_FILE"] == "/data/labels.csv"
+    # SRC_PATH = parent of `images:` dir, since file_transfer.py joins
+    # SRC_PATH/images/<filename>.
+    assert captured_env["SRC_PATH"] == "/data"
+
+
+def test_file_transfer_config_patched_in_place(clean_env, mock_runtime, monkeypatch):
+    """``file_transfer`` holds a module-level ``config = Config()`` captured
+    at import time, before the entrypoint runs. Because ``Config`` is a
+    dataclass whose ``os.getenv`` defaults are evaluated at class-definition
+    time, neither setting env vars nor re-instantiating ``Config()`` would
+    reach that captured instance. The bridge must mutate it in place."""
+    monkeypatch.setenv(
+        "INGEST_CONFIG", str(EXAMPLES_DIR / "image_classification.yaml")
+    )
+
+    from tracebloc_ingestor import file_transfer
+
+    # Poison the captured config with values the entrypoint should overwrite.
+    monkeypatch.setattr(file_transfer.config, "TABLE_NAME", "STALE_TABLE")
+    monkeypatch.setattr(file_transfer.config, "LABEL_FILE", "/stale/labels.csv")
+    monkeypatch.setattr(file_transfer.config, "SRC_PATH", "/stale/src")
+    monkeypatch.setattr(file_transfer.config, "DEST_PATH", "/stale/dest")
+    storage_path = file_transfer.config.STORAGE_PATH
+
+    from tracebloc_ingestor.cli.run import main
+    main()
+
+    assert file_transfer.config.TABLE_NAME == "chest_xrays_train"
+    assert file_transfer.config.LABEL_FILE == "/data/labels.csv"
+    assert file_transfer.config.SRC_PATH == "/data"
+    # DEST_PATH is STORAGE_PATH/<table> — file_transfer joins onto it.
+    assert file_transfer.config.DEST_PATH == os.path.join(storage_path, "chest_xrays_train")
+
+
+# ---------------------------------------------------------------------------
+# Failed-records non-zero exit
+# ---------------------------------------------------------------------------
+
+def test_failed_records_yield_nonzero_exit(clean_env, mock_runtime, monkeypatch):
+    monkeypatch.setenv(
+        "INGEST_CONFIG", str(EXAMPLES_DIR / "image_classification.yaml")
+    )
+    csv_instance = mock_runtime["CSVIngestor"].return_value
+    csv_instance.ingest.return_value = [{"image_id": "broken"}]  # one failure
+
+    from tracebloc_ingestor.cli.run import main
+    rc = main()
+
+    assert rc == 1  # not 0, not 2 (which is reserved for fail-fast)

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -370,23 +370,25 @@ def test_legacy_env_vars_set_before_config_construction(
     assert captured_env["SRC_PATH"] == "/data"
 
 
-def test_file_transfer_config_patched_in_place(clean_env, mock_runtime, monkeypatch):
+def test_file_transfer_config_reads_env_lazily(clean_env, mock_runtime, monkeypatch):
     """``file_transfer`` holds a module-level ``config = Config()`` captured
-    at import time, before the entrypoint runs. Because ``Config`` is a
-    dataclass whose ``os.getenv`` defaults are evaluated at class-definition
-    time, neither setting env vars nor re-instantiating ``Config()`` would
-    reach that captured instance. The bridge must mutate it in place."""
+    at import time, before the entrypoint runs. ``Config``'s env-driven
+    fields are lazy properties, so the bridge just needs to set env vars
+    — the captured instance reads them on next access.
+
+    This test pre-sets env to a stale value, runs the entrypoint (which
+    must overwrite env from the resolved YAML), and verifies the captured
+    ``file_transfer.config`` reflects the post-main env."""
     monkeypatch.setenv(
         "INGEST_CONFIG", str(EXAMPLES_DIR / "image_classification.yaml")
     )
 
     from tracebloc_ingestor import file_transfer
 
-    # Poison the captured config with values the entrypoint should overwrite.
-    monkeypatch.setattr(file_transfer.config, "TABLE_NAME", "STALE_TABLE")
-    monkeypatch.setattr(file_transfer.config, "LABEL_FILE", "/stale/labels.csv")
-    monkeypatch.setattr(file_transfer.config, "SRC_PATH", "/stale/src")
-    monkeypatch.setattr(file_transfer.config, "DEST_PATH", "/stale/dest")
+    # Pre-poison env so the entrypoint has to overwrite it.
+    monkeypatch.setenv("TABLE_NAME", "STALE_TABLE")
+    monkeypatch.setenv("LABEL_FILE", "/stale/labels.csv")
+    monkeypatch.setenv("SRC_PATH", "/stale/src")
     storage_path = file_transfer.config.STORAGE_PATH
 
     from tracebloc_ingestor.cli.run import main
@@ -395,7 +397,8 @@ def test_file_transfer_config_patched_in_place(clean_env, mock_runtime, monkeypa
     assert file_transfer.config.TABLE_NAME == "chest_xrays_train"
     assert file_transfer.config.LABEL_FILE == "/data/labels.csv"
     assert file_transfer.config.SRC_PATH == "/data"
-    # DEST_PATH is STORAGE_PATH/<table> — file_transfer joins onto it.
+    # DEST_PATH is derived from STORAGE_PATH/<table> via property — no
+    # in-place patching needed.
     assert file_transfer.config.DEST_PATH == os.path.join(storage_path, "chest_xrays_train")
 
 

--- a/tests/test_config_lazy.py
+++ b/tests/test_config_lazy.py
@@ -1,0 +1,159 @@
+"""Lock in ``Config``'s lazy-property contract.
+
+The bug this protects against (see #97): validators import
+``config = Config()`` at module top-level. When ``Config`` was a
+``@dataclass`` with ``os.getenv`` defaults, those fields were frozen at
+class-definition time, long before the declarative entrypoint set
+``SRC_PATH`` / ``TABLE_NAME`` / ``LABEL_FILE`` from the resolved YAML.
+Customers hit ``Path does not exist`` against a laptop-default path
+nobody had set.
+
+These tests verify:
+  - env set before ``Config()`` flows through (baseline).
+  - env mutated *after* ``Config()`` flows through (the regression).
+  - validators that captured ``config = Config()`` at import time observe
+    later env mutations (the cluster bug).
+  - ``Config(SRC_PATH=...)`` overrides env (test ergonomics).
+  - Laptop-path defaults are gone — unset env returns empty string / None.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.config import Config
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Strip the env vars these tests read/write."""
+    for var in (
+        "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
+        "BACKEND_TOKEN", "CLIENT_ID", "CLIENT_PASSWORD",
+        "CLIENT_ENV", "LOG_LEVEL", "BATCH_SIZE",
+        "MYSQL_HOST", "MYSQL_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_env_set_before_construction_flows_through(clean_env, monkeypatch):
+    monkeypatch.setenv("SRC_PATH", "/data/cats-dogs/images")
+    monkeypatch.setenv("TABLE_NAME", "cats_dogs_train")
+    monkeypatch.setenv("LABEL_FILE", "/data/cats-dogs/labels.csv")
+
+    config = Config()
+
+    assert config.SRC_PATH == "/data/cats-dogs/images"
+    assert config.TABLE_NAME == "cats_dogs_train"
+    assert config.LABEL_FILE == "/data/cats-dogs/labels.csv"
+    assert config.DEST_PATH == "/data/shared/cats_dogs_train"
+
+
+def test_env_mutation_after_construction_flows_through(clean_env, monkeypatch):
+    """The exact bug from the cluster: a validator imports ``config = Config()``,
+    the entrypoint sets ``SRC_PATH`` later, and the validator must see the
+    new value."""
+    config = Config()
+    assert config.SRC_PATH == ""  # no env, no laptop default
+
+    monkeypatch.setenv("SRC_PATH", "/data/customer/images")
+    assert config.SRC_PATH == "/data/customer/images"
+
+    monkeypatch.setenv("SRC_PATH", "/data/customer/v2/images")
+    assert config.SRC_PATH == "/data/customer/v2/images"
+
+
+def test_module_level_validator_config_picks_up_env_change(clean_env, monkeypatch):
+    """Validators capture ``config = Config()`` at module import. After the
+    entrypoint sets env, ``file_validator.config.SRC_PATH`` must reflect
+    the new value — that's the cluster bug repro."""
+    from tracebloc_ingestor.validators import file_validator
+
+    monkeypatch.setenv("SRC_PATH", "/data/shared/sample-image-classification")
+    assert file_validator.config.SRC_PATH == "/data/shared/sample-image-classification"
+
+    monkeypatch.setenv("SRC_PATH", "/data/shared/other-customer")
+    assert file_validator.config.SRC_PATH == "/data/shared/other-customer"
+
+
+def test_instance_override_wins_over_env(clean_env, monkeypatch):
+    monkeypatch.setenv("BACKEND_TOKEN", "from-env")
+    monkeypatch.setenv("SRC_PATH", "/from/env")
+
+    config = Config(BACKEND_TOKEN="from-override", SRC_PATH="/from/override")
+
+    assert config.BACKEND_TOKEN == "from-override"
+    assert config.SRC_PATH == "/from/override"
+
+
+def test_explicit_none_override_suppresses_env(clean_env, monkeypatch):
+    """Tests pass ``BACKEND_TOKEN=None`` to *disable* the token path even
+    when env has one set. Sentinel-based override-lookup distinguishes
+    'absent' from 'explicit None'."""
+    monkeypatch.setenv("BACKEND_TOKEN", "leaked-from-env")
+
+    config = Config(BACKEND_TOKEN=None)
+    assert config.BACKEND_TOKEN is None
+
+
+def test_unknown_override_kwarg_raises(clean_env):
+    with pytest.raises(TypeError) as exc:
+        Config(NOT_A_REAL_FIELD="x")
+    assert "NOT_A_REAL_FIELD" in str(exc.value)
+
+
+@pytest.mark.parametrize("field", ["DB_PORT", "BATCH_SIZE"])
+def test_numeric_override_rejects_none_at_construction(clean_env, field):
+    """``None`` is a valid suppression for nullable fields (BACKEND_TOKEN
+    etc.) but is nonsensical for numeric ones whose properties do
+    ``int(...)``. The constructor must reject this with a helpful message
+    rather than deferring to a ``TypeError: int() argument must be a
+    string ...`` on first property access."""
+    with pytest.raises(TypeError) as exc:
+        Config(**{field: None})
+    msg = str(exc.value)
+    assert field in msg
+    assert "None" in msg
+
+
+@pytest.mark.parametrize("field,value", [("DB_PORT", 3307), ("BATCH_SIZE", "8000")])
+def test_numeric_override_accepts_ints_and_str_ints(clean_env, field, value):
+    config = Config(**{field: value})
+    assert getattr(config, field) == int(value)
+
+
+def test_laptop_path_defaults_are_gone(clean_env):
+    """The pre-refactor defaults pointed at ``~/Downloads/data-ingestors/...``,
+    which silently scanned a developer laptop dir on customer clusters."""
+    config = Config()
+    assert config.SRC_PATH == ""
+    assert config.LABEL_FILE == ""
+    assert config.TABLE_NAME == ""
+    assert config.TITLE is None
+
+    # And no stray "Downloads" anywhere — be paranoid about regressions
+    # where someone reintroduces a laptop path.
+    assert "Downloads" not in (config.SRC_PATH or "")
+    assert "Downloads" not in (config.LABEL_FILE or "")
+
+
+def test_dest_path_follows_table_name(clean_env, monkeypatch):
+    monkeypatch.setenv("TABLE_NAME", "first_table")
+    config = Config()
+    assert config.DEST_PATH == "/data/shared/first_table"
+
+    monkeypatch.setenv("TABLE_NAME", "second_table")
+    assert config.DEST_PATH == "/data/shared/second_table"
+
+
+def test_api_endpoint_follows_edge_env(clean_env, monkeypatch):
+    config = Config()
+    assert config.EDGE_ENV == "prod"
+    assert config.API_ENDPOINT == "https://api.tracebloc.io"
+
+    monkeypatch.setenv("CLIENT_ENV", "stg")
+    assert config.EDGE_ENV == "stg"
+    assert config.API_ENDPOINT == "https://stg-api.tracebloc.io"
+
+    monkeypatch.setenv("CLIENT_ENV", "local")
+    assert config.API_ENDPOINT == "http://localhost:8000"

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -1,0 +1,338 @@
+"""Tests for the convention-defaults resolver in ``cli/conventions.py``.
+
+These tests pin the contract between the YAML schema (#44 commit 1) and the
+ingestor constructor surface. They run as pure-function tests — no DB, no
+network, no env reads — so they catch resolver regressions in milliseconds.
+
+What they cover:
+
+- Every example in ``examples/yaml/`` round-trips through ``resolve()``.
+- Each category's ``data_format`` matches the framework's existing
+  ``DataFormat`` enum.
+- Convention defaults (csv_options, image target_size, default extensions)
+  are filled in when the customer doesn't override.
+- Customer overrides win over defaults.
+- ``label`` shorthand and object forms produce equivalent ``ResolvedConfig``
+  for classification, and the explicit object form's policy carries through
+  for regression-class.
+- ``data_id.strategy`` correctly drives ``unique_id_column``.
+- The ``processor_specs`` pass through verbatim.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+import yaml
+
+from tracebloc_ingestor.cli.conventions import (
+    DEFAULT_CSV_OPTIONS,
+    DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY,
+    DEFAULT_TEXT_FILE_OPTIONS,
+    IMAGE_CATEGORIES,
+    REGRESSION_CLASS_CATEGORIES,
+    ResolvedConfig,
+    resolve,
+)
+from tracebloc_ingestor.utils.constants import DataFormat, TaskCategory
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples" / "yaml"
+
+
+def _load(name: str) -> Dict[str, Any]:
+    return yaml.safe_load((EXAMPLES_DIR / name).read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: every shipped example resolves without error.
+# ---------------------------------------------------------------------------
+
+EXAMPLES = sorted(p.name for p in EXAMPLES_DIR.glob("*.yaml"))
+
+
+@pytest.mark.parametrize("name", EXAMPLES)
+def test_example_resolves(name: str):
+    resolved = resolve(_load(name))
+    assert isinstance(resolved, ResolvedConfig)
+    assert resolved.category
+    assert resolved.table_name
+    assert resolved.intent in {"train", "test"}
+    assert resolved.data_format in {
+        DataFormat.IMAGE,
+        DataFormat.TEXT,
+        DataFormat.TABULAR,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Identity & source dispatch
+# ---------------------------------------------------------------------------
+
+def test_image_classification_data_format():
+    r = resolve(_load("image_classification.yaml"))
+    assert r.data_format == DataFormat.IMAGE
+    assert r.source_type == "csv"
+    assert r.source_path == "/data/labels.csv"
+    assert r.images == "/data/images/"
+
+
+def test_text_classification_data_format():
+    r = resolve(_load("text_classification.yaml"))
+    assert r.data_format == DataFormat.TEXT
+    assert r.texts == "/data/texts/"
+
+
+def test_tabular_classification_data_format():
+    r = resolve(_load("tabular_classification.yaml"))
+    assert r.data_format == DataFormat.TABULAR
+
+
+def test_time_series_data_format_is_tabular():
+    """Time-series flows through the tabular ingestor path; data_format reflects that."""
+    r = resolve(_load("time_series_forecasting.yaml"))
+    assert r.data_format == DataFormat.TABULAR
+
+
+def test_object_detection_sidecars_set():
+    r = resolve(_load("object_detection.yaml"))
+    assert r.images == "/data/images/"
+    assert r.annotations == "/data/annotations/"
+    assert r.masks is None
+    assert r.texts is None
+
+
+def test_semantic_segmentation_sidecars_set():
+    r = resolve(_load("semantic_segmentation.yaml"))
+    assert r.images == "/data/images/"
+    assert r.masks == "/data/masks/"
+    assert r.annotations is None
+
+
+# ---------------------------------------------------------------------------
+# Default options
+# ---------------------------------------------------------------------------
+
+def test_image_classification_gets_512x512_default():
+    r = resolve(_load("image_classification.yaml"))
+    assert r.file_options == DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[
+        TaskCategory.IMAGE_CLASSIFICATION
+    ]
+
+
+def test_object_detection_gets_448x448_default():
+    """Object detection's template historically uses 448×448, not 512×512."""
+    r = resolve(_load("object_detection.yaml"))
+    assert r.file_options == DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[
+        TaskCategory.OBJECT_DETECTION
+    ]
+    assert r.file_options["target_size"] == [448, 448]
+
+
+def test_keypoint_detection_gets_448x448_default():
+    """Keypoint detection's template also uses 448×448."""
+    r = resolve(_load("keypoint_detection.yaml"))
+    assert r.file_options == DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[
+        TaskCategory.KEYPOINT_DETECTION
+    ]
+    assert r.file_options["target_size"] == [448, 448]
+
+
+def test_text_classification_gets_text_file_option_defaults():
+    r = resolve(_load("text_classification.yaml"))
+    assert r.file_options == DEFAULT_TEXT_FILE_OPTIONS
+
+
+def test_tabular_has_no_file_options():
+    r = resolve(_load("tabular_classification.yaml"))
+    assert r.file_options == {}
+
+
+def test_csv_options_default_when_unspecified():
+    r = resolve(_load("image_classification.yaml"))
+    assert r.csv_options == DEFAULT_CSV_OPTIONS
+
+
+def test_customer_csv_options_override_defaults():
+    config = _load("image_classification.yaml")
+    config["spec"] = {"csv_options": {"chunk_size": 50, "delimiter": "\t"}}
+    r = resolve(config)
+    # chunk_size and delimiter overridden, quotechar/escapechar still defaulted.
+    assert r.csv_options["chunk_size"] == 50
+    assert r.csv_options["delimiter"] == "\t"
+    assert r.csv_options["quotechar"] == DEFAULT_CSV_OPTIONS["quotechar"]
+    assert r.csv_options["escapechar"] == DEFAULT_CSV_OPTIONS["escapechar"]
+
+
+def test_customer_file_options_override_defaults():
+    config = _load("image_classification.yaml")
+    config["spec"] = {"file_options": {"target_size": [224, 224]}}
+    r = resolve(config)
+    assert r.file_options["target_size"] == [224, 224]
+    # extension still defaulted.
+    assert r.file_options["extension"] == DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[
+        TaskCategory.IMAGE_CLASSIFICATION
+    ]["extension"]
+
+
+# ---------------------------------------------------------------------------
+# Label resolution
+# ---------------------------------------------------------------------------
+
+def test_string_label_resolves_to_passthrough_policy():
+    r = resolve(_load("image_classification.yaml"))
+    assert r.label_column == "image_label"
+    assert r.label_policy == "passthrough"
+
+
+def test_object_label_with_passthrough_policy():
+    config = _load("image_classification.yaml")
+    config["label"] = {"column": "image_label", "policy": "passthrough"}
+    r = resolve(config)
+    assert r.label_column == "image_label"
+    assert r.label_policy == "passthrough"
+
+
+def test_regression_label_carries_bucket_policy():
+    r = resolve(_load("tabular_regression.yaml"))
+    assert r.label_column == "price"
+    assert r.label_policy == "bucket"
+
+
+def test_object_label_without_policy_defaults_to_passthrough():
+    """Non-regression categories may omit policy on the object form."""
+    config = _load("image_classification.yaml")
+    config["label"] = {"column": "image_label"}  # no policy key
+    r = resolve(config)
+    assert r.label_policy == "passthrough"
+
+
+# ---------------------------------------------------------------------------
+# data_id resolution
+# ---------------------------------------------------------------------------
+
+def test_no_data_id_block_means_uuid_generation():
+    r = resolve(_load("image_classification.yaml"))
+    assert r.unique_id_column is None
+
+
+def test_uuid_strategy_explicit():
+    config = _load("image_classification.yaml")
+    config["data_id"] = {"strategy": "uuid"}
+    r = resolve(config)
+    assert r.unique_id_column is None
+
+
+def test_column_strategy_sets_unique_id_column():
+    config = _load("image_classification.yaml")
+    config["data_id"] = {"strategy": "column", "column": "image_id"}
+    r = resolve(config)
+    assert r.unique_id_column == "image_id"
+
+
+# ---------------------------------------------------------------------------
+# Schema, time_column, processors
+# ---------------------------------------------------------------------------
+
+def test_tabular_schema_passes_through():
+    r = resolve(_load("tabular_classification.yaml"))
+    assert "age" in r.schema
+    assert r.schema["age"] == "INT"
+
+
+def test_time_to_event_carries_time_column():
+    r = resolve(_load("time_to_event_prediction.yaml"))
+    assert r.time_column == "tenure_days"
+    # Step 7a bridges the top-level field into file_options where the
+    # validator expects it.
+    assert r.file_options["time_column"] == "tenure_days"
+
+
+def test_time_to_event_spec_file_options_time_column_wins_over_top_level():
+    """spec.file_options is the advanced override surface; an explicit
+    spec value must beat the top-level shorthand. Regression guard against
+    overwriting the spec value with the top-level field."""
+    config = _load("time_to_event_prediction.yaml")
+    config.setdefault("spec", {}).setdefault("file_options", {})["time_column"] = "override_time"
+    r = resolve(config)
+    assert r.file_options["time_column"] == "override_time"
+
+
+def test_processor_specs_pass_through_verbatim():
+    r = resolve(_load("custom_processor.yaml"))
+    assert len(r.processor_specs) == 1
+    spec = r.processor_specs[0]
+    assert spec["script"] == "/custom/decrypt.py"
+    assert spec["class"] == "AESDecryptor"
+    assert spec["args"]["column"] == "encrypted_diagnosis"
+
+
+def test_no_processors_means_empty_list():
+    r = resolve(_load("image_classification.yaml"))
+    assert r.processor_specs == []
+
+
+# ---------------------------------------------------------------------------
+# Per-category convention details
+# ---------------------------------------------------------------------------
+
+def test_keypoint_detection_uses_annotation_column_convention():
+    """The existing keypoint_detection template uses column "Annotation";
+    the resolver bakes that convention in so customers don't have to."""
+    r = resolve(_load("keypoint_detection.yaml"))
+    assert r.annotation_column == "Annotation"
+
+
+def test_other_categories_have_no_annotation_column():
+    r = resolve(_load("image_classification.yaml"))
+    assert r.annotation_column is None
+
+
+def test_regression_class_set_matches_schema_requirements():
+    """Sanity-check that REGRESSION_CLASS_CATEGORIES matches the schema's
+    `if/then` block requiring object-form label.policy."""
+    expected = {
+        TaskCategory.TABULAR_REGRESSION,
+        TaskCategory.TIME_SERIES_FORECASTING,
+        TaskCategory.TIME_TO_EVENT_PREDICTION,
+    }
+    assert REGRESSION_CLASS_CATEGORIES == expected
+
+
+def test_image_categories_set_matches_schema_requirements():
+    """The set of image-based categories must match the schema's
+    `if/then` block requiring `images:`."""
+    expected = {
+        TaskCategory.IMAGE_CLASSIFICATION,
+        TaskCategory.OBJECT_DETECTION,
+        TaskCategory.KEYPOINT_DETECTION,
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        TaskCategory.INSTANCE_SEGMENTATION,
+    }
+    assert IMAGE_CATEGORIES == expected
+
+
+# ---------------------------------------------------------------------------
+# JSON source path
+# ---------------------------------------------------------------------------
+
+def test_json_source_dispatches_correctly():
+    """No JSON example ships in examples/yaml/ today (CSV is dominant);
+    construct one inline to verify the dispatch path."""
+    config = {
+        "apiVersion": "tracebloc.io/v1",
+        "kind": "IngestConfig",
+        "category": TaskCategory.TABULAR_CLASSIFICATION,
+        "table": "events_train",
+        "intent": "train",
+        "json": "/data/events.json",
+        "schema": {"event_type": "VARCHAR(64)", "outcome": "VARCHAR(8)"},
+        "label": "outcome",
+    }
+    r = resolve(config)
+    assert r.source_type == "json"
+    assert r.source_path == "/data/events.json"

--- a/tests/test_csv_file_options.py
+++ b/tests/test_csv_file_options.py
@@ -1,0 +1,69 @@
+"""Regression tests for #93: CSVIngestor must not clobber the cleaned
+``file_options["schema"]`` that ``BaseIngestor.__init__`` injects.
+
+Before the fix, ``CSVIngestor.__init__`` re-assigned
+``self.file_options = file_options or {}`` after ``super().__init__``.
+On the new YAML path with tabular/time-series categories the caller
+passes ``file_options={}``, so the subclass replaced the dict base had
+populated with a fresh empty dict — the cleaned schema (and
+``number_of_columns``) were silently dropped before they reached
+``map_validators`` and the metadata API call.
+"""
+
+from unittest.mock import MagicMock
+
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+
+
+def _make_ingestor(schema, file_options, label_column=None):
+    """Build a CSVIngestor with mock DB/API so ``BaseIngestor.__init__``
+    runs end-to-end (including ``database.create_table``)."""
+    database = MagicMock()
+    api_client = MagicMock()
+    return CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name="t",
+        schema=schema,
+        file_options=file_options,
+        label_column=label_column,
+    )
+
+
+def test_yaml_path_empty_file_options_keeps_cleaned_schema():
+    """YAML path: caller passes file_options={}. The cleaned schema base
+    injects must survive subclass init."""
+    schema = {"feature_a": "str", "feature_b": "int", "label": "str"}
+    ing = _make_ingestor(schema=schema, file_options={}, label_column="label")
+
+    assert "schema" in ing.file_options, (
+        "subclass init wiped the schema base injected"
+    )
+    assert ing.file_options["schema"] == {"feature_a": "str", "feature_b": "int"}
+
+
+def test_template_path_existing_file_options_sanitized_and_resized():
+    """Old template path: caller passes file_options with its own schema
+    and ``number_of_columns``. Base must overwrite ``schema`` with the
+    cleaned version and update ``number_of_columns`` to match."""
+    schema = {"feature_a": "str", "feature_b": "int", "label": "str"}
+    file_options = {
+        "schema": schema,  # not yet cleaned — includes label_column
+        "number_of_columns": 3,
+        "custom_flag": True,  # unrelated keys must be preserved
+    }
+    ing = _make_ingestor(
+        schema=schema, file_options=file_options, label_column="label"
+    )
+
+    assert ing.file_options["schema"] == {"feature_a": "str", "feature_b": "int"}
+    assert ing.file_options["number_of_columns"] == 2
+    assert ing.file_options["custom_flag"] is True
+
+
+def test_file_options_none_keeps_cleaned_schema():
+    """Defensive: caller passes file_options=None (the default)."""
+    schema = {"feature_a": "str", "label": "str"}
+    ing = _make_ingestor(schema=schema, file_options=None, label_column="label")
+
+    assert ing.file_options["schema"] == {"feature_a": "str"}

--- a/tests/test_duplicate_validator.py
+++ b/tests/test_duplicate_validator.py
@@ -1,0 +1,58 @@
+"""Regression tests for #101: DuplicateValidator must allow reruns
+when the destination dir was left behind empty by a previous aborted
+ingestion.
+
+Before the fix, *any* existing destination directory failed validation,
+forcing customers to ``kubectl exec`` and ``rm -rf`` on the shared PVC
+between attempts. After the fix, an empty leftover dir passes with a
+warning; a populated dir still fails.
+"""
+
+import os
+
+from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
+
+
+def test_missing_destination_passes(tmp_path):
+    """Happy path: destination doesn't exist yet."""
+    dest = tmp_path / "fresh_table"
+    validator = DuplicateValidator(dest_path=str(dest))
+
+    result = validator.validate(data=None)
+
+    assert result.is_valid
+    assert result.errors == []
+    assert result.metadata["directory_exists"] is False
+
+
+def test_empty_destination_passes_with_warning(tmp_path):
+    """An empty leftover dir (previous run aborted before any data
+    landed) is reused, with a warning. This is the #101 case."""
+    dest = tmp_path / "leftover_empty_table"
+    dest.mkdir()
+    assert os.listdir(dest) == []
+    validator = DuplicateValidator(dest_path=str(dest))
+
+    result = validator.validate(data=None)
+
+    assert result.is_valid, f"unexpected errors: {result.errors}"
+    assert result.errors == []
+    assert any("empty" in w for w in result.warnings), result.warnings
+    assert result.metadata["directory_exists"] is True
+    assert result.metadata["directory_empty"] is True
+
+
+def test_non_empty_destination_fails(tmp_path):
+    """Populated destination is still treated as a real collision — we
+    must not clobber an existing dataset."""
+    dest = tmp_path / "populated_table"
+    dest.mkdir()
+    (dest / "row_0.png").write_bytes(b"not-actually-a-png")
+    validator = DuplicateValidator(dest_path=str(dest))
+
+    result = validator.validate(data=None)
+
+    assert not result.is_valid
+    assert any("already exists" in e for e in result.errors), result.errors
+    assert result.metadata["directory_exists"] is True
+    assert result.metadata["directory_empty"] is False

--- a/tests/test_file_transfer_has_extension.py
+++ b/tests/test_file_transfer_has_extension.py
@@ -1,0 +1,114 @@
+"""Regression tests for #105 — ``_has_extension`` must recognize valid
+suffixes.
+
+Before the fix, ``_has_extension`` did:
+
+    ext = filename.split(".")[-1]   # "jpeg" — no leading dot
+    return ext in allowed_extensions  # [".jpeg", ".jpg", ...]
+
+The membership check never matched (the allowed list has leading
+dots; the suffix doesn't), so the function always returned False.
+``_find_src`` then appended the configured extension a SECOND time,
+producing ``cat1.jpeg.jpeg`` paths that didn't exist on disk and
+silently failed every file_transfer.
+
+These tests pin the three classes of input that need to be handled:
+
+1. Filename with a valid extension (lowercase) → True
+2. Filename with a valid extension (uppercase) → True (case-insensitive)
+3. Filename without any extension → False
+4. Filename with a non-image extension (e.g. ``.tar``) → False
+5. Edge cases: empty string, leading dot only, multiple dots
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.file_transfer import _has_extension
+
+
+# ---------------------------------------------------------------------------
+# Positive cases — the regression that broke real ingestion runs.
+# ---------------------------------------------------------------------------
+
+
+def test_lowercase_jpeg_recognized():
+    """The exact filename pattern that failed in cluster validation
+    2026-05-19: ``cat1.jpeg`` from a CSV with ``filename,label``
+    columns."""
+    assert _has_extension("cat1.jpeg") is True
+
+
+def test_lowercase_jpg_recognized():
+    """``.jpg`` and ``.jpeg`` are both in FileExtension; both must work."""
+    assert _has_extension("photo.jpg") is True
+
+
+def test_lowercase_png_recognized():
+    assert _has_extension("mask.png") is True
+
+
+def test_uppercase_extension_recognized():
+    """Case-insensitive matching, consistent with
+    ImageResolutionValidator._is_image_file. Customers don't always
+    name their files lowercase, especially when sourced from a
+    DSLR or scanner."""
+    assert _has_extension("CAT1.JPEG") is True
+    assert _has_extension("Photo.Jpg") is True
+
+
+def test_xml_annotation_recognized():
+    """Object detection ships Pascal VOC XML — also in FileExtension."""
+    assert _has_extension("annotation.xml") is True
+
+
+def test_txt_recognized():
+    """Text classification sidecars."""
+    assert _has_extension("review_001.txt") is True
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — must still return False.
+# ---------------------------------------------------------------------------
+
+
+def test_no_extension_returns_false():
+    """A bare name with no dots — ``_find_src`` will correctly append
+    the configured extension."""
+    assert _has_extension("cat1") is False
+
+
+def test_unknown_extension_returns_false():
+    """Extensions outside FileExtension's allowlist (e.g. archive
+    formats, video) must return False so ``_find_src`` rejects them
+    rather than appending a second extension."""
+    assert _has_extension("archive.tar") is False
+    assert _has_extension("video.mp4") is False
+
+
+def test_empty_string_returns_false():
+    """Defensive: caller might pass empty string from a malformed
+    CSV row."""
+    assert _has_extension("") is False
+
+
+# ---------------------------------------------------------------------------
+# Tricky paths with multiple dots — the original ``split(".")``
+# logic was correct on these for length reasons; ``rsplit(".", 1)``
+# preserves that.
+# ---------------------------------------------------------------------------
+
+
+def test_dotted_basename_recognized():
+    """``my.file.jpeg`` — multiple dots but a valid trailing
+    extension. ``rsplit(".", 1)`` gives the last suffix, which is
+    what we want."""
+    assert _has_extension("my.file.jpeg") is True
+
+
+def test_dotted_basename_with_unknown_suffix_returns_false():
+    """Trailing suffix is the only one that counts. If the last
+    segment isn't in the allowlist, the function correctly returns
+    False even if an earlier segment looks like an extension."""
+    assert _has_extension("data.jpeg.tar") is False

--- a/tests/test_file_transfer_summary.py
+++ b/tests/test_file_transfer_summary.py
@@ -1,0 +1,343 @@
+"""Regression tests for issue #99 — the silent file_transfer failure
+pattern.
+
+Before the fix, ``image_transfer`` / ``annotation_transfer`` /
+``text_transfer`` returned the record unchanged when their source file
+was missing, so ``map_file_transfer`` returned a truthy record and
+``BaseIngestor.ingest`` happily wrote the row to the DB and pushed it to
+the API. The summary's "Inserted to Database" / "Sent to API" counters
+both incremented, and the customer-facing banner reported
+``🎉 Ingestion completed successfully!`` with 100% success — even though
+zero image files reached the destination directory.
+
+These tests pin three things:
+
+1. The single-file transfer functions return ``None`` on missing source.
+2. ``BaseIngestor.ingest`` increments ``file_transfer_failures`` (NOT
+   ``skipped_records``) for those records and surfaces them in the
+   ``failed_records`` list it returns to the CLI.
+3. ``IngestionSummary.has_failures`` is True whenever any non-trivial
+   failure occurred, so the "completed successfully" banner is gated
+   correctly.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tracebloc_ingestor import file_transfer
+from tracebloc_ingestor.ingestors.base import BaseIngestor, IngestionSummary
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+# ---------------------------------------------------------------------------
+# Unit: single-file transfer functions return None on missing source
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_dirs(tmp_path, monkeypatch):
+    """Point file_transfer's module-level Config at empty tmp dirs so any
+    transfer attempt resolves to a non-existent source.
+
+    Config exposes SRC_PATH as a lazy env-backed property and DEST_PATH
+    as a derived property (``STORAGE_PATH / TABLE_NAME``), so the
+    supported override path is env vars + a STORAGE_PATH override on
+    the module-level Config instance."""
+    src = tmp_path / "src"
+    storage = tmp_path / "storage"
+    src.mkdir()
+    storage.mkdir()
+    monkeypatch.setenv("SRC_PATH", str(src))
+    monkeypatch.setenv("TABLE_NAME", "test_table")
+    # STORAGE_PATH is a plain class attr (not env-driven), so override
+    # the live module-level Config snapshot directly.
+    monkeypatch.setattr(file_transfer.config, "STORAGE_PATH", str(storage))
+    return src, storage
+
+
+def test_image_transfer_returns_none_when_source_missing(isolated_dirs, caplog):
+    """Pre-fix: this returned the record (truthy), letting the DB write
+    proceed despite zero bytes landing on disk. Now: returns None and
+    the caller in BaseIngestor.ingest treats it as a file-transfer skip."""
+    record = {"filename": "does-not-exist", "data_id": "abc"}
+    with caplog.at_level(logging.ERROR):
+        result = file_transfer.image_transfer(record, {"extension": ".jpeg"})
+    assert result is None
+    assert any("Source image not found" in r.message for r in caplog.records)
+
+
+def test_text_transfer_returns_none_when_source_missing(isolated_dirs, caplog):
+    record = {"filename": "missing-doc", "data_id": "abc"}
+    with caplog.at_level(logging.ERROR):
+        result = file_transfer.text_transfer(record, {"extension": ".txt"})
+    assert result is None
+    assert any("Source text file not found" in r.message for r in caplog.records)
+
+
+def test_annotation_transfer_returns_none_when_source_missing(isolated_dirs, caplog):
+    record = {"filename": "missing", "data_id": "abc"}
+    with caplog.at_level(logging.ERROR):
+        result = file_transfer.annotation_transfer(record, {}, ".xml")
+    assert result is None
+    assert any("Source file not found" in r.message for r in caplog.records)
+
+
+def test_image_transfer_returns_none_when_filename_missing(isolated_dirs):
+    """A record arriving without a filename can never have its file
+    transferred — return None so the caller drops it rather than writing
+    a half-record to the DB."""
+    assert file_transfer.image_transfer({}, {"extension": ".jpeg"}) is None
+
+
+# ---------------------------------------------------------------------------
+# Unit: IngestionSummary.has_failures + banner gating
+# ---------------------------------------------------------------------------
+
+
+def _summary(**overrides) -> IngestionSummary:
+    base = dict(
+        ingestor_id="t",
+        total_records=10,
+        processed_records=10,
+        inserted_records=10,
+        api_sent_records=10,
+        failed_records=0,
+        skipped_records=0,
+        file_transfer_failures=0,
+    )
+    base.update(overrides)
+    return IngestionSummary(**base)
+
+
+def test_has_failures_false_on_clean_run():
+    assert _summary().has_failures is False
+
+
+def test_has_failures_true_when_file_transfer_failed():
+    """The headline regression: even if DB+API both reported all 10
+    records as successful, a single file-transfer failure must flip
+    has_failures so the banner can't say 'completed successfully'."""
+    s = _summary(file_transfer_failures=1, total_records=11, processed_records=10)
+    assert s.has_failures is True
+
+
+def test_has_failures_true_when_inserted_less_than_total():
+    assert _summary(inserted_records=9).has_failures is True
+
+
+def test_has_failures_true_when_api_short_of_inserted():
+    assert _summary(api_sent_records=9).has_failures is True
+
+
+def test_has_failures_true_when_db_failed():
+    assert _summary(failed_records=1).has_failures is True
+
+
+# ---------------------------------------------------------------------------
+# Behavior: _log_summary swaps the banner when failures are present
+# ---------------------------------------------------------------------------
+
+
+def _capture_summary(summary: IngestionSummary) -> str:
+    # _log_summary only reads `summary`, so we can call it on a bare
+    # MagicMock that satisfies the bound-method signature.
+    ingestor = MagicMock(spec=BaseIngestor)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        BaseIngestor._log_summary(ingestor, summary)
+    return buf.getvalue()
+
+
+def test_banner_drops_celebration_on_file_transfer_failure():
+    s = _summary(
+        total_records=576,
+        processed_records=576,
+        inserted_records=0,
+        api_sent_records=0,
+        file_transfer_failures=576,
+    )
+    out = _capture_summary(s)
+    assert "🎉 Ingestion completed successfully!" not in out
+    assert "completed with" in out
+    assert "576" in out  # the failure count appears in the banner
+
+
+def test_banner_total_does_not_double_count_file_transfer(capsys):
+    """Bugbot caught this: when every record fails file_transfer, the
+    failure count must be 576, NOT 1152. The bug was summing
+    file_transfer_failures alongside (total_records - api_sent_records),
+    but file-transfer failures never reach the API so they were counted
+    in both terms.
+
+    The failure channels are mutually exclusive per record:
+        file_transfer_failures  — never reached DB
+        failed_records          — DB failures; never reached API
+        api_only_failures       — inserted to DB but didn't ship
+    """
+    s = _summary(
+        total_records=576,
+        processed_records=576,
+        inserted_records=0,
+        api_sent_records=0,
+        file_transfer_failures=576,
+    )
+    out = _capture_summary(s)
+
+    # The "Failed to Send to API" line previously read 576 here too —
+    # double-counting the same records. Should be 0: nothing was
+    # inserted, so nothing was eligible for the API ship step.
+    assert "❌ Failed to Send to API:" in out
+    api_line = next(
+        line for line in out.splitlines() if "Failed to Send to API" in line
+    )
+    # ANSI color codes wrap the count, so check the digits don't include 576.
+    assert "576" not in api_line
+    assert ">0<" in api_line.replace("\x1b[91m", ">").replace("\x1b[0m", "<")
+
+    # The banner total appears only once and equals the unique failures.
+    assert "1,152" not in out
+    assert "1152" not in out
+
+
+def test_banner_total_correct_with_mixed_failure_modes():
+    """Sanity check: the three failure channels add up cleanly when all
+    three are non-zero."""
+    s = _summary(
+        total_records=100,
+        processed_records=95,  # 5 generic skips (not failures)
+        inserted_records=80,   # 15 DB failures
+        api_sent_records=70,   # 10 API-only failures
+        failed_records=15,
+        file_transfer_failures=5,
+    )
+    # Expected unique failure count: 5 (file) + 15 (DB) + 10 (API) = 30.
+    out = _capture_summary(s)
+    assert "30 failure" in out
+
+
+def test_banner_shows_file_transfer_failures_line():
+    s = _summary(file_transfer_failures=3, total_records=13, processed_records=10)
+    out = _capture_summary(s)
+    assert "File Transfer Failures" in out
+    assert "3" in out
+
+
+def test_banner_celebrates_only_on_truly_clean_run():
+    out = _capture_summary(_summary())
+    assert "🎉 Ingestion completed successfully!" in out
+
+
+# ---------------------------------------------------------------------------
+# Integration-ish: BaseIngestor.ingest plumbs file_transfer failures
+# through to the caller (so cli.run.main exits non-zero) and the summary
+# attributes them to the new counter.
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Captures the IngestionSummary that _log_summary is called with.
+
+    Installed via ``monkeypatch.setattr(BaseIngestor, "_log_summary", ...)``,
+    which stores the _Recorder instance as a class attribute. Because
+    _Recorder doesn't implement ``__get__``, instance access returns the
+    recorder itself (no descriptor binding), so ``self._log_summary(s)``
+    inside ``ingest()`` reduces to ``recorder(s)`` — hence the single
+    ``summary`` argument on ``__call__``.
+    """
+
+    def __init__(self):
+        self.summary: IngestionSummary | None = None
+
+    def __call__(self, summary):
+        self.summary = summary
+
+
+def test_ingest_counts_file_transfer_failures_separately(monkeypatch):
+    """End-to-end mocked: image_transfer is forced to return None on every
+    record. After the fix, the ingestor should:
+
+      * NOT increment ``inserted_records`` / ``api_sent_records`` for the
+        failed records,
+      * increment ``file_transfer_failures`` (NOT ``skipped_records``),
+      * append the failures to the returned list so cli.run.main exits 1,
+      * tick the tqdm progress bar for each failed record so an
+        all-transfer-failure run doesn't leave the bar stuck at 0/N
+        (bugbot regression — the `continue` previously skipped
+        ``pbar.update``).
+    """
+    records = [{"filename": f"row{i}", "extension": ".jpeg"} for i in range(5)]
+
+    # Force every map_file_transfer call to fail.
+    monkeypatch.setattr(
+        "tracebloc_ingestor.ingestors.base.map_file_transfer",
+        lambda category, record, options: None,
+    )
+
+    # Replace tqdm with a stub that records update() calls so we can
+    # assert the progress bar actually advances.
+    pbar_updates: list[int] = []
+
+    class _FakePbar:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def update(self, n):
+            pbar_updates.append(n)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("tracebloc_ingestor.ingestors.base.tqdm", _FakePbar)
+
+    captured = _Recorder()
+    monkeypatch.setattr(BaseIngestor, "_log_summary", captured)
+
+    # Patch out the API meta calls so we reach the summary block.
+    mock_api = MagicMock()
+    mock_api.send_generate_edge_label_meta.return_value = True
+    mock_api.send_global_meta_meta.return_value = True
+    mock_api.prepare_dataset.return_value = True
+
+    mock_db = MagicMock()
+    mock_db.create_table.return_value = MagicMock()
+    mock_db.get_table_schema.return_value = {}
+    mock_db.insert_batch.return_value = ([], [])
+
+    with patch.object(BaseIngestor, "__abstractmethods__", set()):
+        ingestor = BaseIngestor(
+            database=mock_db,
+            api_client=mock_api,
+            table_name="t",
+            schema={"filename": "VARCHAR(255)"},
+            category=TaskCategory.IMAGE_CLASSIFICATION,
+            intent="train",  # required for process_record to succeed
+        )
+        ingestor.read_data = lambda source: iter(records)
+        ingestor._count_records = lambda source: len(records)
+        ingestor.validate_data = lambda source: True
+
+        failed = ingestor.ingest("fake-source", batch_size=10)
+
+    assert captured.summary is not None, "summary was never logged"
+    assert captured.summary.file_transfer_failures == 5
+    assert captured.summary.skipped_records == 0  # NOT counted as generic skip
+    assert captured.summary.inserted_records == 0
+    assert captured.summary.api_sent_records == 0
+    assert captured.summary.has_failures is True
+
+    # The CLI exit-code path: cli.run.main returns 1 when this list is
+    # non-empty. Without the fix, a 100%-failed run returned [] and the
+    # K8s job marker was Succeeded.
+    assert len(failed) == 5
+    assert all(f["error"] == "file_transfer_failed" for f in failed)
+
+    # Bugbot regression: the file-transfer skip branch must advance the
+    # progress bar. Sum of ticks must reach total_records (5).
+    assert sum(pbar_updates) == 5

--- a/tests/test_image_validator_resolution.py
+++ b/tests/test_image_validator_resolution.py
@@ -1,0 +1,105 @@
+"""Regression tests for #104 — tuple-vs-list comparison in
+``_resolution_matches``.
+
+Before the fix, ``ImageResolutionValidator._resolution_matches`` did
+``actual == expected`` when ``tolerance == 0``. ``actual`` comes from
+PIL's ``image.size`` (a tuple); ``expected`` comes from YAML's
+``target_size: [H, W]`` (a list). Python's sequence equality is
+type-strict — ``(256, 256) == [256, 256]`` is False — so the
+default-tolerance path rejected every image whose dimensions matched
+exactly.
+
+These tests pin the tolerance==0 path against the four shape
+combinations (tuple/list × actual/expected) so the regression can't
+sneak back via either side switching types.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.validators.image_validator import ImageResolutionValidator
+
+
+@pytest.fixture
+def validator():
+    """Tolerance==0 validator pre-seeded with a 512x512 expected size.
+
+    Each test overrides ``expected_resolution`` on this instance as
+    needed; sharing the fixture keeps the tests focused on the
+    comparison behavior rather than constructor plumbing.
+    """
+    v = ImageResolutionValidator(expected_resolution=(512, 512))
+    assert v.tolerance == 0, "Default tolerance changed; tests need an update"
+    return v
+
+
+# ---------------------------------------------------------------------------
+# Exact matches across every tuple/list combination — these are the
+# regression cases. Before the fix only tuple==tuple returned True.
+# ---------------------------------------------------------------------------
+
+
+def test_tuple_actual_list_expected_matches(validator):
+    """The exact shape combo that failed in cluster validation 2026-05-19:
+    PIL gives a tuple, YAML gives a list."""
+    assert validator._resolution_matches((256, 256), [256, 256]) is True
+
+
+def test_list_actual_tuple_expected_matches(validator):
+    """Reverse — defensive in depth in case a caller pre-converts the
+    PIL side to a list before passing in."""
+    assert validator._resolution_matches([256, 256], (256, 256)) is True
+
+
+def test_tuple_tuple_matches(validator):
+    """The path that worked even before the fix — pinned so a
+    regression in normalization doesn't break it."""
+    assert validator._resolution_matches((256, 256), (256, 256)) is True
+
+
+def test_list_list_matches(validator):
+    """All-list path — exercises the tuple(actual)==tuple(expected)
+    normalization on both sides."""
+    assert validator._resolution_matches([256, 256], [256, 256]) is True
+
+
+# ---------------------------------------------------------------------------
+# Genuine mismatches — must still return False after the fix. (The bug
+# was over-rejection, so the risk of an over-correction is False
+# positives going green.)
+# ---------------------------------------------------------------------------
+
+
+def test_mismatch_returns_false_at_tolerance_zero(validator):
+    """A real dimension mismatch must still be rejected."""
+    assert validator._resolution_matches((512, 512), [256, 256]) is False
+    assert validator._resolution_matches((256, 256), [512, 512]) is False
+
+
+def test_mismatch_off_by_one_returns_false_at_tolerance_zero(validator):
+    """At tolerance 0, even a 1-pixel difference is a mismatch — the
+    tolerance>0 branch is a separate code path."""
+    assert validator._resolution_matches((256, 256), [256, 257]) is False
+    assert validator._resolution_matches((256, 257), [256, 256]) is False
+
+
+# ---------------------------------------------------------------------------
+# Tolerance>0 path — pinned so we don't regress the branch that was
+# already working before the fix.
+# ---------------------------------------------------------------------------
+
+
+def test_tolerance_branch_still_works_for_within_tolerance():
+    """The tolerance>0 branch already worked because it uses index
+    access. Pin that it still does."""
+    v = ImageResolutionValidator(expected_resolution=(256, 256))
+    v.tolerance = 5
+    assert v._resolution_matches((258, 254), [256, 256]) is True
+
+
+def test_tolerance_branch_rejects_outside_tolerance():
+    """And rejects when the difference exceeds the tolerance."""
+    v = ImageResolutionValidator(expected_resolution=(256, 256))
+    v.tolerance = 5
+    assert v._resolution_matches((270, 256), [256, 256]) is False

--- a/tests/test_label_policy.py
+++ b/tests/test_label_policy.py
@@ -1,0 +1,210 @@
+"""Tests for the label-policy bucketing module + the BaseIngestor wiring.
+
+The pure-function tests pin the bucketing contract:
+  - passthrough is a no-op
+  - bucket is stable, deterministic, in [0, NUM_BUCKETS)
+  - missing values produce MISSING_LABEL_BUCKET
+  - unknown policies raise
+
+The integration test pins that the policy fires inside ``BaseIngestor``
+just before the API payload is built, so the central backend never sees
+raw regression target values.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tracebloc_ingestor.utils import label_policy
+from tracebloc_ingestor.utils.label_policy import (
+    BUCKET,
+    MISSING_LABEL_BUCKET,
+    NUM_BUCKETS,
+    PASSTHROUGH,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure function: apply()
+# ---------------------------------------------------------------------------
+
+class TestPassthroughPolicy:
+    def test_string_value_unchanged(self):
+        assert label_policy.apply("benign", PASSTHROUGH) == "benign"
+
+    def test_numeric_value_unchanged(self):
+        assert label_policy.apply(42, PASSTHROUGH) == 42
+
+    def test_none_value_unchanged(self):
+        assert label_policy.apply(None, PASSTHROUGH) is None
+
+    def test_empty_string_unchanged(self):
+        assert label_policy.apply("", PASSTHROUGH) == ""
+
+
+class TestBucketPolicy:
+    def test_returns_int_in_range(self):
+        result = label_policy.apply("123.45", BUCKET)
+        assert isinstance(result, int)
+        assert 0 <= result < NUM_BUCKETS
+
+    def test_stable_for_same_input(self):
+        a = label_policy.apply(100, BUCKET)
+        b = label_policy.apply(100, BUCKET)
+        c = label_policy.apply("100", BUCKET)
+        assert a == b == c  # same string repr → same bucket
+
+    def test_different_inputs_likely_different_buckets(self):
+        # Not a strict requirement (collisions exist) but a sanity check
+        # against pathological hash collapse.
+        buckets = {label_policy.apply(i, BUCKET) for i in range(1000)}
+        # Should distribute reasonably across NUM_BUCKETS=64.
+        assert len(buckets) >= NUM_BUCKETS // 2
+
+    def test_none_value_returns_missing_sentinel(self):
+        assert label_policy.apply(None, BUCKET) == MISSING_LABEL_BUCKET
+
+    def test_empty_string_returns_missing_sentinel(self):
+        assert label_policy.apply("", BUCKET) == MISSING_LABEL_BUCKET
+
+    def test_whitespace_string_returns_missing_sentinel(self):
+        assert label_policy.apply("   ", BUCKET) == MISSING_LABEL_BUCKET
+
+    def test_nan_value_returns_missing_sentinel(self):
+        # pandas renders missing numeric cells as float('nan'). `str(nan)`
+        # is "nan" — non-empty — so an explicit isnan check is required
+        # to keep NaN labels out of the regular bucket space.
+        assert label_policy.apply(float("nan"), BUCKET) == MISSING_LABEL_BUCKET
+
+    def test_missing_sentinel_outside_valid_range(self):
+        # MISSING_LABEL_BUCKET must not collide with a real bucket.
+        assert MISSING_LABEL_BUCKET < 0 or MISSING_LABEL_BUCKET >= NUM_BUCKETS
+
+
+def test_unknown_policy_raises():
+    with pytest.raises(ValueError, match="Unknown label policy"):
+        label_policy.apply(42, "ohno")
+
+
+# ---------------------------------------------------------------------------
+# Integration: BaseIngestor wiring
+# ---------------------------------------------------------------------------
+#
+# We can't construct CSVIngestor / JSONIngestor without a working DB, but we
+# can construct BaseIngestor subclass-shape directly and exercise
+# _map_unique_id which is where the label-policy hook lives.
+
+class _TestIngestor:
+    """Minimal stand-in mimicking the BaseIngestor surface needed for
+    _map_unique_id, without invoking BaseIngestor.__init__ (which calls
+    Database.create_table)."""
+
+    def __init__(self, label_column, label_policy_value, intent="train"):
+        from tracebloc_ingestor.ingestors.base import BaseIngestor
+        # Bind the unbound method so `self` works.
+        self._map_unique_id = BaseIngestor._map_unique_id.__get__(self)
+        self.label_column = label_column
+        self.label_policy = label_policy_value
+        self.intent = intent
+        self.annotation_column = None
+        self.unique_id_column = None  # → UUID generation
+
+
+def test_base_ingestor_passthrough_does_not_mutate_label():
+    ing = _TestIngestor(label_column="label", label_policy_value=PASSTHROUGH)
+    cleaned = ing._map_unique_id(
+        record={"label": "cancer_positive"},
+        cleaned_record={},
+    )
+    assert cleaned["label"] == "cancer_positive"
+
+
+def test_base_ingestor_bucket_replaces_label_with_int():
+    ing = _TestIngestor(label_column="label", label_policy_value=BUCKET)
+    cleaned = ing._map_unique_id(
+        record={"label": 1234.56},
+        cleaned_record={},
+    )
+    assert isinstance(cleaned["label"], int)
+    assert 0 <= cleaned["label"] < NUM_BUCKETS
+
+
+def test_base_ingestor_bucket_stable_across_calls():
+    """Two records with the same label must land in the same bucket so the
+    central backend can group identical labels without seeing them."""
+    ing = _TestIngestor(label_column="label", label_policy_value=BUCKET)
+    a = ing._map_unique_id({"label": 99.5}, {})
+    b = ing._map_unique_id({"label": 99.5}, {})
+    assert a["label"] == b["label"]
+
+
+def test_base_ingestor_bucket_missing_label_uses_sentinel():
+    ing = _TestIngestor(label_column="label", label_policy_value=BUCKET)
+    cleaned = ing._map_unique_id({"label": None}, {})
+    assert cleaned["label"] == MISSING_LABEL_BUCKET
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint integration: regression YAML config flows through with bucket
+# ---------------------------------------------------------------------------
+
+def test_entrypoint_passes_bucket_policy_for_regression(tmp_path, monkeypatch):
+    """End-to-end-ish: a tabular_regression YAML reaches CSVIngestor with
+    label_policy='bucket' as kwarg, regardless of resolver internals."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    examples_dir = Path(__file__).resolve().parent.parent / "examples" / "yaml"
+    monkeypatch.setenv("INGEST_CONFIG", str(examples_dir / "tabular_regression.yaml"))
+
+    with patch("tracebloc_ingestor.cli.run.Config") as mock_config_cls, \
+         patch("tracebloc_ingestor.cli.run.Database"), \
+         patch("tracebloc_ingestor.cli.run.APIClient"), \
+         patch("tracebloc_ingestor.cli.run.CSVIngestor") as mock_csv_cls, \
+         patch("tracebloc_ingestor.cli.run.setup_logging"):
+        mock_config = MagicMock()
+        mock_config.BATCH_SIZE = 4000
+        mock_config_cls.return_value = mock_config
+        instance = MagicMock()
+        instance.__enter__ = MagicMock(return_value=instance)
+        instance.__exit__ = MagicMock(return_value=False)
+        instance.ingest = MagicMock(return_value=[])
+        mock_csv_cls.return_value = instance
+
+        from tracebloc_ingestor.cli.run import main
+        rc = main()
+
+    assert rc == 0
+    _, kwargs = mock_csv_cls.call_args
+    assert kwargs["label_policy"] == BUCKET
+
+
+def test_entrypoint_passes_passthrough_policy_for_classification(tmp_path, monkeypatch):
+    """And the inverse: classification gets passthrough."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    examples_dir = Path(__file__).resolve().parent.parent / "examples" / "yaml"
+    monkeypatch.setenv("INGEST_CONFIG", str(examples_dir / "image_classification.yaml"))
+
+    with patch("tracebloc_ingestor.cli.run.Config") as mock_config_cls, \
+         patch("tracebloc_ingestor.cli.run.Database"), \
+         patch("tracebloc_ingestor.cli.run.APIClient"), \
+         patch("tracebloc_ingestor.cli.run.CSVIngestor") as mock_csv_cls, \
+         patch("tracebloc_ingestor.cli.run.setup_logging"):
+        mock_config = MagicMock()
+        mock_config.BATCH_SIZE = 4000
+        mock_config_cls.return_value = mock_config
+        instance = MagicMock()
+        instance.__enter__ = MagicMock(return_value=instance)
+        instance.__exit__ = MagicMock(return_value=False)
+        instance.ingest = MagicMock(return_value=[])
+        mock_csv_cls.return_value = instance
+
+        from tracebloc_ingestor.cli.run import main
+        main()
+
+    _, kwargs = mock_csv_cls.call_args
+    assert kwargs["label_policy"] == PASSTHROUGH

--- a/tests/test_schema_bundled.py
+++ b/tests/test_schema_bundled.py
@@ -1,0 +1,69 @@
+"""Regression tests for #103 — bundled schema file must ship in the
+wheel.
+
+Before the fix, ``tracebloc_ingestor/schema/`` was not a Python package
+(no ``__init__.py``), so ``find_packages()`` ignored it and the
+``package_data`` declaration in ``setup.py`` referencing
+``tracebloc_ingestor.schema`` was a silent no-op. The built wheel
+shipped without ``ingest.v1.json`` and the released image crashed on
+first call to ``cli.run._load_schema`` with:
+
+    FileNotFoundError: [Errno 2] No such file or directory:
+    '/usr/local/lib/python3.11/site-packages/tracebloc_ingestor/schema/
+     ingest.v1.json'
+
+These tests pin two things:
+
+1. ``tracebloc_ingestor.schema`` is importable as a Python package
+   (i.e. the marker ``__init__.py`` is present).
+2. ``cli.run._load_schema`` resolves the schema file and returns a
+   well-formed dict — meaning the file is discoverable through the
+   same path the production code uses, not just on disk.
+
+These run against the installed package (``pip install -e .`` or
+the built wheel), so a future regression in the wheel-build pipeline
+would surface here, not three weeks later in cluster validation.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_schema_subpackage_is_importable():
+    """The marker __init__.py exists and the subpackage imports cleanly.
+
+    The wheel-bundling bug was caused by the absence of this marker —
+    setuptools silently skipped data files attached to a directory it
+    didn't see as a package. Asserting the import succeeds is the
+    cheapest possible canary for that regression.
+    """
+    mod = importlib.import_module("tracebloc_ingestor.schema")
+    assert mod is not None
+    # Sanity: the module's __file__ points at the directory's
+    # __init__.py, not somewhere unexpected.
+    assert mod.__file__ is not None
+    assert mod.__file__.endswith("__init__.py")
+
+
+def test_load_schema_returns_v1_definition():
+    """End-to-end: the production code path can load the schema.
+
+    This is the exact call site that crashed in cluster validation.
+    If the wheel ships without the JSON file, this raises
+    FileNotFoundError; if the JSON is present but malformed, it
+    raises json.JSONDecodeError. Both would be regressions.
+    """
+    from tracebloc_ingestor.cli.run import _load_schema
+
+    schema = _load_schema()
+    assert isinstance(schema, dict)
+    # The v1 schema has well-known top-level keys; pin the most
+    # invariant ones so a future schema bump doesn't silently
+    # invalidate this test.
+    assert schema.get("$schema") == "http://json-schema.org/draft-07/schema#"
+    assert schema.get("title") == "tracebloc IngestConfig (v1)"
+    assert "apiVersion" in schema.get("properties", {})
+    assert "category" in schema.get("properties", {})

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,0 +1,277 @@
+"""Schema validation for the declarative ``ingest.yaml`` config (v1).
+
+Covers the acceptance criteria that come from #44:
+
+- Every example in ``examples/yaml/`` validates against ``schema/ingest.v1.json``
+  (positive coverage for all task categories + the custom-processor escape
+  hatch).
+- Invalid ``category`` is rejected at validation, listing the valid options
+  via the JSON Schema enum.
+- Regression-class tasks missing ``label.policy`` are rejected at validation.
+- Unknown top-level fields are rejected (catches typos like ``catagory:`` or
+  ``lable:``).
+- Image-based categories without ``images``, ``object_detection`` without
+  ``annotations``, etc., are rejected.
+- Exactly one of ``csv`` / ``json`` is required.
+
+The tests don't run the entrypoint — that comes in a later commit's tests.
+This file's job is to lock the shape of the YAML surface in isolation.
+"""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft7Validator, ValidationError
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "tracebloc_ingestor" / "schema" / "ingest.v1.json"
+EXAMPLES_DIR = REPO_ROOT / "examples" / "yaml"
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def validator(schema) -> Draft7Validator:
+    Draft7Validator.check_schema(schema)
+    return Draft7Validator(schema)
+
+
+def _load_example(name: str) -> dict:
+    return yaml.safe_load((EXAMPLES_DIR / name).read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Positive coverage: every shipped example must validate.
+# ---------------------------------------------------------------------------
+
+EXAMPLES = sorted(p.name for p in EXAMPLES_DIR.glob("*.yaml"))
+
+
+@pytest.mark.parametrize("example_name", EXAMPLES)
+def test_example_validates(validator: Draft7Validator, example_name: str):
+    config = _load_example(example_name)
+    errors = sorted(validator.iter_errors(config), key=lambda e: e.path)
+    assert not errors, (
+        f"{example_name} failed schema validation:\n  "
+        + "\n  ".join(f"{list(e.absolute_path) or '<root>'}: {e.message}" for e in errors)
+    )
+
+
+def test_image_classification_is_eight_lines():
+    """The dominant case has to fit in ~8 lines, per #44 design constraint."""
+    body = (EXAMPLES_DIR / "image_classification.yaml").read_text(encoding="utf-8")
+    non_blank_non_comment = [
+        line for line in body.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert len(non_blank_non_comment) == 8, (
+        f"image_classification.yaml has {len(non_blank_non_comment)} payload "
+        f"lines, expected 8. Customers should not need more for the dominant case."
+    )
+
+
+def test_all_task_categories_covered():
+    """Every value in the schema's category enum has a corresponding example,
+    except instance_segmentation which has no template/validator support yet."""
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    enum_values = set(schema["properties"]["category"]["enum"])
+
+    covered = {
+        yaml.safe_load((EXAMPLES_DIR / name).read_text(encoding="utf-8"))["category"]
+        for name in EXAMPLES
+        if name != "custom_processor.yaml"  # uses tabular_classification, already covered
+    }
+
+    # instance_segmentation is in the enum but has no map_validators branch
+    # yet (no template either) — tracked separately.
+    expected = enum_values - {"instance_segmentation"}
+    missing = expected - covered
+    assert not missing, f"No example for categories: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Negative coverage: each rejection path the schema is supposed to enforce.
+# ---------------------------------------------------------------------------
+
+def _ic_base() -> dict:
+    """A known-good image_classification config to mutate per test."""
+    return _load_example("image_classification.yaml")
+
+
+def test_unknown_top_level_field_rejected(validator):
+    config = _ic_base()
+    config["lable"] = "image_label"  # typo
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_invalid_category_rejected_with_enum_in_message(validator):
+    config = _ic_base()
+    config["category"] = "image_klassification"  # typo
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate(config)
+    msg = str(exc_info.value.message)
+    # The error must point users at the valid set so they can fix it.
+    assert "image_classification" in msg
+
+
+def test_missing_table_rejected(validator):
+    config = _ic_base()
+    del config["table"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_missing_intent_rejected(validator):
+    config = _ic_base()
+    del config["intent"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_neither_csv_nor_json_rejected(validator):
+    config = _ic_base()
+    del config["csv"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_both_csv_and_json_rejected(validator):
+    config = _ic_base()
+    config["json"] = "/data/labels.json"
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_image_category_without_images_rejected(validator):
+    config = _ic_base()
+    del config["images"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_object_detection_without_annotations_rejected(validator):
+    config = _load_example("object_detection.yaml")
+    del config["annotations"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_semantic_segmentation_without_masks_rejected(validator):
+    config = _load_example("semantic_segmentation.yaml")
+    del config["masks"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_text_classification_without_texts_rejected(validator):
+    config = _load_example("text_classification.yaml")
+    del config["texts"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_tabular_without_schema_rejected(validator):
+    config = _load_example("tabular_classification.yaml")
+    del config["schema"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+# Regression-class tasks must specify label.policy explicitly; the shorthand
+# string form must be rejected for these categories.
+@pytest.mark.parametrize(
+    "example_name",
+    [
+        "tabular_regression.yaml",
+        "time_series_forecasting.yaml",
+        "time_to_event_prediction.yaml",
+    ],
+)
+def test_regression_class_string_label_rejected(validator, example_name: str):
+    config = _load_example(example_name)
+    # Replace the object-form label with the shorthand string.
+    config["label"] = config["label"]["column"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+@pytest.mark.parametrize(
+    "example_name",
+    [
+        "tabular_regression.yaml",
+        "time_series_forecasting.yaml",
+        "time_to_event_prediction.yaml",
+    ],
+)
+def test_regression_class_missing_policy_rejected(validator, example_name: str):
+    config = _load_example(example_name)
+    del config["label"]["policy"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+# Classification-class tasks must accept either form: the shorthand string
+# (dominant case) or the explicit object form.
+def test_classification_accepts_string_label(validator):
+    validator.validate(_load_example("image_classification.yaml"))
+
+
+def test_classification_accepts_object_label_passthrough(validator):
+    config = _load_example("image_classification.yaml")
+    config["label"] = {"column": "image_label", "policy": "passthrough"}
+    validator.validate(config)
+
+
+def test_data_id_column_strategy_requires_column(validator):
+    config = _ic_base()
+    config["data_id"] = {"strategy": "column"}  # missing `column`
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_data_id_uuid_strategy_alone(validator):
+    config = _ic_base()
+    config["data_id"] = {"strategy": "uuid"}
+    validator.validate(config)
+
+
+def test_data_id_column_without_strategy_rejected(validator):
+    # Guards against the vacuous-if/then bug: `{column: filename}` without
+    # `strategy` previously passed schema validation and was silently
+    # dropped by the resolver (which checks strategy=="column"), so the
+    # customer's explicit column selection was ignored.
+    config = _ic_base()
+    config["data_id"] = {"column": "filename"}
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_processor_requires_script_and_class(validator):
+    config = _ic_base()
+    config["spec"] = {"processors": [{"script": "/custom/x.py"}]}  # missing `class`
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_apiversion_locked_to_v1(validator):
+    config = _ic_base()
+    config["apiVersion"] = "tracebloc.io/v2"
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_kind_locked_to_ingestconfig(validator):
+    config = _ic_base()
+    config["kind"] = "Ingest"
+    with pytest.raises(ValidationError):
+        validator.validate(config)

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -1,0 +1,421 @@
+"""Equivalence harness — YAML path produces the same ingestor configuration
+as the existing template scripts.
+
+This pins the #44 acceptance criterion:
+
+    > For each of the seven existing templates plus segmentation, an
+    > equivalent ``examples/yaml/<name>.yaml`` exists and produces the same
+    > end state (same MySQL rows, same backend POSTs).
+
+We don't run real DB / API I/O. Instead we capture the kwargs each path
+hands to the ingestor and assert they match. The framework code that
+turns those kwargs into MySQL rows + backend POSTs is the same on both
+paths, so equivalent kwargs imply equivalent end-state.
+
+Two intentional, documented divergences from the templates (per #44 design):
+
+1. **``unique_id_column`` defaults to None** (UUID generation, no source
+   column leaves the cluster) for all categories. The existing
+   ``keypoint_detection`` and ``semantic_segmentation`` templates set
+   ``unique_id_column="filename"`` — leaking the filename to the central
+   backend. Customers wanting that behavior must opt in explicitly via
+   ``data_id: {strategy: column, column: filename}`` in their YAML; the
+   harness configs below do so for those two categories to preserve
+   template-equivalent behavior.
+
+2. **``label_policy: bucket``** is required by the schema for
+   regression-class categories (regression, time-series, time-to-event).
+   The existing templates send the raw target value through. The YAML
+   path applies hash-bucket. This is a deliberate behavior change per
+   parent client#85 — raw targets shouldn't leak. The equivalence test
+   asserts ``label_policy="bucket"`` for those three categories rather
+   than asserting payload equivalence on the label.
+
+A third, non-functional difference: tabular templates set
+``file_options={"number_of_columns": len(schema)}``. The
+``number_of_columns`` field is dead code (no consumer in the package;
+``grep`` confirms). YAML path omits it; harness allows the diff.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from tracebloc_ingestor.cli.conventions import resolve
+from tracebloc_ingestor.utils.constants import (
+    DataFormat,
+    FileExtension,
+    Intent,
+    TaskCategory,
+)
+from tracebloc_ingestor.utils.label_policy import BUCKET, PASSTHROUGH
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples" / "yaml"
+
+
+# ---------------------------------------------------------------------------
+# One case per existing template. Each case is a tuple of
+#   (yaml_config, expected_kwargs_for_ingestor)
+# The yaml_config is built inline (rather than reading from examples/yaml/)
+# so we can control intent / label_column / data_id strategy to match the
+# template exactly.
+# ---------------------------------------------------------------------------
+
+def _yaml(**fields) -> Dict[str, Any]:
+    """Helper: build a YAML config dict with apiVersion/kind boilerplate."""
+    return {
+        "apiVersion": "tracebloc.io/v1",
+        "kind": "IngestConfig",
+        **fields,
+    }
+
+
+CASES = [
+    # -----------------------------------------------------------------------
+    # image_classification — template uses 512×512, intent=TEST, label_column="label"
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.IMAGE_CLASSIFICATION,
+            table="image_classification_train",
+            intent="test",  # template default is Intent.TEST
+            csv="/data/labels.csv",
+            images="/data/images/",
+            label="label",
+        ),
+        {
+            "category": TaskCategory.IMAGE_CLASSIFICATION,
+            "data_format": DataFormat.IMAGE,
+            "intent": Intent.TEST,
+            "label_column": "label",
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"target_size": [512, 512], "extension": FileExtension.JPG},
+        },
+        id="image_classification",
+    ),
+
+    # -----------------------------------------------------------------------
+    # object_detection — template uses 448×448, label_column="image_label"
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.OBJECT_DETECTION,
+            table="object_detection_train",
+            intent="train",
+            csv="/data/labels.csv",
+            images="/data/images/",
+            annotations="/data/annotations/",
+            label="image_label",
+        ),
+        {
+            "category": TaskCategory.OBJECT_DETECTION,
+            "data_format": DataFormat.IMAGE,
+            "intent": Intent.TRAIN,
+            "label_column": "image_label",
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"target_size": [448, 448], "extension": FileExtension.JPG},
+        },
+        id="object_detection",
+    ),
+
+    # -----------------------------------------------------------------------
+    # keypoint_detection — template uses 448×448, label_column="image_label",
+    # annotation_column="Annotation", unique_id_column="filename" (opt-in
+    # column-mapping per #44 default-UUID change).
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.KEYPOINT_DETECTION,
+            table="keypoint_detection_train",
+            intent="train",
+            csv="/data/labels.csv",
+            images="/data/images/",
+            label="image_label",
+            data_id={"strategy": "column", "column": "filename"},
+        ),
+        {
+            "category": TaskCategory.KEYPOINT_DETECTION,
+            "data_format": DataFormat.IMAGE,
+            "intent": Intent.TRAIN,
+            "label_column": "image_label",
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": "filename",
+            "annotation_column": "Annotation",  # convention default per category
+            "file_options": {"target_size": [448, 448], "extension": FileExtension.JPG},
+        },
+        id="keypoint_detection",
+    ),
+
+    # -----------------------------------------------------------------------
+    # semantic_segmentation — template uses 512×512, label_column="image_label",
+    # unique_id_column="filename" (opt-in).
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.SEMANTIC_SEGMENTATION,
+            table="semantic_segmentation_train",
+            intent="train",
+            csv="/data/labels.csv",
+            images="/data/images/",
+            masks="/data/masks/",
+            label="image_label",
+            data_id={"strategy": "column", "column": "filename"},
+        ),
+        {
+            "category": TaskCategory.SEMANTIC_SEGMENTATION,
+            "data_format": DataFormat.IMAGE,
+            "intent": Intent.TRAIN,
+            "label_column": "image_label",
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": "filename",
+            "annotation_column": None,
+            "file_options": {"target_size": [512, 512], "extension": FileExtension.JPG},
+        },
+        id="semantic_segmentation",
+    ),
+
+    # -----------------------------------------------------------------------
+    # text_classification — template uses extension=.txt, label_column="label"
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.TEXT_CLASSIFICATION,
+            table="text_classification_train",
+            intent="train",
+            csv="/data/labels.csv",
+            texts="/data/texts/",
+            schema={"text_id": "VARCHAR(255)", "label": "VARCHAR(64)"},
+            label="label",
+        ),
+        {
+            "category": TaskCategory.TEXT_CLASSIFICATION,
+            "data_format": DataFormat.TEXT,
+            "intent": Intent.TRAIN,
+            "label_column": "label",
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"extension": FileExtension.TXT},
+        },
+        id="text_classification",
+    ),
+
+    # -----------------------------------------------------------------------
+    # tabular_classification — template label_column="name"
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.TABULAR_CLASSIFICATION,
+            table="tabular_classification_train",
+            intent="train",
+            csv="/data/data.csv",
+            schema={"age": "INT", "name": "VARCHAR(255)"},
+            label="name",
+        ),
+        {
+            "category": TaskCategory.TABULAR_CLASSIFICATION,
+            "data_format": DataFormat.TABULAR,
+            "intent": Intent.TRAIN,
+            "label_column": "name",
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            # number_of_columns is dead code in templates — YAML path omits it.
+            "file_options": {},
+        },
+        id="tabular_classification",
+    ),
+
+    # -----------------------------------------------------------------------
+    # tabular_regression — regression-class, label_policy MUST be bucket
+    # (#44 deliberate behavior change vs template's raw passthrough).
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.TABULAR_REGRESSION,
+            table="tabular_regression_train",
+            intent="train",
+            csv="/data/data.csv",
+            schema={
+                "square_feet": "FLOAT",
+                "bedrooms": "INT",
+                "price": "FLOAT",
+            },
+            label={"column": "price", "policy": "bucket"},
+        ),
+        {
+            "category": TaskCategory.TABULAR_REGRESSION,
+            "data_format": DataFormat.TABULAR,
+            "intent": Intent.TRAIN,
+            "label_column": "price",
+            "label_policy": BUCKET,  # ← intentional divergence
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {},
+        },
+        id="tabular_regression",
+    ),
+
+    # -----------------------------------------------------------------------
+    # time_series_forecasting — regression-class, label_policy=bucket.
+    # Template label_column="max_magnitude".
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.TIME_SERIES_FORECASTING,
+            table="time_series_forecasting_train",
+            intent="train",
+            csv="/data/data.csv",
+            schema={
+                "timestamp": "VARCHAR(64)",
+                "region": "VARCHAR(32)",
+                "max_magnitude": "FLOAT",
+            },
+            label={"column": "max_magnitude", "policy": "bucket"},
+        ),
+        {
+            "category": TaskCategory.TIME_SERIES_FORECASTING,
+            "data_format": DataFormat.TABULAR,
+            "intent": Intent.TRAIN,
+            "label_column": "max_magnitude",
+            "label_policy": BUCKET,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {},
+        },
+        id="time_series_forecasting",
+    ),
+
+    # -----------------------------------------------------------------------
+    # time_to_event_prediction — regression-class, label_policy=bucket,
+    # plus time_column="time" (template's value).
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.TIME_TO_EVENT_PREDICTION,
+            table="time_to_event_prediction_train",
+            intent="train",
+            csv="/data/data.csv",
+            time_column="time",
+            schema={
+                "patient_id": "VARCHAR(64)",
+                "time": "INT",
+                "DEATH_EVENT": "INT",
+            },
+            label={"column": "DEATH_EVENT", "policy": "bucket"},
+        ),
+        {
+            "category": TaskCategory.TIME_TO_EVENT_PREDICTION,
+            "data_format": DataFormat.TABULAR,
+            "intent": Intent.TRAIN,
+            "label_column": "DEATH_EVENT",
+            "label_policy": BUCKET,
+            "unique_id_column": None,
+            "annotation_column": None,
+            # time_column bridged into file_options for TimeToEventValidator.
+            "file_options": {"time_column": "time"},
+        },
+        id="time_to_event_prediction",
+    ),
+]
+
+
+@pytest.mark.parametrize("yaml_config,expected", CASES)
+def test_yaml_resolves_to_template_equivalent_kwargs(yaml_config, expected):
+    """For each existing template, the equivalent YAML must produce
+    identical ingestor kwargs (with the documented intentional divergences:
+    UUID-by-default for data_id, BUCKET-for-regression label policy)."""
+    resolved = resolve(yaml_config)
+
+    for key, want in expected.items():
+        got = getattr(resolved, key)
+        assert got == want, (
+            f"{yaml_config['category']}: {key} mismatch\n"
+            f"  expected: {want!r}\n"
+            f"  got:      {got!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# All existing templates have a YAML equivalent that's exercisable here.
+# ---------------------------------------------------------------------------
+
+def test_every_existing_template_has_a_case():
+    """The acceptance criterion enumerates 'seven existing templates plus
+    segmentation' (= 8). The repo also added keypoint_detection (+1 = 9).
+    Every template directory under templates/ must have a parametrized
+    case in this file."""
+    template_dirs = sorted(p.name for p in (REPO_ROOT / "templates").iterdir() if p.is_dir())
+    template_categories = {
+        d for d in template_dirs
+        if d != "example_data"  # the only non-template dir
+    }
+
+    case_categories = {c.values[0]["category"] for c in CASES}
+
+    missing = template_categories - case_categories
+    assert not missing, (
+        f"templates/ contains category dirs without an equivalence case: "
+        f"{sorted(missing)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end-but-mocked: the YAML configs above flow through the entrypoint
+# and the same kwargs land on the ingestor constructor.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("yaml_config,expected", CASES)
+def test_yaml_config_reaches_ingestor_via_entrypoint(
+    yaml_config, expected, tmp_path, monkeypatch
+):
+    """Smoke test that the kwargs verified above also land on the ingestor
+    when run through the full ``cli.run.main`` flow with mocked DB / API."""
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text(yaml.safe_dump(yaml_config), encoding="utf-8")
+    monkeypatch.setenv("INGEST_CONFIG", str(cfg_file))
+
+    with patch("tracebloc_ingestor.cli.run.Config") as mock_config_cls, \
+         patch("tracebloc_ingestor.cli.run.Database"), \
+         patch("tracebloc_ingestor.cli.run.APIClient"), \
+         patch("tracebloc_ingestor.cli.run.CSVIngestor") as mock_csv_cls, \
+         patch("tracebloc_ingestor.cli.run.JSONIngestor") as mock_json_cls, \
+         patch("tracebloc_ingestor.cli.run.setup_logging"):
+        mock_config = MagicMock()
+        mock_config.BATCH_SIZE = 4000
+        mock_config_cls.return_value = mock_config
+        for cls_mock in (mock_csv_cls, mock_json_cls):
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.ingest = MagicMock(return_value=[])
+            cls_mock.return_value = inst
+
+        from tracebloc_ingestor.cli.run import main
+        rc = main()
+
+    assert rc == 0
+    # All current cases use csv source; assert CSV path was taken.
+    assert mock_csv_cls.call_count == 1, (
+        f"expected CSVIngestor for {yaml_config['category']}, got {mock_csv_cls.call_count} call(s)"
+    )
+
+    _, kwargs = mock_csv_cls.call_args
+    for key, want in expected.items():
+        got = kwargs.get(key)
+        assert got == want, (
+            f"{yaml_config['category']}: ingestor kwarg {key} mismatch\n"
+            f"  expected: {want!r}\n"
+            f"  got:      {got!r}"
+        )

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -17,7 +17,7 @@ from .validators import (
     TableNameValidator,
 )
 
-__version__ = "0.2.10"
+__version__ = "0.3.0"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/cli/__init__.py
+++ b/tracebloc_ingestor/cli/__init__.py
@@ -1,0 +1,17 @@
+"""Command-line entry point for the declarative ``ingest.yaml`` flow.
+
+The official ingestor image (Ticket #45) runs ``tracebloc_ingestor.cli.run:main``
+as its entrypoint. The flow:
+
+    1. Read INGEST_CONFIG env (path to the YAML body mounted by the Helm
+       subchart from Ticket client#86).
+    2. Validate against ``schema/ingest.v1.json``; fail fast with line-numbered
+       errors before any DB connection or network call.
+    3. Resolve convention defaults from ``category`` (validators, sidecar
+       patterns, default columns, default file extensions) — see ``conventions``.
+    4. Dispatch to ``CSVIngestor`` or ``JSONIngestor`` based on the source type.
+    5. Apply ``label.policy`` bucketing in ``APIClient.send_batch`` for
+       regression-class tasks.
+
+Customers no longer write Python or build Docker images for the dominant case.
+"""

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -1,0 +1,325 @@
+"""Translate a validated ``ingest.yaml`` config into ingestor kwargs.
+
+This module is the convention-over-configuration layer of #44. The schema
+(``schema/ingest.v1.json``) defines what the customer can write; this module
+defines what every elision means. Setting ``category: image_classification``
+implies::
+
+    data_format        = "image"
+    file_options       = {"target_size": [512, 512], "extension": ".jpg"}
+    csv_options        = {chunk_size: 1000, delimiter: ",", quotechar: '"',
+                          escapechar: "\\\\"}
+    unique_id_column   = None        # UUID generation, no PII leakage
+    label_policy       = "passthrough"
+
+Customers override only when they deviate. The function is pure (no I/O,
+no env reads, no globals); the caller passes a config dict and gets a
+:class:`ResolvedConfig` back. That keeps the resolver trivially testable
+and lets the entrypoint compose it with environment setup separately.
+
+Pre-condition: the input dict must already have passed ``jsonschema``
+validation against ``schema/ingest.v1.json``. ``resolve()`` does not
+re-validate; it assumes well-formed input.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, List, Optional
+
+from ..utils.constants import DataFormat, Intent, TaskCategory
+
+
+# ---------------------------------------------------------------------------
+# Category groupings — used both here and by the entrypoint when deciding
+# which sidecar paths matter. Single source of truth.
+# ---------------------------------------------------------------------------
+
+IMAGE_CATEGORIES: FrozenSet[str] = frozenset({
+    TaskCategory.IMAGE_CLASSIFICATION,
+    TaskCategory.OBJECT_DETECTION,
+    TaskCategory.KEYPOINT_DETECTION,
+    TaskCategory.SEMANTIC_SEGMENTATION,
+    TaskCategory.INSTANCE_SEGMENTATION,
+})
+
+TEXT_CATEGORIES: FrozenSet[str] = frozenset({
+    TaskCategory.TEXT_CLASSIFICATION,
+})
+
+TABULAR_CATEGORIES: FrozenSet[str] = frozenset({
+    TaskCategory.TABULAR_CLASSIFICATION,
+    TaskCategory.TABULAR_REGRESSION,
+})
+
+TIME_SERIES_CATEGORIES: FrozenSet[str] = frozenset({
+    TaskCategory.TIME_SERIES_FORECASTING,
+})
+
+TIME_TO_EVENT_CATEGORIES: FrozenSet[str] = frozenset({
+    TaskCategory.TIME_TO_EVENT_PREDICTION,
+})
+
+# Categories where the label is a numeric prediction target rather than
+# class metadata. The schema requires `label.policy` for these so the raw
+# value never ships to the central backend by default.
+REGRESSION_CLASS_CATEGORIES: FrozenSet[str] = frozenset(
+    {TaskCategory.TABULAR_REGRESSION}
+    | TIME_SERIES_CATEGORIES
+    | TIME_TO_EVENT_CATEGORIES
+)
+
+
+# ---------------------------------------------------------------------------
+# Default values per category. Single source of truth so the entrypoint and
+# tests both read from here rather than redefining locally.
+# ---------------------------------------------------------------------------
+
+DEFAULT_CSV_OPTIONS: Dict[str, Any] = {
+    "chunk_size": 1000,
+    "delimiter": ",",
+    "quotechar": '"',
+    "escapechar": "\\",
+}
+
+# Per-category image defaults. The values match what the existing templates
+# in ``templates/*`` set explicitly, so YAML-driven runs default-equivalent
+# to script-driven runs (verified by the equivalence harness in
+# ``tests/test_template_equivalence.py``).
+#
+# The asymmetry across categories — 512×512 for classification / segmentation,
+# 448×448 for detection / keypoints — is inherited from the templates'
+# customer-tuned values. Refining these defaults after first customer
+# migrations is explicitly out-of-scope for #44 per the ticket.
+DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY: Dict[str, Dict[str, Any]] = {
+    TaskCategory.IMAGE_CLASSIFICATION:    {"target_size": [512, 512], "extension": ".jpg"},
+    TaskCategory.SEMANTIC_SEGMENTATION:   {"target_size": [512, 512], "extension": ".jpg"},
+    TaskCategory.OBJECT_DETECTION:        {"target_size": [448, 448], "extension": ".jpg"},
+    TaskCategory.KEYPOINT_DETECTION:      {"target_size": [448, 448], "extension": ".jpg"},
+    # No template exists yet for instance_segmentation; mirror semantic for
+    # forward-compatibility, revisit when the template lands.
+    TaskCategory.INSTANCE_SEGMENTATION:   {"target_size": [512, 512], "extension": ".jpg"},
+}
+
+DEFAULT_TEXT_FILE_OPTIONS: Dict[str, Any] = {
+    "extension": ".txt",
+}
+
+
+# ---------------------------------------------------------------------------
+# Resolved configuration — what the entrypoint actually consumes.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ResolvedConfig:
+    """A fully-resolved ingest configuration.
+
+    Every field is filled in: customer-supplied values win, convention
+    defaults from ``category`` cover the rest. The entrypoint maps these
+    fields to ``CSVIngestor`` / ``JSONIngestor`` constructor kwargs and to
+    ``os.environ`` for the legacy path-resolution layer in
+    ``file_transfer.py`` (which still reads ``SRC_PATH``/``DEST_PATH`` from
+    env — the YAML-side cleanup is a follow-up after the dominant flow lands).
+    """
+
+    # ----- Identity -----
+    category: str
+    table_name: str
+    intent: str
+    data_format: str
+
+    # ----- Source -----
+    source_type: str  # "csv" or "json"
+    source_path: str  # absolute path inside the pod
+
+    # ----- Sidecar directories (None when irrelevant for the category) -----
+    images: Optional[str] = None
+    annotations: Optional[str] = None
+    masks: Optional[str] = None
+    texts: Optional[str] = None
+
+    # ----- Tabular / time-series -----
+    schema: Dict[str, str] = field(default_factory=dict)
+    time_column: Optional[str] = None  # time_to_event_prediction only
+
+    # ----- Label -----
+    label_column: str = ""
+    label_policy: str = "passthrough"  # "passthrough" | "bucket"
+
+    # ----- data_id -----
+    unique_id_column: Optional[str] = None  # None ⇒ UUID generation
+
+    # ----- Pass-through to ingestors -----
+    annotation_column: Optional[str] = None
+    csv_options: Dict[str, Any] = field(default_factory=dict)
+    file_options: Dict[str, Any] = field(default_factory=dict)
+
+    # ----- Custom processors (specs only; entrypoint loads classes) -----
+    processor_specs: List[Dict[str, Any]] = field(default_factory=list)
+
+    # ----- Deferred-feature passthroughs -----
+    # Schema-accepted in v1 for forward-compatibility, but the runtime path
+    # to honour them isn't built yet (validator-name resolution + the
+    # sidecar mounting story both wait for client#86). The entrypoint
+    # warns when these are non-empty so customers know the keys are inert.
+    validators_override: List[str] = field(default_factory=list)
+    sidecars: List[Dict[str, Any]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+def resolve(config: Dict[str, Any]) -> ResolvedConfig:
+    """Translate a validated ingest.yaml dict into a :class:`ResolvedConfig`.
+
+    Args:
+        config: The parsed YAML body. Must already have passed jsonschema
+            validation against ``schema/ingest.v1.json``.
+
+    Returns:
+        A :class:`ResolvedConfig` with convention defaults filled in.
+
+    The resolver makes three classes of decisions, in order:
+      1. **Identity** — direct copies of required fields plus
+         ``data_format`` derived from ``category``.
+      2. **Source dispatch** — ``source_type`` and ``source_path`` from the
+         ``csv:`` or ``json:`` shorthand (the schema enforces exactly one).
+      3. **Per-category defaults** — ``file_options`` / ``csv_options`` /
+         label / data_id, with customer values overriding.
+    """
+    category = config["category"]
+
+    # 1. Identity
+    resolved = ResolvedConfig(
+        category=category,
+        table_name=config["table"],
+        intent=config["intent"],
+        data_format=_data_format_for(category),
+        source_type="csv" if "csv" in config else "json",
+        source_path=config.get("csv") or config["json"],
+    )
+
+    # 2. Sidecar directories — set whatever the customer specified; the
+    #    schema's conditional `if/then` already enforced that the right ones
+    #    are present for each category.
+    for key in ("images", "annotations", "masks", "texts"):
+        if key in config:
+            setattr(resolved, key, config[key])
+
+    # 3. Schema (tabular / time-series / time-to-event)
+    if "schema" in config:
+        resolved.schema = dict(config["schema"])
+    if "time_column" in config:
+        resolved.time_column = config["time_column"]
+
+    # 4. Label — string shorthand or object form
+    label = config.get("label")
+    if isinstance(label, str):
+        resolved.label_column = label
+        # passthrough is the default; classification-class only — schema
+        # forbids string-shorthand for regression-class, so this is safe.
+    elif isinstance(label, dict):
+        resolved.label_column = label["column"]
+        resolved.label_policy = label.get("policy", "passthrough")
+
+    # 5. data_id — strategy: uuid (default, no source col leaves the cluster)
+    #    or column (loud, opt-in, captured in unique_id_column for the
+    #    BaseIngestor warning we added in #43).
+    data_id = config.get("data_id") or {}
+    if data_id.get("strategy") == "column":
+        resolved.unique_id_column = data_id["column"]
+    # else: leave unique_id_column = None ⇒ UUID generation
+
+    # 6. csv_options — merge customer overrides over defaults.
+    csv_overrides = (config.get("spec") or {}).get("csv_options") or {}
+    resolved.csv_options = {**DEFAULT_CSV_OPTIONS, **csv_overrides}
+
+    # 7. file_options — per-category defaults, merged with customer overrides.
+    spec_file_options = (config.get("spec") or {}).get("file_options") or {}
+    resolved.file_options = {**_default_file_options_for(category), **spec_file_options}
+
+    # 7a. For time_to_event_prediction the validator (TimeToEventValidator)
+    #     reads `time_column` from file_options. Bridge the top-level field
+    #     so the validator gets it without customers having to repeat the
+    #     value in spec.file_options. ``setdefault`` so an explicit
+    #     spec.file_options.time_column (the advanced override) wins over
+    #     the documented top-level shorthand, consistent with how every
+    #     other spec.file_options key behaves.
+    if category == TaskCategory.TIME_TO_EVENT_PREDICTION and resolved.time_column:
+        resolved.file_options.setdefault("time_column", resolved.time_column)
+
+    # 8. annotation_column — keypoint_detection's existing template uses
+    #    column "Annotation" (the keypoint coords carried in the CSV). The
+    #    YAML schema doesn't expose this directly in v1; we honour the
+    #    convention here. Other categories rely on sidecar files only.
+    if category == TaskCategory.KEYPOINT_DETECTION:
+        resolved.annotation_column = "Annotation"
+
+    # 9. Processor specs — pass through verbatim. The entrypoint will import
+    #    the script and instantiate the named class. We don't do that here
+    #    so the resolver stays I/O-free and unit-testable.
+    spec = config.get("spec") or {}
+    resolved.processor_specs = list(spec.get("processors") or [])
+
+    # 10. Deferred passthroughs — captured so the entrypoint can warn about
+    #     them. Honouring these is part of the v1.1 surface (validator-name
+    #     resolution and the sidecar mounting story from client#86).
+    resolved.validators_override = list(spec.get("validators") or [])
+    resolved.sidecars = list(spec.get("sidecars") or [])
+
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _data_format_for(category: str) -> str:
+    """Map ``category`` to the ``DataFormat`` value the framework expects."""
+    if category in IMAGE_CATEGORIES:
+        return DataFormat.IMAGE
+    if category in TEXT_CATEGORIES:
+        return DataFormat.TEXT
+    if (
+        category in TABULAR_CATEGORIES
+        or category in TIME_SERIES_CATEGORIES
+        or category in TIME_TO_EVENT_CATEGORIES
+    ):
+        return DataFormat.TABULAR
+    raise ValueError(
+        f"Unknown category {category!r}; cannot derive data_format. "
+        "If this is a new category, add it to the relevant CATEGORY set "
+        "in conventions.py and to the schema enum."
+    )
+
+
+def _default_file_options_for(category: str) -> Dict[str, Any]:
+    """Return the default ``file_options`` dict for a category.
+
+    Image categories use per-category defaults to match the templates'
+    customer-tuned values (see ``DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY``);
+    text uses a single shared default; tabular / time-series carry no
+    ``file_options``.
+    """
+    if category in IMAGE_CATEGORIES:
+        return dict(DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[category])
+    if category in TEXT_CATEGORIES:
+        return dict(DEFAULT_TEXT_FILE_OPTIONS)
+    # Tabular / time-series categories don't carry file_options.
+    return {}
+
+
+__all__ = [
+    "ResolvedConfig",
+    "resolve",
+    "IMAGE_CATEGORIES",
+    "TEXT_CATEGORIES",
+    "TABULAR_CATEGORIES",
+    "TIME_SERIES_CATEGORIES",
+    "TIME_TO_EVENT_CATEGORIES",
+    "REGRESSION_CLASS_CATEGORIES",
+    "DEFAULT_CSV_OPTIONS",
+    "DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY",
+    "DEFAULT_TEXT_FILE_OPTIONS",
+]

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -60,6 +60,10 @@ TIME_TO_EVENT_CATEGORIES: FrozenSet[str] = frozenset({
     TaskCategory.TIME_TO_EVENT_PREDICTION,
 })
 
+MLM_CATEGORIES: FrozenSet[str] = frozenset({
+    TaskCategory.MASKED_LANGUAGE_MODELING,
+})
+
 # Categories where the label is a numeric prediction target rather than
 # class metadata. The schema requires `label.policy` for these so the raw
 # value never ships to the central backend by default.
@@ -105,6 +109,10 @@ DEFAULT_TEXT_FILE_OPTIONS: Dict[str, Any] = {
     "extension": ".txt",
 }
 
+DEFAULT_MLM_FILE_OPTIONS: Dict[str, Any] = {
+    "extension": ".txt",
+}
+
 
 # ---------------------------------------------------------------------------
 # Resolved configuration — what the entrypoint actually consumes.
@@ -137,6 +145,7 @@ class ResolvedConfig:
     annotations: Optional[str] = None
     masks: Optional[str] = None
     texts: Optional[str] = None
+    sequences: Optional[str] = None
 
     # ----- Tabular / time-series -----
     schema: Dict[str, str] = field(default_factory=dict)
@@ -203,7 +212,7 @@ def resolve(config: Dict[str, Any]) -> ResolvedConfig:
     # 2. Sidecar directories — set whatever the customer specified; the
     #    schema's conditional `if/then` already enforced that the right ones
     #    are present for each category.
-    for key in ("images", "annotations", "masks", "texts"):
+    for key in ("images", "annotations", "masks", "texts", "sequences"):
         if key in config:
             setattr(resolved, key, config[key])
 
@@ -287,6 +296,8 @@ def _data_format_for(category: str) -> str:
         or category in TIME_TO_EVENT_CATEGORIES
     ):
         return DataFormat.TABULAR
+    if category in MLM_CATEGORIES:
+        return DataFormat.TEXT
     raise ValueError(
         f"Unknown category {category!r}; cannot derive data_format. "
         "If this is a new category, add it to the relevant CATEGORY set "
@@ -306,6 +317,8 @@ def _default_file_options_for(category: str) -> Dict[str, Any]:
         return dict(DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[category])
     if category in TEXT_CATEGORIES:
         return dict(DEFAULT_TEXT_FILE_OPTIONS)
+    if category in MLM_CATEGORIES:
+        return dict(DEFAULT_MLM_FILE_OPTIONS)
     # Tabular / time-series categories don't carry file_options.
     return {}
 
@@ -322,4 +335,6 @@ __all__ = [
     "DEFAULT_CSV_OPTIONS",
     "DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY",
     "DEFAULT_TEXT_FILE_OPTIONS",
+    "MLM_CATEGORIES",
+    "DEFAULT_MLM_FILE_OPTIONS",
 ]

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -197,17 +197,12 @@ def _set_legacy_env_vars(resolved: ResolvedConfig) -> None:
     """Bridge the resolved YAML config into the legacy env-var path layer
     in ``file_transfer.py``.
 
-    The ingestor's path-resolution layer was built around env vars
-    (``SRC_PATH``, ``TABLE_NAME``, ``LABEL_FILE``). Refactoring it to take
-    paths as parameters is a follow-up; for v1 we bridge in two steps:
-
-    1. Set the env vars so any downstream code that reads them lazily
-       picks up the resolved values.
-    2. Patch ``file_transfer.config`` (a module-level ``Config()`` instance
-       captured at import time, before this function runs) in place. The
-       ``Config`` dataclass evaluates its ``os.getenv`` defaults once when
-       the class body executes, so neither step (1) alone nor a fresh
-       ``Config()`` call would reach the already-constructed instance.
+    The path-resolution layer reads ``SRC_PATH`` / ``TABLE_NAME`` /
+    ``LABEL_FILE`` via :class:`Config`, whose env-driven fields are now
+    lazy properties — they read ``os.environ`` on access. So this
+    function just needs to set the env vars; module-level
+    ``config = Config()`` snapshots scattered across validators and
+    ingestors all pick up the new values at their next attribute read.
 
     ``SRC_PATH`` is derived from whichever sidecar directory is set, since
     ``file_transfer.py`` joins ``SRC_PATH/<subfolder>/<filename>`` for each
@@ -227,19 +222,6 @@ def _set_legacy_env_vars(resolved: ResolvedConfig) -> None:
     os.environ["LABEL_FILE"] = resolved.source_path
     if src_path:
         os.environ["SRC_PATH"] = src_path
-
-    # Patch the already-constructed file_transfer.config in place. Its
-    # fields were frozen with stale env values at import time (long before
-    # we got here), and Config's dataclass defaults are evaluated at
-    # class-definition time, so re-instantiating wouldn't help either.
-    from .. import file_transfer
-    file_transfer.config.TABLE_NAME = resolved.table_name
-    file_transfer.config.LABEL_FILE = resolved.source_path
-    file_transfer.config.DEST_PATH = os.path.join(
-        file_transfer.config.STORAGE_PATH, resolved.table_name
-    )
-    if src_path:
-        file_transfer.config.SRC_PATH = src_path
 
 
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -1,0 +1,305 @@
+"""Declarative ingest entrypoint — ``tracebloc_ingestor.cli.run:main``.
+
+Run by the official ingestor image (Ticket #45) when a customer triggers a
+``helm install tracebloc/ingestor -f ingest.yaml`` (Ticket client#86). The
+flow:
+
+    1. Read ``INGEST_CONFIG`` env (path to YAML mounted by the Helm subchart).
+    2. Parse + validate against ``schema/ingest.v1.json``. Fail fast with
+       a single multi-line error listing every violation by JSON-pointer
+       path. No DB / network I/O happens before validation passes.
+    3. Resolve convention defaults via ``conventions.resolve`` (pure).
+    4. Bridge to the legacy env-var path-resolution layer in
+       ``file_transfer.py`` by setting ``SRC_PATH`` / ``TABLE_NAME`` /
+       ``LABEL_FILE`` from the resolved config. Direct refactor of
+       ``file_transfer.py`` to take paths via parameters is a follow-up;
+       env-var injection is the minimal bridge for v1.
+    5. Construct ``Config``, ``Database``, ``APIClient``. ``APIClient``
+       triggers ``Config.validate()`` which fails fast on missing auth
+       (per #43).
+    6. Dispatch to ``CSVIngestor`` or ``JSONIngestor`` based on
+       ``source_type``.
+    7. Run ``ingestor.ingest(source_path, batch_size=...)``.
+
+Deferred to v1.1 (after client#86 lands):
+
+- **Custom processors.** The schema accepts ``spec.processors[]`` today,
+  but the runtime path requires the Helm subchart's ConfigMap-mounting
+  story to actually deliver script bodies into the pod. We log a warning
+  and skip when a config supplies processors; the rest of the run
+  continues unchanged. Deferring this keeps the v1 surface honest:
+  customers shouldn't write `processors:` until the deployment path is
+  real.
+- **Line-numbered validation errors.** Today the entrypoint emits
+  ``<json-pointer>: <message>`` per error, which lets customers grep
+  their YAML. Real line numbers require a YAML loader that preserves
+  position info (``ruamel.yaml`` or a custom ``SafeLoader``); deferred
+  as a quality-of-life improvement.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, NoReturn
+
+import yaml
+from jsonschema import Draft7Validator, ValidationError
+
+from ..api.client import APIClient
+from ..config import Config
+from ..database import Database
+from ..ingestors import CSVIngestor, JSONIngestor
+from ..utils.logging import setup_logging
+from .conventions import ResolvedConfig, resolve
+
+
+logger = logging.getLogger(__name__)
+
+
+# Schema is bundled inside the package at tracebloc_ingestor/schema/ingest.v1.json
+# so it's discoverable post pip-install (not just from a repo checkout). This
+# file lives at tracebloc_ingestor/cli/run.py, so the schema is one parent up.
+_SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schema" / "ingest.v1.json"
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+def main(argv: List[str] | None = None) -> int:  # pragma: no cover - thin shell
+    """Entrypoint registered as the ``tracebloc-ingest`` console script.
+
+    Returns the process exit code. A non-zero return is converted to
+    ``sys.exit`` by the console-script wrapper; using a return value (rather
+    than raising) keeps the function testable from inside pytest.
+    """
+    config_path = os.environ.get("INGEST_CONFIG")
+    if not config_path:
+        return _fail(
+            "INGEST_CONFIG env var not set. The official image expects the "
+            "Helm subchart (client#86) to mount the ingest.yaml and set "
+            "INGEST_CONFIG to its path."
+        )
+
+    raw_path = Path(config_path)
+    if not raw_path.is_file():
+        return _fail(f"INGEST_CONFIG points to {config_path} which does not exist.")
+
+    try:
+        raw_config = yaml.safe_load(raw_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        return _fail(f"ingest.yaml is not valid YAML:\n  {e}")
+
+    if not isinstance(raw_config, dict):
+        return _fail(
+            "ingest.yaml must be a mapping at the top level "
+            "(apiVersion / kind / category / ...)."
+        )
+
+    errors = list(_validate(raw_config))
+    if errors:
+        return _fail(
+            "ingest.yaml validation failed:\n" + _format_errors(errors)
+        )
+
+    resolved = resolve(raw_config)
+    _set_legacy_env_vars(resolved)
+
+    if resolved.processor_specs:
+        logger.warning(
+            "spec.processors is accepted by the schema but is not yet "
+            "executed at runtime. Custom-processor support requires the "
+            "Helm subchart from client#86 to land first; skipping %d "
+            "processor(s) and continuing without them.",
+            len(resolved.processor_specs),
+        )
+
+    if resolved.validators_override:
+        logger.warning(
+            "spec.validators is accepted by the schema but is not yet "
+            "honoured at runtime; the default validator set from "
+            "map_validators(category) will run instead. Ignoring %d "
+            "override(s).",
+            len(resolved.validators_override),
+        )
+
+    if resolved.sidecars:
+        logger.warning(
+            "spec.sidecars is accepted by the schema but is not yet "
+            "honoured at runtime; the framework's per-category sidecar "
+            "convention (images/, annotations/, masks/, texts/ under "
+            "SRC_PATH) will be used instead. Ignoring %d sidecar entry(s).",
+            len(resolved.sidecars),
+        )
+
+    config = Config()
+    setup_logging(config)
+
+    database = Database(config)
+    api_client = APIClient(config)  # triggers config.validate() per #43
+
+    ingestor = _build_ingestor(database, api_client, resolved)
+
+    with ingestor:
+        failed = ingestor.ingest(resolved.source_path, batch_size=config.BATCH_SIZE)
+        if failed:
+            logger.warning(
+                "%d record(s) failed during ingestion; see logs for details.",
+                len(failed),
+            )
+            return 1
+
+    logger.info("Ingestion completed successfully.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def _load_schema() -> Dict[str, Any]:
+    return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _validate(raw_config: Dict[str, Any]) -> Iterable[ValidationError]:
+    """Yield every validation error against the v1 schema.
+
+    Returns errors sorted by their absolute path so output is deterministic
+    regardless of jsonschema's internal traversal order.
+    """
+    validator = Draft7Validator(_load_schema())
+    return sorted(validator.iter_errors(raw_config), key=lambda e: list(e.absolute_path))
+
+
+def _format_errors(errors: List[ValidationError]) -> str:
+    """Format errors as ``<json-pointer>: <message>``, one per line.
+
+    Real line numbers (per the ticket) require a YAML loader that preserves
+    position info. v1.1 follow-up — for now, the JSON-pointer path is
+    enough to grep the customer's YAML.
+    """
+    lines = []
+    for e in errors:
+        path = ".".join(str(p) for p in e.absolute_path) or "<root>"
+        lines.append(f"  {path}: {e.message}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Bridging — the legacy env-var path layer
+# ---------------------------------------------------------------------------
+
+def _set_legacy_env_vars(resolved: ResolvedConfig) -> None:
+    """Bridge the resolved YAML config into the legacy env-var path layer
+    in ``file_transfer.py``.
+
+    The ingestor's path-resolution layer was built around env vars
+    (``SRC_PATH``, ``TABLE_NAME``, ``LABEL_FILE``). Refactoring it to take
+    paths as parameters is a follow-up; for v1 we bridge in two steps:
+
+    1. Set the env vars so any downstream code that reads them lazily
+       picks up the resolved values.
+    2. Patch ``file_transfer.config`` (a module-level ``Config()`` instance
+       captured at import time, before this function runs) in place. The
+       ``Config`` dataclass evaluates its ``os.getenv`` defaults once when
+       the class body executes, so neither step (1) alone nor a fresh
+       ``Config()`` call would reach the already-constructed instance.
+
+    ``SRC_PATH`` is derived from whichever sidecar directory is set, since
+    ``file_transfer.py`` joins ``SRC_PATH/<subfolder>/<filename>`` for each
+    category. The dominant convention is that all sidecar dirs share a
+    parent (``/data/images/``, ``/data/annotations/``, etc.) — for non-
+    standard layouts, customers use ``spec.sidecars[]`` (also deferred).
+    """
+    src_path = None
+    src_path_source = (
+        resolved.images or resolved.texts or resolved.masks or resolved.annotations
+    )
+    if src_path_source:
+        src_path = os.path.dirname(src_path_source.rstrip("/"))
+
+    os.environ["TABLE_NAME"] = resolved.table_name
+    os.environ["LABEL_FILE"] = resolved.source_path
+    if src_path:
+        os.environ["SRC_PATH"] = src_path
+
+    # Patch the already-constructed file_transfer.config in place. Its
+    # fields were frozen with stale env values at import time (long before
+    # we got here), and Config's dataclass defaults are evaluated at
+    # class-definition time, so re-instantiating wouldn't help either.
+    from .. import file_transfer
+    file_transfer.config.TABLE_NAME = resolved.table_name
+    file_transfer.config.LABEL_FILE = resolved.source_path
+    file_transfer.config.DEST_PATH = os.path.join(
+        file_transfer.config.STORAGE_PATH, resolved.table_name
+    )
+    if src_path:
+        file_transfer.config.SRC_PATH = src_path
+
+
+# ---------------------------------------------------------------------------
+# Ingestor dispatch
+# ---------------------------------------------------------------------------
+
+def _build_ingestor(
+    database: Database,
+    api_client: APIClient,
+    resolved: ResolvedConfig,
+):
+    """Construct the right ingestor for the source type."""
+    common_kwargs = dict(
+        database=database,
+        api_client=api_client,
+        table_name=resolved.table_name,
+        schema=resolved.schema,
+        unique_id_column=resolved.unique_id_column,
+        label_column=resolved.label_column,
+        intent=resolved.intent,
+        annotation_column=resolved.annotation_column,
+        category=resolved.category,
+        data_format=resolved.data_format,
+        label_policy=resolved.label_policy,
+    )
+
+    if resolved.source_type == "csv":
+        return CSVIngestor(
+            **common_kwargs,
+            csv_options=resolved.csv_options,
+            file_options=resolved.file_options,
+        )
+
+    if resolved.source_type == "json":
+        # The schema doesn't expose json_options yet; defaults are fine
+        # for v1. file_options carries category-specific knobs that
+        # BaseIngestor passes to map_validators (e.g. time_column for
+        # time_to_event_prediction, target_size for image categories).
+        return JSONIngestor(
+            **common_kwargs,
+            json_options={},
+            file_options=resolved.file_options,
+        )
+
+    raise ValueError(
+        f"Unknown source_type {resolved.source_type!r}; "
+        "this is a bug — the schema's oneOf should have rejected the config."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fail(message: str) -> int:
+    """Print to stderr and return non-zero. Logger may not be configured yet
+    when validation fails (it depends on Config() which depends on env
+    being set), so a plain stderr write is the most reliable channel."""
+    print(message, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -217,7 +217,8 @@ def _set_legacy_env_vars(resolved: ResolvedConfig) -> None:
     """
     src_path = None
     src_path_source = (
-        resolved.images or resolved.texts or resolved.masks or resolved.annotations
+        resolved.images or resolved.texts or resolved.masks
+        or resolved.annotations or resolved.sequences
     )
     if src_path_source:
         src_path = os.path.dirname(src_path_source.rstrip("/"))

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -1,69 +1,184 @@
-from typing import Dict, Any, Optional
+"""Lazy, env-driven configuration.
+
+Every env-driven field is a ``@property`` that reads ``os.environ`` on
+access. Module-level ``config = Config()`` snapshots in validators and
+ingestors stay valid even when env vars are set after those modules
+import — e.g. the declarative entrypoint (``cli/run.py:main``) resolves
+``ingest.yaml`` into env vars *after* the validator modules have already
+imported.
+
+Tests inject pinpoint values via ``Config(FIELD=value)``; instance
+overrides win over env. Production callers pass no kwargs.
+"""
+
+from typing import Any, Dict, Optional
 import os
-from dataclasses import dataclass
+
 from .utils.constants import LogLevel
 
 
-@dataclass
+# Sentinel signalling \"caller did not pass this field as an override\".
+# Distinguishes the absent case from an explicit ``Field=None``, which
+# tests use to *suppress* a value (e.g. ``BACKEND_TOKEN=None``).
+_MISSING = object()
+
+
 class Config:
-    # ===== Database =====
-    # The cluster-internal MySQL is bundled by the tracebloc client and ships
-    # with these credentials baked into its image. They never vary per customer,
-    # are not exposed outside the cluster, and are connection conventions rather
-    # than secrets. Override via env only if you've replaced the bundled MySQL.
-    DB_HOST: str = os.getenv("MYSQL_HOST", "localhost")
-    DB_PORT: int = int(os.getenv("MYSQL_PORT", "3306"))
-    DB_USER: str = os.getenv("DB_USER", "edgeuser")
-    DB_PASSWORD: str = os.getenv("DB_PASSWORD", "Edg9@Tr@ce")
-    DB_NAME: str = os.getenv("DB_NAME", "training_test_datasets")
-
-    BATCH_SIZE: int = int(os.getenv("BATCH_SIZE", "4000"))
-
-    # Define API endpoints for different environments
-    API_ENDPOINTS = {
+    # ===== Cluster-safe class-level constants (not env-driven) =====
+    API_ENDPOINTS: Dict[str, str] = {
         "dev": "https://dev-api.tracebloc.io",
         "stg": "https://stg-api.tracebloc.io",
         "prod": "https://api.tracebloc.io",
-        "local": "http://localhost:8000",  # Add local endpoint
+        "local": "http://localhost:8000",
     }
-    STORAGE_PATH = "/data/shared"
+    STORAGE_PATH: str = "/data/shared"
 
-    # Get environment and set appropriate API endpoint, default to prod
-    EDGE_ENV: str = os.getenv("CLIENT_ENV", "prod")
-    API_ENDPOINT: str = API_ENDPOINTS.get(EDGE_ENV, API_ENDPOINTS["dev"])
+    # Whitelist of valid override keys. A typo at the call site raises
+    # immediately rather than silently no-op'ing.
+    _ENV_FIELDS = frozenset({
+        "DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
+        "BATCH_SIZE",
+        "EDGE_ENV",
+        "BACKEND_TOKEN", "CLIENT_USERNAME", "CLIENT_PASSWORD",
+        "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
+        "LOG_LEVEL",
+    })
+
+    # Numeric fields whose properties unconditionally coerce via ``int(...)``.
+    # ``Config(FIELD=None)`` works for nullable fields (BACKEND_TOKEN etc.)
+    # but is nonsensical here — reject at construction with a clear message
+    # rather than letting ``int(None)`` blow up later at property access.
+    _NUMERIC_FIELDS = frozenset({"DB_PORT", "BATCH_SIZE"})
+
+    def __init__(self, **overrides: Any) -> None:
+        unknown = set(overrides) - self._ENV_FIELDS
+        if unknown:
+            raise TypeError(
+                f"Config got unexpected keyword arguments: {sorted(unknown)}"
+            )
+        for field in self._NUMERIC_FIELDS & set(overrides):
+            if overrides[field] is None:
+                raise TypeError(
+                    f"Config({field}=None) is invalid: {field} is numeric "
+                    "and cannot be suppressed via None. Omit the kwarg to "
+                    "fall back to env / default."
+                )
+        self._overrides: Dict[str, Any] = dict(overrides)
+
+    def _override(self, name: str, default: Any = _MISSING) -> Any:
+        """Return the per-instance override for ``name`` if one was passed,
+        otherwise ``default`` (sentinel by default — callers branch on it)."""
+        if name in self._overrides:
+            return self._overrides[name]
+        return default
+
+    # ===== Database =====
+    # Cluster-internal MySQL ships with these credentials baked into its
+    # image; they're connection conventions, not secrets. Override via env
+    # only if you've replaced the bundled MySQL.
+    @property
+    def DB_HOST(self) -> str:
+        ov = self._override("DB_HOST")
+        return ov if ov is not _MISSING else os.environ.get("MYSQL_HOST", "localhost")
+
+    @property
+    def DB_PORT(self) -> int:
+        ov = self._override("DB_PORT")
+        raw = ov if ov is not _MISSING else os.environ.get("MYSQL_PORT", "3306")
+        return int(raw)
+
+    @property
+    def DB_USER(self) -> str:
+        ov = self._override("DB_USER")
+        return ov if ov is not _MISSING else os.environ.get("DB_USER", "edgeuser")
+
+    @property
+    def DB_PASSWORD(self) -> str:
+        ov = self._override("DB_PASSWORD")
+        return ov if ov is not _MISSING else os.environ.get("DB_PASSWORD", "Edg9@Tr@ce")
+
+    @property
+    def DB_NAME(self) -> str:
+        ov = self._override("DB_NAME")
+        return ov if ov is not _MISSING else os.environ.get("DB_NAME", "training_test_datasets")
+
+    @property
+    def BATCH_SIZE(self) -> int:
+        ov = self._override("BATCH_SIZE")
+        raw = ov if ov is not _MISSING else os.environ.get("BATCH_SIZE", "4000")
+        return int(raw)
+
+    # ===== API =====
+    @property
+    def EDGE_ENV(self) -> str:
+        ov = self._override("EDGE_ENV")
+        return ov if ov is not _MISSING else os.environ.get("CLIENT_ENV", "prod")
+
+    @property
+    def API_ENDPOINT(self) -> str:
+        return self.API_ENDPOINTS.get(self.EDGE_ENV, self.API_ENDPOINTS["dev"])
 
     # ===== Auth =====
-    # Preferred: pre-minted token from upstream (e.g. jobs-manager), passed via env.
-    # Mirrors the training-pod pattern; no long-lived credentials in the pod.
-    BACKEND_TOKEN: Optional[str] = os.getenv("BACKEND_TOKEN")
+    # Preferred: pre-minted token from upstream (e.g. jobs-manager) via env.
+    @property
+    def BACKEND_TOKEN(self) -> Optional[str]:
+        ov = self._override("BACKEND_TOKEN")
+        return ov if ov is not _MISSING else os.environ.get("BACKEND_TOKEN")
 
-    # Fallback: username/password. Deprecated — kept for one minor version while
-    # callers migrate to BACKEND_TOKEN, then removed in a follow-up.
-    CLIENT_USERNAME: Optional[str] = os.getenv("CLIENT_ID")
-    CLIENT_PASSWORD: Optional[str] = os.getenv("CLIENT_PASSWORD")
+    # Fallback: username/password. Deprecated — kept for one minor version
+    # while callers migrate to BACKEND_TOKEN, then removed in a follow-up.
+    @property
+    def CLIENT_USERNAME(self) -> Optional[str]:
+        ov = self._override("CLIENT_USERNAME")
+        return ov if ov is not _MISSING else os.environ.get("CLIENT_ID")
 
-    SRC_PATH: str = os.getenv(
-        "SRC_PATH",
-        "~/Downloads/data-ingestors/data/crowd_monitoring/dataset_voc_512_mini/train",
-    )  # path to the source data
-    DEST_PATH: str = os.path.join(
-        STORAGE_PATH, os.getenv("TABLE_NAME", "image_ingestor_train")
-    )  # path to the destination data with table name
-    LABEL_FILE: str = os.getenv(
-        "LABEL_FILE",
-        "~/Downloads/data-ingestors/data/crowd_monitoring/dataset_voc_512_mini/train/labels_file.csv",
-    )
-    TABLE_NAME: str = os.getenv("TABLE_NAME", "image_classification_ingestor_train2")
-    TITLE: str = os.getenv("TITLE", "DELETE-Object detection training data")
+    @property
+    def CLIENT_PASSWORD(self) -> Optional[str]:
+        ov = self._override("CLIENT_PASSWORD")
+        return ov if ov is not _MISSING else os.environ.get("CLIENT_PASSWORD")
 
-    # Logging configuration
-    LOG_LEVEL: int = LogLevel.get_level_code(os.getenv("LOG_LEVEL", "WARNING"))
+    # ===== Paths =====
+    # No laptop-path defaults: in production, the declarative entrypoint
+    # (cli/run.py:main) sets these from the resolved ingest.yaml. Empty
+    # string fails loudly in path operations rather than silently scanning
+    # a developer-laptop directory.
+    @property
+    def SRC_PATH(self) -> str:
+        ov = self._override("SRC_PATH")
+        return ov if ov is not _MISSING else os.environ.get("SRC_PATH", "")
+
+    @property
+    def LABEL_FILE(self) -> str:
+        ov = self._override("LABEL_FILE")
+        return ov if ov is not _MISSING else os.environ.get("LABEL_FILE", "")
+
+    @property
+    def TABLE_NAME(self) -> str:
+        ov = self._override("TABLE_NAME")
+        return ov if ov is not _MISSING else os.environ.get("TABLE_NAME", "")
+
+    @property
+    def DEST_PATH(self) -> str:
+        return os.path.join(self.STORAGE_PATH, self.TABLE_NAME)
+
+    @property
+    def TITLE(self) -> Optional[str]:
+        ov = self._override("TITLE")
+        return ov if ov is not _MISSING else os.environ.get("TITLE")
+
+    # ===== Logging =====
+    @property
+    def LOG_LEVEL(self) -> int:
+        ov = self._override("LOG_LEVEL")
+        if ov is not _MISSING:
+            return ov if isinstance(ov, int) else LogLevel.get_level_code(ov)
+        return LogLevel.get_level_code(os.environ.get("LOG_LEVEL", "WARNING"))
 
     def validate(self) -> None:
         """Fail fast on missing backend authentication.
 
         Called explicitly by ``APIClient.__init__`` (the boot moment for a
-        real run) rather than from ``__post_init__`` so that incidental
+        real run) rather than from ``__init__`` so that incidental
         module-level ``Config()`` instantiations elsewhere in the package
         don't blow up at import time.
 
@@ -72,12 +187,13 @@ class Config:
           - ``CLIENT_ID`` + ``CLIENT_PASSWORD`` (deprecated fallback).
 
         Database credentials are intentionally **not** validated here: the
-        bundled MySQL container ships with fixed credentials that the ingestor
-        defaults match. They're a connection convention, not a secret, and
-        forcing customers to set them in env vars adds friction with no
-        security benefit.
+        bundled MySQL container ships with fixed credentials that the
+        ingestor defaults match. They're a connection convention, not a
+        secret, and forcing customers to set them in env vars adds friction
+        with no security benefit.
 
-        Set ``CLIENT_ENV=local`` to bypass for development against a mock backend.
+        Set ``CLIENT_ENV=local`` to bypass for development against a mock
+        backend.
 
         Raises:
             ValueError: with a single, comma-joined list of missing vars,
@@ -88,7 +204,6 @@ class Config:
 
         missing = []
 
-        # Backend auth: either pre-minted token, or the deprecated cred pair.
         has_token = bool(self.BACKEND_TOKEN)
         has_creds = bool(self.CLIENT_USERNAME and self.CLIENT_PASSWORD)
         if not has_token and not has_creds:

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -63,14 +63,28 @@ def _copy_file_with_retry(src_path: str, dest_path: str) -> None:
 
 
 def _has_extension(filename: str) -> bool:
-    """Check if filename has an extension, handling multiple dots correctly."""
+    """Check if filename has an extension, handling multiple dots correctly.
+
+    ``FileExtension.get_all_extensions()`` returns values WITH the leading
+    dot (``".jpeg"`` etc.), but ``str.split(".")`` on a filename like
+    ``"cat1.jpeg"`` yields ``["cat1", "jpeg"]`` — the last part has no
+    leading dot. Without normalization, the membership check always
+    returned False, ``_find_src`` then appended the extension a second
+    time, and the resulting ``cat1.jpeg.jpeg`` path never existed on
+    disk. Surfaced during real-cluster ingestion (2026-05-19): all 576
+    sample records were ``Source image not found: ...jpeg.jpeg`` while
+    the ingestion summary still reported 100% success (which the
+    summary fix #99/#100 now addresses separately).
+    """
     if not filename:
         return False
 
     allowed_extensions = FileExtension.get_all_extensions()
-    parts = filename.split(".")
+    parts = filename.rsplit(".", 1)
     if len(parts) > 1:
-        ext = parts[len(parts) - 1]
+        # Compare with leading dot + case-insensitive so ``Cat1.JPEG``
+        # also resolves to a hit.
+        ext = "." + parts[-1].lower()
         return ext in allowed_extensions
     return False
 

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -7,7 +7,7 @@ supporting both binary data and file-based image processing.
 
 import logging
 import os
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 import shutil
 import time
 
@@ -99,13 +99,19 @@ def image_transfer(
     options: Dict[str, Any],
     src_path: str = None,
     filename_with_ext: str = None,
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """Copy an image from SRC_PATH/images/ to DEST_PATH/.
 
     Callers that have already resolved the source via `_find_src` (e.g.
     atomic multi-file branches that need to pre-check existence) can
     pass `src_path` and `filename_with_ext` to skip the lookup; in that
     mode no filesystem stat happens here.
+
+    Returns ``None`` if the source file cannot be located or the record
+    is missing a filename. The caller in ``BaseIngestor.ingest`` treats
+    ``None`` as a file-transfer skip — see issue #99 (silent data-loss
+    pattern: returning the record on a missing source let the DB/API
+    write succeed and falsely report 100% success).
     """
     # Create destination directory if it doesn't exist
     os.makedirs(config.DEST_PATH, exist_ok=True)
@@ -116,7 +122,7 @@ def image_transfer(
         extension = options.get("extension")
         if not filename:
             logger.error(f"{RED}No filename found in record{RESET}")
-            return record
+            return None
 
         if src_path is None:
             src_path, filename_with_ext = _find_src("images", filename, extension)
@@ -124,7 +130,7 @@ def image_transfer(
                 logger.error(
                     f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', filename_with_ext)}{RESET}"
                 )
-                return record
+                return None
 
         # Save the resized image
         image_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)
@@ -154,12 +160,14 @@ def annotation_transfer(
     extension: str,
     src_path: str = None,
     filename_with_ext: str = None,
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """Copy an annotation file from SRC_PATH/annotations/ to DEST_PATH/.
 
     Callers that have already resolved the source via `_find_src` can
     pass `src_path` and `filename_with_ext` to skip the lookup; in that
     mode no filesystem stat happens here.
+
+    Returns ``None`` on missing source (see issue #99).
     """
     # Create destination directory if it doesn't exist
     os.makedirs(config.DEST_PATH, exist_ok=True)
@@ -169,7 +177,7 @@ def annotation_transfer(
         filename = record.get("filename")
         if not filename:
             logger.error(f"{RED}No filename found in record{RESET}")
-            return record
+            return None
 
         if src_path is None:
             src_path, filename_with_ext = _find_src(
@@ -179,7 +187,7 @@ def annotation_transfer(
                 logger.error(
                     f"{RED}Source file not found: {os.path.join(config.SRC_PATH, 'annotations', filename_with_ext)}{RESET}"
                 )
-                return record
+                return None
 
         # Save the file
         file_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)
@@ -197,7 +205,7 @@ def text_transfer(
     record: Dict[str, Any],
     options: Dict[str, Any],
     src_subdir: str = "texts",
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """Transfer text files for text-based tasks.
 
     Args:
@@ -208,7 +216,7 @@ def text_transfer(
                      ``"sequences"`` for masked language modeling)
 
     Returns:
-        Updated record dictionary
+        Updated record dictionary, or ``None`` on missing source (see issue #99).
     """
     # Create destination directory if it doesn't exist
     os.makedirs(config.DEST_PATH, exist_ok=True)
@@ -219,7 +227,7 @@ def text_transfer(
         extension = options.get("extension")
         if not filename:
             logger.error(f"{RED}No filename found in record{RESET}")
-            return record
+            return None
 
         # Add extension to filename if it doesn't have one
         if not _has_extension(filename):
@@ -231,7 +239,7 @@ def text_transfer(
         text_src_path = os.path.join(config.SRC_PATH, src_subdir, filename_with_ext)
         if not os.path.exists(text_src_path):
             logger.error(f"{RED}Source text file not found: {text_src_path}{RESET}")
-            return record
+            return None
 
         # Save the text file
         text_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -193,12 +193,19 @@ def annotation_transfer(
         raise ValueError(f"{RED}Error processing binary file: {str(e)}{RESET}")
 
 
-def text_transfer(record: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, Any]:
-    """Transfer text files for text classification tasks.
+def text_transfer(
+    record: Dict[str, Any],
+    options: Dict[str, Any],
+    src_subdir: str = "texts",
+) -> Dict[str, Any]:
+    """Transfer text files for text-based tasks.
 
     Args:
         record: Dictionary containing filename and other record data
         options: Dictionary containing transfer options like extension
+        src_subdir: Subdirectory under SRC_PATH where source files live
+                    (``"texts"`` for text classification,
+                     ``"sequences"`` for masked language modeling)
 
     Returns:
         Updated record dictionary
@@ -221,7 +228,7 @@ def text_transfer(record: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, 
             filename_with_ext = filename
 
         # Process the text file
-        text_src_path = os.path.join(config.SRC_PATH, "texts", filename_with_ext)
+        text_src_path = os.path.join(config.SRC_PATH, src_subdir, filename_with_ext)
         if not os.path.exists(text_src_path):
             logger.error(f"{RED}Source text file not found: {text_src_path}{RESET}")
             return record
@@ -328,6 +335,9 @@ def map_file_transfer(
         return result
     elif task_category == TaskCategory.TEXT_CLASSIFICATION:
         result = text_transfer(record, options)
+        return result
+    elif task_category == TaskCategory.MASKED_LANGUAGE_MODELING:
+        result = text_transfer(record, options, src_subdir="sequences")
         return result
     elif task_category == TaskCategory.SEMANTIC_SEGMENTATION:
         # Atomic: only copy image+mask together. Pre-verify both sources

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -143,10 +143,6 @@ class BaseIngestor(ABC):
                 f"server-side UUIDs instead.{RESET}"
             )
         
-        # Add schema to file_options for validators if not already present
-        if schema and "schema" not in self.file_options:
-            self.file_options["schema"] = schema
-
         # Remove label_column, annotation_column, and unique_id_column from schema
         # These are handled separately and should not be ingested as regular columns
         table_schema = schema.copy()
@@ -156,6 +152,15 @@ class BaseIngestor(ABC):
             del table_schema[self.annotation_column]
         if self.unique_id_column and self.unique_id_column in table_schema:
             del table_schema[self.unique_id_column]
+
+        # Add cleaned schema to file_options for validators / downstream metadata.
+        # Always overwrite so a schema passed in by the template (which may still
+        # contain the label/annotation/unique_id columns) is sanitized before
+        # being sent to the backend as part of meta_data.
+        if schema:
+            self.file_options["schema"] = table_schema
+            if "number_of_columns" in self.file_options:
+                self.file_options["number_of_columns"] = len(table_schema)
 
         # Ensure table exists
         self.table = self.database.create_table(table_name, table_schema)

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -40,7 +40,13 @@ class IngestionSummary(NamedTuple):
         inserted_records: Number of records inserted into database
         api_sent_records: Number of records sent to API
         failed_records: Number of records that failed processing
-        skipped_records: Number of records that were skipped
+        skipped_records: Number of records that were skipped for non-file
+            reasons (e.g. missing label / invalid intent / processing error)
+        file_transfer_failures: Number of records whose source file (image,
+            annotation, mask, text) was missing or unreadable, so the
+            record was dropped before the DB / API write. Tracked
+            separately from ``skipped_records`` so operators can
+            distinguish data-loss from validation skips (issue #99).
     """
 
     ingestor_id: str
@@ -50,6 +56,21 @@ class IngestionSummary(NamedTuple):
     api_sent_records: int
     failed_records: int
     skipped_records: int
+    file_transfer_failures: int = 0
+
+    @property
+    def has_failures(self) -> bool:
+        """True if any non-trivial failure occurred — DB insert short of
+        total, API short of inserted, file-transfer skipped any record,
+        or processing errored. Used to gate the "completed successfully"
+        banner so customers can't mistake a partial run for a clean one.
+        """
+        return (
+            self.failed_records > 0
+            or self.file_transfer_failures > 0
+            or self.inserted_records < self.total_records
+            or self.api_sent_records < self.inserted_records
+        )
 
 
 class BaseIngestor(ABC):
@@ -376,6 +397,7 @@ class BaseIngestor(ABC):
             "api_sent_records": 0,
             "failed_records": 0,
             "skipped_records": 0,
+            "file_transfer_failures": 0,
         }
 
         # Try to get total count for progress bar
@@ -405,12 +427,36 @@ class BaseIngestor(ABC):
                                 processed_record = map_file_transfer(
                                     self.category, processed_record, self.file_options
                                 )
-                                # Skip record if file transfer failed
+                                # Skip record if file transfer failed. Tracked as
+                                # `file_transfer_failures` (not `skipped_records`)
+                                # so the summary can flag the silent-data-loss
+                                # pattern from issue #99 — a missing source
+                                # would otherwise let the DB / API write succeed
+                                # and falsely report 100% success.
                                 if processed_record is None:
-                                    stats["skipped_records"] += 1
+                                    stats["file_transfer_failures"] += 1
+                                    filename = record.get("filename", "Unknown")
                                     logger.warning(
-                                        f"Skipping record due to file transfer failure: {record.get('filename', 'Unknown')}"
+                                        f"Skipping record due to file transfer failure: {filename}"
                                     )
+                                    # Also surface the failure to the caller
+                                    # so cli.run.main exits non-zero — without
+                                    # this, a 100%-failed run would still
+                                    # return [] and the K8s job marker would
+                                    # be `Succeeded` (the silent-data-loss
+                                    # pattern from #99).
+                                    failed_records.append(
+                                        {
+                                            "record": record,
+                                            "error": "file_transfer_failed",
+                                        }
+                                    )
+                                    # Advance the progress bar so an
+                                    # all-transfer-failure run doesn't leave
+                                    # tqdm stuck at 0/N — without this the
+                                    # `continue` skips the batch update that
+                                    # would normally tick the bar.
+                                    pbar.update(1)
                                     continue
 
                             batch.append(processed_record)
@@ -547,16 +593,31 @@ class BaseIngestor(ABC):
             raise
 
     def _log_summary(self, summary: IngestionSummary):
-        """Log ingestion summary in a clear, formatted way with enhanced visual appeal"""
+        """Log ingestion summary in a clear, formatted way with enhanced visual appeal.
 
-        # Calculate success rate
+        A "success" here means the record was inserted to the DB, sent to
+        the API, AND its sidecar file (image / annotation / mask / text)
+        was copied to the destination. Records whose source file was
+        missing are subtracted from the success count even if the DB
+        row landed — see issue #99 for the silent-data-loss pattern that
+        motivated this.
+        """
+
+        # A successful record requires DB insert AND API send AND, where
+        # applicable, a successful file transfer. File-transfer failures
+        # short-circuit before the DB write (they're skipped from the
+        # batch), so subtracting them from total_records gives the
+        # denominator's effective ceiling. Use inserted_records (the
+        # actual durable outcome) as the numerator.
         success_rate = 0
         if summary.total_records > 0:
             success_rate = (summary.inserted_records / summary.total_records) * 100
 
         # Determine overall status color
         status_color = (
-            GREEN if success_rate >= 90 else YELLOW if success_rate >= 70 else RED
+            GREEN if success_rate >= 90 and not summary.has_failures
+            else YELLOW if success_rate >= 70
+            else RED
         )
 
         print(f"\n{CYAN}{'═'*60}{RESET}")
@@ -581,11 +642,24 @@ class BaseIngestor(ABC):
         print(
             f"{BOLD}⏭️  Skipped Records:{RESET}        {YELLOW}{summary.skipped_records:,}{RESET}"
         )
+        file_transfer_color = (
+            RED if summary.file_transfer_failures > 0 else GREEN
+        )
+        print(
+            f"{BOLD}📁 File Transfer Failures:{RESET}  {file_transfer_color}{summary.file_transfer_failures:,}{RESET}"
+        )
         print(
             f"{BOLD}❌ Failed DB Insertion:{RESET}     {RED}{summary.failed_records:,}{RESET}"
         )
+        # Only count records that made it to a DB insert but didn't ship
+        # to the API. Using `total_records - api_sent_records` would also
+        # include file-transfer failures and DB failures (which never had
+        # a chance to ship), giving an inflated, double-counted total.
+        api_only_failures = max(
+            0, summary.inserted_records - summary.api_sent_records
+        )
         print(
-            f"{BOLD}❌ Failed to Send to API:{RESET}   {RED}{(summary.total_records - summary.api_sent_records):,}{RESET}"
+            f"{BOLD}❌ Failed to Send to API:{RESET}   {RED}{api_only_failures:,}{RESET}"
         )
         print(f"{CYAN}{'─'*60}{RESET}")
 
@@ -599,15 +673,36 @@ class BaseIngestor(ABC):
                 f"{BOLD}📊 Success Rate:{RESET} [{status_color}{bar}{RESET}] {status_color}{success_rate:.1f}%{RESET}"
             )
 
-        # Status message
-        if success_rate >= 95:
+        # Status banner. Any non-trivial failure (DB, API, or file-transfer)
+        # disqualifies the "completed successfully" message — a customer
+        # seeing 🎉 should be able to trust that no record was silently
+        # dropped. The three failure channels are mutually exclusive per
+        # record (file-transfer failures never reach DB; DB failures never
+        # reach API; api_only_failures are records that hit DB but didn't
+        # ship), so summing them gives a clean unique count instead of
+        # the double-count `total_records - api_sent_records` would produce.
+        total_failures = (
+            summary.failed_records
+            + summary.file_transfer_failures
+            + api_only_failures
+        )
+        if not summary.has_failures:
             status_msg = "🎉 Ingestion completed successfully!"
         elif success_rate >= 80:
-            status_msg = "👍 Most records processed successfully."
+            status_msg = (
+                f"⚠️  Ingestion completed with {total_failures:,} failure(s), "
+                "see logs."
+            )
         elif success_rate >= 60:
-            status_msg = "⚠️  Some records failed to process."
+            status_msg = (
+                f"⚠️  Ingestion completed with {total_failures:,} failure(s); "
+                "many records failed to process — see logs."
+            )
         else:
-            status_msg = "❌ Critical! Many records failed to process."
+            status_msg = (
+                f"❌ Critical! Ingestion completed with {total_failures:,} "
+                "failure(s); most records failed — see logs."
+            )
 
         print(f"{CYAN}{'─'*60}{RESET}")
         print(f"{BOLD}{status_color}{status_msg}{RESET}")

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -400,6 +400,7 @@ class BaseIngestor(ABC):
                                 TaskCategory.TEXT_CLASSIFICATION,
                                 TaskCategory.SEMANTIC_SEGMENTATION,
                                 TaskCategory.KEYPOINT_DETECTION,
+                                TaskCategory.MASKED_LANGUAGE_MODELING,
                             ]:
                                 processed_record = map_file_transfer(
                                     self.category, processed_record, self.file_options

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -20,6 +20,7 @@ from ..utils.constants import (
     BLUE,
     CYAN,
 )
+from ..utils import label_policy as label_policy_module
 from ..utils.validators_mapping import map_validators
 from ..file_transfer import map_file_transfer
 
@@ -86,6 +87,7 @@ class BaseIngestor(ABC):
         category: Optional[str] = None,
         data_format: Optional[str] = None,
         file_options: Optional[Dict[str, Any]] = None,
+        label_policy: str = label_policy_module.PASSTHROUGH,
     ):
         """Initialize the base ingestor.
 
@@ -102,6 +104,13 @@ class BaseIngestor(ABC):
             category: Category of the data
             data_format: Format of the data
             file_options: File options to run before ingestion
+            label_policy: ``"passthrough"`` (default; classification — the
+                label value crosses the cluster boundary unchanged) or
+                ``"bucket"`` (regression-class — each label is replaced
+                with a stable hash-bucket ID before the API payload is
+                built, so raw target values never leak). Schema-validated
+                upstream by the YAML entrypoint; templates pass the
+                appropriate constant from :mod:`tracebloc_ingestor.utils.label_policy`.
         Raises:
             ValueError: If unique_id_column is not provided
         """
@@ -119,6 +128,7 @@ class BaseIngestor(ABC):
         self.category = category
         self.data_format = data_format
         self.file_options = file_options or {}
+        self.label_policy = label_policy
 
         # Default behavior is UUID-generated data_id (no source column leaves
         # the cluster). Opting into source-column mapping is allowed but loud:
@@ -190,7 +200,15 @@ class BaseIngestor(ABC):
             )
 
         if self.label_column:
-            cleaned_record["label"] = record.get(self.label_column)
+            # Apply the configured label policy at the latest possible moment
+            # before the API client builds its payload. For classification-class
+            # categories ``label_policy="passthrough"`` is a no-op; for
+            # regression-class categories ``"bucket"`` replaces the raw target
+            # with a stable hash-bucket ID so the value never leaks to the
+            # central backend (#44 / parent client#85).
+            cleaned_record["label"] = label_policy_module.apply(
+                record.get(self.label_column), self.label_policy
+            )
 
         if self.intent:
             cleaned_record["data_intent"] = self.intent

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -13,6 +13,7 @@ from .base import BaseIngestor
 from ..database import Database
 from ..api.client import APIClient
 from ..utils.constants import RESET, RED, YELLOW, TaskCategory
+from ..utils import label_policy as label_policy_module
 from ..config import Config
 
 config = Config()
@@ -49,6 +50,7 @@ class CSVIngestor(BaseIngestor):
         annotation_column: Optional[str] = None,
         category: Optional[str] = None,
         data_format: Optional[str] = None,
+        label_policy: str = label_policy_module.PASSTHROUGH,
     ):
         """Initialize CSV Ingestor.
 
@@ -66,7 +68,10 @@ class CSVIngestor(BaseIngestor):
             annotation_column: Name of the column to use as annotation
             category: Category of the data
             data_format: Format of the data
-            log_level: Level of the logger
+            label_policy: Bucketing policy for the label value before it's
+                sent to the central backend. ``"passthrough"`` for
+                classification (default); ``"bucket"`` for regression-class
+                tasks so raw target values never leak.
         """
         super().__init__(
             database,
@@ -81,6 +86,7 @@ class CSVIngestor(BaseIngestor):
             category,
             data_format,
             file_options,
+            label_policy=label_policy,
         )
         self.csv_options = csv_options or {}
         self.file_options = file_options or {}

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -89,7 +89,6 @@ class CSVIngestor(BaseIngestor):
             label_policy=label_policy,
         )
         self.csv_options = csv_options or {}
-        self.file_options = file_options or {}
 
     def _validate_csv(self, df: pd.DataFrame) -> None:
         """Validate CSV data against schema using pandas functionality.

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -14,7 +14,7 @@ from .base import BaseIngestor
 from ..database import Database
 from ..api.client import APIClient
 from ..utils.constants import RESET, RED, YELLOW
-from ..validators import BaseValidator
+from ..utils import label_policy as label_policy_module
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +46,9 @@ class JSONIngestor(BaseIngestor):
         annotation_column: Optional[str] = None,
         category: Optional[str] = None,
         data_format: Optional[str] = None,
+        file_options: Optional[Dict[str, Any]] = None,
         log_level: Optional[int] = None,
-        validators: Optional[List[BaseValidator]] = None,
+        label_policy: str = label_policy_module.PASSTHROUGH,
     ):
         """Initialize JSON Ingestor.
 
@@ -64,8 +65,14 @@ class JSONIngestor(BaseIngestor):
             annotation_column: Name of the column to use as annotation
             category: Category of the data
             data_format: Format of the data
+            file_options: Options passed to the validator set resolved by
+                ``map_validators(category, file_options)``. For
+                ``time_to_event_prediction`` this carries ``time_column``;
+                for image categories it carries ``target_size`` / ``extension``.
             log_level: Level of the logger
-            validators: List of validators to run before ingestion
+            label_policy: Bucketing policy for the label value before it's
+                sent to the central backend. ``"passthrough"`` (default)
+                for classification; ``"bucket"`` for regression-class.
         """
         super().__init__(
             database,
@@ -79,11 +86,12 @@ class JSONIngestor(BaseIngestor):
             annotation_column,
             category,
             data_format,
-            log_level,
-            validators,
+            file_options,
+            label_policy=label_policy,
         )
         self.json_options = json_options or {}
-        logger.setLevel(log_level)
+        if log_level is not None:
+            logger.setLevel(log_level)
 
     def _validate_record(self, record: Dict[str, Any]) -> None:
         """Validate JSON record against schema.

--- a/tracebloc_ingestor/schema/__init__.py
+++ b/tracebloc_ingestor/schema/__init__.py
@@ -1,0 +1,9 @@
+# Marker file so setuptools.find_packages() treats this directory as a
+# subpackage of tracebloc_ingestor. Without this, the package_data
+# declaration ``"tracebloc_ingestor.schema": ["*.json"]`` in setup.py
+# is a silent no-op — setuptools refuses to attach data files to a
+# directory it doesn't know is a package, and the bundled
+# ``ingest.v1.json`` ends up missing from the built wheel.
+# Discovered during real-cluster validation (2026-05-19): the ingestor
+# Job crashed with FileNotFoundError on the schema path inside the
+# installed site-packages tree.

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -35,7 +35,8 @@
         "tabular_classification",
         "tabular_regression",
         "time_series_forecasting",
-        "time_to_event_prediction"
+        "time_to_event_prediction",
+        "masked_language_modeling"
       ],
       "description": "Task category. Drives convention defaults: validators, data_format, default columns, default file extensions, default validator set."
     },
@@ -86,6 +87,12 @@
       "type": "string",
       "minLength": 1,
       "description": "Directory holding text files referenced by the labels CSV. Required for text_classification."
+    },
+
+    "sequences": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Directory holding sequence text files (.txt). Required for masked_language_modeling."
     },
 
     "label": {
@@ -299,6 +306,14 @@
         "required": ["category"]
       },
       "then": { "required": ["texts"] }
+    },
+    {
+      "description": "masked_language_modeling requires `sequences`.",
+      "if": {
+        "properties": { "category": { "const": "masked_language_modeling" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["sequences"] }
     },
     {
       "description": "tabular and time-series categories require `schema`.",

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -1,0 +1,365 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tracebloc.io/schemas/ingest.v1.json",
+  "title": "tracebloc IngestConfig (v1)",
+  "description": "Declarative configuration for the tracebloc data ingestor. Replaces the per-customer Python script + Dockerfile pattern. Customers describe their dataset; the official image runs it.",
+  "type": "object",
+  "additionalProperties": false,
+
+  "required": [
+    "apiVersion",
+    "kind",
+    "category",
+    "table",
+    "intent"
+  ],
+
+  "properties": {
+    "apiVersion": {
+      "const": "tracebloc.io/v1",
+      "description": "Schema version. Breaking changes require v2."
+    },
+    "kind": {
+      "const": "IngestConfig"
+    },
+
+    "category": {
+      "type": "string",
+      "enum": [
+        "image_classification",
+        "object_detection",
+        "keypoint_detection",
+        "semantic_segmentation",
+        "instance_segmentation",
+        "text_classification",
+        "tabular_classification",
+        "tabular_regression",
+        "time_series_forecasting",
+        "time_to_event_prediction"
+      ],
+      "description": "Task category. Drives convention defaults: validators, data_format, default columns, default file extensions, default validator set."
+    },
+
+    "table": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Destination table name in the cluster-internal MySQL. Used to identify the dataset in subsequent runs."
+    },
+
+    "intent": {
+      "type": "string",
+      "enum": ["train", "test"],
+      "description": "Whether this dataset is for training or held-out testing."
+    },
+
+    "csv": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to the labels CSV. Mutually exclusive with `json`. The dominant source type."
+    },
+
+    "json": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to a JSON dataset. Mutually exclusive with `csv`."
+    },
+
+    "images": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Directory holding the image files referenced by the labels CSV. Required for image-based categories."
+    },
+
+    "annotations": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Directory holding annotation files (e.g. Pascal VOC XML). Required for object_detection."
+    },
+
+    "masks": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Directory holding segmentation mask images (PNG). Required for semantic_segmentation."
+    },
+
+    "texts": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification."
+    },
+
+    "label": {
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "description": "Shorthand: column name in the CSV that holds the label. Implies policy=passthrough."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["column"],
+          "properties": {
+            "column": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Column name in the CSV that holds the label."
+            },
+            "policy": {
+              "type": "string",
+              "enum": ["passthrough", "bucket"],
+              "description": "How label values are sent to the central backend. `passthrough` (default for classification) sends the raw value. `bucket` (required for regression-class tasks) bins the value before send so the central backend never sees the raw target."
+            }
+          }
+        }
+      ],
+      "description": "Label specification. Can be a string (column name) for the common case, or an object for explicit policy control."
+    },
+
+    "schema": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Column → SQL type map (e.g. {'age': 'INT', 'name': 'VARCHAR(255)'}). Required for tabular and time-series categories."
+    },
+
+    "time_column": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Name of the time column for time_to_event_prediction. Falls back to a column named `time` if unset."
+    },
+
+    "data_id": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["strategy"],
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": ["uuid", "column"],
+          "default": "uuid",
+          "description": "How `data_id` is generated. `uuid` (default) generates a fresh UUID per record — no source column leaves the cluster. `column` maps a source column's value, which is louder (logged warning) and only safe when the column doesn't carry PII."
+        },
+        "column": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Required when strategy=column. The source column whose values become `data_id`."
+        }
+      },
+      "if": { "properties": { "strategy": { "const": "column" } }, "required": ["strategy"] },
+      "then": { "required": ["column"] }
+    },
+
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Advanced overrides. Most customers don't touch this; convention defaults from `category` cover the dominant case.",
+      "properties": {
+        "csv_options": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "chunk_size": { "type": "integer", "minimum": 1 },
+            "delimiter": { "type": "string", "minLength": 1 },
+            "quotechar": { "type": "string", "minLength": 1 },
+            "escapechar": { "type": "string", "minLength": 1 }
+          },
+          "description": "Pandas read_csv passthrough. Defaults: chunk_size=1000, delimiter=',', quotechar='\"', escapechar='\\\\'."
+        },
+        "file_options": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "target_size": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1 },
+              "minItems": 2,
+              "maxItems": 2,
+              "description": "[height, width]. Image categories only. Default [512, 512]."
+            },
+            "extension": {
+              "type": "string",
+              "enum": [".jpg", ".jpeg", ".png", ".txt", ".text", ".xml"],
+              "description": "Allowed extension for sidecar files. Defaults: .jpg for image categories, .txt for text_classification."
+            }
+          }
+        },
+        "validators": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Override the default validator set resolved by `map_validators(category)`. Rarely needed."
+        },
+        "sidecars": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["column", "source"],
+            "properties": {
+              "column": { "type": "string", "minLength": 1 },
+              "source": { "type": "string", "minLength": 1 },
+              "dest": { "type": "string", "minLength": 1 },
+              "transform": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "resize": {
+                    "type": "array",
+                    "items": { "type": "integer", "minimum": 1 },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "validators": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
+          },
+          "description": "Advanced: explicit sidecar-file declaration when the convention defaults don't fit. Most users rely on `images`/`annotations`/`masks`/`texts` shorthand instead."
+        },
+        "processors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["script", "class"],
+            "properties": {
+              "script": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Path inside the pod where the script body has been mounted (typically a ConfigMap mount under /custom/...)."
+              },
+              "class": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Class name within the script. Must subclass tracebloc_ingestor.processors.BaseProcessor."
+              },
+              "args": {
+                "type": "object",
+                "description": "Keyword arguments passed to the processor's constructor."
+              }
+            }
+          },
+          "description": "Custom-processor escape hatch. The Helm subchart (client#86) takes the script body as a chart value, writes a ConfigMap, mounts it. The official image dynamically imports the class and applies it to every record. No customer-built Docker image required."
+        }
+      }
+    }
+  },
+
+  "allOf": [
+    {
+      "description": "Exactly one data source: csv or json.",
+      "oneOf": [
+        { "required": ["csv"], "not": { "required": ["json"] } },
+        { "required": ["json"], "not": { "required": ["csv"] } }
+      ]
+    },
+    {
+      "description": "Image-based categories require `images`.",
+      "if": {
+        "properties": {
+          "category": {
+            "enum": [
+              "image_classification",
+              "object_detection",
+              "keypoint_detection",
+              "semantic_segmentation",
+              "instance_segmentation"
+            ]
+          }
+        },
+        "required": ["category"]
+      },
+      "then": { "required": ["images"] }
+    },
+    {
+      "description": "object_detection requires `annotations`.",
+      "if": {
+        "properties": { "category": { "const": "object_detection" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["annotations"] }
+    },
+    {
+      "description": "semantic_segmentation requires `masks`.",
+      "if": {
+        "properties": { "category": { "const": "semantic_segmentation" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["masks"] }
+    },
+    {
+      "description": "text_classification requires `texts`.",
+      "if": {
+        "properties": { "category": { "const": "text_classification" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["texts"] }
+    },
+    {
+      "description": "tabular and time-series categories require `schema`.",
+      "if": {
+        "properties": {
+          "category": {
+            "enum": [
+              "tabular_classification",
+              "tabular_regression",
+              "time_series_forecasting",
+              "time_to_event_prediction"
+            ]
+          }
+        },
+        "required": ["category"]
+      },
+      "then": { "required": ["schema"] }
+    },
+    {
+      "description": "Regression-class tasks require an explicit label.policy decision (must be the object form).",
+      "if": {
+        "properties": {
+          "category": {
+            "enum": [
+              "tabular_regression",
+              "time_series_forecasting",
+              "time_to_event_prediction"
+            ]
+          }
+        },
+        "required": ["category"]
+      },
+      "then": {
+        "properties": {
+          "label": {
+            "type": "object",
+            "required": ["column", "policy"]
+          }
+        },
+        "required": ["label"]
+      }
+    },
+    {
+      "description": "Most categories require `label`.",
+      "if": {
+        "properties": {
+          "category": {
+            "enum": [
+              "image_classification",
+              "object_detection",
+              "keypoint_detection",
+              "semantic_segmentation",
+              "instance_segmentation",
+              "text_classification",
+              "tabular_classification"
+            ]
+          }
+        },
+        "required": ["category"]
+      },
+      "then": { "required": ["label"] }
+    }
+  ]
+}

--- a/tracebloc_ingestor/utils/constants.py
+++ b/tracebloc_ingestor/utils/constants.py
@@ -45,6 +45,7 @@ class TaskCategory:
     TIME_TO_EVENT_PREDICTION = "time_to_event_prediction"
     SEMANTIC_SEGMENTATION = "semantic_segmentation"
     INSTANCE_SEGMENTATION = "instance_segmentation"
+    MASKED_LANGUAGE_MODELING = "masked_language_modeling"
 
     @classmethod
     def get_all_categories(cls) -> list[str]:
@@ -65,6 +66,7 @@ class TaskCategory:
             cls.TIME_TO_EVENT_PREDICTION,
             cls.SEMANTIC_SEGMENTATION,
             cls.INSTANCE_SEGMENTATION,
+            cls.MASKED_LANGUAGE_MODELING,
         ]
 
     @classmethod

--- a/tracebloc_ingestor/utils/label_policy.py
+++ b/tracebloc_ingestor/utils/label_policy.py
@@ -1,0 +1,105 @@
+"""Label-policy bucketing for regression-class tasks.
+
+Per #44 (and the parent client#85): when the ``label`` column is a numeric
+prediction target — regression, time-series forecasting, time-to-event
+prediction — the raw value must NOT leak to the central backend. The
+on-prem-data principle is that only metadata crosses the cluster boundary;
+shipping the literal target value defeats it.
+
+This module is the single point where raw labels become bucket IDs before
+``APIClient.send_batch`` builds its payload.
+
+v1 strategy: stable hash-bucket. ``sha256(str(value))`` truncated to 8 bytes,
+modulo ``NUM_BUCKETS``. Properties:
+
+- **Stable**: same value always lands in the same bucket. The central
+  backend can correlate identical labels across runs without seeing them.
+- **Privacy-preserving**: raw value is not derivable from the bucket ID.
+- **One-pass**: no need to scan the dataset twice to find min/max for
+  equal-width bins. Plays nicely with the existing chunked CSV reader.
+- **Lossy on ordinality**: close numeric values may land in distant
+  buckets. That's a feature for privacy; analytic insights stay on-prem.
+
+Equal-width or quantile bucketing is a v1.1 improvement if customers ask for
+it; the schema can grow ``label.policy: equal_width`` / ``quantile`` without
+breaking ``passthrough`` / ``bucket`` consumers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import Any
+
+
+# Number of buckets. 64 is enough granularity for the central backend to
+# reason about distribution without offering reconstruction power. Trade-off
+# is documented; bumping this number requires no schema change.
+NUM_BUCKETS = 64
+
+# Sentinel used when the label is missing/empty under the ``bucket`` policy.
+# ``-1`` is outside the ``[0, NUM_BUCKETS)`` range so it can't collide with
+# a real bucket; central backend can render it as "no label" without a flag.
+MISSING_LABEL_BUCKET = -1
+
+
+# Policy name constants — mirror the schema enum. Importable so the
+# entrypoint and tests don't string-literal these in three places.
+PASSTHROUGH = "passthrough"
+BUCKET = "bucket"
+
+
+def apply(value: Any, policy: str) -> Any:
+    """Apply the configured label policy to a single label value.
+
+    Args:
+        value: Raw label as read from the source CSV/JSON.
+        policy: Either ``"passthrough"`` (classification — value sent
+            unchanged) or ``"bucket"`` (regression-class — value replaced
+            with a stable hash-derived bucket ID in ``[0, NUM_BUCKETS)``,
+            or ``MISSING_LABEL_BUCKET`` if missing).
+
+    Returns:
+        The value unchanged for ``passthrough``; an int for ``bucket``.
+
+    Raises:
+        ValueError: if ``policy`` is unknown. Should be unreachable since
+            the schema's enum constrains valid values.
+    """
+    if policy == PASSTHROUGH:
+        return value
+    if policy == BUCKET:
+        return _bucket(value)
+    raise ValueError(
+        f"Unknown label policy: {policy!r}. "
+        f"Valid: {PASSTHROUGH!r}, {BUCKET!r}."
+    )
+
+
+def _bucket(value: Any) -> int:
+    """Stable hash-bucket of ``str(value)``.
+
+    None / NaN / empty / whitespace-only values produce ``MISSING_LABEL_BUCKET``
+    so the central backend can distinguish "no label" from "bucket 0"
+    without an extra flag. pandas reads missing numeric cells as
+    ``float('nan')``, which ``str()`` renders as ``"nan"`` — non-empty —
+    so it needs an explicit float-NaN check before stringification.
+    """
+    if value is None:
+        return MISSING_LABEL_BUCKET
+    if isinstance(value, float) and math.isnan(value):
+        return MISSING_LABEL_BUCKET
+    text = str(value).strip()
+    if not text:
+        return MISSING_LABEL_BUCKET
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") % NUM_BUCKETS
+
+
+__all__ = [
+    "apply",
+    "PASSTHROUGH",
+    "BUCKET",
+    "NUM_BUCKETS",
+    "MISSING_LABEL_BUCKET",
+]

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -138,5 +138,24 @@ def map_validators(
             DuplicateValidator(),
         ]
         return validators
+    elif task_category == TaskCategory.MASKED_LANGUAGE_MODELING:
+        validators = []
+
+        # Validate text file extensions
+        validators.append(
+            FileTypeValidator(
+                allowed_extension=options.get("extension", FileExtension.TXT),
+                path="sequences",
+            ),
+        )
+
+        # Add data validator if schema is provided
+        if options.get("schema"):
+            validators.append(DataValidator(schema=options["schema"]))
+
+        validators.append(TableNameValidator())
+        validators.append(DuplicateValidator())
+
+        return validators
     else:
         return []

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -13,6 +13,7 @@ from tracebloc_ingestor.validators.time_before_today_validator import TimeBefore
 from tracebloc_ingestor.validators.numeric_columns_validator import NumericColumnsValidator
 from tracebloc_ingestor.validators.keypoint_annotation_validator import KeypointAnnotationValidator
 from tracebloc_ingestor.validators.keypoint_visibility_validator import KeypointVisibilityValidator
+from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
 from tracebloc_ingestor.utils.constants import TaskCategory, FileExtension
 
 
@@ -148,6 +149,9 @@ def map_validators(
                 path="sequences",
             ),
         )
+
+        # Validate tokenizer.json has required special tokens ([MASK], [PAD])
+        validators.append(TokenizerValidator())
 
         # Add data validator if schema is provided
         if options.get("schema"):

--- a/tracebloc_ingestor/validators/__init__.py
+++ b/tracebloc_ingestor/validators/__init__.py
@@ -19,6 +19,7 @@ from .time_ordered_validator import TimeOrderedValidator
 from .time_before_today_validator import TimeBeforeTodayValidator
 from .keypoint_annotation_validator import KeypointAnnotationValidator
 from .keypoint_visibility_validator import KeypointVisibilityValidator
+from .tokenizer_validator import TokenizerValidator
 
 __all__ = [
     "BaseValidator",
@@ -35,4 +36,5 @@ __all__ = [
     "TimeBeforeTodayValidator",
     "KeypointAnnotationValidator",
     "KeypointVisibilityValidator",
+    "TokenizerValidator",
 ]

--- a/tracebloc_ingestor/validators/duplicate_validator.py
+++ b/tracebloc_ingestor/validators/duplicate_validator.py
@@ -62,9 +62,21 @@ class DuplicateValidator(BaseValidator):
             metadata["directory_exists"] = directory_exists
 
             if directory_exists:
-                errors.append(
-                    f"Destination directory '{self.dest_path}' already exists"
-                )
+                # An empty directory typically means a previous ingestion
+                # attempt aborted before any data landed. Reusing it is
+                # safe and lets customers rerun without manual PVC cleanup.
+                # A populated directory is treated as a real collision.
+                is_empty = self._is_directory_empty()
+                metadata["directory_empty"] = is_empty
+                if is_empty:
+                    warnings.append(
+                        f"Destination directory '{self.dest_path}' exists but "
+                        "is empty (likely from a previous failed run); reusing."
+                    )
+                else:
+                    errors.append(
+                        f"Destination directory '{self.dest_path}' already exists"
+                    )
 
             # Check if parent directory exists (for creating the destination)
             parent_dir = Path(self.dest_path).parent
@@ -101,6 +113,18 @@ class DuplicateValidator(BaseValidator):
             return dest_path.exists() and dest_path.is_dir()
         except Exception as e:
             logger.error(f"Error checking directory existence: {str(e)}")
+            return False
+
+    def _is_directory_empty(self) -> bool:
+        """Return True iff dest_path is an empty directory.
+
+        Returns False on any error so the validator falls back to the
+        existing "fail loudly" behavior rather than masking a real issue.
+        """
+        try:
+            return not any(Path(self.dest_path).iterdir())
+        except Exception as e:
+            logger.error(f"Error checking if directory is empty: {str(e)}")
             return False
 
     def _create_directory_if_needed(self) -> bool:

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -335,8 +335,19 @@ class ImageResolutionValidator(BaseValidator):
         Returns:
             True if resolutions match within tolerance, False otherwise
         """
+        # Normalize both sides to tuple before comparison. PIL returns
+        # ``image.size`` as a tuple; YAML/JSON parses ``target_size: [H, W]``
+        # as a list. Python's equality is type-strict (``(256, 256) ==
+        # [256, 256]`` is False), so without this normalization the
+        # tolerance==0 path falsely flags every image as mismatched even
+        # when dimensions are identical. Surfaced during real-cluster
+        # ingestion (2026-05-19): a 6-image cats/dogs sample at 256×256
+        # with explicit target_size=[256, 256] reported all 6 as
+        # "(256, 256) (expected: [256, 256])". The tolerance>0 branch
+        # accidentally avoided this by going through index access, which
+        # doesn't care about sequence type.
         if self.tolerance == 0:
-            return actual == expected
+            return tuple(actual) == tuple(expected)
 
         width_diff = abs(actual[0] - expected[0])
         height_diff = abs(actual[1] - expected[1])

--- a/tracebloc_ingestor/validators/tokenizer_validator.py
+++ b/tracebloc_ingestor/validators/tokenizer_validator.py
@@ -1,0 +1,149 @@
+"""Tokenizer Validator Module.
+
+Validates that a tokenizer.json file exists alongside the data and contains
+the required special tokens ([MASK] and [PAD]) for masked language modeling.
+Without these tokens the training client will fail with an embedding
+out-of-bounds IndexError.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from .base import BaseValidator, ValidationResult
+from ..config import Config
+from ..utils.logging import setup_logging
+
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+
+class TokenizerValidator(BaseValidator):
+    """Validator for tokenizer.json special-token requirements.
+
+    Ensures that a tokenizer.json file exists at the configured data path
+    and that its vocabulary includes all required special tokens.  For MLM
+    the mandatory tokens are [MASK] (used to create training targets) and
+    [PAD] (used to pad variable-length sequences in a batch).
+
+    Attributes:
+        required_tokens: Set of token strings that must appear in the vocab.
+    """
+
+    def __init__(
+        self,
+        required_tokens: tuple = ("[MASK]", "[PAD]"),
+        name: str = "Tokenizer Validator",
+    ):
+        super().__init__(name)
+        self.required_tokens = set(required_tokens)
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        """Validate tokenizer.json at the configured source path.
+
+        Args:
+            data: Unused (path is read from config.SRC_PATH).
+            **kwargs: Additional validation parameters.
+
+        Returns:
+            ValidationResult with status and error details.
+        """
+        try:
+            tokenizer_path = Path(config.SRC_PATH) / "tokenizer.json"
+
+            if not tokenizer_path.exists():
+                return self._create_result(
+                    is_valid=False,
+                    errors=[
+                        f"tokenizer.json not found at {tokenizer_path}. "
+                        "MLM training requires a tokenizer.json file alongside "
+                        "the sequence data."
+                    ],
+                    metadata={"path_checked": str(tokenizer_path)},
+                )
+
+            with open(tokenizer_path, "r", encoding="utf-8") as f:
+                tokenizer_data = json.load(f)
+
+            vocab = self._extract_vocab(tokenizer_data)
+            if vocab is None:
+                return self._create_result(
+                    is_valid=False,
+                    errors=[
+                        "Could not extract vocabulary from tokenizer.json. "
+                        "Expected a 'model.vocab' mapping or an 'added_tokens' list."
+                    ],
+                    metadata={"path_checked": str(tokenizer_path)},
+                )
+
+            missing = sorted(self.required_tokens - vocab)
+            if missing:
+                return self._create_result(
+                    is_valid=False,
+                    errors=[
+                        f"Tokenizer is missing required special tokens: "
+                        f"{', '.join(missing)}. "
+                        f"Without these tokens, training will fail with an "
+                        f"embedding out-of-bounds error. "
+                        f"Re-train or update the tokenizer to include them."
+                    ],
+                    metadata={
+                        "path_checked": str(tokenizer_path),
+                        "missing_tokens": missing,
+                        "required_tokens": sorted(self.required_tokens),
+                    },
+                )
+
+            return self._create_result(
+                is_valid=True,
+                metadata={
+                    "path_checked": str(tokenizer_path),
+                    "required_tokens": sorted(self.required_tokens),
+                    "vocab_size": len(vocab),
+                },
+            )
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse tokenizer.json: {e}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"tokenizer.json is not valid JSON: {e}"],
+            )
+        except Exception as e:
+            logger.error(f"Tokenizer validation error: {e}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Tokenizer validation error: {str(e)}"],
+            )
+
+    @staticmethod
+    def _extract_vocab(tokenizer_data: dict):
+        """Extract the set of token strings from a HuggingFace tokenizer JSON.
+
+        Checks both ``model.vocab`` (WordLevel / WordPiece / BPE) and
+        ``added_tokens`` (special tokens added after training).
+
+        Returns:
+            Set of token strings, or None if the structure is unrecognised.
+        """
+        tokens = set()
+
+        # model.vocab — the main vocabulary mapping
+        model = tokenizer_data.get("model", {})
+        vocab = model.get("vocab")
+        if isinstance(vocab, dict):
+            tokens.update(vocab.keys())
+
+        # added_tokens — special tokens registered separately
+        added_tokens = tokenizer_data.get("added_tokens", [])
+        if isinstance(added_tokens, list):
+            for entry in added_tokens:
+                if isinstance(entry, dict) and "content" in entry:
+                    tokens.update([entry["content"]])
+                elif isinstance(entry, str):
+                    tokens.add(entry)
+
+        return tokens if tokens else None

--- a/tracebloc_ingestor/validators/tokenizer_validator.py
+++ b/tracebloc_ingestor/validators/tokenizer_validator.py
@@ -132,10 +132,16 @@ class TokenizerValidator(BaseValidator):
         tokens = set()
 
         # model.vocab — the main vocabulary mapping
+        # WordLevel/WordPiece/BPE store vocab as {token: id} dict.
+        # Unigram stores vocab as [[token, score], ...] list.
         model = tokenizer_data.get("model", {})
         vocab = model.get("vocab")
         if isinstance(vocab, dict):
             tokens.update(vocab.keys())
+        elif isinstance(vocab, list):
+            for entry in vocab:
+                if isinstance(entry, (list, tuple)) and len(entry) >= 1:
+                    tokens.add(str(entry[0]))
 
         # added_tokens — special tokens registered separately
         added_tokens = tokenizer_data.get("added_tokens", [])


### PR DESCRIPTION
## Summary

Brings master up to date with develop in preparation for tagging the
v0.3.0 release. Matches the established sync pattern (see PR #79
\"Develop to master\" for prior art).

After this merges, the next step is tagging `v0.3.0` against master,
which fires the release-image.yml workflow and publishes the signed
ingestor image to GHCR.

## What's in this sync

Since the last develop → master sync, develop has gained:

- **Declarative YAML entrypoint + schema** — #69 / data-ingestors#44
- **Official image release pipeline** with cosign + SBOM — #77 / #45
- **Masked-language-modeling template** — #88
- **Bug fixes:**
  - #90 MLM ingestor file transfer routing to cluster storage
  - #92 Dockerfile pins numeric `USER 65534` for K8s admission compat
  - #93 / #94 CSV ingestor stops clobbering cleaned schema in file_options
  - #97 / #98 Config refactored to lazy env reads (drops laptop-path defaults)
  - #100 File-transfer failures now surface in ingestion summary (#99)
  - #102 DuplicateValidator allows rerun when destination dir is empty (#101)
  - #106 Three real-cluster bugs found during 2026-05-19 validation:
    - #103 Schema JSON now bundled in wheel + sdist
    - #104 Image-resolution validator handles tuple-vs-list comparison
    - #105 File-extension detection handles leading-dot + case-insensitive

## Conflict resolution

One conflict in `setup.py`: master had `version=\"0.2.11\"`, develop had
`version=\"0.3.0\"`. Resolved by taking develop's version since we're
tagging v0.3.0 immediately after this merges.

## Test plan

- [x] Local pytest: 196 pass, 1 fail. The single failure
      (`test_every_existing_template_has_a_case` on
      `masked_language_modeling`) is pre-existing on develop tip and
      tracked separately as #107. Not introduced by this sync.
- [x] No other merge conflicts; auto-merged `base.py` cleanly.
- [ ] After merge → tag v0.3.0 → watch release-image.yml run to green.
- [ ] After release → bump `images.ingestor.digest` in tracebloc/client
      and run override-free EKS smoke test.

## Reviewer notes

- This is a merge-commit sync (not squash), matching the prior \"Develop
  to master\" PR. Preserves the full history of every develop commit on
  master.
- No new code added in this PR beyond the merge resolution. Every line
  is already on develop and has passed its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new YAML-driven CLI entrypoint and refactors config/env + file-transfer behavior, which changes ingestion runtime semantics and packaging. Also adds an automated image release/signing workflow that can impact release integrity if misconfigured.
> 
> **Overview**
> **Prepares the v0.3.0 release** by adding a declarative `ingest.yaml` execution path and an official container release pipeline.
> 
> Adds a new `tracebloc-ingest` console script (`tracebloc_ingestor.cli.run`) that validates `INGEST_CONFIG` against a bundled JSON schema, resolves convention defaults (`cli/conventions.py`), bridges to legacy env vars, and dispatches to `CSVIngestor`/`JSONIngestor` with label-policy support.
> 
> Updates packaging and runtime: bundles `tracebloc_ingestor/schema/*.json` in wheels/sdists, bumps Python requirement to 3.11, adds YAML/jsonschema deps, and reworks the Docker image to build/install the repo wheel, run as non-root, and use the new entrypoint.
> 
> Fixes several ingestion correctness issues (file-transfer missing-source now fails records + summary accounting, extension detection, image resolution matching, DuplicateValidator empty-dir reruns, CSVIngestor file_options clobber) and adds extensive regression/e2e-mocked tests plus YAML examples and an MLM template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc48243efd3cfb761ea97b64b5ae4ef41af15dcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->