### PR TITLE
test: raise coverage toward 90% (Phase 2 — pandas/file validators)

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -1,0 +1,211 @@
+"""Tests for DataValidator — per-type schema compliance checks."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.data_validator import DataValidator
+
+
+# ---------------------------------------------------------------------------
+# validate() top-level flow
+# ---------------------------------------------------------------------------
+
+def test_no_schema_passes_with_warning():
+    result = DataValidator().validate(pd.DataFrame({"a": [1]}))
+    assert result.is_valid
+    assert result.metadata["schema_provided"] is False
+
+
+def test_empty_dataframe_fails():
+    result = DataValidator(schema={"a": "INT"}).validate(pd.DataFrame())
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_non_csv_path_returns_no_data():
+    result = DataValidator(schema={"a": "INT"}).validate("/nope.parquet")
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_loads_from_csv(make_csv):
+    path = make_csv({"age": [1, 2, 3]})
+    result = DataValidator(schema={"age": "INT"}).validate(str(path))
+    assert result.is_valid
+
+
+def test_unknown_type_fails():
+    df = pd.DataFrame({"a": [1]})
+    result = DataValidator(schema={"a": "WEIRDTYPE"}).validate(df)
+    assert not result.is_valid
+    assert "Unknown data type" in result.errors[0]
+
+
+def test_schema_column_not_in_df_is_ignored():
+    df = pd.DataFrame({"a": [1]})
+    result = DataValidator(schema={"b": "INT"}).validate(df)
+    # 'b' isn't in df.columns, so nothing is validated -> valid.
+    assert result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# INT / BIGINT
+# ---------------------------------------------------------------------------
+
+def test_int_valid():
+    df = pd.DataFrame({"n": [1, 2, 3]})
+    assert DataValidator(schema={"n": "INT"}).validate(df).is_valid
+
+
+def test_int_non_numeric_fails():
+    df = pd.DataFrame({"n": ["a", "b"]})
+    result = DataValidator(schema={"n": "INT"}).validate(df)
+    assert not result.is_valid
+    assert "non-numeric" in result.errors[0]
+
+
+def test_int_non_integer_float_fails():
+    df = pd.DataFrame({"n": [1.5, 2.0]})
+    result = DataValidator(schema={"n": "INT"}).validate(df)
+    assert not result.is_valid
+    assert "non-integer" in result.errors[0]
+
+
+def test_bigint_delegates_to_int():
+    df = pd.DataFrame({"n": [10_000_000_000]})
+    assert DataValidator(schema={"n": "BIGINT"}).validate(df).is_valid
+
+
+# ---------------------------------------------------------------------------
+# FLOAT / DOUBLE / DECIMAL
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("dtype", ["FLOAT", "DOUBLE", "DECIMAL(10,2)"])
+def test_float_family_valid(dtype):
+    df = pd.DataFrame({"x": [1.5, 2.25]})
+    assert DataValidator(schema={"x": dtype}).validate(df).is_valid
+
+
+def test_float_non_numeric_fails():
+    df = pd.DataFrame({"x": ["a", "b"]})
+    result = DataValidator(schema={"x": "FLOAT"}).validate(df)
+    assert not result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# VARCHAR / CHAR / TEXT
+# ---------------------------------------------------------------------------
+
+def test_varchar_valid():
+    df = pd.DataFrame({"s": ["abc", "de"]})
+    assert DataValidator(schema={"s": "VARCHAR(255)"}).validate(df).is_valid
+
+
+def test_varchar_too_long_fails():
+    df = pd.DataFrame({"s": ["abcdef", "gh"]})
+    result = DataValidator(schema={"s": "VARCHAR(3)"}).validate(df)
+    assert not result.is_valid
+    assert "exceeding max length" in result.errors[0]
+
+
+def test_char_wrong_length_fails():
+    df = pd.DataFrame({"s": ["ab", "cde"]})
+    result = DataValidator(schema={"s": "CHAR(2)"}).validate(df)
+    assert not result.is_valid
+    assert "length !=" in result.errors[0]
+
+
+def test_text_valid():
+    df = pd.DataFrame({"s": ["any length text here"]})
+    assert DataValidator(schema={"s": "TEXT"}).validate(df).is_valid
+
+
+# ---------------------------------------------------------------------------
+# BOOLEAN across dtypes
+# ---------------------------------------------------------------------------
+
+def test_boolean_bool_dtype_valid():
+    df = pd.DataFrame({"b": [True, False]})
+    assert DataValidator(schema={"b": "BOOLEAN"}).validate(df).is_valid
+
+
+def test_boolean_int_valid():
+    df = pd.DataFrame({"b": [0, 1, 1]})
+    assert DataValidator(schema={"b": "BOOL"}).validate(df).is_valid
+
+
+def test_boolean_int_out_of_range_fails():
+    df = pd.DataFrame({"b": [0, 2]})
+    result = DataValidator(schema={"b": "BOOLEAN"}).validate(df)
+    assert not result.is_valid
+    assert "non-boolean" in result.errors[0]
+
+
+def test_boolean_string_valid():
+    df = pd.DataFrame({"b": ["true", "no", "1", "False"]})
+    assert DataValidator(schema={"b": "BOOLEAN"}).validate(df).is_valid
+
+
+def test_boolean_string_invalid_fails():
+    df = pd.DataFrame({"b": ["maybe", "true"]})
+    result = DataValidator(schema={"b": "BOOLEAN"}).validate(df)
+    assert not result.is_valid
+
+
+def test_boolean_all_null_valid():
+    df = pd.DataFrame({"b": pd.Series([None, None], dtype="object")})
+    assert DataValidator(schema={"b": "BOOLEAN"}).validate(df).is_valid
+
+
+def test_boolean_float_valid():
+    df = pd.DataFrame({"b": [0.0, 1.0]})
+    assert DataValidator(schema={"b": "BOOLEAN"}).validate(df).is_valid
+
+
+def test_boolean_float_invalid_fails():
+    df = pd.DataFrame({"b": [0.0, 0.5]})
+    result = DataValidator(schema={"b": "BOOLEAN"}).validate(df)
+    assert not result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# DATE / DATETIME / TIMESTAMP / TIME
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("dtype", ["DATE", "DATETIME", "TIMESTAMP", "TIME"])
+def test_date_family_valid(dtype):
+    df = pd.DataFrame({"d": ["2024-01-01", "2024-02-02"]})
+    assert DataValidator(schema={"d": dtype}).validate(df).is_valid
+
+
+def test_date_invalid_fails():
+    df = pd.DataFrame({"d": ["not-a-date", "2024-01-01"]})
+    result = DataValidator(schema={"d": "DATE"}).validate(df)
+    assert not result.is_valid
+    assert "invalid date" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# type parsing + auto-detect helper
+# ---------------------------------------------------------------------------
+
+def test_constraints_are_stripped_from_type():
+    df = pd.DataFrame({"n": [1, 2]})
+    # "INT NOT NULL" should resolve to the INT validator.
+    assert DataValidator(schema={"n": "INT NOT NULL"}).validate(df).is_valid
+
+
+@pytest.mark.parametrize(
+    "series,expected",
+    [
+        (pd.Series([True, False]), "BOOLEAN"),
+        (pd.Series([1, 2, 3]), "INT"),
+        (pd.Series([1.0, 2.5]), "FLOAT"),
+        (pd.Series(pd.to_datetime(["2024-01-01"])), "DATETIME"),
+        (pd.Series(["x", "y"]), "VARCHAR(255)"),
+    ],
+)
+def test_detect_column_type(series, expected):
+    assert DataValidator()._detect_column_type(series) == expected

--- a/tests/test_duplicate_validator_extra.py
+++ b/tests/test_duplicate_validator_extra.py
@@ -1,0 +1,52 @@
+"""Supplementary DuplicateValidator coverage: parent-dir warnings, dir
+creation, and the error-handling fallbacks not exercised by
+test_duplicate_validator.py."""
+
+from __future__ import annotations
+
+from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
+
+
+def test_missing_parent_directory_warns(tmp_path):
+    dest = tmp_path / "missing_parent" / "table"
+    result = DuplicateValidator(dest_path=str(dest)).validate(None)
+    assert result.is_valid
+    assert any("Parent directory" in w for w in result.warnings)
+    assert result.metadata["parent_directory_exists"] is False
+
+
+def test_check_directory_exists_true(tmp_path):
+    d = tmp_path / "existing"
+    d.mkdir()
+    assert DuplicateValidator(dest_path=str(d))._check_directory_exists() is True
+
+
+def test_check_directory_exists_false_for_file(tmp_path):
+    f = tmp_path / "a_file"
+    f.write_text("x")
+    # A file is not a directory.
+    assert DuplicateValidator(dest_path=str(f))._check_directory_exists() is False
+
+
+def test_is_directory_empty_true(tmp_path):
+    d = tmp_path / "empty"
+    d.mkdir()
+    assert DuplicateValidator(dest_path=str(d))._is_directory_empty() is True
+
+
+def test_is_directory_empty_handles_missing(tmp_path):
+    # iterdir on a nonexistent dir raises -> caught -> returns False.
+    assert DuplicateValidator(dest_path=str(tmp_path / "nope"))._is_directory_empty() is False
+
+
+def test_create_directory_if_needed(tmp_path):
+    dest = tmp_path / "to_create" / "nested"
+    v = DuplicateValidator(dest_path=str(dest))
+    assert v._create_directory_if_needed() is True
+    assert dest.exists()
+
+
+def test_create_directory_if_needed_existing(tmp_path):
+    dest = tmp_path / "already"
+    dest.mkdir()
+    assert DuplicateValidator(dest_path=str(dest))._create_directory_if_needed() is True

--- a/tests/test_file_validator.py
+++ b/tests/test_file_validator.py
@@ -1,0 +1,109 @@
+"""Tests for FileTypeValidator — extension uniformity under config.SRC_PATH/<path>."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tracebloc_ingestor.validators.file_validator import FileTypeValidator
+
+
+def test_invalid_allowed_extension_raises():
+    with pytest.raises(ValueError):
+        FileTypeValidator(allowed_extension=".gif")
+
+
+def test_uniform_extension_passes(clean_env, tmp_path):
+    images = tmp_path / "images"
+    images.mkdir()
+    (images / "a.jpg").write_bytes(b"x")
+    (images / "b.jpg").write_bytes(b"y")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = FileTypeValidator(allowed_extension=".jpg").validate(None)
+    assert result.is_valid, result.errors
+    assert result.metadata["uniform_extension"] == ".jpg"
+
+
+def test_mixed_extensions_fail(clean_env, tmp_path):
+    images = tmp_path / "images"
+    images.mkdir()
+    (images / "a.jpg").write_bytes(b"x")
+    (images / "b.png").write_bytes(b"y")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = FileTypeValidator(allowed_extension=".jpg").validate(None)
+    assert not result.is_valid
+    assert any("Multiple file extensions" in e for e in result.errors)
+
+
+def test_invalid_extension_in_strict_mode_fails(clean_env, tmp_path):
+    images = tmp_path / "images"
+    images.mkdir()
+    (images / "a.png").write_bytes(b"x")
+    (images / "b.png").write_bytes(b"y")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = FileTypeValidator(allowed_extension=".jpg").validate(None)
+    assert not result.is_valid
+    assert any("invalid extensions" in e for e in result.errors)
+
+
+def test_no_files_fails(clean_env, tmp_path):
+    (tmp_path / "images").mkdir()
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = FileTypeValidator(allowed_extension=".jpg").validate(None)
+    assert not result.is_valid
+    assert "No files found" in result.errors[0]
+
+
+def test_nonexistent_path_fails(clean_env, tmp_path):
+    clean_env.setenv("SRC_PATH", str(tmp_path))  # no "images" subdir
+    result = FileTypeValidator(allowed_extension=".jpg").validate(None)
+    assert not result.is_valid
+
+
+def test_custom_subpath(clean_env, tmp_path):
+    texts = tmp_path / "texts"
+    texts.mkdir()
+    (texts / "a.txt").write_text("hi")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = FileTypeValidator(allowed_extension=".txt", path="texts").validate(None)
+    assert result.is_valid
+
+
+# ---- helpers --------------------------------------------------------------
+
+def test_get_files_single_file(tmp_path):
+    p = tmp_path / "a.jpg"
+    p.write_bytes(b"x")
+    v = FileTypeValidator(allowed_extension=".jpg")
+    assert v._get_files_to_validate(str(p), True, True) == [p]
+
+
+def test_get_files_list(tmp_path):
+    p = tmp_path / "a.jpg"
+    p.write_bytes(b"x")
+    v = FileTypeValidator(allowed_extension=".jpg")
+    files = v._get_files_to_validate([str(p), str(tmp_path / "missing.jpg")], True, True)
+    assert files == [p]
+
+
+def test_get_files_unsupported_type_raises():
+    v = FileTypeValidator(allowed_extension=".jpg")
+    with pytest.raises(ValueError):
+        v._get_files_to_validate(123, True, True)
+
+
+def test_get_files_ignores_hidden(tmp_path):
+    (tmp_path / ".h.jpg").write_bytes(b"x")
+    visible = tmp_path / "v.jpg"
+    visible.write_bytes(b"x")
+    v = FileTypeValidator(allowed_extension=".jpg")
+    files = v._get_files_to_validate(str(tmp_path), True, True)
+    assert visible in files
+    assert all(not p.name.startswith(".") for p in files)
+
+
+def test_validate_file_extensions_empty():
+    v = FileTypeValidator(allowed_extension=".jpg")
+    res = v._validate_file_extensions([])
+    assert not res.is_valid

--- a/tests/test_image_validator_flow.py
+++ b/tests/test_image_validator_flow.py
@@ -1,0 +1,124 @@
+"""Tests for ImageResolutionValidator's validate() flow and helpers.
+
+The resolution-matching unit tests live in test_image_validator_resolution.py;
+this file covers the file-discovery + uniformity flow, which reads images from
+``config.SRC_PATH/images``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from tracebloc_ingestor.validators.image_validator import ImageResolutionValidator
+
+
+@pytest.fixture
+def images_dir(tmp_path):
+    """Return a factory that creates <tmp>/images/<name> at a given size."""
+    d = tmp_path / "images"
+    d.mkdir()
+
+    def _add(name, size=(64, 64), color=(120, 120, 120)):
+        Image.new("RGB", size, color).save(d / name)
+        return d / name
+
+    return tmp_path, _add
+
+
+def test_uniform_images_pass(clean_env, images_dir):
+    src, add = images_dir
+    add("a.jpg", (64, 64))
+    add("b.jpg", (64, 64))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert result.is_valid, result.errors
+    assert result.metadata["files_checked"] == 2
+
+
+def test_mixed_resolutions_fail(clean_env, images_dir):
+    src, add = images_dir
+    add("a.jpg", (64, 64))
+    add("b.jpg", (32, 32))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+    assert any("Multiple image resolutions" in e for e in result.errors)
+
+
+def test_no_images_fails(clean_env, tmp_path):
+    (tmp_path / "images").mkdir()
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+    assert "No image files found" in result.errors[0]
+
+
+def test_explicit_resolution_mismatch_fails(clean_env, images_dir):
+    src, add = images_dir
+    add("a.jpg", (64, 64))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator(expected_resolution=(128, 128)).validate(None)
+    assert not result.is_valid
+    assert any("incorrect resolution" in e for e in result.errors)
+
+
+def test_nonexistent_src_path_fails(clean_env):
+    clean_env.setenv("SRC_PATH", "/no/such/dir")
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+
+
+# ---- helpers --------------------------------------------------------------
+
+def test_is_image_file():
+    v = ImageResolutionValidator()
+    assert v._is_image_file(Path("a.JPG"))
+    assert v._is_image_file(Path("a.png"))
+    assert not v._is_image_file(Path("a.txt"))
+
+
+def test_get_image_files_single(tmp_path):
+    p = tmp_path / "a.jpg"
+    Image.new("RGB", (10, 10)).save(p)
+    v = ImageResolutionValidator()
+    assert v._get_image_files(str(p), True, True) == [p]
+
+
+def test_get_image_files_list(tmp_path):
+    p = tmp_path / "a.png"
+    Image.new("RGB", (10, 10)).save(p)
+    v = ImageResolutionValidator()
+    files = v._get_image_files([str(p), str(tmp_path / "b.txt")], True, True)
+    assert files == [p]
+
+
+def test_get_image_files_unsupported_type_raises():
+    with pytest.raises(ValueError):
+        ImageResolutionValidator()._get_image_files(123, True, True)
+
+
+def test_get_image_files_missing_path_raises(tmp_path):
+    with pytest.raises(ValueError):
+        ImageResolutionValidator()._get_image_files(str(tmp_path / "nope"), True, True)
+
+
+def test_get_image_resolution_bad_file(tmp_path):
+    bad = tmp_path / "a.jpg"
+    bad.write_text("not an image")
+    assert ImageResolutionValidator()._get_image_resolution(bad) is None
+
+
+def test_validate_image_resolutions_empty_list():
+    res = ImageResolutionValidator()._validate_image_resolutions([])
+    assert not res.is_valid
+
+
+def test_validate_image_resolutions_unprocessable(tmp_path):
+    bad = tmp_path / "a.jpg"
+    bad.write_text("nope")
+    res = ImageResolutionValidator(expected_resolution=(10, 10))._validate_image_resolutions([bad])
+    assert not res.is_valid
+    assert any("could not be processed" in e for e in res.errors)

--- a/tests/test_xml_validator.py
+++ b/tests/test_xml_validator.py
@@ -1,0 +1,276 @@
+"""Tests for PascalVOCXMLValidator — full VOC structure compliance."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from tracebloc_ingestor.validators.xml_validator import PascalVOCXMLValidator
+
+
+# ---------------------------------------------------------------------------
+# Builders for valid / customizable VOC XML.
+# ---------------------------------------------------------------------------
+
+def _object_xml(
+    name="cat", pose="Unspecified", truncated="0", difficult="0",
+    xmin=10, ymin=10, xmax=100, ymax=100,
+):
+    return f"""
+  <object>
+    <name>{name}</name>
+    <pose>{pose}</pose>
+    <truncated>{truncated}</truncated>
+    <difficult>{difficult}</difficult>
+    <bndbox>
+      <xmin>{xmin}</xmin>
+      <ymin>{ymin}</ymin>
+      <xmax>{xmax}</xmax>
+      <ymax>{ymax}</ymax>
+    </bndbox>
+  </object>"""
+
+
+def _voc_xml(objects=None, width=640, height=480, depth=3, segmented="0"):
+    if objects is None:
+        objects = [_object_xml()]
+    return f"""<annotation>
+  <folder>images</folder>
+  <filename>img.jpg</filename>
+  <source>
+    <database>Unknown</database>
+    <annotation>PASCAL VOC</annotation>
+  </source>
+  <size>
+    <width>{width}</width>
+    <height>{height}</height>
+    <depth>{depth}</depth>
+  </size>
+  <segmented>{segmented}</segmented>
+{"".join(objects)}
+</annotation>"""
+
+
+@pytest.fixture
+def write_xml(tmp_path):
+    """Write XML text into SRC_PATH and point config at it via env."""
+
+    def _write(xml_text, *, name="ann.xml", monkeypatch=None):
+        path = tmp_path / name
+        path.write_text(xml_text, encoding="utf-8")
+        return path
+
+    return _write
+
+
+@pytest.fixture
+def validator():
+    return PascalVOCXMLValidator()
+
+
+# ---------------------------------------------------------------------------
+# validate() flow (reads config.SRC_PATH directory)
+# ---------------------------------------------------------------------------
+
+def test_valid_file_passes(clean_env, tmp_path, validator):
+    (tmp_path / "ann.xml").write_text(_voc_xml(), encoding="utf-8")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(None)
+    assert result.is_valid, result.errors
+    assert result.metadata["valid_files"] == 1
+
+
+def test_no_xml_files_fails(clean_env, tmp_path, validator):
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert "No XML files found" in result.errors[0]
+
+
+def test_invalid_file_reports_errors(clean_env, tmp_path, validator):
+    bad = _voc_xml(objects=[_object_xml(xmin=100, xmax=100)])  # zero width box
+    (tmp_path / "ann.xml").write_text(bad, encoding="utf-8")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert result.metadata["invalid_files"] == 1
+
+
+def test_nonexistent_src_path_fails(clean_env, validator):
+    clean_env.setenv("SRC_PATH", "/definitely/not/here")
+    result = validator.validate(None)
+    assert not result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# _get_xml_files
+# ---------------------------------------------------------------------------
+
+def test_get_xml_files_single_file(tmp_path, validator):
+    f = tmp_path / "a.xml"
+    f.write_text(_voc_xml(), encoding="utf-8")
+    files = validator._get_xml_files(str(f), True, True)
+    assert files == [f]
+
+
+def test_get_xml_files_list_input(tmp_path, validator):
+    f = tmp_path / "a.xml"
+    f.write_text(_voc_xml(), encoding="utf-8")
+    files = validator._get_xml_files([str(f), str(tmp_path / "missing.xml")], True, True)
+    assert files == [f]
+
+
+def test_get_xml_files_unsupported_type_raises(validator):
+    with pytest.raises(ValueError):
+        validator._get_xml_files(123, True, True)
+
+
+def test_get_xml_files_ignores_hidden(tmp_path, validator):
+    (tmp_path / ".hidden.xml").write_text(_voc_xml(), encoding="utf-8")
+    visible = tmp_path / "v.xml"
+    visible.write_text(_voc_xml(), encoding="utf-8")
+    files = validator._get_xml_files(str(tmp_path), True, True)
+    assert visible in files
+    assert all(not p.name.startswith(".") for p in files)
+
+
+# ---------------------------------------------------------------------------
+# _validate_single_xml + sub-validators
+# ---------------------------------------------------------------------------
+
+def test_single_xml_valid(tmp_path, validator):
+    f = tmp_path / "a.xml"
+    f.write_text(_voc_xml(), encoding="utf-8")
+    result = validator._validate_single_xml(f)
+    assert result.is_valid, result.errors
+
+
+def test_wrong_root_tag_fails(tmp_path, validator):
+    f = tmp_path / "a.xml"
+    f.write_text("<dataset></dataset>", encoding="utf-8")
+    result = validator._validate_single_xml(f)
+    assert not result.is_valid
+    assert "Root element must be 'annotation'" in result.errors[0]
+
+
+def test_parse_error_fails(tmp_path, validator):
+    f = tmp_path / "a.xml"
+    f.write_text("<annotation><unclosed>", encoding="utf-8")
+    result = validator._validate_single_xml(f)
+    assert not result.is_valid
+    assert "XML parsing error" in result.errors[0]
+
+
+def _root(xml_text):
+    return ET.fromstring(xml_text)
+
+
+def test_root_elements_missing():
+    v = PascalVOCXMLValidator()
+    root = _root("<annotation><filename>x.jpg</filename></annotation>")
+    res = v._validate_root_elements(root)
+    assert any("Missing required root elements" in e for e in res["errors"])
+
+
+def test_root_empty_filename_fails():
+    v = PascalVOCXMLValidator()
+    root = _root(_voc_xml().replace("<filename>img.jpg</filename>", "<filename></filename>"))
+    res = v._validate_root_elements(root)
+    assert any("Filename element must have non-empty" in e for e in res["errors"])
+
+
+def test_root_bad_segmented_fails():
+    v = PascalVOCXMLValidator()
+    root = _root(_voc_xml(segmented="2"))
+    res = v._validate_root_elements(root)
+    assert any("Segmented element must be" in e for e in res["errors"])
+
+
+def test_source_missing_fails():
+    v = PascalVOCXMLValidator()
+    root = _root("<annotation></annotation>")
+    res = v._validate_source_element(root)
+    assert any("Missing required 'source'" in e for e in res["errors"])
+
+
+def test_source_empty_database_fails():
+    v = PascalVOCXMLValidator()
+    root = _root(_voc_xml().replace("<database>Unknown</database>", "<database></database>"))
+    res = v._validate_source_element(root)
+    assert any("Database element must have non-empty" in e for e in res["errors"])
+
+
+def test_size_missing_fails():
+    v = PascalVOCXMLValidator()
+    root = _root("<annotation></annotation>")
+    res = v._validate_size_element(root)
+    assert any("Missing required 'size'" in e for e in res["errors"])
+
+
+def test_size_non_positive_fails():
+    v = PascalVOCXMLValidator()
+    root = _root(_voc_xml(width=0))
+    res = v._validate_size_element(root)
+    assert any("width must be a positive integer" in e for e in res["errors"])
+
+
+def test_size_non_integer_fails():
+    v = PascalVOCXMLValidator()
+    root = _root(_voc_xml().replace("<width>640</width>", "<width>abc</width>"))
+    res = v._validate_size_element(root)
+    assert any("width must be a valid integer" in e for e in res["errors"])
+
+
+def test_objects_none_warns():
+    v = PascalVOCXMLValidator()
+    root = _root(_voc_xml(objects=[]))
+    res = v._validate_objects(root)
+    assert res["errors"] == []
+    assert any("No objects found" in w for w in res["warnings"])
+
+
+def test_object_missing_bndbox_fails():
+    v = PascalVOCXMLValidator()
+    obj = _root("""
+      <object>
+        <name>cat</name><pose>Unspecified</pose>
+        <truncated>0</truncated><difficult>0</difficult>
+      </object>""")
+    res = v._validate_single_object(obj, 0)
+    assert any("Missing required 'bndbox'" in e for e in res["errors"])
+
+
+def test_object_bad_truncated_fails():
+    v = PascalVOCXMLValidator()
+    obj = _root(_object_xml(truncated="5"))
+    res = v._validate_single_object(obj, 0)
+    assert any("Truncated element must be" in e for e in res["errors"])
+
+
+def test_bndbox_xmin_ge_xmax_fails():
+    v = PascalVOCXMLValidator()
+    obj = _root(_object_xml(xmin=100, xmax=50))
+    res = v._validate_bndbox_element(obj, 0)
+    assert any("must be less than xmax" in e for e in res["errors"])
+
+
+def test_bndbox_negative_coord_fails():
+    v = PascalVOCXMLValidator()
+    obj = _root(_object_xml(xmin=-5))
+    res = v._validate_bndbox_element(obj, 0)
+    assert any("must be non-negative" in e for e in res["errors"])
+
+
+def test_bndbox_non_integer_coord_fails():
+    v = PascalVOCXMLValidator()
+    obj = _root(_object_xml().replace("<xmin>10</xmin>", "<xmin>abc</xmin>"))
+    res = v._validate_bndbox_element(obj, 0)
+    assert any("must be a valid integer" in e for e in res["errors"])
+
+
+def test_bndbox_small_area_warns():
+    v = PascalVOCXMLValidator()
+    obj = _root(_object_xml(xmin=10, ymin=10, xmax=12, ymax=12))  # area 4 < 10
+    res = v._validate_bndbox_element(obj, 0)
+    assert any("Very small bounding box" in w for w in res["warnings"])

--- a/tests/test_xml_validator.py
+++ b/tests/test_xml_validator.py
@@ -53,18 +53,6 @@ def _voc_xml(objects=None, width=640, height=480, depth=3, segmented="0"):
 
 
 @pytest.fixture
-def write_xml(tmp_path):
-    """Write XML text into SRC_PATH and point config at it via env."""
-
-    def _write(xml_text, *, name="ann.xml", monkeypatch=None):
-        path = tmp_path / name
-        path.write_text(xml_text, encoding="utf-8")
-        return path
-
-    return _write
-
-
-@pytest.fixture
 def validator():
     return PascalVOCXMLValidator()
 


### PR DESCRIPTION
## Summary

Phase 2 of the 90% coverage effort (Phase 1 = #126, already merged). Adds tests for the pandas- and filesystem-backed validators.

- `data_validator` — every per-type validator (INT/BIGINT, FLOAT/DOUBLE/DECIMAL, VARCHAR/CHAR/TEXT, BOOLEAN across dtypes, DATE/DATETIME/TIMESTAMP/TIME), constraint stripping, and `_detect_column_type`.
- `xml_validator` — full Pascal VOC structure: root/source/size/object/bndbox sub-validators, parse errors, coordinate relationships, file discovery.
- `image_validator` — the `validate()` discovery + uniformity flow (resolution-matching unit tests already existed).
- `file_validator` — extension uniformity, strict-mode rejection, file discovery.
- `duplicate_validator` — parent-dir warning, dir creation, error fallbacks.

**Coverage: 53% → 73%.** Per module: file_validator 99%, image 91%, xml 90%, data_validator 87%, duplicate 85%.

## Phased plan (remaining)

- **Phase 3** — ingestors (`base`/`csv`/`json`), `file_transfer`, `api/client`, `validators_mapping`
- **Phase 4** — `database.py` via mocked SQLAlchemy

## Test plan

- [ ] CI green on Python 3.11 + 3.12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or ingest behavior modifications; risk is limited to CI maintenance if fixtures or env handling drift.
> 
> **Overview**
> Phase 2 of the coverage push adds **five new pytest modules** (~760 lines) that exercise pandas- and filesystem-backed validators; production code is unchanged.
> 
> **`DataValidator`** (`test_data_validator.py`): top-level `validate()` (no schema, empty data, CSV load, unknown types), per-SQL-type rules (INT/BIGINT, float family, VARCHAR/CHAR/TEXT, BOOLEAN variants, date family), constraint stripping on types, and `_detect_column_type`.
> 
> **`PascalVOCXMLValidator`** (`test_xml_validator.py`): directory flow under `SRC_PATH`, file discovery helpers, and granular VOC checks (root/source/size/object/bndbox, parse errors, warnings).
> 
> **`ImageResolutionValidator`** (`test_image_validator_flow.py`): `SRC_PATH/images` discovery, uniform vs mixed resolutions, expected size mismatch, and helper edge cases (complements existing resolution unit tests).
> 
> **`FileTypeValidator`** (`test_file_validator.py`): extension uniformity, strict mode, custom subpaths, and `_get_files_to_validate` behavior with `clean_env` + `tmp_path`.
> 
> **`DuplicateValidator`** (`test_duplicate_validator_extra.py`): parent-dir warnings, directory existence/empty checks, and `_create_directory_if_needed` paths not covered elsewhere.
> 
> Together these tests are intended to raise overall coverage from ~53% toward ~73% for the targeted validator modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e7fad14aef1b7e17236c149f037858c2e316a76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->