### PR TITLE
test: add masked_language_modeling equivalence case

### DIFF
--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -222,6 +222,33 @@ CASES = [
     ),
 
     # -----------------------------------------------------------------------
+    # masked_language_modeling — self-supervised, no label column. CSV manifest
+    # points at .txt sidecar files containing space-separated token sequences;
+    # the MLM client masks tokens on-the-fly during training. Sidecar dir is
+    # ``sequences/`` (not ``texts/``) to signal it's pre-tokenized, not raw text.
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.MASKED_LANGUAGE_MODELING,
+            table="masked_language_modeling_train",
+            intent="train",
+            csv="/data/labels.csv",
+            sequences="/data/sequences/",
+        ),
+        {
+            "category": TaskCategory.MASKED_LANGUAGE_MODELING,
+            "data_format": DataFormat.TEXT,
+            "intent": Intent.TRAIN,
+            "label_column": "",  # self-supervised — no label
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"extension": FileExtension.TXT},
+        },
+        id="masked_language_modeling",
+    ),
+
+    # -----------------------------------------------------------------------
     # tabular_classification — template label_column="name"
     # -----------------------------------------------------------------------
     pytest.param(


### PR DESCRIPTION
## Summary

Fixes a real test failure surfaced by the new CI workflow in #124.

`templates/masked_language_modeling/` was added without a matching case in `tests/test_template_equivalence.py::CASES`, so `test_every_existing_template_has_a_case` fails:

```
AssertionError: templates/ contains category dirs without an equivalence case: ['masked_language_modeling']
```

This PR adds the MLM case to the equivalence harness, matching the pattern used by the other 9 templates. The new case is exercised by both parametrized tests:

- `test_yaml_resolves_to_template_equivalent_kwargs[masked_language_modeling]`
- `test_yaml_config_reaches_ingestor_via_entrypoint[masked_language_modeling]`

## MLM specifics

- **Self-supervised** — no label column. `label_column` resolves to `""`.
- `data_format = TEXT` (derived from `MLM_CATEGORIES` in `conventions.py`).
- `file_options = {"extension": FileExtension.TXT}` from `DEFAULT_MLM_FILE_OPTIONS`.
- Sidecar dir is `sequences/` (not `texts/`) — signals pre-tokenized sequences from graph random walks, per the template README.

## Test plan

- [x] Local: `pytest tests/test_template_equivalence.py` → 21/21 pass under Python 3.12
- [ ] PR #124 (CI workflow) goes green after this merges + rebase

## Why this matters

The equivalence harness is the pin for client #44's "YAML path equivalent to existing templates" acceptance criterion. Without a case per template, that criterion is unverified for new templates. The `test_every_existing_template_has_a_case` guard is doing its job — surfacing drift in CI rather than silently letting it slip.
