### PR TITLE
docs: flag per-category ingest.yaml + curl-installer helm upgrade tip

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,11 +53,21 @@ helm repo update
 
 The `tracebloc/client` parent chart bootstraps the cluster (jobs-manager, MySQL, RBAC). The `tracebloc/ingestor` subchart submits per-dataset ingestion runs against it.
 
+> **Already installed the client via the one-liner (`bash <(curl -fsSL https://tracebloc.io/i.sh)`)?** Use `--reset-then-reuse-values` so the helm upgrade doesn't drop the values the installer applied:
+>
+> ```bash
+> helm upgrade <workspace> tracebloc/client -n <namespace> --reset-then-reuse-values
+> ```
+>
+> Append `--version <version-number>` to pin a specific chart version.
+
 **2. Stage your data on the cluster's shared PVC.**
 
 The chart **doesn't transport data into the cluster** — it points at data already accessible to the cluster's shared PVC (`client-pvc` by default, mounted at `/data/shared/` inside the ingestor Pod). Before installing, get your raw files there. The simplest pattern for a small dataset is a throwaway `kubectl cp` Pod that mounts the PVC; for production you'd typically use an init container with cloud-storage sync. Full staging recipe + manifests → [`tracebloc/client/ingestor/README.md#stage-your-data-on-the-shared-pvc`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc).
 
 **3. Write your `ingest.yaml`.**
+
+The example below is for `image_classification`. **Other categories require different fields** — e.g. `tabular_classification` has no `images:` and instead needs a typed `schema:` block. Don't copy this one blindly; grab the matching file from [`examples/yaml/`](examples/yaml/) (one per category) and edit from there. Per-category sample data and READMEs live under [`templates/`](https://github.com/tracebloc/data-ingestors/tree/master/templates).
 
 ```yaml
 apiVersion: tracebloc.io/v1
@@ -70,7 +80,7 @@ images: /data/shared/cats-dogs/images/
 label: label
 ```
 
-The schema is the same for every category; the `category` field picks the validator set, file-extension defaults, and column conventions. The `csv:` / `images:` (etc.) paths are *paths inside the ingestor Pod*, which is the PVC mount you populated in step 2. See [`examples/yaml/`](examples/yaml/) for a working example per category.
+The top-level shape (`apiVersion`, `kind`, `category`, `table`, `intent`, `label`) is the same for every category; the `category` field picks the validator set, file-extension defaults, and column conventions, and the data-source fields (`csv:`, `images:`, `schema:`, …) vary per category. The paths are *paths inside the ingestor Pod*, which is the PVC mount you populated in step 2.
 
 **4. Install once per dataset.**
 


### PR DESCRIPTION
## Summary

Two small Quickstart updates driven by user feedback after a fresh setup attempt:

- **Step 1 (helm repo / chart)** — clients installed via the curl one-liner (`bash <(curl -fsSL https://tracebloc.io/i.sh)`) need `helm upgrade <workspace> tracebloc/client -n <namespace> --reset-then-reuse-values` to upgrade without losing installer-applied values. Added an inline note with the `--version <x>` pinning tip.
- **Step 3 (write \`ingest.yaml\`)** — the example is `image_classification`-specific; users following it for `tabular_classification` ended up with a yaml missing the `schema:` block and including a stale `images:` field. Called this out before the snippet and pointed at [`examples/yaml/`](https://github.com/tracebloc/data-ingestors/tree/master/examples/yaml) and [`templates/`](https://github.com/tracebloc/data-ingestors/tree/master/templates) as the per-category source of truth.

## Test plan

- [ ] Render the Readme on GitHub and confirm both callouts read correctly
- [ ] Follow the Quickstart end-to-end for a non-image category (e.g. tabular_classification) and confirm the new pointers land users on the right example file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; no code or configuration behavior is modified.
> 
> **Overview**
> Improves Quickstart docs by adding a callout for users who installed the client via the curl one-liner, recommending `helm upgrade ... --reset-then-reuse-values` (and noting optional `--version` pinning) to avoid losing installer-applied values.
> 
> Clarifies that the provided `ingest.yaml` snippet is *category-specific* (`image_classification`) and directs users to per-category examples in `examples/yaml/` and `templates/`, while updating the surrounding text to distinguish common top-level fields from category-specific data-source fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1038409850fe1bc5c167d3d171b94f23a668e095. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->