### PR TITLE
docs: fix staging-recipe link branch ref (main → develop)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,7 @@ The `tracebloc/client` parent chart bootstraps the cluster (jobs-manager, MySQL,
 
 **2. Stage your data on the cluster's shared PVC.**
 
-The chart **doesn't transport data into the cluster** — it points at data already accessible to the cluster's shared PVC (`client-pvc` by default, mounted at `/data/shared/` inside the ingestor Pod). Before installing, get your raw files there. The simplest pattern for a small dataset is a throwaway `kubectl cp` Pod that mounts the PVC; for production you'd typically use an init container with cloud-storage sync. Full staging recipe + manifests → [`tracebloc/client/ingestor/README.md#stage-your-data-on-the-shared-pvc`](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc).
+The chart **doesn't transport data into the cluster** — it points at data already accessible to the cluster's shared PVC (`client-pvc` by default, mounted at `/data/shared/` inside the ingestor Pod). Before installing, get your raw files there. The simplest pattern for a small dataset is a throwaway `kubectl cp` Pod that mounts the PVC; for production you'd typically use an init container with cloud-storage sync. Full staging recipe + manifests → [`tracebloc/client/ingestor/README.md#stage-your-data-on-the-shared-pvc`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc).
 
 **3. Write your `ingest.yaml`.**
 
@@ -82,7 +82,7 @@ helm install my-cats-dogs tracebloc/ingestor \
 
 The ingestor runs once: validates your data, copies files into the destination directory on the PVC, inserts rows into MySQL, sends metadata to the tracebloc backend, then exits. Repeat per dataset. Customers never build an image, never write a Dockerfile, never track digest versions — the cluster's auto-upgrade flow keeps the official image current.
 
-Full chart docs (data-staging recipe, schema, every category, update model, verification, override knobs) → **[`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md)**.
+Full chart docs (data-staging recipe, schema, every category, update model, verification, override knobs) → **[`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md)**.
 
 ## Advanced: custom processors (legacy Python pattern)
 

--- a/templates/image_classification/README.md
+++ b/templates/image_classification/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest image classification data with images a
 
 Ingest with ~8 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` per the recipe above. The chart mounts this volume into the ingestor pod.
 
@@ -33,7 +33,7 @@ helm install my-cats-dogs tracebloc/ingestor \
 
 The ingestor validates the data, copies files into the destination directory on the PVC, inserts rows into MySQL, sends metadata to the backend, then exits.
 
-Canonical example: [`examples/yaml/image_classification.yaml`](../../examples/yaml/image_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Canonical example: [`examples/yaml/image_classification.yaml`](../../examples/yaml/image_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/keypoint_detection/README.md
+++ b/templates/keypoint_detection/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest keypoint detection data with images and
 
 Ingest with ~8 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with an `images/` subdirectory; keypoint annotations are columns in the CSV.
 
@@ -31,7 +31,7 @@ helm install my-keypoint-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Canonical example: [`examples/yaml/keypoint_detection.yaml`](../../examples/yaml/keypoint_detection.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Canonical example: [`examples/yaml/keypoint_detection.yaml`](../../examples/yaml/keypoint_detection.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/masked_language_modeling/README.md
+++ b/templates/masked_language_modeling/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest pre-tokenized text sequences for masked
 
 Ingest with ~7 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `sequences/` subdirectory holding the per-record `.txt` sequence files.
 
@@ -30,7 +30,7 @@ helm install my-mlm-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-MLM is unsupervised — no `label:` field; the tokenizer validator checks that sequences match the configured vocabulary. Canonical example: [`examples/yaml/masked_language_modeling.yaml`](../../examples/yaml/masked_language_modeling.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+MLM is unsupervised — no `label:` field; the tokenizer validator checks that sequences match the configured vocabulary. Canonical example: [`examples/yaml/masked_language_modeling.yaml`](../../examples/yaml/masked_language_modeling.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/object_detection/README.md
+++ b/templates/object_detection/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest object detection data with images and X
 
 Ingest with ~9 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with `images/` and `annotations/` (Pascal VOC XML) subdirectories.
 
@@ -32,7 +32,7 @@ helm install my-od-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Object detection uses atomic image+annotation transfer — a record is committed only when both files copy successfully. Canonical example: [`examples/yaml/object_detection.yaml`](../../examples/yaml/object_detection.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Object detection uses atomic image+annotation transfer — a record is committed only when both files copy successfully. Canonical example: [`examples/yaml/object_detection.yaml`](../../examples/yaml/object_detection.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/semantic_segmentation/README.md
+++ b/templates/semantic_segmentation/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest semantic segmentation data with images 
 
 Ingest with ~9 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with `images/` and `masks/` subdirectories.
 
@@ -32,7 +32,7 @@ helm install my-segmentation-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Semantic segmentation uses atomic image+mask transfer — a record is committed only when both files copy successfully. Canonical example: [`examples/yaml/semantic_segmentation.yaml`](../../examples/yaml/semantic_segmentation.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Semantic segmentation uses atomic image+mask transfer — a record is committed only when both files copy successfully. Canonical example: [`examples/yaml/semantic_segmentation.yaml`](../../examples/yaml/semantic_segmentation.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/tabular_classification/README.md
+++ b/templates/tabular_classification/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest tabular classification data from a CSV 
 
 Ingest with ~12 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the CSV** on the shared PVC at `/data/shared/<your-prefix>/<file>.csv`.
 
@@ -36,7 +36,7 @@ helm install my-tabular-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-The `schema:` block maps your CSV columns to SQL types — required for tabular categories. Canonical example: [`examples/yaml/tabular_classification.yaml`](../../examples/yaml/tabular_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+The `schema:` block maps your CSV columns to SQL types — required for tabular categories. Canonical example: [`examples/yaml/tabular_classification.yaml`](../../examples/yaml/tabular_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/tabular_regression/README.md
+++ b/templates/tabular_regression/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest tabular regression data from a CSV file
 
 Ingest with ~13 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the CSV** on the shared PVC at `/data/shared/<your-prefix>/<file>.csv`.
 
@@ -38,7 +38,7 @@ helm install my-regression-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Regression-class tasks require an explicit `label.policy` (typically `bucket`) so the central backend never sees raw target values — the schema enforces this. Canonical example: [`examples/yaml/tabular_regression.yaml`](../../examples/yaml/tabular_regression.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Regression-class tasks require an explicit `label.policy` (typically `bucket`) so the central backend never sees raw target values — the schema enforces this. Canonical example: [`examples/yaml/tabular_regression.yaml`](../../examples/yaml/tabular_regression.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/text_classification/README.md
+++ b/templates/text_classification/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest text classification data with `.txt` fi
 
 Ingest with ~10 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `texts/` subdirectory holding the `.txt` files.
 
@@ -34,7 +34,7 @@ helm install my-text-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Canonical example: [`examples/yaml/text_classification.yaml`](../../examples/yaml/text_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Canonical example: [`examples/yaml/text_classification.yaml`](../../examples/yaml/text_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/time_series_forecasting/README.md
+++ b/templates/time_series_forecasting/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest time series forecasting data from a CSV
 
 Ingest with ~13 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the CSV** on the shared PVC at `/data/shared/<your-prefix>/<file>.csv`.
 
@@ -38,7 +38,7 @@ helm install my-forecast-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Forecasting is a regression-class task — `label.policy: bucket` is required so the central backend never sees raw target values. Canonical example: [`examples/yaml/time_series_forecasting.yaml`](../../examples/yaml/time_series_forecasting.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Forecasting is a regression-class task — `label.policy: bucket` is required so the central backend never sees raw target values. Canonical example: [`examples/yaml/time_series_forecasting.yaml`](../../examples/yaml/time_series_forecasting.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/time_to_event_prediction/README.md
+++ b/templates/time_to_event_prediction/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest time-to-event (survival analysis) data 
 
 Ingest with ~13 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the CSV** on the shared PVC at `/data/shared/<your-prefix>/<file>.csv`.
 
@@ -39,7 +39,7 @@ helm install my-survival-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-`time_column:` names the column that holds the time-to-event value. `label.policy: bucket` is required so the central backend never sees raw target values. Canonical example: [`examples/yaml/time_to_event_prediction.yaml`](../../examples/yaml/time_to_event_prediction.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+`time_column:` names the column that holds the time-to-event value. `label.policy: bucket` is required so the central backend never sees raw target values. Canonical example: [`examples/yaml/time_to_event_prediction.yaml`](../../examples/yaml/time_to_event_prediction.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 


### PR DESCRIPTION
## Summary

PR #111 landed with the staging-recipe links pointing at \`/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc\` (22 references across 11 files). But the staging section only exists on \`tracebloc/client\` **develop** right now — it gets to **main** only after the next develop→main sync in that repo.

Result: a reader of any data-ingestors template README on \`develop\` who clicks the "data-staging recipe" link lands on \`main\`, where the section doesn't render. Anchor 404.

This PR cherry-picks the URL fix that was meant to land in #111 but missed the merge window. Changes \`/blob/main/\` → \`/blob/develop/\` for all 22 references.

\`develop\` is a stable enough ref long-term; once tracebloc/client does its develop→main sync, both URLs will resolve and we can optionally migrate back to \`/blob/main/\` for aesthetics. Not blocking.

## Acceptance criteria

- \`curl -sS https://raw.githubusercontent.com/tracebloc/data-ingestors/develop/templates/image_classification/README.md | grep -c "blob/develop/ingestor/README.md"\` returns ≥1 (currently returns 0 on develop pre-merge of this PR)
- Clicking the staging-recipe link from any template's README scrolls to the "Stage your data on the shared PVC" section in tracebloc/client/blob/develop/ingestor/README.md

## Out of scope

A separate follow-up could enforce a CI link checker on every PR so this class of cross-repo anchor staleness is caught at PR time, not at merge time. Filing if useful; not blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates cross-repo URLs; no runtime/code behavior is affected, but incorrect links could still confuse users if the target repo structure changes again.
> 
> **Overview**
> Fixes broken documentation links to the tracebloc client chart docs by updating all references to the staging-recipe section from `tracebloc/client/blob/main/ingestor/README.md` to `.../blob/develop/...` (including the top-level `Readme.md` and all ingestion template READMEs). This ensures the “Stage your data on the shared PVC” anchor resolves while that section lives on the client repo’s `develop` branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94dcad07a326a2b27dd14753dbcbc81985beb72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->