### PR TITLE
Add smoke tests for ingestor image and update documentation

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -29,6 +29,10 @@ jobs:
         run: |
           pip install dist/*.tar.gz
 
-      - name: Run basic import test
+      - name: Smoke-test installed sdist
+        # Sdists go through MANIFEST.in, a different packaging code path
+        # from the wheel's package_data. The v0.3.0-rc1 schema-missing bug
+        # surfaced here too. _load_schema() reads schema/ingest.v1.json
+        # from site-packages and fails fast if the file wasn't installed.
         run: |
-          python -c "import tracebloc_ingestor"
+          python -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -28,9 +28,13 @@ jobs:
         run: |
           pip install dist/*.tar.gz
 
-      - name: Run basic import test
+      - name: Smoke-test installed sdist
+        # Sdists go through MANIFEST.in, a different packaging code path
+        # from the wheel's package_data. The v0.3.0-rc1 schema-missing bug
+        # surfaced here too. _load_schema() reads schema/ingest.v1.json
+        # from site-packages and fails fast if the file wasn't installed.
         run: |
-          python -c "import tracebloc_ingestor"
+          python -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
 
       - name: Publish to GitHub Packages
         run: |

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -129,6 +129,46 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Smoke-test built image
+        # Runs against the digest produced by `Build and push image`, BEFORE
+        # cosign signing or release-notes update — so a packaging regression
+        # aborts the workflow with no signed image and no published release.
+        #
+        # First command: import _load_schema() and read it. Catches the
+        # v0.3.0-rc1 regression where tracebloc_ingestor/schema/ was missing
+        # from site-packages because the directory had no __init__.py and
+        # find_packages() silently dropped it.
+        #
+        # Second command: invoke the tracebloc-ingest console script. The
+        # CLI has no --help; main() expects INGEST_CONFIG and exits with a
+        # friendly message when it's absent. We run with no args, accept
+        # the non-zero exit, and grep for that message — which proves:
+        # console_scripts metadata was installed, the wrapper resolves
+        # `tracebloc_ingestor.cli.run:main`, and main() runs far enough to
+        # print its first error. A missing wrapper or import-time failure
+        # produces a different output and fails the grep.
+        #
+        # IMAGE/DIGEST go through the env: block (same security stance as
+        # the release-notes step) to keep ${{ ... }} out of inline shell.
+        #
+        # --entrypoint is load-bearing: the image's ENTRYPOINT is
+        # docker-entrypoint.sh, which exits 64 immediately if MYSQL_HOST
+        # is unset — before the shell ever reaches `exec tracebloc-ingest`.
+        # We're not testing the MySQL-wait wrapper here, we're testing the
+        # Python package; overriding the entrypoint lets the smoke probes
+        # run without standing up a MySQL sidecar for what should be a
+        # ~5-second sanity check.
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint python "${IMAGE}@${DIGEST}" \
+            -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
+          output=$(docker run --rm --entrypoint tracebloc-ingest "${IMAGE}@${DIGEST}" 2>&1 || true)
+          echo "$output"
+          echo "$output" | grep -q "INGEST_CONFIG"
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
         with:

--- a/Readme.md
+++ b/Readme.md
@@ -31,34 +31,80 @@ Only metadata (schema, statistics, structure) syncs to the web app. Raw data sta
 
 ## Supported data types
 
-| Type | Templates |
+| Type | Categories |
 |---|---|
-| **Image** | [`image_classification`](templates/image_classification), [`object_detection`](templates/object_detection) |
-| **Text / NLP** | [`text_classification`](templates/text_classification) |
+| **Image** | [`image_classification`](templates/image_classification), [`object_detection`](templates/object_detection), [`keypoint_detection`](templates/keypoint_detection), [`semantic_segmentation`](templates/semantic_segmentation) |
+| **Text / NLP** | [`text_classification`](templates/text_classification), [`masked_language_modeling`](templates/masked_language_modeling) |
 | **Tabular** | [`tabular_classification`](templates/tabular_classification), [`tabular_regression`](templates/tabular_regression) |
 | **Time series** | [`time_series_forecasting`](templates/time_series_forecasting), [`time_to_event_prediction`](templates/time_to_event_prediction) |
 
-Each template is a runnable starting point — copy it, point it at your data, ship it.
+Each template ships a sample dataset and an [example `ingest.yaml`](examples/yaml/) you can copy as a starting point.
 
-## Quickstart
+## Quickstart — declarative YAML (recommended)
 
-### 1. Install
+Describe your dataset in ~8 lines of YAML, then `helm install`. The official ingestor image (this package, signed + SBOM-attested, published as `ghcr.io/tracebloc/ingestor`) runs it. No Dockerfile, no Python script.
+
+**1. One-time: add the chart repo on your workstation.**
+
+```bash
+helm repo add tracebloc https://tracebloc.github.io/client
+helm repo update
+```
+
+The `tracebloc/client` parent chart bootstraps the cluster (jobs-manager, MySQL, RBAC). The `tracebloc/ingestor` subchart submits per-dataset ingestion runs against it.
+
+**2. Stage your data on the cluster's shared PVC.**
+
+The chart **doesn't transport data into the cluster** — it points at data already accessible to the cluster's shared PVC (`client-pvc` by default, mounted at `/data/shared/` inside the ingestor Pod). Before installing, get your raw files there. The simplest pattern for a small dataset is a throwaway `kubectl cp` Pod that mounts the PVC; for production you'd typically use an init container with cloud-storage sync. Full staging recipe + manifests → [`tracebloc/client/ingestor/README.md#stage-your-data-on-the-shared-pvc`](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc).
+
+**3. Write your `ingest.yaml`.**
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: image_classification
+table: cats_dogs_train
+intent: train
+csv: /data/shared/cats-dogs/labels.csv
+images: /data/shared/cats-dogs/images/
+label: label
+```
+
+The schema is the same for every category; the `category` field picks the validator set, file-extension defaults, and column conventions. The `csv:` / `images:` (etc.) paths are *paths inside the ingestor Pod*, which is the PVC mount you populated in step 2. See [`examples/yaml/`](examples/yaml/) for a working example per category.
+
+**4. Install once per dataset.**
+
+```bash
+helm install my-cats-dogs tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+The ingestor runs once: validates your data, copies files into the destination directory on the PVC, inserts rows into MySQL, sends metadata to the tracebloc backend, then exits. Repeat per dataset. Customers never build an image, never write a Dockerfile, never track digest versions — the cluster's auto-upgrade flow keeps the official image current.
+
+Full chart docs (data-staging recipe, schema, every category, update model, verification, override knobs) → **[`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md)**.
+
+## Advanced: custom processors (legacy Python pattern)
+
+Use this when the declarative schema can't express what your data needs — typically when you have non-trivial preprocessing logic, a custom validator, or a `BaseProcessor` subclass.
+
+**1. Install the package.**
 
 ```bash
 pip install tracebloc-ingestor
 ```
 
-### 2. Pick a template
+**2. Pick a template + adapt the script.**
 
 ```bash
-cp templates/image_classification/ingestor.py .
+cp templates/image_classification/image_classification.py .
 ```
 
-Each template builds on the same primitives — `BaseIngestor`, `CSVIngestor`, validators — and overrides the parts that vary by data type.
+The package exports `BaseIngestor`, `CSVIngestor`, `JSONIngestor`, plus validators (`FileTypeValidator`, `ImageResolutionValidator`, `TableNameValidator`, etc.) and the `Database` / `APIClient` helpers. See [`examples/`](examples) for working scripts.
 
-### 3. Deploy as a Kubernetes Job
+**3. Build + deploy as a Kubernetes Job.**
 
-The ingestor runs *inside* your cluster, next to a tracebloc client. The provided [`Dockerfile`](Dockerfile) and [`ingestor-job.yaml`](ingestor-job.yaml) are the canonical pattern:
+The legacy [`Dockerfile`](Dockerfile) and [`ingestor-job.yaml`](ingestor-job.yaml) remain the canonical pattern for custom-processor flows:
 
 ```bash
 docker build -t <your-registry>/<image-name>:latest .
@@ -79,9 +125,9 @@ The Job needs these environment variables (set in [`ingestor-job.yaml`](ingestor
 | `TITLE` | *(optional)* Human-readable dataset name |
 | `LOG_LEVEL` | *(optional)* `INFO`, `WARNING`, `ERROR` |
 
-### Running under Pod Security Standards (`restricted`)
+### Running custom-processor flows under Pod Security Standards (`restricted`)
 
-If the namespace you're deploying into enforces the [`restricted`](https://kubernetes.io/docs/concepts/security/pod-security-standards/) Pod Security Standard (OpenShift, hardened clusters, many managed-Kubernetes namespaces), the stock [`Dockerfile`](Dockerfile) and [`ingestor-job.yaml`](ingestor-job.yaml) won't admit. Two changes are needed.
+If the namespace you're deploying into enforces the [`restricted`](https://kubernetes.io/docs/concepts/security/pod-security-standards/) Pod Security Standard (OpenShift, hardened clusters, many managed-Kubernetes namespaces), the stock [`Dockerfile`](Dockerfile) and [`ingestor-job.yaml`](ingestor-job.yaml) won't admit. (The declarative path's image is already PSA-restricted-compatible; this section only applies to custom Dockerfiles built from this repo.) Two changes are needed.
 
 Check first:
 
@@ -119,9 +165,9 @@ spec:
             drop: ["ALL"]
 ```
 
-## Writing a custom ingestor
+### Subclassing BaseIngestor
 
-For data that doesn't fit a template, subclass `BaseIngestor`:
+For data that doesn't fit any of the existing templates, subclass `BaseIngestor`:
 
 ```python
 from tracebloc_ingestor import BaseIngestor, FileTypeValidator
@@ -136,8 +182,6 @@ class MyIngestor(BaseIngestor):
 if __name__ == "__main__":
     MyIngestor().ingest()
 ```
-
-The package exports `BaseIngestor`, `CSVIngestor`, `JSONIngestor`, plus validators (`FileTypeValidator`, `ImageResolutionValidator`, `TableNameValidator`) and the `Database` / `APIClient` helpers. See [`examples/`](examples) for working scripts.
 
 ## Prerequisites
 

--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,7 @@ The `tracebloc/client` parent chart bootstraps the cluster (jobs-manager, MySQL,
 
 **2. Stage your data on the cluster's shared PVC.**
 
-The chart **doesn't transport data into the cluster** — it points at data already accessible to the cluster's shared PVC (`client-pvc` by default, mounted at `/data/shared/` inside the ingestor Pod). Before installing, get your raw files there. The simplest pattern for a small dataset is a throwaway `kubectl cp` Pod that mounts the PVC; for production you'd typically use an init container with cloud-storage sync. Full staging recipe + manifests → [`tracebloc/client/ingestor/README.md#stage-your-data-on-the-shared-pvc`](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc).
+The chart **doesn't transport data into the cluster** — it points at data already accessible to the cluster's shared PVC (`client-pvc` by default, mounted at `/data/shared/` inside the ingestor Pod). Before installing, get your raw files there. The simplest pattern for a small dataset is a throwaway `kubectl cp` Pod that mounts the PVC; for production you'd typically use an init container with cloud-storage sync. Full staging recipe + manifests → [`tracebloc/client/ingestor/README.md#stage-your-data-on-the-shared-pvc`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc).
 
 **3. Write your `ingest.yaml`.**
 
@@ -82,7 +82,7 @@ helm install my-cats-dogs tracebloc/ingestor \
 
 The ingestor runs once: validates your data, copies files into the destination directory on the PVC, inserts rows into MySQL, sends metadata to the tracebloc backend, then exits. Repeat per dataset. Customers never build an image, never write a Dockerfile, never track digest versions — the cluster's auto-upgrade flow keeps the official image current.
 
-Full chart docs (data-staging recipe, schema, every category, update model, verification, override knobs) → **[`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md)**.
+Full chart docs (data-staging recipe, schema, every category, update model, verification, override knobs) → **[`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md)**.
 
 ## Advanced: custom processors (legacy Python pattern)
 

--- a/templates/image_classification/README.md
+++ b/templates/image_classification/README.md
@@ -2,6 +2,39 @@
 
 This template demonstrates how to ingest image classification data with images and a CSV labels file into a database using the tracebloc_ingestor framework.
 
+## Quickstart — declarative (recommended)
+
+Ingest with ~8 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` per the recipe above. The chart mounts this volume into the ingestor pod.
+
+**2. Write `ingest.yaml`:**
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: image_classification
+table: cats_dogs_train
+intent: train
+csv: /data/shared/cats-dogs/labels.csv
+images: /data/shared/cats-dogs/images/
+label: label
+```
+
+**3. Install:**
+
+```bash
+helm install my-cats-dogs tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+The ingestor validates the data, copies files into the destination directory on the PVC, inserts rows into MySQL, sends metadata to the backend, then exits.
+
+Canonical example: [`examples/yaml/image_classification.yaml`](../../examples/yaml/image_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+
 ## Directory Structure
 
 ```
@@ -31,7 +64,9 @@ The CSV contains the following columns:
 - `filename`: Image filename with extension, e.g. `cat1.jpeg`
 - `label`: Class label for the image, e.g. `cat`, `dog`
 
-## Usage
+## Advanced: custom processor script
+
+Use the Python+Dockerfile pattern when the declarative schema can't express your processing needs (custom validators, non-standard transforms, etc.). Otherwise prefer the Quickstart above.
 
 1. Place your images in the `data/images/` directory
 2. Update `labels_file_sample.csv` with your `(filename, label)` pairs

--- a/templates/image_classification/README.md
+++ b/templates/image_classification/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest image classification data with images a
 
 Ingest with ~8 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` per the recipe above. The chart mounts this volume into the ingestor pod.
 
@@ -33,7 +33,7 @@ helm install my-cats-dogs tracebloc/ingestor \
 
 The ingestor validates the data, copies files into the destination directory on the PVC, inserts rows into MySQL, sends metadata to the backend, then exits.
 
-Canonical example: [`examples/yaml/image_classification.yaml`](../../examples/yaml/image_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Canonical example: [`examples/yaml/image_classification.yaml`](../../examples/yaml/image_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/keypoint_detection/README.md
+++ b/templates/keypoint_detection/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest keypoint detection data with images and
 
 Ingest with ~8 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with an `images/` subdirectory; keypoint annotations are columns in the CSV.
 
@@ -31,7 +31,7 @@ helm install my-keypoint-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Canonical example: [`examples/yaml/keypoint_detection.yaml`](../../examples/yaml/keypoint_detection.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Canonical example: [`examples/yaml/keypoint_detection.yaml`](../../examples/yaml/keypoint_detection.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/keypoint_detection/README.md
+++ b/templates/keypoint_detection/README.md
@@ -2,6 +2,37 @@
 
 This template demonstrates how to ingest keypoint detection data with images and JSON-based keypoint annotations into a database using the tracebloc_ingestor framework.
 
+## Quickstart — declarative (recommended)
+
+Ingest with ~8 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with an `images/` subdirectory; keypoint annotations are columns in the CSV.
+
+**2. Write `ingest.yaml`:**
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: keypoint_detection
+table: pose_train
+intent: train
+csv: /data/shared/pose/labels.csv
+images: /data/shared/pose/images/
+label: image_label
+```
+
+**3. Install:**
+
+```bash
+helm install my-keypoint-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+Canonical example: [`examples/yaml/keypoint_detection.yaml`](../../examples/yaml/keypoint_detection.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+
 ## Directory Structure
 
 ```

--- a/templates/masked_language_modeling/README.md
+++ b/templates/masked_language_modeling/README.md
@@ -2,6 +2,36 @@
 
 This template demonstrates how to ingest pre-tokenized text sequences for masked language modeling (MLM) into a database using the tracebloc_ingestor framework.
 
+## Quickstart — declarative (recommended)
+
+Ingest with ~7 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `sequences/` subdirectory holding the per-record `.txt` sequence files.
+
+**2. Write `ingest.yaml`:**
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: masked_language_modeling
+table: primekg_mlm_train
+intent: train
+csv: /data/shared/primekg/labels_file.csv
+sequences: /data/shared/primekg/sequences/
+```
+
+**3. Install:**
+
+```bash
+helm install my-mlm-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+MLM is unsupervised — no `label:` field; the tokenizer validator checks that sequences match the configured vocabulary. Canonical example: [`examples/yaml/masked_language_modeling.yaml`](../../examples/yaml/masked_language_modeling.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+
 ## Directory Structure
 
 ```

--- a/templates/masked_language_modeling/README.md
+++ b/templates/masked_language_modeling/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest pre-tokenized text sequences for masked
 
 Ingest with ~7 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `sequences/` subdirectory holding the per-record `.txt` sequence files.
 
@@ -30,7 +30,7 @@ helm install my-mlm-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-MLM is unsupervised — no `label:` field; the tokenizer validator checks that sequences match the configured vocabulary. Canonical example: [`examples/yaml/masked_language_modeling.yaml`](../../examples/yaml/masked_language_modeling.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+MLM is unsupervised — no `label:` field; the tokenizer validator checks that sequences match the configured vocabulary. Canonical example: [`examples/yaml/masked_language_modeling.yaml`](../../examples/yaml/masked_language_modeling.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/object_detection/README.md
+++ b/templates/object_detection/README.md
@@ -2,6 +2,38 @@
 
 This template demonstrates how to ingest object detection data with images and XML annotations into a database using the tracebloc_ingestor framework.
 
+## Quickstart — declarative (recommended)
+
+Ingest with ~9 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with `images/` and `annotations/` (Pascal VOC XML) subdirectories.
+
+**2. Write `ingest.yaml`:**
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: object_detection
+table: visdrone_train
+intent: train
+csv: /data/shared/visdrone/labels.csv
+images: /data/shared/visdrone/images/
+annotations: /data/shared/visdrone/annotations/
+label: image_label
+```
+
+**3. Install:**
+
+```bash
+helm install my-od-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+Object detection uses atomic image+annotation transfer — a record is committed only when both files copy successfully. Canonical example: [`examples/yaml/object_detection.yaml`](../../examples/yaml/object_detection.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+
 ## Directory Structure
 
 ```
@@ -73,7 +105,9 @@ Each XML file should contain:
 </annotation>
 ```
 
-## Usage
+## Advanced: custom processor script
+
+Use the Python+Dockerfile pattern when the declarative schema can't express your processing needs. Otherwise prefer the Quickstart above.
 
 1. Place your images in the `data/images/` directory
 2. Create corresponding XML annotation files in the `data/annotations/` directory

--- a/templates/object_detection/README.md
+++ b/templates/object_detection/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest object detection data with images and X
 
 Ingest with ~9 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with `images/` and `annotations/` (Pascal VOC XML) subdirectories.
 
@@ -32,7 +32,7 @@ helm install my-od-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Object detection uses atomic image+annotation transfer — a record is committed only when both files copy successfully. Canonical example: [`examples/yaml/object_detection.yaml`](../../examples/yaml/object_detection.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Object detection uses atomic image+annotation transfer — a record is committed only when both files copy successfully. Canonical example: [`examples/yaml/object_detection.yaml`](../../examples/yaml/object_detection.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/semantic_segmentation/README.md
+++ b/templates/semantic_segmentation/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest semantic segmentation data with images 
 
 Ingest with ~9 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with `images/` and `masks/` subdirectories.
 
@@ -32,7 +32,7 @@ helm install my-segmentation-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Semantic segmentation uses atomic image+mask transfer — a record is committed only when both files copy successfully. Canonical example: [`examples/yaml/semantic_segmentation.yaml`](../../examples/yaml/semantic_segmentation.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Semantic segmentation uses atomic image+mask transfer — a record is committed only when both files copy successfully. Canonical example: [`examples/yaml/semantic_segmentation.yaml`](../../examples/yaml/semantic_segmentation.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/semantic_segmentation/README.md
+++ b/templates/semantic_segmentation/README.md
@@ -2,6 +2,38 @@
 
 This template demonstrates how to ingest semantic segmentation data with images and corresponding mask annotations into a database using the tracebloc_ingestor framework.
 
+## Quickstart — declarative (recommended)
+
+Ingest with ~9 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with `images/` and `masks/` subdirectories.
+
+**2. Write `ingest.yaml`:**
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: semantic_segmentation
+table: tumors_train
+intent: train
+csv: /data/shared/tumors/labels.csv
+images: /data/shared/tumors/images/
+masks: /data/shared/tumors/masks/
+label: image_label
+```
+
+**3. Install:**
+
+```bash
+helm install my-segmentation-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+Semantic segmentation uses atomic image+mask transfer — a record is committed only when both files copy successfully. Canonical example: [`examples/yaml/semantic_segmentation.yaml`](../../examples/yaml/semantic_segmentation.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+
 ## Directory Structure
 
 ```

--- a/templates/tabular_classification/README.md
+++ b/templates/tabular_classification/README.md
@@ -2,6 +2,42 @@
 
 This template demonstrates how to ingest tabular classification data from a CSV file into a database using the tracebloc_ingestor framework.
 
+## Quickstart — declarative (recommended)
+
+Ingest with ~12 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+
+**1. Stage the CSV** on the shared PVC at `/data/shared/<your-prefix>/<file>.csv`.
+
+**2. Write `ingest.yaml`:**
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: tabular_classification
+table: churn_train
+intent: train
+csv: /data/shared/churn/customers.csv
+schema:
+  age: INT
+  tenure_months: INT
+  monthly_charge: FLOAT
+  contract_type: VARCHAR(64)
+  churned: VARCHAR(8)
+label: churned
+```
+
+**3. Install:**
+
+```bash
+helm install my-tabular-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+The `schema:` block maps your CSV columns to SQL types — required for tabular categories. Canonical example: [`examples/yaml/tabular_classification.yaml`](../../examples/yaml/tabular_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+
 ## Directory Structure
 
 ```

--- a/templates/tabular_classification/README.md
+++ b/templates/tabular_classification/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest tabular classification data from a CSV 
 
 Ingest with ~12 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the CSV** on the shared PVC at `/data/shared/<your-prefix>/<file>.csv`.
 
@@ -36,7 +36,7 @@ helm install my-tabular-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-The `schema:` block maps your CSV columns to SQL types — required for tabular categories. Canonical example: [`examples/yaml/tabular_classification.yaml`](../../examples/yaml/tabular_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+The `schema:` block maps your CSV columns to SQL types — required for tabular categories. Canonical example: [`examples/yaml/tabular_classification.yaml`](../../examples/yaml/tabular_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/tabular_regression/README.md
+++ b/templates/tabular_regression/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest tabular regression data from a CSV file
 
 Ingest with ~13 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the CSV** on the shared PVC at `/data/shared/<your-prefix>/<file>.csv`.
 
@@ -38,7 +38,7 @@ helm install my-regression-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Regression-class tasks require an explicit `label.policy` (typically `bucket`) so the central backend never sees raw target values — the schema enforces this. Canonical example: [`examples/yaml/tabular_regression.yaml`](../../examples/yaml/tabular_regression.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Regression-class tasks require an explicit `label.policy` (typically `bucket`) so the central backend never sees raw target values — the schema enforces this. Canonical example: [`examples/yaml/tabular_regression.yaml`](../../examples/yaml/tabular_regression.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/tabular_regression/README.md
+++ b/templates/tabular_regression/README.md
@@ -2,6 +2,44 @@
 
 This template demonstrates how to ingest tabular regression data from a CSV file into a database using the tracebloc_ingestor framework.
 
+## Quickstart — declarative (recommended)
+
+Ingest with ~13 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+
+**1. Stage the CSV** on the shared PVC at `/data/shared/<your-prefix>/<file>.csv`.
+
+**2. Write `ingest.yaml`:**
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: tabular_regression
+table: house_prices_train
+intent: train
+csv: /data/shared/houses/houses.csv
+schema:
+  square_feet: FLOAT
+  bedrooms: INT
+  bathrooms: FLOAT
+  age_years: INT
+  price: FLOAT
+label:
+  column: price
+  policy: bucket
+```
+
+**3. Install:**
+
+```bash
+helm install my-regression-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+Regression-class tasks require an explicit `label.policy` (typically `bucket`) so the central backend never sees raw target values — the schema enforces this. Canonical example: [`examples/yaml/tabular_regression.yaml`](../../examples/yaml/tabular_regression.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+
 ## Directory Structure
 
 ```

--- a/templates/text_classification/README.md
+++ b/templates/text_classification/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest text classification data with `.txt` fi
 
 Ingest with ~10 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `texts/` subdirectory holding the `.txt` files.
 
@@ -34,7 +34,7 @@ helm install my-text-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Canonical example: [`examples/yaml/text_classification.yaml`](../../examples/yaml/text_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Canonical example: [`examples/yaml/text_classification.yaml`](../../examples/yaml/text_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/text_classification/README.md
+++ b/templates/text_classification/README.md
@@ -2,6 +2,40 @@
 
 This template demonstrates how to ingest text classification data with `.txt` files and a CSV labels file into a database using the tracebloc_ingestor framework.
 
+## Quickstart — declarative (recommended)
+
+Ingest with ~10 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `texts/` subdirectory holding the `.txt` files.
+
+**2. Write `ingest.yaml`:**
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: text_classification
+table: support_tickets_train
+intent: train
+csv: /data/shared/tickets/labels.csv
+texts: /data/shared/tickets/texts/
+schema:
+  text_id: VARCHAR(255)
+  label: VARCHAR(64)
+label: label
+```
+
+**3. Install:**
+
+```bash
+helm install my-text-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+Canonical example: [`examples/yaml/text_classification.yaml`](../../examples/yaml/text_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+
 ## Directory Structure
 
 ```

--- a/templates/time_series_forecasting/README.md
+++ b/templates/time_series_forecasting/README.md
@@ -2,6 +2,44 @@
 
 This template demonstrates how to ingest time series forecasting data from a CSV file into a database using the tracebloc_ingestor framework.
 
+## Quickstart — declarative (recommended)
+
+Ingest with ~13 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+
+**1. Stage the CSV** on the shared PVC at `/data/shared/<your-prefix>/<file>.csv`.
+
+**2. Write `ingest.yaml`:**
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: time_series_forecasting
+table: energy_demand_train
+intent: train
+csv: /data/shared/energy/demand.csv
+schema:
+  timestamp: VARCHAR(64)
+  region: VARCHAR(32)
+  temperature_c: FLOAT
+  is_holiday: INT
+  demand_mw: FLOAT
+label:
+  column: demand_mw
+  policy: bucket
+```
+
+**3. Install:**
+
+```bash
+helm install my-forecast-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+Forecasting is a regression-class task — `label.policy: bucket` is required so the central backend never sees raw target values. Canonical example: [`examples/yaml/time_series_forecasting.yaml`](../../examples/yaml/time_series_forecasting.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+
 ## Directory Structure
 
 ```

--- a/templates/time_series_forecasting/README.md
+++ b/templates/time_series_forecasting/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest time series forecasting data from a CSV
 
 Ingest with ~13 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the CSV** on the shared PVC at `/data/shared/<your-prefix>/<file>.csv`.
 
@@ -38,7 +38,7 @@ helm install my-forecast-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Forecasting is a regression-class task — `label.policy: bucket` is required so the central backend never sees raw target values. Canonical example: [`examples/yaml/time_series_forecasting.yaml`](../../examples/yaml/time_series_forecasting.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+Forecasting is a regression-class task — `label.policy: bucket` is required so the central backend never sees raw target values. Canonical example: [`examples/yaml/time_series_forecasting.yaml`](../../examples/yaml/time_series_forecasting.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/time_to_event_prediction/README.md
+++ b/templates/time_to_event_prediction/README.md
@@ -2,6 +2,45 @@
 
 This template demonstrates how to ingest time-to-event (survival analysis) data from a CSV file into a database using the tracebloc_ingestor framework.
 
+## Quickstart — declarative (recommended)
+
+Ingest with ~13 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+
+**1. Stage the CSV** on the shared PVC at `/data/shared/<your-prefix>/<file>.csv`.
+
+**2. Write `ingest.yaml`:**
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: time_to_event_prediction
+table: customer_churn_survival_train
+intent: train
+csv: /data/shared/survival/survival.csv
+time_column: tenure_days
+schema:
+  customer_id: VARCHAR(64)
+  tenure_days: INT
+  plan_tier: VARCHAR(32)
+  monthly_spend: FLOAT
+  churned: INT
+label:
+  column: churned
+  policy: bucket
+```
+
+**3. Install:**
+
+```bash
+helm install my-survival-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+`time_column:` names the column that holds the time-to-event value. `label.policy: bucket` is required so the central backend never sees raw target values. Canonical example: [`examples/yaml/time_to_event_prediction.yaml`](../../examples/yaml/time_to_event_prediction.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+
 ## Directory Structure
 
 ```

--- a/templates/time_to_event_prediction/README.md
+++ b/templates/time_to_event_prediction/README.md
@@ -6,7 +6,7 @@ This template demonstrates how to ingest time-to-event (survival analysis) data 
 
 Ingest with ~13 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
 
-> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/main/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
 **1. Stage the CSV** on the shared PVC at `/data/shared/<your-prefix>/<file>.csv`.
 
@@ -39,7 +39,7 @@ helm install my-survival-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-`time_column:` names the column that holds the time-to-event value. `label.policy: bucket` is required so the central backend never sees raw target values. Canonical example: [`examples/yaml/time_to_event_prediction.yaml`](../../examples/yaml/time_to_event_prediction.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/main/ingestor/README.md).
+`time_column:` names the column that holds the time-to-event value. `label.policy: bucket` is required so the central backend never sees raw target values. Canonical example: [`examples/yaml/time_to_event_prediction.yaml`](../../examples/yaml/time_to_event_prediction.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release/publish GitHub Actions workflows; failures could block package/image publishing even though runtime code is unchanged. The added checks are simple but run on critical release paths.
> 
> **Overview**
> Adds **smoke tests** to the `publish-dev`/`publish-master` workflows by installing the built sdist and executing `tracebloc_ingestor.cli.run._load_schema()` to ensure packaged schema files are present.
> 
> Enhances `release-image.yml` with a **post-build, pre-signing image smoke test** that (1) loads the bundled schema from the built image and (2) runs the `tracebloc-ingest` console script and asserts the expected `INGEST_CONFIG` error output, aborting before cosign signing/release updates on regressions.
> 
> Updates the top-level `Readme.md` and template READMEs to promote the **declarative YAML + Helm** ingestion path (with staging/PVC guidance and per-category example `ingest.yaml`s) and re-frames Python scripts as an advanced/legacy custom-processor option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 178702452764f2e62e35dbb2bb7f09488a1c4cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->