### PR TITLE
test: raise coverage toward 90% (Phase 1 — validators)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,167 @@
+"""Shared fixtures for the test suite.
+
+Validators and ingestors snapshot ``config = Config()`` at import time but
+read ``os.environ`` lazily on each property access, so tests set env vars via
+``monkeypatch.setenv`` and the module-level config picks them up. The
+``clean_env`` fixture strips the env vars these tests touch so a developer's
+shell environment can't leak into a run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+
+_ENV_VARS = (
+    "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
+    "BACKEND_TOKEN", "CLIENT_ID", "CLIENT_PASSWORD",
+    "CLIENT_ENV", "LOG_LEVEL", "BATCH_SIZE",
+    "MYSQL_HOST", "MYSQL_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Strip env vars the ingestor config reads, so the host shell can't leak in."""
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+@pytest.fixture
+def make_csv(tmp_path):
+    """Write rows to a temp CSV and return its path.
+
+    Accepts either a pandas DataFrame or a list-of-dicts. ``name`` lets a
+    single test create several distinct files.
+    """
+
+    def _make(rows, name: str = "data.csv") -> Path:
+        df = rows if isinstance(rows, pd.DataFrame) else pd.DataFrame(rows)
+        path = tmp_path / name
+        df.to_csv(path, index=False)
+        return path
+
+    return _make
+
+
+@pytest.fixture
+def make_voc_xml(tmp_path):
+    """Write a Pascal VOC annotation XML and return its path.
+
+    ``objects`` is a list of dicts with keys: name, xmin, ymin, xmax, ymax.
+    Pass ``raw=`` to write arbitrary XML text instead (for malformed cases).
+    """
+
+    def _make(
+        objects: Optional[Sequence[Dict[str, Any]]] = None,
+        *,
+        filename: str = "img.jpg",
+        width: int = 640,
+        height: int = 480,
+        depth: int = 3,
+        name: str = "ann.xml",
+        raw: Optional[str] = None,
+    ) -> Path:
+        path = tmp_path / name
+        if raw is not None:
+            path.write_text(raw, encoding="utf-8")
+            return path
+
+        obj_xml = ""
+        for obj in objects or []:
+            obj_xml += f"""
+  <object>
+    <name>{obj['name']}</name>
+    <bndbox>
+      <xmin>{obj['xmin']}</xmin>
+      <ymin>{obj['ymin']}</ymin>
+      <xmax>{obj['xmax']}</xmax>
+      <ymax>{obj['ymax']}</ymax>
+    </bndbox>
+  </object>"""
+
+        xml = f"""<annotation>
+  <filename>{filename}</filename>
+  <size>
+    <width>{width}</width>
+    <height>{height}</height>
+    <depth>{depth}</depth>
+  </size>{obj_xml}
+</annotation>"""
+        path.write_text(xml, encoding="utf-8")
+        return path
+
+    return _make
+
+
+@pytest.fixture
+def make_tokenizer(tmp_path):
+    """Write a HuggingFace-style tokenizer.json into a dir, return that dir.
+
+    ``vocab`` is the model.vocab token list; ``added`` is the added_tokens
+    content list. Pass ``raw=`` to write invalid JSON.
+    """
+
+    def _make(
+        vocab: Optional[Sequence[str]] = ("hello", "world", "[MASK]", "[PAD]"),
+        added: Optional[Sequence[str]] = None,
+        *,
+        subdir: str = "src",
+        raw: Optional[str] = None,
+    ) -> Path:
+        src = tmp_path / subdir
+        src.mkdir(parents=True, exist_ok=True)
+        path = src / "tokenizer.json"
+        if raw is not None:
+            path.write_text(raw, encoding="utf-8")
+            return src
+
+        body: Dict[str, Any] = {"model": {}}
+        if vocab is not None:
+            body["model"]["vocab"] = {tok: i for i, tok in enumerate(vocab)}
+        if added is not None:
+            body["added_tokens"] = [{"content": t} for t in added]
+        path.write_text(json.dumps(body), encoding="utf-8")
+        return src
+
+    return _make
+
+
+@pytest.fixture
+def make_image(tmp_path):
+    """Write a solid-color image of a given size and return its path."""
+    from PIL import Image
+
+    def _make(
+        size=(64, 64),
+        *,
+        name: str = "img.jpg",
+        color=(128, 128, 128),
+        mode: str = "RGB",
+    ) -> Path:
+        path = tmp_path / name
+        Image.new(mode, size, color).save(path)
+        return path
+
+    return _make
+
+
+@pytest.fixture
+def mock_database():
+    """A MagicMock standing in for tracebloc_ingestor.database.Database."""
+    db = MagicMock(name="Database")
+    return db
+
+
+@pytest.fixture
+def mock_api_client():
+    """A MagicMock standing in for tracebloc_ingestor.api.client.APIClient."""
+    api = MagicMock(name="APIClient")
+    return api

--- a/tests/test_keypoint_annotation_validator.py
+++ b/tests/test_keypoint_annotation_validator.py
@@ -1,0 +1,109 @@
+"""Tests for KeypointAnnotationValidator — JSON structure / coordinate checks."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.keypoint_annotation_validator import (
+    KeypointAnnotationValidator,
+)
+
+
+@pytest.fixture
+def validator():
+    return KeypointAnnotationValidator()
+
+
+def _df(annotations):
+    return pd.DataFrame({"Annotation": [json.dumps(a) for a in annotations]})
+
+
+def test_valid_keypoints_pass(validator):
+    df = _df([
+        {"nose": [10, 20], "eye": [30, 40]},
+        {"nose": [11, 21], "eye": [31, 41]},
+    ])
+    result = validator.validate(df)
+    assert result.is_valid
+    assert result.metadata["rows_checked"] == 2
+
+
+def test_dict_coordinate_form_passes(validator):
+    df = _df([{"nose": {"x": 1, "y": 2}, "eye": {"x": 3, "y": 4}}])
+    result = validator.validate(df)
+    assert result.is_valid
+
+
+def test_empty_dataframe_fails(validator):
+    result = validator.validate(pd.DataFrame())
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_missing_column_fails(validator):
+    result = validator.validate(pd.DataFrame({"other": [1]}))
+    assert not result.is_valid
+    assert "Missing required column" in result.errors[0]
+
+
+def test_invalid_json_fails(validator):
+    df = pd.DataFrame({"Annotation": ["{not json"]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "Invalid JSON" in result.errors[0]
+
+
+def test_non_dict_annotation_fails(validator):
+    df = pd.DataFrame({"Annotation": [json.dumps([1, 2, 3])]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "must be a JSON object" in result.errors[0]
+
+
+def test_wrong_coordinate_count_fails(validator):
+    df = _df([{"nose": [1, 2, 3]}])
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "exactly" in result.errors[0]
+
+
+def test_non_numeric_coordinates_fail(validator):
+    df = _df([{"nose": ["a", "b"], "eye": [1, 2]}])
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("must be numeric" in e for e in result.errors)
+
+
+def test_negative_coordinates_fail(validator):
+    df = _df([{"nose": [-1, 2], "eye": [3, 4]}])
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("negative coordinates" in e for e in result.errors)
+
+
+def test_malformed_keypoint_value_fails(validator):
+    df = _df([{"nose": 5}])  # neither list nor x/y dict
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("[x, y] list" in e for e in result.errors)
+
+
+def test_degenerate_bounding_box_fails(validator):
+    # All keypoints share the same coordinates -> zero width/height.
+    df = _df([{"a": [5, 5], "b": [5, 5]}])
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("degenerate bounding box" in e for e in result.errors)
+
+
+def test_inconsistent_keypoint_names_fail(validator):
+    df = _df([
+        {"nose": [1, 2], "eye": [3, 4]},
+        {"nose": [1, 2], "ear": [3, 4]},  # different key set
+    ])
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("differ from first record" in e for e in result.errors)

--- a/tests/test_keypoint_visibility_validator.py
+++ b/tests/test_keypoint_visibility_validator.py
@@ -1,0 +1,85 @@
+"""Tests for KeypointVisibilityValidator — visibility 0/1 + key consistency."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.keypoint_visibility_validator import (
+    KeypointVisibilityValidator,
+)
+
+
+@pytest.fixture
+def validator():
+    return KeypointVisibilityValidator()
+
+
+def test_valid_visibility_passes(validator):
+    df = pd.DataFrame({
+        "Annotation": [json.dumps({"nose": [1, 2], "eye": [3, 4]})],
+        "Visibility": [json.dumps({"nose": 1, "eye": 0})],
+    })
+    result = validator.validate(df)
+    assert result.is_valid
+
+
+def test_visibility_without_annotation_column_passes(validator):
+    df = pd.DataFrame({"Visibility": [json.dumps({"nose": 1})]})
+    result = validator.validate(df)
+    assert result.is_valid
+
+
+def test_empty_dataframe_fails(validator):
+    result = validator.validate(pd.DataFrame())
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_missing_visibility_column_fails(validator):
+    result = validator.validate(pd.DataFrame({"Annotation": ["{}"]}))
+    assert not result.is_valid
+    assert "Missing required column" in result.errors[0]
+
+
+def test_invalid_json_fails(validator):
+    df = pd.DataFrame({"Visibility": ["{bad"]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "Invalid JSON" in result.errors[0]
+
+
+def test_non_dict_visibility_fails(validator):
+    df = pd.DataFrame({"Visibility": [json.dumps([1, 0])]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "must be a JSON object" in result.errors[0]
+
+
+def test_out_of_range_value_fails(validator):
+    df = pd.DataFrame({"Visibility": [json.dumps({"nose": 2})]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("must be 0 or 1" in e for e in result.errors)
+
+
+def test_missing_keys_vs_annotation_fails(validator):
+    df = pd.DataFrame({
+        "Annotation": [json.dumps({"nose": [1, 2], "eye": [3, 4]})],
+        "Visibility": [json.dumps({"nose": 1})],  # missing "eye"
+    })
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("missing keys" in e for e in result.errors)
+
+
+def test_extra_keys_vs_annotation_fails(validator):
+    df = pd.DataFrame({
+        "Annotation": [json.dumps({"nose": [1, 2]})],
+        "Visibility": [json.dumps({"nose": 1, "eye": 0})],  # extra "eye"
+    })
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("extra keys" in e for e in result.errors)

--- a/tests/test_numeric_columns_validator.py
+++ b/tests/test_numeric_columns_validator.py
@@ -1,0 +1,76 @@
+"""Tests for NumericColumnsValidator — non-timestamp schema columns must be numeric/non-null."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.validators.numeric_columns_validator import (
+    NumericColumnsValidator,
+)
+
+
+SCHEMA = {"timestamp": "TIMESTAMP", "value": "FLOAT", "count": "INT"}
+
+
+def test_all_numeric_passes(make_csv):
+    path = make_csv({
+        "timestamp": ["2024-01-01", "2024-01-02"],
+        "value": [1.0, 2.0],
+        "count": [3, 4],
+    })
+    result = NumericColumnsValidator(schema=SCHEMA).validate(str(path))
+    assert result.is_valid
+    assert result.metadata["columns_to_validate"] == 2
+
+
+def test_null_value_fails(make_csv):
+    path = make_csv({
+        "timestamp": ["2024-01-01", "2024-01-02"],
+        "value": [1.0, None],
+        "count": [3, 4],
+    })
+    result = NumericColumnsValidator(schema=SCHEMA).validate(str(path))
+    assert not result.is_valid
+    assert any("null/missing" in e for e in result.errors)
+
+
+def test_non_numeric_fails(make_csv):
+    path = make_csv({
+        "timestamp": ["2024-01-01", "2024-01-02"],
+        "value": ["x", "y"],
+        "count": [3, 4],
+    })
+    result = NumericColumnsValidator(schema=SCHEMA).validate(str(path))
+    assert not result.is_valid
+    assert any("non-numeric" in e for e in result.errors)
+
+
+def test_timestamp_column_excluded(make_csv):
+    # timestamp is non-numeric but must be skipped.
+    path = make_csv({
+        "timestamp": ["2024-01-01", "2024-01-02"],
+        "value": [1.0, 2.0],
+    })
+    result = NumericColumnsValidator(schema={"timestamp": "TIMESTAMP", "value": "FLOAT"}).validate(str(path))
+    assert result.is_valid
+
+
+def test_no_schema_skips_validation(make_csv):
+    path = make_csv({"value": ["anything"]})
+    result = NumericColumnsValidator().validate(str(path))
+    assert result.is_valid
+    assert "No schema provided" in result.metadata["message"]
+
+
+def test_no_overlapping_columns_passes(make_csv):
+    # Schema columns aren't present in the CSV (besides timestamp) -> nothing to check.
+    path = make_csv({"timestamp": ["2024-01-01"], "other": [1]})
+    result = NumericColumnsValidator(schema={"timestamp": "TIMESTAMP", "value": "FLOAT"}).validate(str(path))
+    assert result.is_valid
+    assert "No schema columns to validate" in result.metadata["message"]
+
+
+def test_no_data_for_non_csv():
+    result = NumericColumnsValidator(schema=SCHEMA).validate("/missing.csv")
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]

--- a/tests/test_table_name_validator.py
+++ b/tests/test_table_name_validator.py
@@ -1,0 +1,77 @@
+"""Tests for TableNameValidator — regex naming rules read from config.TABLE_NAME."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.validators.table_name_validator import TableNameValidator
+
+
+@pytest.fixture
+def validator():
+    return TableNameValidator()
+
+
+def test_valid_name_passes(clean_env, validator):
+    clean_env.setenv("TABLE_NAME", "cats_dogs_train")
+    result = validator.validate(None)
+    assert result.is_valid
+    assert result.errors == []
+    assert result.metadata["table_names_checked"] == 1
+
+
+def test_missing_table_name_fails(clean_env, validator):
+    # TABLE_NAME unset -> config returns "" -> the no-name branch.
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert "No table name found" in result.errors[0]
+    assert result.metadata["table_names_checked"] == 0
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "1table",         # starts with a digit
+        "my-table",       # hyphen
+        "my table",       # space
+        "table$",         # symbol
+        "_leading",       # underscore start (pattern requires a letter)
+    ],
+)
+def test_invalid_characters_fail(clean_env, validator, bad_name):
+    clean_env.setenv("TABLE_NAME", bad_name)
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert any("invalid characters" in e for e in result.errors)
+    assert result.metadata["invalid_names"]
+
+
+def test_reserved_keyword_warns_but_passes(clean_env, validator):
+    clean_env.setenv("TABLE_NAME", "select")
+    result = validator.validate(None)
+    assert result.is_valid
+    assert any("reserved keyword" in w for w in result.warnings)
+
+
+def test_validate_table_names_empty_list(validator):
+    result = validator._validate_table_names([])
+    assert not result.is_valid
+    assert "No table names to validate" in result.errors[0]
+
+
+def test_validate_table_names_non_string(validator):
+    result = validator._validate_table_names([123])
+    assert not result.is_valid
+    assert any("not a string" in e for e in result.errors)
+
+
+def test_validate_table_names_whitespace_only(validator):
+    result = validator._validate_table_names(["   "])
+    assert not result.is_valid
+    assert any("empty table name" in e for e in result.errors)
+
+
+def test_is_reserved_keyword_case_insensitive(validator):
+    assert validator._is_reserved_keyword("SELECT")
+    assert validator._is_reserved_keyword("from")
+    assert not validator._is_reserved_keyword("customers")

--- a/tests/test_time_validators.py
+++ b/tests/test_time_validators.py
@@ -1,0 +1,189 @@
+"""Tests for the time-series validators: format, ordering, before-today, to-event."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.time_format_validator import TimeFormatValidator
+from tracebloc_ingestor.validators.time_ordered_validator import TimeOrderedValidator
+from tracebloc_ingestor.validators.time_before_today_validator import (
+    TimeBeforeTodayValidator,
+)
+from tracebloc_ingestor.validators.time_to_event_validator import TimeToEventValidator
+
+
+# ---------------------------------------------------------------------------
+# TimeFormatValidator
+# ---------------------------------------------------------------------------
+
+def test_format_valid_timestamps_pass(make_csv):
+    path = make_csv({"timestamp": ["2024-01-01", "2024-01-02"], "v": [1, 2]})
+    result = TimeFormatValidator().validate(str(path))
+    assert result.is_valid
+    assert result.metadata["rows_checked"] == 2
+
+
+def test_format_invalid_timestamp_fails(make_csv):
+    path = make_csv({"timestamp": ["2024-01-01", "not-a-date"], "v": [1, 2]})
+    result = TimeFormatValidator().validate(str(path))
+    assert not result.is_valid
+    assert "invalid timestamp" in result.errors[0]
+    assert result.metadata["invalid_timestamps"] == 1
+
+
+def test_format_missing_column_fails(make_csv):
+    path = make_csv({"ts": ["2024-01-01"], "v": [1]})
+    result = TimeFormatValidator().validate(str(path))
+    assert not result.is_valid
+    assert "not found" in result.errors[0]
+
+
+def test_format_no_data_when_path_not_csv():
+    result = TimeFormatValidator().validate("/nonexistent/path.txt")
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_format_schema_missing_timestamp_fails():
+    v = TimeFormatValidator(schema={"value": "FLOAT"})
+    result = v.validate("ignored")
+    assert not result.is_valid
+    assert "must contain a 'timestamp' column" in result.errors[0]
+
+
+def test_format_schema_wrong_type_fails():
+    v = TimeFormatValidator(schema={"timestamp": "DATE"})
+    result = v.validate("ignored")
+    assert not result.is_valid
+    assert "must be of type 'TIMESTAMP'" in result.errors[0]
+
+
+def test_format_schema_timestamp_with_precision_passes(make_csv):
+    path = make_csv({"timestamp": ["2024-01-01"], "v": [1]})
+    v = TimeFormatValidator(schema={"timestamp": "TIMESTAMP(6)"})
+    result = v.validate(str(path))
+    assert result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# TimeOrderedValidator
+# ---------------------------------------------------------------------------
+
+def test_ordered_monotonic_passes(make_csv):
+    path = make_csv({"timestamp": ["2024-01-01", "2024-01-02", "2024-01-03"]})
+    result = TimeOrderedValidator().validate(str(path))
+    assert result.is_valid
+    assert result.metadata["is_ordered"] is True
+
+
+def test_ordered_out_of_order_fails(make_csv):
+    path = make_csv({"timestamp": ["2024-01-03", "2024-01-01"]})
+    result = TimeOrderedValidator().validate(str(path))
+    assert not result.is_valid
+    assert "out-of-order" in result.errors[0]
+    assert result.metadata["out_of_order_pairs"] == 1
+
+
+def test_ordered_missing_column_fails(make_csv):
+    path = make_csv({"ts": ["2024-01-01"]})
+    result = TimeOrderedValidator().validate(str(path))
+    assert not result.is_valid
+    assert "not found" in result.errors[0]
+
+
+def test_ordered_no_data_for_non_csv():
+    result = TimeOrderedValidator().validate("/nope.parquet")
+    assert not result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# TimeBeforeTodayValidator
+# ---------------------------------------------------------------------------
+
+def test_before_today_past_passes(make_csv):
+    path = make_csv({"timestamp": ["2000-01-01", "2001-01-01"]})
+    result = TimeBeforeTodayValidator().validate(str(path))
+    assert result.is_valid
+    assert "earliest" in result.metadata
+
+
+def test_before_today_future_fails(make_csv):
+    future = (pd.Timestamp.now() + pd.Timedelta(days=365)).strftime("%Y-%m-%d")
+    path = make_csv({"timestamp": ["2000-01-01", future]})
+    result = TimeBeforeTodayValidator().validate(str(path))
+    assert not result.is_valid
+    assert "not before today" in result.errors[0]
+    assert result.metadata["future_timestamps"] == 1
+
+
+def test_before_today_missing_column_fails(make_csv):
+    path = make_csv({"ts": ["2000-01-01"]})
+    result = TimeBeforeTodayValidator().validate(str(path))
+    assert not result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# TimeToEventValidator (accepts DataFrames directly)
+# ---------------------------------------------------------------------------
+
+def test_to_event_valid_passes():
+    df = pd.DataFrame({"time": [0, 1.5, 10], "event": [1, 0, 1]})
+    result = TimeToEventValidator().validate(df)
+    assert result.is_valid
+    assert result.metadata["min_time"] == 0.0
+    assert result.metadata["max_time"] == 10.0
+
+
+def test_to_event_missing_column_fails():
+    df = pd.DataFrame({"duration": [1, 2]})
+    result = TimeToEventValidator().validate(df)
+    assert not result.is_valid
+    assert "Required time column 'time' not found" in result.errors[0]
+
+
+def test_to_event_non_numeric_fails():
+    df = pd.DataFrame({"time": [1, "abc", 3]})
+    result = TimeToEventValidator().validate(df)
+    assert not result.is_valid
+    assert "non-numeric" in result.errors[0]
+    assert result.metadata["non_numeric_count"] == 1
+
+
+def test_to_event_negative_fails():
+    df = pd.DataFrame({"time": [1, -2, 3]})
+    result = TimeToEventValidator().validate(df)
+    assert not result.is_valid
+    assert "negative" in result.errors[0]
+    assert result.metadata["negative_count"] == 1
+
+
+def test_to_event_null_warns_but_can_pass():
+    df = pd.DataFrame({"time": [1.0, None, 3.0]})
+    result = TimeToEventValidator().validate(df)
+    assert result.is_valid
+    assert any("null/missing" in w for w in result.warnings)
+
+
+def test_to_event_empty_dataframe_fails():
+    result = TimeToEventValidator().validate(pd.DataFrame())
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_to_event_custom_column_name():
+    df = pd.DataFrame({"duration": [1, 2, 3]})
+    result = TimeToEventValidator(time_column="duration").validate(df)
+    assert result.is_valid
+
+
+def test_to_event_loads_from_csv(make_csv):
+    path = make_csv({"time": [1, 2, 3]})
+    result = TimeToEventValidator().validate(str(path))
+    assert result.is_valid
+
+
+def test_to_event_sample_size_limits_rows():
+    df = pd.DataFrame({"time": list(range(100))})
+    result = TimeToEventValidator().validate(df, sample_size=10)
+    assert result.metadata["rows_checked"] == 10

--- a/tests/test_tokenizer_validator.py
+++ b/tests/test_tokenizer_validator.py
@@ -1,0 +1,81 @@
+"""Tests for TokenizerValidator — checks tokenizer.json at config.SRC_PATH."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
+
+
+@pytest.fixture
+def validator():
+    return TokenizerValidator()
+
+
+def test_passes_when_required_tokens_present(clean_env, validator, make_tokenizer):
+    src = make_tokenizer(vocab=["a", "b", "[MASK]", "[PAD]"])
+    clean_env.setenv("SRC_PATH", str(src))
+    result = validator.validate(None)
+    assert result.is_valid
+    assert result.metadata["vocab_size"] == 4
+
+
+def test_missing_file_fails(clean_env, validator, tmp_path):
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert "tokenizer.json not found" in result.errors[0]
+
+
+def test_missing_required_token_fails(clean_env, validator, make_tokenizer):
+    src = make_tokenizer(vocab=["a", "b", "[PAD]"])  # no [MASK]
+    clean_env.setenv("SRC_PATH", str(src))
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert "[MASK]" in result.errors[0]
+    assert result.metadata["missing_tokens"] == ["[MASK]"]
+
+
+def test_tokens_from_added_tokens_section(clean_env, validator, make_tokenizer):
+    # vocab lacks the special tokens; added_tokens supplies them.
+    src = make_tokenizer(vocab=["a", "b"], added=["[MASK]", "[PAD]"])
+    clean_env.setenv("SRC_PATH", str(src))
+    result = validator.validate(None)
+    assert result.is_valid
+
+
+def test_unrecognized_structure_fails(clean_env, validator, make_tokenizer):
+    src = make_tokenizer(vocab=None)  # empty model, no added_tokens
+    clean_env.setenv("SRC_PATH", str(src))
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert "Could not extract vocabulary" in result.errors[0]
+
+
+def test_invalid_json_fails(clean_env, validator, make_tokenizer):
+    src = make_tokenizer(raw="{not valid json")
+    clean_env.setenv("SRC_PATH", str(src))
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert "not valid JSON" in result.errors[0]
+
+
+def test_extract_vocab_unigram_list_form():
+    data = {"model": {"vocab": [["[MASK]", -1.0], ["[PAD]", -2.0]]}}
+    vocab = TokenizerValidator._extract_vocab(data)
+    assert vocab == {"[MASK]", "[PAD]"}
+
+
+def test_extract_vocab_added_tokens_string_form():
+    data = {"added_tokens": ["[MASK]", "[PAD]"]}
+    vocab = TokenizerValidator._extract_vocab(data)
+    assert vocab == {"[MASK]", "[PAD]"}
+
+
+def test_extract_vocab_returns_none_when_empty():
+    assert TokenizerValidator._extract_vocab({}) is None
+
+
+def test_custom_required_tokens():
+    v = TokenizerValidator(required_tokens=("[CLS]",))
+    assert v.required_tokens == {"[CLS]"}


### PR DESCRIPTION
## Summary

First phase of an effort to bring the repo to **90% test coverage** (currently the suite covers ~39%). This PR adds shared test fixtures and unit tests for the pure-logic validators.

- `tests/conftest.py` — shared fixtures: temp-CSV builder, PIL image factory, Pascal VOC XML factory, tokenizer.json factory, mock `Database`/`APIClient`, and a `clean_env` helper.
- Validator tests: `table_name`, `tokenizer`, `keypoint_annotation`, `keypoint_visibility`, and the time-series validators (`time_format`, `time_ordered`, `time_before_today`, `time_to_event`, `numeric_columns`).

**Coverage: 39% → 53%.** Tests: 205 → 278 (+73). The targeted validators are now 82–97% each.

## Phased plan (subsequent PRs)

- **Phase 2** — `xml_validator`, `data_validator`, `image_validator`, `file_validator`, `duplicate_validator` (~597 stmts)
- **Phase 3** — ingestors (`base`/`csv`/`json`), `file_transfer`, `api/client`, `validators_mapping` (~491 stmts)
- **Phase 4** — `database.py` via mocked SQLAlchemy (~92 stmts)

Coverage stays report-only (no `--cov-fail-under` gate) per discussion.

## Test plan

- [ ] CI green on both Python 3.11 + 3.12 matrix jobs
- [ ] Coverage block in job summary shows the increase

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with fixtures and assertions; no runtime ingestor or validator logic is modified.
> 
> **Overview**
> **Phase 1** of raising test coverage adds shared pytest infrastructure and focused unit tests for ingest validators—no production code changes.
> 
> `tests/conftest.py` introduces reusable helpers: **`clean_env`** (clears config-related env vars so local shells don’t affect runs), **`make_csv`**, **`make_voc_xml`**, **`make_tokenizer`**, **`make_image`**, and **`mock_database`** / **`mock_api_client`**.
> 
> New test modules exercise **`TableNameValidator`**, **`TokenizerValidator`**, keypoint annotation/visibility validators, **`NumericColumnsValidator`**, and the time-series validators (**format**, **ordered**, **before today**, **to event**), covering happy paths, schema/JSON edge cases, env-driven config (`TABLE_NAME`, `SRC_PATH`), and error metadata.
> 
> Per the PR description, this is intended to move overall coverage from ~39% toward 90% in later phases; targeted validators are expected to reach the low–high 80s–90s% range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e216dab144c7b19e7c5f6b371c305fff643f1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->