### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="tracebloc_ingestor",
-    version="0.3.0",
+    version="0.3.1",
     author="Tracebloc",
     author_email="support@tracebloc.com",
     description="A flexible data ingestion library for various file formats",


### PR DESCRIPTION
## Summary

Bumps `setup.py` from `0.3.0` to `0.3.1` ahead of the v0.3.1 patch release.

Closes #120 once the full release procedure (this PR → sync PR → tag) completes.

## What goes out in v0.3.1

Two bug fixes that landed on develop since v0.3.0:

- **#108** — Copy `tokenizer.json` to training pod for MLM datasets. Without it the client fell back to `bert-base-uncased` (vocab=30522), which exceeded user models' `nn.Embedding` and crashed training with a CUDA device-side assert.
- **#119** — Close YAML-vs-template parity gaps in per-category metadata. Tabular `number_of_columns` was never sent over the YAML path; keypoint `target_size` / `number_of_keypoints` defaults were wrong; tabular `na_values` cells like `"NA"` / `"NULL"` / `"None"` were stored as strings instead of NaN. Backend metadata diverged silently depending on ingestion path.

Plus #118 (this session's `RELEASING.md` runbook), which is the doc this release is following.

## Next steps after merge

Per [`RELEASING.md`](https://github.com/tracebloc/data-ingestors/blob/develop/RELEASING.md):

1. Open `sync/develop-to-master-v0.3.1` PR base `master`.
2. Merge; `publish-master.yml` builds and smoke-tests the sdist.
3. Tag `v0.3.1` on the resulting `master` commit; `release-image.yml` builds, smoke-tests against the digest, cosign-signs, attaches SBOM/provenance, updates release notes.
4. Pin the new digest downstream in `tracebloc/client`.

This is also the first release where the smoke tests from #95 / #96 run end-to-end against a real new image.

## Test plan

- [ ] CI on this PR is green (no test changes, version-string-only diff).
- [ ] After merge, `publish-dev.yml` builds a `0.3.1` pre-release sdist+wheel without smoke-test failures.
- [ ] Sync PR opened and merged.
- [ ] Tag pushed; `release-image.yml` digest-level smoke probes pass; release notes auto-populate with the digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version bump with no runtime or ingestion logic changes in the diff.
> 
> **Overview**
> Bumps the published package version in `setup.py` from **0.3.0** to **0.3.1** to cut the v0.3.1 patch release. The diff is only that version string; behavior changes for this release (MLM `tokenizer.json` copy, YAML metadata parity fixes) are already on `develop` and are described in the PR/release notes, not in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6f21af47d5c2e334f3842c7dcb5de3febffe197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->