### PR TITLE
ci: add pytest test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,74 @@
+name: Tests
+
+# Runs the pytest suite on every PR + push to develop/master/main.
+# Matrix: Python 3.11 + 3.12 (matches setup.py: python_requires=">=3.11").
+# Coverage measured but not yet gated by --cov-fail-under; lock that in once
+# the baseline number is recorded.
+#
+# After this lands and stabilizes:
+#   - 'pytest (3.11)' + 'pytest (3.12)' become required status checks via
+#     branch protection.
+
+on:
+  pull_request:
+    branches: [develop, master, main]
+  push:
+    branches: [develop, master, main]
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.11', '3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+
+      - name: Install package + test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Run pytest with coverage
+        run: |
+          pytest \
+            --cov=tracebloc_ingestor \
+            --cov-report=term \
+            --cov-report=xml \
+            --cov-report=html
+
+      - name: Coverage summary
+        if: always()
+        run: |
+          if [ -f .coverage ]; then
+            echo "## Coverage (Python ${{ matrix.python }})" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            coverage report >> "$GITHUB_STEP_SUMMARY" || true
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload coverage HTML
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html-py${{ matrix.python }}
+          path: htmlcov/
+          retention-days: 7
+          if-no-files-found: warn

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -222,6 +222,31 @@ CASES = [
     ),
 
     # -----------------------------------------------------------------------
+    # masked_language_modeling — self-supervised: no label_column. Template
+    # uses data_format=TEXT, extension=.txt, intent=TRAIN.
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.MASKED_LANGUAGE_MODELING,
+            table="masked_language_modeling_train",
+            intent="train",
+            csv="/data/labels.csv",
+            sequences="/data/sequences/",
+        ),
+        {
+            "category": TaskCategory.MASKED_LANGUAGE_MODELING,
+            "data_format": DataFormat.TEXT,
+            "intent": Intent.TRAIN,
+            "label_column": "",
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"extension": FileExtension.TXT},
+        },
+        id="masked_language_modeling",
+    ),
+
+    # -----------------------------------------------------------------------
     # tabular_classification — template label_column="name"
     # -----------------------------------------------------------------------
     pytest.param(


### PR DESCRIPTION
## Summary

Adds `.github/workflows/tests.yml` so PRs and pushes to `develop` / `master` / `main` run the existing pytest suite in CI. 15 test files already exist on disk; they just were not running on any commit.

- Matrix: Python **3.11 + 3.12** (matches `setup.py`: `python_requires=">=3.11"`).
- Installs `requirements.txt` + editable package, runs `pytest --cov` with terminal + XML + HTML reports.
- Posts coverage report to the job summary, uploads `htmlcov/` as a per-version artifact.

## Test plan

- [ ] CI runs on this PR — both matrix jobs visible (`pytest (3.11)` + `pytest (3.12)`)
- [ ] Both jobs green
- [ ] Coverage block appears in the job summary for each Python version
- [ ] `coverage-html-py3.11` + `coverage-html-py3.12` artifacts uploaded
- [ ] Once merged + green on develop, add both check names as required status checks on develop/master/main

## Follow-ups (separate work)

- Add `--cov-fail-under` once a baseline is recorded
- Surface the coverage % on the kanban for the ingestor epic (backend #597)
