### PR TITLE
fix: close YAML-vs-template parity gaps in per-category metadata

### DIFF
--- a/examples/yaml/keypoint_detection.yaml
+++ b/examples/yaml/keypoint_detection.yaml
@@ -1,5 +1,10 @@
 # Keypoint detection: image + per-image keypoint coordinates carried in the CSV.
 # Same validator surface as image_classification (no XML, no masks).
+#
+# Unlike other image categories, keypoint_detection has no convention defaults
+# for `target_size` or `number_of_keypoints` — both are dataset-specific (pose
+# model input resolution + dataset's keypoint schema), so the schema requires
+# them top-level.
 apiVersion: tracebloc.io/v1
 kind: IngestConfig
 table: pose_train
@@ -8,3 +13,5 @@ category: keypoint_detection
 csv: /data/labels.csv
 images: /data/images/
 label: image_label
+target_size: [256, 256]      # height, width — must match your pose model's input
+number_of_keypoints: 9        # e.g. 17 for COCO pose, 9 for the upper-body sample

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -133,13 +133,15 @@ def test_object_detection_gets_448x448_default():
     assert r.file_options["target_size"] == [448, 448]
 
 
-def test_keypoint_detection_gets_448x448_default():
-    """Keypoint detection's template also uses 448×448."""
+def test_keypoint_detection_bridges_top_level_fields():
+    """Keypoint detection has no convention defaults for target_size or
+    number_of_keypoints — both are dataset-specific. The example YAML
+    supplies them top-level; resolve() must bridge them into file_options
+    so validators see them at the same key the template path uses."""
     r = resolve(_load("keypoint_detection.yaml"))
-    assert r.file_options == DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[
-        TaskCategory.KEYPOINT_DETECTION
-    ]
-    assert r.file_options["target_size"] == [448, 448]
+    assert r.file_options["extension"] == ".jpg"
+    assert r.file_options["target_size"] == [256, 256]
+    assert r.file_options["number_of_keypoints"] == 9
 
 
 def test_text_classification_gets_text_file_option_defaults():

--- a/tests/test_csv_file_options.py
+++ b/tests/test_csv_file_options.py
@@ -40,6 +40,9 @@ def test_yaml_path_empty_file_options_keeps_cleaned_schema():
         "subclass init wiped the schema base injected"
     )
     assert ing.file_options["schema"] == {"feature_a": "str", "feature_b": "int"}
+    # number_of_columns must reflect the cleaned schema even when the YAML
+    # path passes file_options={} (i.e. without a pre-seeded key).
+    assert ing.file_options["number_of_columns"] == 2
 
 
 def test_template_path_existing_file_options_sanitized_and_resized():

--- a/tests/test_csv_file_options.py
+++ b/tests/test_csv_file_options.py
@@ -13,9 +13,10 @@ populated with a fresh empty dict — the cleaned schema (and
 from unittest.mock import MagicMock
 
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
 
 
-def _make_ingestor(schema, file_options, label_column=None):
+def _make_ingestor(schema, file_options, label_column=None, category=None):
     """Build a CSVIngestor with mock DB/API so ``BaseIngestor.__init__``
     runs end-to-end (including ``database.create_table``)."""
     database = MagicMock()
@@ -27,14 +28,21 @@ def _make_ingestor(schema, file_options, label_column=None):
         schema=schema,
         file_options=file_options,
         label_column=label_column,
+        category=category,
     )
 
 
 def test_yaml_path_empty_file_options_keeps_cleaned_schema():
     """YAML path: caller passes file_options={}. The cleaned schema base
-    injects must survive subclass init."""
+    injects must survive subclass init, and tabular categories must get
+    ``number_of_columns`` derived from the cleaned schema."""
     schema = {"feature_a": "str", "feature_b": "int", "label": "str"}
-    ing = _make_ingestor(schema=schema, file_options={}, label_column="label")
+    ing = _make_ingestor(
+        schema=schema,
+        file_options={},
+        label_column="label",
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
 
     assert "schema" in ing.file_options, (
         "subclass init wiped the schema base injected"
@@ -56,12 +64,30 @@ def test_template_path_existing_file_options_sanitized_and_resized():
         "custom_flag": True,  # unrelated keys must be preserved
     }
     ing = _make_ingestor(
-        schema=schema, file_options=file_options, label_column="label"
+        schema=schema,
+        file_options=file_options,
+        label_column="label",
+        category=TaskCategory.TABULAR_CLASSIFICATION,
     )
 
     assert ing.file_options["schema"] == {"feature_a": "str", "feature_b": "int"}
     assert ing.file_options["number_of_columns"] == 2
     assert ing.file_options["custom_flag"] is True
+
+
+def test_non_tabular_schema_does_not_get_number_of_columns():
+    """Non-tabular categories may still carry a schema (e.g. keypoint
+    detection's "Visibility" column) — but ``number_of_columns`` is a
+    tabular-only metric and must not be injected for them."""
+    schema = {"Visibility": "TEXT"}
+    ing = _make_ingestor(
+        schema=schema,
+        file_options={},
+        category=TaskCategory.KEYPOINT_DETECTION,
+    )
+
+    assert ing.file_options["schema"] == {"Visibility": "TEXT"}
+    assert "number_of_columns" not in ing.file_options
 
 
 def test_file_options_none_keeps_cleaned_schema():

--- a/tests/test_csv_na_values.py
+++ b/tests/test_csv_na_values.py
@@ -1,0 +1,63 @@
+"""Per-category na_values defaults inside CSVIngestor.
+
+Templates in ``templates/tabular_*/`` and ``templates/time_*/`` pass
+``na_values=["", "NA", "NULL", "None"]`` via csv_options. The YAML path
+can't express that key (schema restricts ``spec.csv_options`` to a small
+whitelist), so the ingestor itself widens its internal default for
+tabular-family categories. Other categories keep the narrower ``[""]``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+def _make_ingestor(category):
+    return CSVIngestor(
+        database=MagicMock(),
+        api_client=MagicMock(),
+        table_name="t",
+        schema={"feature_a": "str", "label": "str"},
+        category=category,
+        label_column="label",
+    )
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        TaskCategory.TABULAR_CLASSIFICATION,
+        TaskCategory.TABULAR_REGRESSION,
+        TaskCategory.TIME_SERIES_FORECASTING,
+        TaskCategory.TIME_TO_EVENT_PREDICTION,
+    ],
+)
+def test_tabular_family_uses_wider_na_values(category, tmp_path):
+    """Tabular-family ingestors must call pd.read_csv with the wider
+    na_values set so 'NA'/'NULL'/'None' string cells parse as NaN."""
+    csv_path = tmp_path / "x.csv"
+    csv_path.write_text("feature_a,label\n1,a\n")
+    ing = _make_ingestor(category)
+
+    with patch.object(pd, "read_csv", return_value=iter([])) as mock_read:
+        list(ing.read_data(str(csv_path)))
+
+    _, kwargs = mock_read.call_args
+    assert kwargs["na_values"] == ["", "NA", "NULL", "None"]
+
+
+def test_non_tabular_keeps_narrow_na_values(tmp_path):
+    """Image / text categories don't get the wider sentinel."""
+    csv_path = tmp_path / "x.csv"
+    csv_path.write_text("feature_a,label\n1,a\n")
+    ing = _make_ingestor(TaskCategory.IMAGE_CLASSIFICATION)
+
+    with patch.object(pd, "read_csv", return_value=iter([])) as mock_read:
+        list(ing.read_data(str(csv_path)))
+
+    _, kwargs = mock_read.call_args
+    assert kwargs["na_values"] == [""]

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -31,10 +31,13 @@ Two intentional, documented divergences from the templates (per #44 design):
    asserts ``label_policy="bucket"`` for those three categories rather
    than asserting payload equivalence on the label.
 
-A third, non-functional difference: tabular templates set
-``file_options={"number_of_columns": len(schema)}``. The
-``number_of_columns`` field is dead code (no consumer in the package;
-``grep`` confirms). YAML path omits it; harness allows the diff.
+A third difference: tabular templates set
+``file_options={"number_of_columns": len(schema)}`` at the call site.
+The YAML resolver returns ``file_options={}`` for tabular categories —
+this test asserts that. ``number_of_columns`` is then injected at
+runtime by ``BaseIngestor.__init__`` (against the *cleaned* schema, with
+label/annotation/unique_id columns removed) for both paths, so the
+metadata sent to the backend is equivalent.
 """
 
 from __future__ import annotations
@@ -130,9 +133,10 @@ CASES = [
     ),
 
     # -----------------------------------------------------------------------
-    # keypoint_detection — template uses 448×448, label_column="image_label",
-    # annotation_column="Annotation", unique_id_column="filename" (opt-in
-    # column-mapping per #44 default-UUID change).
+    # keypoint_detection — template uses 256×256 with 9 keypoints. No
+    # convention defaults for these (both dataset-specific); schema requires
+    # them top-level. label_column="image_label", annotation_column="Annotation",
+    # unique_id_column="filename" (opt-in column-mapping per #44).
     # -----------------------------------------------------------------------
     pytest.param(
         _yaml(
@@ -142,6 +146,8 @@ CASES = [
             csv="/data/labels.csv",
             images="/data/images/",
             label="image_label",
+            target_size=[256, 256],
+            number_of_keypoints=9,
             data_id={"strategy": "column", "column": "filename"},
         ),
         {
@@ -152,7 +158,11 @@ CASES = [
             "label_policy": PASSTHROUGH,
             "unique_id_column": "filename",
             "annotation_column": "Annotation",  # convention default per category
-            "file_options": {"target_size": [448, 448], "extension": FileExtension.JPG},
+            "file_options": {
+                "target_size": [256, 256],
+                "extension": FileExtension.JPG,
+                "number_of_keypoints": 9,
+            },
         },
         id="keypoint_detection",
     ),
@@ -231,7 +241,8 @@ CASES = [
             "label_policy": PASSTHROUGH,
             "unique_id_column": None,
             "annotation_column": None,
-            # number_of_columns is dead code in templates — YAML path omits it.
+            # resolve() returns empty file_options for tabular; base.py
+            # injects number_of_columns from the cleaned schema at runtime.
             "file_options": {},
         },
         id="tabular_classification",

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -99,7 +99,9 @@ DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY: Dict[str, Dict[str, Any]] = {
     TaskCategory.IMAGE_CLASSIFICATION:    {"target_size": [512, 512], "extension": ".jpg"},
     TaskCategory.SEMANTIC_SEGMENTATION:   {"target_size": [512, 512], "extension": ".jpg"},
     TaskCategory.OBJECT_DETECTION:        {"target_size": [448, 448], "extension": ".jpg"},
-    TaskCategory.KEYPOINT_DETECTION:      {"target_size": [448, 448], "extension": ".jpg"},
+    # keypoint_detection: no target_size default — the customer's pose model
+    # dictates input resolution, so the schema requires it top-level.
+    TaskCategory.KEYPOINT_DETECTION:      {"extension": ".jpg"},
     # No template exists yet for instance_segmentation; mirror semantic for
     # forward-compatibility, revisit when the template lands.
     TaskCategory.INSTANCE_SEGMENTATION:   {"target_size": [512, 512], "extension": ".jpg"},
@@ -257,6 +259,20 @@ def resolve(config: Dict[str, Any]) -> ResolvedConfig:
     #     other spec.file_options key behaves.
     if category == TaskCategory.TIME_TO_EVENT_PREDICTION and resolved.time_column:
         resolved.file_options.setdefault("time_column", resolved.time_column)
+
+    # 7b. Bridge top-level `target_size` (any image category — customer
+    #     override, or the only source for keypoint_detection) and
+    #     `number_of_keypoints` (keypoint_detection only — schema requires it).
+    #     Precedence is spec.file_options > top-level > category default; since
+    #     spec was already merged in step 7, top-level only fills in when spec
+    #     didn't set it.
+    if "target_size" in config and "target_size" not in spec_file_options:
+        resolved.file_options["target_size"] = list(config["target_size"])
+    if (
+        "number_of_keypoints" in config
+        and "number_of_keypoints" not in spec_file_options
+    ):
+        resolved.file_options["number_of_keypoints"] = config["number_of_keypoints"]
 
     # 8. annotation_column — keypoint_detection's existing template uses
     #    column "Annotation" (the keypoint coords carried in the CSV). The

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -180,8 +180,7 @@ class BaseIngestor(ABC):
         # being sent to the backend as part of meta_data.
         if schema:
             self.file_options["schema"] = table_schema
-            if "number_of_columns" in self.file_options:
-                self.file_options["number_of_columns"] = len(table_schema)
+            self.file_options["number_of_columns"] = len(table_schema)
 
         # Ensure table exists
         self.table = self.database.create_table(table_name, table_schema)

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -31,6 +31,18 @@ logger = logging.getLogger(__name__)
 __all__ = ["BaseIngestor", "IngestionSummary"]
 
 
+# Tabular-family categories carry `number_of_columns` in file_options;
+# image / text categories do not (a schema may still be supplied — e.g.
+# keypoint_detection's "Visibility" column — but a column count there
+# would be a misleading metric).
+_TABULAR_FAMILY_CATEGORIES = frozenset({
+    TaskCategory.TABULAR_CLASSIFICATION,
+    TaskCategory.TABULAR_REGRESSION,
+    TaskCategory.TIME_SERIES_FORECASTING,
+    TaskCategory.TIME_TO_EVENT_PREDICTION,
+})
+
+
 class IngestionSummary(NamedTuple):
     """Data class to hold ingestion summary statistics.
 
@@ -180,7 +192,13 @@ class BaseIngestor(ABC):
         # being sent to the backend as part of meta_data.
         if schema:
             self.file_options["schema"] = table_schema
-            self.file_options["number_of_columns"] = len(table_schema)
+            # number_of_columns is only meaningful for tabular-family
+            # categories — that's where the validator + backend metadata
+            # consume it. Image categories may also carry a schema (e.g.
+            # keypoint_detection's "Visibility" column) but the count
+            # would be misleading there, so don't inject it.
+            if self.category in _TABULAR_FAMILY_CATEGORIES:
+                self.file_options["number_of_columns"] = len(table_schema)
 
         # Ensure table exists
         self.table = self.database.create_table(table_name, table_schema)

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -24,6 +24,20 @@ logger.setLevel(config.LOG_LEVEL)
 __all__ = ["Ingestor"]
 
 
+# Tabular-family categories parse CSVs with a wider null sentinel set so the
+# strings "NA" / "NULL" / "None" become NaN instead of being stored verbatim.
+# This matches what the legacy templates (templates/tabular_*/...) passed
+# explicitly via csv_options; the YAML path can't express it because
+# schema/ingest.v1.json restricts spec.csv_options to a small whitelist.
+_TABULAR_NA_VALUES = ["", "NA", "NULL", "None"]
+_TABULAR_FAMILY_CATEGORIES = frozenset({
+    TaskCategory.TABULAR_CLASSIFICATION,
+    TaskCategory.TABULAR_REGRESSION,
+    TaskCategory.TIME_SERIES_FORECASTING,
+    TaskCategory.TIME_TO_EVENT_PREDICTION,
+})
+
+
 class CSVIngestor(BaseIngestor):
     """A specialized ingestor for CSV files.
 
@@ -157,11 +171,20 @@ class CSVIngestor(BaseIngestor):
         try:
             chunk_size = self.csv_options.pop("chunk_size", 1000)
 
+            # Wider null sentinel for tabular-family categories — matches the
+            # legacy templates and prevents "NA"/"NULL"/"None" string cells
+            # from being stored verbatim instead of as NaN.
+            na_values = (
+                _TABULAR_NA_VALUES
+                if self.category in _TABULAR_FAMILY_CATEGORIES
+                else [""]
+            )
+
             # Enhanced default options for pandas
             default_options = {
                 "dtype": None,  # Let pandas infer types initially
                 "keep_default_na": False,
-                "na_values": [""],
+                "na_values": na_values,
                 "encoding": "utf-8",
                 "on_bad_lines": "warn",
                 "low_memory": False,  # Prevent mixed type inference warnings

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -138,6 +138,20 @@
       "description": "Name of the time column for time_to_event_prediction. Falls back to a column named `time` if unset."
     },
 
+    "target_size": {
+      "type": "array",
+      "items": { "type": "integer", "minimum": 1 },
+      "minItems": 2,
+      "maxItems": 2,
+      "description": "[height, width] to resize images to. Required for keypoint_detection (no default — depends on the customer's pose model). Other image categories use category defaults if unset."
+    },
+
+    "number_of_keypoints": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of keypoints per sample. Required for keypoint_detection — dataset-specific (e.g. 17 for COCO pose, 9 for the upper-body sample in templates/keypoint_detection)."
+    },
+
     "data_id": {
       "type": "object",
       "additionalProperties": false,
@@ -355,6 +369,14 @@
         },
         "required": ["label"]
       }
+    },
+    {
+      "description": "keypoint_detection requires customer-supplied `target_size` and `number_of_keypoints` (no convention defaults — both are dataset-specific).",
+      "if": {
+        "properties": { "category": { "const": "keypoint_detection" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["target_size", "number_of_keypoints"] }
     },
     {
       "description": "Most categories require `label`.",


### PR DESCRIPTION
## Summary

The YAML path (#44) silently dropped three pieces of per-category config that the template scripts carried, so YAML-driven runs produced different backend metadata / parsed records than equivalent template runs. Each gap was identified by walking each `templates/*/` file against the YAML resolver.

### 1. Tabular family — `number_of_columns` never sent

Templates set `file_options={\"number_of_columns\": len(schema)}` at the call site. The YAML resolver returns `file_options={}` for tabular, and `BaseIngestor.__init__` only refreshed the value when the key was already present:

```python
if \"number_of_columns\" in self.file_options:           # gated
    self.file_options[\"number_of_columns\"] = len(table_schema)
```

So YAML-path tabular runs never sent `number_of_columns` to the backend. Removed the guard — when a schema is supplied, `number_of_columns` is always set from the **cleaned** schema length (after label / annotation / unique_id columns are stripped).

### 2. keypoint_detection — `target_size` / `number_of_keypoints`

Both are dataset-specific (pose-model input resolution and the dataset's keypoint count); no convention default makes sense. The resolver was returning `target_size=[448, 448]` (template uses 256×256) and never set `number_of_keypoints` at all.

- Schema: new top-level `target_size` and `number_of_keypoints` properties; `if/then` requires both for `category: keypoint_detection`.
- Resolver: drop `target_size` from the keypoint default block; bridge top-level fields into `file_options` (precedence: `spec.file_options` > top-level > category default).
- Example YAML: updated with the required fields and explanatory comments.

### 3. Tabular family — `na_values` cell-parsing divergence

Templates pass `na_values=[\"\", \"NA\", \"NULL\", \"None\"]` via csv_options. `spec.csv_options` in the schema is `additionalProperties: false` and only accepts `{chunk_size, delimiter, quotechar, escapechar}`, so the YAML path stored `\"NA\"` / `\"NULL\"` / `\"None\"` cells **as strings** instead of NaN — a silent data-parsing diff against template runs.

Widened CSVIngestor's internal `na_values` default to the wider list for the four tabular-family categories. Template runs are unaffected: their explicit `csv_options` still wins via the existing `{**default_options, **self.csv_options}` merge.

Out of scope (deliberately, per discussion): `chunk_size` mismatch (template uses 100 for image/text-heavy categories vs 1000 default — perf, not correctness).

## Test plan
- [ ] `pytest tests/test_csv_file_options.py` — YAML-path `file_options={}` now asserts `number_of_columns == len(cleaned_schema)`.
- [ ] `pytest tests/test_conventions.py::test_keypoint_detection_bridges_top_level_fields` — top-level fields land in `file_options`.
- [ ] `pytest tests/test_template_equivalence.py::test_yaml_resolves_to_template_equivalent_kwargs[keypoint_detection]` — 256×256 + 9 keypoints, no stale 448×448 default.
- [ ] `pytest tests/test_csv_na_values.py` — tabular-family categories get wide `na_values`; image_classification keeps narrow.
- [ ] Manual: validate an `ingest.yaml` for `category: keypoint_detection` without `target_size` or `number_of_keypoints` and confirm the entrypoint fails fast with a schema error pointing at the missing fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ingest schema validation and per-category defaulting/CSV parsing, which can change runtime metadata and how tabular values are interpreted. Scope is moderate but well-covered by new/updated unit tests across conventions, equivalence, and CSV parsing.
> 
> **Overview**
> Improves YAML-vs-template parity for per-category metadata and CSV parsing.
> 
> **Keypoint detection** now requires top-level `target_size` and `number_of_keypoints` in the JSON schema and example YAML; the resolver drops the keypoint `target_size` default and bridges these top-level fields into `file_options` so validators/templates consume them consistently.
> 
> **Tabular/time-series** runs now always populate `file_options.number_of_columns` from the *cleaned* schema at `BaseIngestor` init (tabular-family only), and `CSVIngestor` widens default `na_values` to include `"NA"/"NULL"/"None"` for tabular-family categories (non-tabular keeps `['']`). Tests are updated/added to pin these behaviors and the template-equivalence expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 153a0618624492ec7fa6f38b7a4e3fe01d7555cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->