### PR TITLE
Sync develop → master for v0.3.1 release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,176 @@
+# Releasing data-ingestors
+
+How to cut a new release of `tracebloc-ingestor` (PyPI package) and `ghcr.io/tracebloc/ingestor` (signed image). Aimed at maintainers; assumes you have push access and a `gh` token with `repo` + `workflow` + `packages` scopes.
+
+## What publishes from what
+
+| Trigger | Workflow | Artifact |
+|---|---|---|
+| Push to `develop` | `.github/workflows/publish-dev.yml` | sdist + wheel → GitHub Packages (dev pre-release) |
+| Push to `master` | `.github/workflows/publish-master.yml` | sdist + wheel → PyPI / GitHub Packages |
+| Push of tag `v*.*.*` (any branch) | `.github/workflows/release-image.yml` | Signed multi-tag image at `ghcr.io/tracebloc/ingestor`, plus a GitHub Release |
+
+Each publisher runs the schema-load smoke probe (`tracebloc_ingestor.cli.run._load_schema()`) before publishing. If the bundled `schema/ingest.v1.json` ever goes missing from the artifact (the v0.3.0-rc1 bug), the workflow aborts and nothing ships.
+
+The image and the PyPI package release **independently**. A tag without a `setup.py` bump produces an image whose pip-reported version lags. A `master` merge without a tag produces a PyPI release with no image. Doing the bump *inside* the sync PR (step 2) keeps them aligned.
+
+## Pre-flight
+
+Make sure you're not above the WIP limit on the [kanban](https://github.com/orgs/tracebloc/projects/2/views/1), then:
+
+```bash
+# Always release from a clean tree.
+cd /Volumes/VPPD/projects/tracebloc/data-ingestors
+git fetch origin
+git checkout develop && git pull --ff-only
+
+# Sanity-check what's about to ship.
+git log --oneline origin/master..origin/develop
+```
+
+If that log is empty, there's nothing to release — stop here.
+
+## 1. Verify the dev publish is green
+
+The last commit on `develop` should already have a successful `Publish Dev Package` run. If not, something in the dev pipeline is broken and you should fix that before pinning a release version.
+
+```bash
+gh run list --repo tracebloc/data-ingestors \
+  --workflow publish-dev.yml --branch develop --limit 5
+```
+
+## 2. Bump the version in `setup.py`
+
+Pick the next SemVer per [semver.org](https://semver.org/) — patch for fixes, minor for backwards-compatible features, major for breaking changes. Export it once so the rest of this doc copy-pastes cleanly:
+
+```bash
+export VERSION=X.Y.Z   # e.g. 0.3.1
+git checkout -b release/v${VERSION} origin/develop
+# Edit setup.py: version="X.Y.Z"
+git diff setup.py     # confirm only the version string changed
+git add setup.py
+git commit -m "chore(release): bump version to ${VERSION}"
+git push -u origin release/v${VERSION}
+
+gh pr create --base develop \
+  --title "chore(release): bump version to ${VERSION}" \
+  --body "Version bump ahead of v${VERSION} release. Companion sync PR will follow."
+```
+
+Get it reviewed and merged into `develop` like any other PR.
+
+## 3. Open the develop → master sync PR
+
+Branch convention is `sync/develop-to-master-v${VERSION}` (see #109 for prior art). **This is the only kind of PR that targets `master` directly.**
+
+```bash
+git fetch origin
+git checkout -b sync/develop-to-master-v${VERSION} origin/develop
+
+gh pr create --base master --head sync/develop-to-master-v${VERSION} \
+  --title "Sync develop → master for v${VERSION} release" \
+  --body "Promotes \`develop\` to \`master\` for the v${VERSION} release. CI on merge will publish to PyPI; the v${VERSION} tag (created after merge) will trigger the signed image build."
+```
+
+You may need to push the branch first if `gh pr create` complains:
+
+```bash
+git push -u origin sync/develop-to-master-v${VERSION}
+```
+
+## 4. Merge the sync PR
+
+Merge as a **merge commit** (not squash) so `master` keeps the develop history. Once merged, `publish-master.yml` fires automatically:
+
+```bash
+# Tail the run while it goes.
+gh run watch --repo tracebloc/data-ingestors \
+  $(gh run list --repo tracebloc/data-ingestors \
+      --workflow publish-master.yml --branch master --limit 1 \
+      --json databaseId --jq '.[0].databaseId')
+```
+
+If the smoke probe inside that workflow fails, the package will not be uploaded. Fix the regression and reopen a new sync PR — do **not** force the upload.
+
+## 5. Tag the release
+
+After the master publish is green:
+
+```bash
+git checkout master && git pull --ff-only
+git tag -a v${VERSION} -m "v${VERSION}"
+git push origin v${VERSION}
+```
+
+That tag push triggers `release-image.yml`, which:
+
+1. builds the image,
+2. runs the digest-level smoke probes (`_load_schema()` and a bare `tracebloc-ingest` invocation via `--entrypoint`),
+3. cosign-signs the digest keyless via OIDC,
+4. attaches SBOM + SLSA provenance,
+5. creates the GitHub Release at `v${VERSION}` with the digest and verify command in the notes.
+
+Tail it:
+
+```bash
+gh run watch --repo tracebloc/data-ingestors \
+  $(gh run list --repo tracebloc/data-ingestors \
+      --workflow release-image.yml --limit 1 \
+      --json databaseId --jq '.[0].databaseId')
+```
+
+## 6. Verify the published image
+
+The release notes embed the exact verify command. Reproduce it locally:
+
+```bash
+# Pull the digest the workflow published.
+DIGEST=$(gh release view v${VERSION} --repo tracebloc/data-ingestors \
+  --json body --jq '.body' | grep -oE 'sha256:[a-f0-9]{64}' | head -1)
+IMAGE=ghcr.io/tracebloc/ingestor
+
+# Cosign keyless verify.
+cosign verify ${IMAGE}@${DIGEST} \
+  --certificate-identity-regexp 'https://github.com/tracebloc/data-ingestors/.github/workflows/release-image.yml@.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# Optional: inspect SBOM / provenance.
+docker buildx imagetools inspect ${IMAGE}@${DIGEST} --format '{{ json .SBOM }}'
+docker buildx imagetools inspect ${IMAGE}@${DIGEST} --format '{{ json .Provenance }}'
+
+# Optional: re-run the smoke probes locally.
+docker run --rm --entrypoint python ${IMAGE}@${DIGEST} \
+  -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
+```
+
+## 7. Pin the new digest downstream
+
+The Helm subchart in [`tracebloc/client`](https://github.com/tracebloc/client) reads the digest out of these release notes and bakes it into its values. Open a follow-up PR there pinning to the new digest. (Pull by digest, not tag — that's the whole point of signing.)
+
+## Manual fallback (workflow_dispatch)
+
+If the tag push didn't trigger the image workflow, or the workflow failed for an infrastructure reason and you want to retry against the same code:
+
+```bash
+gh workflow run release-image.yml --repo tracebloc/data-ingestors \
+  -f ref=v${VERSION}
+```
+
+`inputs.ref` must point at an existing tag — the workflow reads it through `docker/metadata-action` to produce the `X.Y.Z`, `X.Y`, `X` tag set. Don't pass a branch.
+
+## Conventions and gotchas
+
+- **No `:latest`** is published (deliberate, see #45). Consumers pin to a major, minor, or specific patch.
+- **No CHANGELOG.md** in the repo — release notes are auto-generated from the digest. If you want a human-written summary, edit it in afterwards: `gh release edit v${VERSION} --notes-file <(...)`.
+- **PR base is always `develop`** for normal work. The `sync/develop-to-master-vX.Y.Z` PR is the only one targeting `master`.
+- **Version bump lives in the sync flow**, not as a tag-time afterthought, so the PyPI version and image-baked version don't drift.
+- **The image entrypoint requires `MYSQL_HOST`** at runtime (see `docker-entrypoint.sh`). Smoke probes bypass it with `--entrypoint`; if you're sanity-checking by hand outside CI, you'll need the same flag.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `publish-master.yml` smoke step fails with `FileNotFoundError: schema/ingest.v1.json` | A packaging regression dropped `schema/` from the sdist. | Verify `tracebloc_ingestor/schema/__init__.py` exists and `MANIFEST.in` has the `recursive-include tracebloc_ingestor/schema *.json` line. |
+| `release-image.yml` smoke step fails with `INGEST_CONFIG` not in output | `tracebloc-ingest` console script not installed (broken `entry_points` in setup.py) or `main()` raises at import time. | Run the second smoke probe locally against the digest with `--entrypoint tracebloc-ingest`. |
+| Image workflow ran but no image was pushed | `docker/metadata-action` produced zero tags (the `inputs.ref` / `github.ref` mismatch class of bug). | Re-run via `gh workflow run release-image.yml -f ref=v${VERSION}`. The `Verify tags were produced` step exists exactly to catch this and fail loudly. |
+| Cosign verify fails after a successful release | OIDC certificate identity changed (someone moved the workflow file). | Update the `--certificate-identity-regexp` to match the new path. |

--- a/Readme.md
+++ b/Readme.md
@@ -203,6 +203,8 @@ if __name__ == "__main__":
 
 [Platform](https://ai.tracebloc.io/) · [Docs](https://docs.tracebloc.io/) · [Data preparation guide](https://docs.tracebloc.io/create-use-case/prepare-dataset) · [Discord](https://discord.gg/tracebloc)
 
+Maintainers: see [RELEASING.md](RELEASING.md) for the release procedure.
+
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE).

--- a/examples/yaml/keypoint_detection.yaml
+++ b/examples/yaml/keypoint_detection.yaml
@@ -1,5 +1,10 @@
 # Keypoint detection: image + per-image keypoint coordinates carried in the CSV.
 # Same validator surface as image_classification (no XML, no masks).
+#
+# Unlike other image categories, keypoint_detection has no convention defaults
+# for `target_size` or `number_of_keypoints` — both are dataset-specific (pose
+# model input resolution + dataset's keypoint schema), so the schema requires
+# them top-level.
 apiVersion: tracebloc.io/v1
 kind: IngestConfig
 table: pose_train
@@ -8,3 +13,5 @@ category: keypoint_detection
 csv: /data/labels.csv
 images: /data/images/
 label: image_label
+target_size: [256, 256]      # height, width — must match your pose model's input
+number_of_keypoints: 9        # e.g. 17 for COCO pose, 9 for the upper-body sample

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="tracebloc_ingestor",
-    version="0.3.0",
+    version="0.3.1",
     author="Tracebloc",
     author_email="support@tracebloc.com",
     description="A flexible data ingestion library for various file formats",

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -133,13 +133,15 @@ def test_object_detection_gets_448x448_default():
     assert r.file_options["target_size"] == [448, 448]
 
 
-def test_keypoint_detection_gets_448x448_default():
-    """Keypoint detection's template also uses 448×448."""
+def test_keypoint_detection_bridges_top_level_fields():
+    """Keypoint detection has no convention defaults for target_size or
+    number_of_keypoints — both are dataset-specific. The example YAML
+    supplies them top-level; resolve() must bridge them into file_options
+    so validators see them at the same key the template path uses."""
     r = resolve(_load("keypoint_detection.yaml"))
-    assert r.file_options == DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[
-        TaskCategory.KEYPOINT_DETECTION
-    ]
-    assert r.file_options["target_size"] == [448, 448]
+    assert r.file_options["extension"] == ".jpg"
+    assert r.file_options["target_size"] == [256, 256]
+    assert r.file_options["number_of_keypoints"] == 9
 
 
 def test_text_classification_gets_text_file_option_defaults():

--- a/tests/test_csv_file_options.py
+++ b/tests/test_csv_file_options.py
@@ -13,9 +13,10 @@ populated with a fresh empty dict — the cleaned schema (and
 from unittest.mock import MagicMock
 
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
 
 
-def _make_ingestor(schema, file_options, label_column=None):
+def _make_ingestor(schema, file_options, label_column=None, category=None):
     """Build a CSVIngestor with mock DB/API so ``BaseIngestor.__init__``
     runs end-to-end (including ``database.create_table``)."""
     database = MagicMock()
@@ -27,19 +28,29 @@ def _make_ingestor(schema, file_options, label_column=None):
         schema=schema,
         file_options=file_options,
         label_column=label_column,
+        category=category,
     )
 
 
 def test_yaml_path_empty_file_options_keeps_cleaned_schema():
     """YAML path: caller passes file_options={}. The cleaned schema base
-    injects must survive subclass init."""
+    injects must survive subclass init, and tabular categories must get
+    ``number_of_columns`` derived from the cleaned schema."""
     schema = {"feature_a": "str", "feature_b": "int", "label": "str"}
-    ing = _make_ingestor(schema=schema, file_options={}, label_column="label")
+    ing = _make_ingestor(
+        schema=schema,
+        file_options={},
+        label_column="label",
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
 
     assert "schema" in ing.file_options, (
         "subclass init wiped the schema base injected"
     )
     assert ing.file_options["schema"] == {"feature_a": "str", "feature_b": "int"}
+    # number_of_columns must reflect the cleaned schema even when the YAML
+    # path passes file_options={} (i.e. without a pre-seeded key).
+    assert ing.file_options["number_of_columns"] == 2
 
 
 def test_template_path_existing_file_options_sanitized_and_resized():
@@ -53,12 +64,30 @@ def test_template_path_existing_file_options_sanitized_and_resized():
         "custom_flag": True,  # unrelated keys must be preserved
     }
     ing = _make_ingestor(
-        schema=schema, file_options=file_options, label_column="label"
+        schema=schema,
+        file_options=file_options,
+        label_column="label",
+        category=TaskCategory.TABULAR_CLASSIFICATION,
     )
 
     assert ing.file_options["schema"] == {"feature_a": "str", "feature_b": "int"}
     assert ing.file_options["number_of_columns"] == 2
     assert ing.file_options["custom_flag"] is True
+
+
+def test_non_tabular_schema_does_not_get_number_of_columns():
+    """Non-tabular categories may still carry a schema (e.g. keypoint
+    detection's "Visibility" column) — but ``number_of_columns`` is a
+    tabular-only metric and must not be injected for them."""
+    schema = {"Visibility": "TEXT"}
+    ing = _make_ingestor(
+        schema=schema,
+        file_options={},
+        category=TaskCategory.KEYPOINT_DETECTION,
+    )
+
+    assert ing.file_options["schema"] == {"Visibility": "TEXT"}
+    assert "number_of_columns" not in ing.file_options
 
 
 def test_file_options_none_keeps_cleaned_schema():

--- a/tests/test_csv_na_values.py
+++ b/tests/test_csv_na_values.py
@@ -1,0 +1,63 @@
+"""Per-category na_values defaults inside CSVIngestor.
+
+Templates in ``templates/tabular_*/`` and ``templates/time_*/`` pass
+``na_values=["", "NA", "NULL", "None"]`` via csv_options. The YAML path
+can't express that key (schema restricts ``spec.csv_options`` to a small
+whitelist), so the ingestor itself widens its internal default for
+tabular-family categories. Other categories keep the narrower ``[""]``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+def _make_ingestor(category):
+    return CSVIngestor(
+        database=MagicMock(),
+        api_client=MagicMock(),
+        table_name="t",
+        schema={"feature_a": "str", "label": "str"},
+        category=category,
+        label_column="label",
+    )
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        TaskCategory.TABULAR_CLASSIFICATION,
+        TaskCategory.TABULAR_REGRESSION,
+        TaskCategory.TIME_SERIES_FORECASTING,
+        TaskCategory.TIME_TO_EVENT_PREDICTION,
+    ],
+)
+def test_tabular_family_uses_wider_na_values(category, tmp_path):
+    """Tabular-family ingestors must call pd.read_csv with the wider
+    na_values set so 'NA'/'NULL'/'None' string cells parse as NaN."""
+    csv_path = tmp_path / "x.csv"
+    csv_path.write_text("feature_a,label\n1,a\n")
+    ing = _make_ingestor(category)
+
+    with patch.object(pd, "read_csv", return_value=iter([])) as mock_read:
+        list(ing.read_data(str(csv_path)))
+
+    _, kwargs = mock_read.call_args
+    assert kwargs["na_values"] == ["", "NA", "NULL", "None"]
+
+
+def test_non_tabular_keeps_narrow_na_values(tmp_path):
+    """Image / text categories don't get the wider sentinel."""
+    csv_path = tmp_path / "x.csv"
+    csv_path.write_text("feature_a,label\n1,a\n")
+    ing = _make_ingestor(TaskCategory.IMAGE_CLASSIFICATION)
+
+    with patch.object(pd, "read_csv", return_value=iter([])) as mock_read:
+        list(ing.read_data(str(csv_path)))
+
+    _, kwargs = mock_read.call_args
+    assert kwargs["na_values"] == [""]

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -31,10 +31,13 @@ Two intentional, documented divergences from the templates (per #44 design):
    asserts ``label_policy="bucket"`` for those three categories rather
    than asserting payload equivalence on the label.
 
-A third, non-functional difference: tabular templates set
-``file_options={"number_of_columns": len(schema)}``. The
-``number_of_columns`` field is dead code (no consumer in the package;
-``grep`` confirms). YAML path omits it; harness allows the diff.
+A third difference: tabular templates set
+``file_options={"number_of_columns": len(schema)}`` at the call site.
+The YAML resolver returns ``file_options={}`` for tabular categories —
+this test asserts that. ``number_of_columns`` is then injected at
+runtime by ``BaseIngestor.__init__`` (against the *cleaned* schema, with
+label/annotation/unique_id columns removed) for both paths, so the
+metadata sent to the backend is equivalent.
 """
 
 from __future__ import annotations
@@ -130,9 +133,10 @@ CASES = [
     ),
 
     # -----------------------------------------------------------------------
-    # keypoint_detection — template uses 448×448, label_column="image_label",
-    # annotation_column="Annotation", unique_id_column="filename" (opt-in
-    # column-mapping per #44 default-UUID change).
+    # keypoint_detection — template uses 256×256 with 9 keypoints. No
+    # convention defaults for these (both dataset-specific); schema requires
+    # them top-level. label_column="image_label", annotation_column="Annotation",
+    # unique_id_column="filename" (opt-in column-mapping per #44).
     # -----------------------------------------------------------------------
     pytest.param(
         _yaml(
@@ -142,6 +146,8 @@ CASES = [
             csv="/data/labels.csv",
             images="/data/images/",
             label="image_label",
+            target_size=[256, 256],
+            number_of_keypoints=9,
             data_id={"strategy": "column", "column": "filename"},
         ),
         {
@@ -152,7 +158,11 @@ CASES = [
             "label_policy": PASSTHROUGH,
             "unique_id_column": "filename",
             "annotation_column": "Annotation",  # convention default per category
-            "file_options": {"target_size": [448, 448], "extension": FileExtension.JPG},
+            "file_options": {
+                "target_size": [256, 256],
+                "extension": FileExtension.JPG,
+                "number_of_keypoints": 9,
+            },
         },
         id="keypoint_detection",
     ),
@@ -231,7 +241,8 @@ CASES = [
             "label_policy": PASSTHROUGH,
             "unique_id_column": None,
             "annotation_column": None,
-            # number_of_columns is dead code in templates — YAML path omits it.
+            # resolve() returns empty file_options for tabular; base.py
+            # injects number_of_columns from the cleaned schema at runtime.
             "file_options": {},
         },
         id="tabular_classification",

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -99,7 +99,9 @@ DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY: Dict[str, Dict[str, Any]] = {
     TaskCategory.IMAGE_CLASSIFICATION:    {"target_size": [512, 512], "extension": ".jpg"},
     TaskCategory.SEMANTIC_SEGMENTATION:   {"target_size": [512, 512], "extension": ".jpg"},
     TaskCategory.OBJECT_DETECTION:        {"target_size": [448, 448], "extension": ".jpg"},
-    TaskCategory.KEYPOINT_DETECTION:      {"target_size": [448, 448], "extension": ".jpg"},
+    # keypoint_detection: no target_size default — the customer's pose model
+    # dictates input resolution, so the schema requires it top-level.
+    TaskCategory.KEYPOINT_DETECTION:      {"extension": ".jpg"},
     # No template exists yet for instance_segmentation; mirror semantic for
     # forward-compatibility, revisit when the template lands.
     TaskCategory.INSTANCE_SEGMENTATION:   {"target_size": [512, 512], "extension": ".jpg"},
@@ -257,6 +259,20 @@ def resolve(config: Dict[str, Any]) -> ResolvedConfig:
     #     other spec.file_options key behaves.
     if category == TaskCategory.TIME_TO_EVENT_PREDICTION and resolved.time_column:
         resolved.file_options.setdefault("time_column", resolved.time_column)
+
+    # 7b. Bridge top-level `target_size` (any image category — customer
+    #     override, or the only source for keypoint_detection) and
+    #     `number_of_keypoints` (keypoint_detection only — schema requires it).
+    #     Precedence is spec.file_options > top-level > category default; since
+    #     spec was already merged in step 7, top-level only fills in when spec
+    #     didn't set it.
+    if "target_size" in config and "target_size" not in spec_file_options:
+        resolved.file_options["target_size"] = list(config["target_size"])
+    if (
+        "number_of_keypoints" in config
+        and "number_of_keypoints" not in spec_file_options
+    ):
+        resolved.file_options["number_of_keypoints"] = config["number_of_keypoints"]
 
     # 8. annotation_column — keypoint_detection's existing template uses
     #    column "Annotation" (the keypoint coords carried in the CSV). The

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -360,6 +360,22 @@ def map_file_transfer(
         return result
     elif task_category == TaskCategory.MASKED_LANGUAGE_MODELING:
         result = text_transfer(record, options, src_subdir="sequences")
+        # Copy tokenizer.json once (if provided by the user).
+        # The client's MLM strategy looks for tokenizer.json at
+        # DEST_PATH/tokenizer.json to use the user's custom tokenizer
+        # instead of falling back to bert-base-uncased.  Without this
+        # copy the tokenizer vocab_size may mismatch the model's
+        # nn.Embedding, causing CUDA device-side assert at training.
+        tokenizer_src = os.path.join(config.SRC_PATH, "tokenizer.json")
+        tokenizer_dest = os.path.join(config.DEST_PATH, "tokenizer.json")
+        if (
+            os.path.isfile(tokenizer_src)
+            and not os.path.exists(tokenizer_dest)
+        ):
+            _copy_file_with_retry(tokenizer_src, tokenizer_dest)
+            logger.info(
+                f"{GREEN}Copied tokenizer.json to {config.DEST_PATH}{RESET}"
+            )
         return result
     elif task_category == TaskCategory.SEMANTIC_SEGMENTATION:
         # Atomic: only copy image+mask together. Pre-verify both sources

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -31,6 +31,18 @@ logger = logging.getLogger(__name__)
 __all__ = ["BaseIngestor", "IngestionSummary"]
 
 
+# Tabular-family categories carry `number_of_columns` in file_options;
+# image / text categories do not (a schema may still be supplied — e.g.
+# keypoint_detection's "Visibility" column — but a column count there
+# would be a misleading metric).
+_TABULAR_FAMILY_CATEGORIES = frozenset({
+    TaskCategory.TABULAR_CLASSIFICATION,
+    TaskCategory.TABULAR_REGRESSION,
+    TaskCategory.TIME_SERIES_FORECASTING,
+    TaskCategory.TIME_TO_EVENT_PREDICTION,
+})
+
+
 class IngestionSummary(NamedTuple):
     """Data class to hold ingestion summary statistics.
 
@@ -180,7 +192,12 @@ class BaseIngestor(ABC):
         # being sent to the backend as part of meta_data.
         if schema:
             self.file_options["schema"] = table_schema
-            if "number_of_columns" in self.file_options:
+            # number_of_columns is only meaningful for tabular-family
+            # categories — that's where the validator + backend metadata
+            # consume it. Image categories may also carry a schema (e.g.
+            # keypoint_detection's "Visibility" column) but the count
+            # would be misleading there, so don't inject it.
+            if self.category in _TABULAR_FAMILY_CATEGORIES:
                 self.file_options["number_of_columns"] = len(table_schema)
 
         # Ensure table exists

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -24,6 +24,20 @@ logger.setLevel(config.LOG_LEVEL)
 __all__ = ["Ingestor"]
 
 
+# Tabular-family categories parse CSVs with a wider null sentinel set so the
+# strings "NA" / "NULL" / "None" become NaN instead of being stored verbatim.
+# This matches what the legacy templates (templates/tabular_*/...) passed
+# explicitly via csv_options; the YAML path can't express it because
+# schema/ingest.v1.json restricts spec.csv_options to a small whitelist.
+_TABULAR_NA_VALUES = ["", "NA", "NULL", "None"]
+_TABULAR_FAMILY_CATEGORIES = frozenset({
+    TaskCategory.TABULAR_CLASSIFICATION,
+    TaskCategory.TABULAR_REGRESSION,
+    TaskCategory.TIME_SERIES_FORECASTING,
+    TaskCategory.TIME_TO_EVENT_PREDICTION,
+})
+
+
 class CSVIngestor(BaseIngestor):
     """A specialized ingestor for CSV files.
 
@@ -157,11 +171,20 @@ class CSVIngestor(BaseIngestor):
         try:
             chunk_size = self.csv_options.pop("chunk_size", 1000)
 
+            # Wider null sentinel for tabular-family categories — matches the
+            # legacy templates and prevents "NA"/"NULL"/"None" string cells
+            # from being stored verbatim instead of as NaN.
+            na_values = (
+                _TABULAR_NA_VALUES
+                if self.category in _TABULAR_FAMILY_CATEGORIES
+                else [""]
+            )
+
             # Enhanced default options for pandas
             default_options = {
                 "dtype": None,  # Let pandas infer types initially
                 "keep_default_na": False,
-                "na_values": [""],
+                "na_values": na_values,
                 "encoding": "utf-8",
                 "on_bad_lines": "warn",
                 "low_memory": False,  # Prevent mixed type inference warnings

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -138,6 +138,20 @@
       "description": "Name of the time column for time_to_event_prediction. Falls back to a column named `time` if unset."
     },
 
+    "target_size": {
+      "type": "array",
+      "items": { "type": "integer", "minimum": 1 },
+      "minItems": 2,
+      "maxItems": 2,
+      "description": "[height, width] to resize images to. Required for keypoint_detection (no default — depends on the customer's pose model). Other image categories use category defaults if unset."
+    },
+
+    "number_of_keypoints": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of keypoints per sample. Required for keypoint_detection — dataset-specific (e.g. 17 for COCO pose, 9 for the upper-body sample in templates/keypoint_detection)."
+    },
+
     "data_id": {
       "type": "object",
       "additionalProperties": false,
@@ -355,6 +369,14 @@
         },
         "required": ["label"]
       }
+    },
+    {
+      "description": "keypoint_detection requires customer-supplied `target_size` and `number_of_keypoints` (no convention defaults — both are dataset-specific).",
+      "if": {
+        "properties": { "category": { "const": "keypoint_detection" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["target_size", "number_of_keypoints"] }
     },
     {
       "description": "Most categories require `label`.",


### PR DESCRIPTION
## Summary

Promotes `develop` to `master` for the v0.3.1 patch release. Part of the release sequence tracked in #120.

## What ships in v0.3.1

- **#108** — Copy `tokenizer.json` to training pod for MLM datasets. Prevents the CUDA device-side assert that hit any MLM training run with a custom tokenizer.
- **#119** — Close YAML-vs-template parity gaps in per-category metadata (tabular `number_of_columns`, keypoint `target_size` / `number_of_keypoints`, tabular `na_values`).
- **#118** — `RELEASING.md` runbook (this release is the first one following it).
- **#121** — `setup.py` version bump `0.3.0` → `0.3.1`.

Bug fixes only, no API changes, no new features → SemVer patch.

## Merge precondition

Wait for `publish-dev.yml` on `ebf6db2` (#121's merge commit) to finish green before merging this. The dev publish exercises the schema-load smoke probe against the sdist at version 0.3.1 — if anything in the packaging path regressed at the new version, we want to know **before** running `publish-master.yml` against the same code.

Current run: https://github.com/tracebloc/data-ingestors/actions/workflows/publish-dev.yml

## What happens on merge

`publish-master.yml` fires automatically:
1. Builds sdist + wheel at version 0.3.1.
2. Runs `_load_schema()` smoke probe against the installed sdist (#95 / #96 guardrail).
3. Publishes to PyPI / GitHub Packages.

After publish-master is green, I'll push the `v0.3.1` tag separately; `release-image.yml` then builds the image, runs the digest-level smoke probes, cosign-signs, and updates the release notes.

## Merge strategy

**Merge commit, not squash** — preserves develop's linear feature history on master. (Convention from prior sync PRs #79, #109, #113.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level ingestion parity and MLM file copy with expanded tests; no new public API, but keypoint YAML must now include target_size and number_of_keypoints.
> 
> **Overview**
> Promotes **develop → master** for the **v0.3.1** patch release (`setup.py` **0.3.0 → 0.3.1**), triggering PyPI publish on merge and a separate tagged container image build.
> 
> **YAML / template parity (#119):** Tabular-family ingestors now derive **`number_of_columns`** from the cleaned schema at runtime (tabular only), and **`CSVIngestor`** uses wider **`na_values`** for tabular/time-series categories to match legacy templates. **Keypoint detection** drops fixed **448×448** defaults—**`ingest.v1.json`** requires top-level **`target_size`** and **`number_of_keypoints`**, with **`resolve()`** bridging them into **`file_options`**.
> 
> **MLM fix (#108):** **`file_transfer`** copies **`tokenizer.json`** from source to destination when present so custom tokenizers align with training.
> 
> **Docs:** New **`RELEASING.md`** maintainer runbook; **`Readme.md`** links to it. Tests and examples updated for the above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebf6db2716ea9b1c91b3b00f9109bcdf89c25a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->