### PR TITLE
test: raise coverage toward 90% (Phase 3 — ingestors/transfer/api)

### DIFF
--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -19,8 +19,10 @@ from tracebloc_ingestor.utils.constants import TaskCategory
 
 
 def _client(**overrides):
+    # TITLE=None by default so create_dataset's title-generation path is
+    # deterministic regardless of any TITLE exported in the host/CI env.
     defaults = dict(BACKEND_TOKEN="tok", CLIENT_USERNAME=None,
-                    CLIENT_PASSWORD=None, EDGE_ENV="prod")
+                    CLIENT_PASSWORD=None, EDGE_ENV="prod", TITLE=None)
     defaults.update(overrides)
     return APIClient(Config(**defaults))
 

--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -28,7 +28,7 @@ def _client(**overrides):
 def _resp(status=200, json_body=None, text=""):
     r = MagicMock()
     r.status_code = status
-    r.json.return_value = json_body or {}
+    r.json.return_value = json_body if json_body is not None else {}
     r.text = text
     return r
 

--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -1,0 +1,208 @@
+"""Tests for APIClient request methods (send_batch, metadata, prepare, create).
+
+Auth boot paths are covered in test_api_client_auth.py. Here we build a client
+with BACKEND_TOKEN set (so __init__ does no network call) and patch the
+session's get/post to exercise each method's success / error / local-mode path.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.api.client import APIClient
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+def _client(**overrides):
+    defaults = dict(BACKEND_TOKEN="tok", CLIENT_USERNAME=None,
+                    CLIENT_PASSWORD=None, EDGE_ENV="prod")
+    defaults.update(overrides)
+    return APIClient(Config(**defaults))
+
+
+def _resp(status=200, json_body=None, text=""):
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = json_body or {}
+    r.text = text
+    return r
+
+
+# ---------------------------------------------------------------------------
+# authenticate() error path
+# ---------------------------------------------------------------------------
+
+def test_authenticate_http_error_raises():
+    cfg = Config(BACKEND_TOKEN=None, CLIENT_USERNAME="u",
+                 CLIENT_PASSWORD="p", EDGE_ENV="prod")
+    with patch("requests.Session.post", return_value=_resp(403, text="forbidden")):
+        with pytest.raises(ValueError) as exc:
+            APIClient(cfg)
+    # The manually-raised HTTPError carries no .response, so the client
+    # falls through to the generic "Error response" branch.
+    assert "403" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# send_batch
+# ---------------------------------------------------------------------------
+
+def test_send_batch_success():
+    client = _client()
+    records = [(1, {"data_id": "a", "label": "cat"}), (2, {"data_id": "b"})]
+    with patch.object(client.session, "post", return_value=_resp(200)) as post:
+        assert client.send_batch(records, "tbl", ingestor_id="ing") is True
+    post.assert_called_once()
+    assert "/global_meta/tbl/" in post.call_args[0][0]
+
+
+def test_send_batch_http_error_returns_false():
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(500, text="boom")):
+        assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+
+
+def test_send_batch_local_mode_skips_network():
+    client = _client(EDGE_ENV="local")
+    with patch.object(client.session, "post") as post:
+        assert client.send_batch([(1, {})], "tbl", "ing") is True
+    post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# send_global_meta_meta
+# ---------------------------------------------------------------------------
+
+def test_send_global_meta_success():
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(200, {"ok": 1})):
+        assert client.send_global_meta_meta("tbl", {"a": "INT"}, {"k": "v"}) is True
+
+
+def test_send_global_meta_error_returns_false():
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(400, text="bad")):
+        assert client.send_global_meta_meta("tbl", {}, {}) is False
+
+
+def test_send_global_meta_local_mode():
+    client = _client(EDGE_ENV="local")
+    with patch.object(client.session, "post") as post:
+        assert client.send_global_meta_meta("tbl", {}, {}) is True
+    post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# send_generate_edge_label_meta
+# ---------------------------------------------------------------------------
+
+def test_generate_edge_label_success():
+    client = _client()
+    with patch.object(client.session, "get", return_value=_resp(200)) as get:
+        assert client.send_generate_edge_label_meta("tbl", "ing", "train") is True
+    assert "generate-edge-labels-meta" in get.call_args[0][0]
+
+
+def test_generate_edge_label_error_returns_false():
+    client = _client()
+    with patch.object(client.session, "get", return_value=_resp(503, text="down")):
+        assert client.send_generate_edge_label_meta("tbl", "ing", "train") is False
+
+
+def test_generate_edge_label_local_mode():
+    client = _client(EDGE_ENV="local")
+    with patch.object(client.session, "get") as get:
+        assert client.send_generate_edge_label_meta("tbl", "ing", "train") is True
+    get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# prepare_dataset
+# ---------------------------------------------------------------------------
+
+def test_prepare_dataset_success():
+    client = _client()
+    with patch.object(client.session, "get", return_value=_resp(200, {"ok": 1})):
+        assert client.prepare_dataset(
+            TaskCategory.IMAGE_CLASSIFICATION, "ing", "image", "train"
+        ) is True
+
+
+def test_prepare_dataset_invalid_category_returns_false():
+    client = _client()
+    with patch.object(client.session, "get") as get:
+        assert client.prepare_dataset("nonsense", "ing", "image", "train") is False
+    get.assert_not_called()
+
+
+def test_prepare_dataset_error_returns_false():
+    client = _client()
+    with patch.object(client.session, "get", return_value=_resp(500, text="x")):
+        assert client.prepare_dataset(
+            TaskCategory.IMAGE_CLASSIFICATION, "ing", "image", "train"
+        ) is False
+
+
+def test_prepare_dataset_local_mode():
+    client = _client(EDGE_ENV="local")
+    with patch.object(client.session, "get") as get:
+        assert client.prepare_dataset("anything", "ing", "image", "train") is True
+    get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# create_dataset
+# ---------------------------------------------------------------------------
+
+def test_create_dataset_success_generates_title():
+    client = _client()
+    captured = {}
+
+    def fake_post(url, data=None, headers=None, timeout=None):
+        captured["data"] = data
+        return _resp(200, {"id": 7})
+
+    with patch.object(client.session, "post", side_effect=fake_post):
+        result = client.create_dataset(
+            ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
+        )
+    assert result == {"id": 7}
+    assert "image_classification_ing" in captured["data"]
+
+
+def test_create_dataset_tabular_allows_feature_modification():
+    client = _client()
+    captured = {}
+    with patch.object(client.session, "post",
+                      side_effect=lambda url, data=None, **k: captured.update(data=data) or _resp(200, {"id": 1})):
+        client.create_dataset(ingestor_id="ing", category=TaskCategory.TABULAR_CLASSIFICATION)
+    assert '"allow_feature_modification": true' in captured["data"]
+
+
+def test_create_dataset_uses_config_title():
+    client = _client(TITLE="My Title")
+    captured = {}
+    with patch.object(client.session, "post",
+                      side_effect=lambda url, data=None, **k: captured.update(data=data) or _resp(200, {"id": 1})):
+        client.create_dataset(ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION)
+    assert "My Title" in captured["data"]
+
+
+def test_create_dataset_error_raises():
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(500, text="err")):
+        with pytest.raises(requests.exceptions.RequestException):
+            client.create_dataset(ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION)
+
+
+def test_create_dataset_local_mode():
+    client = _client(EDGE_ENV="local")
+    with patch.object(client.session, "post") as post:
+        result = client.create_dataset(ingestor_id="ing", category="x")
+    assert result["id"] == "mock_dataset_id"
+    post.assert_not_called()

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -1,0 +1,108 @@
+"""Tests for CSVIngestor: read_data chunking, schema type validation, counting."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+def make_csv_ingestor(schema=None, **overrides):
+    db = MagicMock()
+    db.create_table.return_value = MagicMock()
+    api = MagicMock()
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema=schema if schema is not None else {"a": "INT"},
+        intent="train",
+        category=None,
+    )
+    kwargs.update(overrides)
+    return CSVIngestor(**kwargs)
+
+
+def test_read_data_yields_records(make_csv):
+    path = make_csv({"a": [1, 2], "b": ["x", "y"]})
+    ing = make_csv_ingestor(schema={"a": "INT", "b": "VARCHAR(10)"})
+    records = list(ing.read_data(str(path)))
+    assert len(records) == 2
+    assert records[0]["a"] == 1
+    assert records[0]["b"] == "x"
+
+
+def test_read_data_missing_file_raises():
+    ing = make_csv_ingestor()
+    with pytest.raises(FileNotFoundError):
+        list(ing.read_data("/no/such/file.csv"))
+
+
+def test_read_data_strips_column_whitespace(make_csv, tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text(" a , b \n1,2\n")
+    ing = make_csv_ingestor(schema={"a": "INT", "b": "INT"})
+    records = list(ing.read_data(str(p)))
+    assert "a" in records[0] and "b" in records[0]
+
+
+def test_read_data_schema_column_missing_raises(make_csv):
+    path = make_csv({"a": [1]})
+    ing = make_csv_ingestor(schema={"a": "INT", "missing": "INT"})
+    with pytest.raises(ValueError, match="Schema columns not present"):
+        list(ing.read_data(str(path)))
+
+
+def test_read_data_unique_id_column_missing_raises(make_csv):
+    path = make_csv({"a": [1]})
+    ing = make_csv_ingestor(schema={"a": "INT"}, unique_id_column="uid")
+    with pytest.raises(ValueError, match="unique_id_column"):
+        list(ing.read_data(str(path)))
+
+
+def test_read_data_empty_file_returns_nothing(tmp_path):
+    p = tmp_path / "empty.csv"
+    p.write_text("")
+    ing = make_csv_ingestor(schema={})
+    assert list(ing.read_data(str(p))) == []
+
+
+def test_validate_csv_type_coercion():
+    ing = make_csv_ingestor(schema={"n": "INT", "f": "FLOAT", "b": "BOOLEAN", "d": "DATE"})
+    df = pd.DataFrame({
+        "n": ["1", "2"],
+        "f": ["1.5", "2.5"],
+        "b": [True, False],
+        "d": ["2024-01-01", "2024-02-02"],
+    })
+    # Should not raise; coerces in place.
+    ing._validate_csv(df)
+    assert str(df["d"].dtype).startswith("datetime")
+
+
+def test_count_records(make_csv):
+    path = make_csv({"a": [1, 2, 3, 4]})
+    ing = make_csv_ingestor(schema={"a": "INT"})
+    assert ing._count_records(str(path)) == 4
+
+
+def test_count_records_bad_path_returns_none():
+    ing = make_csv_ingestor()
+    assert ing._count_records("/no/such.csv") is None
+
+
+def test_tabular_na_values_applied(tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("a,b\n1,NA\n2,NULL\n")
+    ing = make_csv_ingestor(
+        schema={"a": "INT", "b": "VARCHAR(10)"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    records = list(ing.read_data(str(p)))
+    # "NA"/"NULL" should be parsed as NaN for tabular categories.
+    assert pd.isna(records[0]["b"])
+    assert pd.isna(records[1]["b"])

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -42,7 +42,7 @@ def test_read_data_missing_file_raises():
         list(ing.read_data("/no/such/file.csv"))
 
 
-def test_read_data_strips_column_whitespace(make_csv, tmp_path):
+def test_read_data_strips_column_whitespace(tmp_path):
     p = tmp_path / "d.csv"
     p.write_text(" a , b \n1,2\n")
     ing = make_csv_ingestor(schema={"a": "INT", "b": "INT"})

--- a/tests/test_file_transfer_transfers.py
+++ b/tests/test_file_transfer_transfers.py
@@ -1,0 +1,225 @@
+"""Tests for the file_transfer copy functions and map_file_transfer routing.
+
+The 'missing source returns None' paths are covered in
+test_file_transfer_summary.py; here we cover the successful-copy paths,
+source resolution helpers, and the multi-file map_file_transfer branches.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tracebloc_ingestor import file_transfer
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+@pytest.fixture
+def dirs(tmp_path, monkeypatch):
+    """Point file_transfer's Config at tmp src + storage dirs.
+
+    SRC_PATH is env-backed; DEST_PATH derives from STORAGE_PATH / TABLE_NAME,
+    so override STORAGE_PATH on the live module-level Config and set TABLE_NAME.
+    """
+    src = tmp_path / "src"
+    storage = tmp_path / "storage"
+    src.mkdir()
+    storage.mkdir()
+    monkeypatch.setenv("SRC_PATH", str(src))
+    monkeypatch.setenv("TABLE_NAME", "tbl")
+    monkeypatch.setattr(file_transfer.config, "STORAGE_PATH", str(storage))
+    dest = storage / "tbl"
+    return src, dest
+
+
+def _seed(src, subdir, name, content=b"data"):
+    d = src / subdir
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_bytes(content)
+    return d / name
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def test_find_src_with_extension(dirs):
+    src, _ = dirs
+    _seed(src, "images", "cat.jpg")
+    path, fname = file_transfer._find_src("images", "cat.jpg", ".jpg")
+    assert path is not None and fname == "cat.jpg"
+
+
+def test_find_src_appends_extension(dirs):
+    src, _ = dirs
+    _seed(src, "images", "cat.jpg")
+    path, fname = file_transfer._find_src("images", "cat", ".jpg")
+    assert path is not None and fname == "cat.jpg"
+
+
+def test_find_src_missing(dirs):
+    path, fname = file_transfer._find_src("images", "ghost", ".jpg")
+    assert path is None and fname == "ghost.jpg"
+
+
+def test_find_mask_src_tries_extensions(dirs):
+    src, _ = dirs
+    _seed(src, "masks", "m1.png")
+    path, ext, name = file_transfer._find_mask_src("m1")
+    assert path is not None and ext == ".png" and name == "m1"
+
+
+def test_find_mask_src_missing(dirs):
+    path, ext, name = file_transfer._find_mask_src("nope")
+    assert path is None and ext is None and name == "nope"
+
+
+def test_copy_file_with_retry_overwrites(dirs, tmp_path):
+    src, dest = dirs
+    s = _seed(src, "images", "a.jpg", b"new")
+    dest.mkdir(parents=True, exist_ok=True)
+    target = dest / "a.jpg"
+    target.write_bytes(b"old")
+    file_transfer._copy_file_with_retry(str(s), str(target))
+    assert target.read_bytes() == b"new"
+
+
+# ---------------------------------------------------------------------------
+# image_transfer / text_transfer / annotation / mask success
+# ---------------------------------------------------------------------------
+
+def test_image_transfer_success(dirs):
+    src, dest = dirs
+    _seed(src, "images", "cat.jpg")
+    rec = file_transfer.image_transfer({"filename": "cat"}, {"extension": ".jpg"})
+    assert rec is not None
+    assert rec["filename"] == "cat"
+    assert rec["extension"] == ".jpg"
+    assert (dest / "cat.jpg").exists()
+
+
+def test_text_transfer_success(dirs):
+    src, dest = dirs
+    _seed(src, "texts", "doc.txt", b"hello")
+    rec = file_transfer.text_transfer({"filename": "doc"}, {"extension": ".txt"})
+    assert rec is not None
+    assert (dest / "doc.txt").exists()
+
+
+def test_text_transfer_custom_subdir(dirs):
+    src, dest = dirs
+    _seed(src, "sequences", "seq.txt", b"tokens")
+    rec = file_transfer.text_transfer(
+        {"filename": "seq"}, {"extension": ".txt"}, src_subdir="sequences"
+    )
+    assert rec is not None
+    assert (dest / "seq.txt").exists()
+
+
+def test_text_transfer_missing_filename_returns_none(dirs):
+    assert file_transfer.text_transfer({}, {"extension": ".txt"}) is None
+
+
+def test_annotation_transfer_success(dirs):
+    src, dest = dirs
+    s = _seed(src, "annotations", "img.xml", b"<x/>")
+    rec = file_transfer.annotation_transfer(
+        {"filename": "img"}, {}, ".xml", str(s), "img.xml"
+    )
+    assert rec is not None
+    assert (dest / "img.xml").exists()
+
+
+def test_mask_transfer_success(dirs):
+    src, dest = dirs
+    s = _seed(src, "masks", "m.png")
+    rec = file_transfer.mask_transfer({"filename": "x"}, str(s), ".png", "m")
+    assert rec is not None
+    assert (dest / "m.png").exists()
+
+
+# ---------------------------------------------------------------------------
+# map_file_transfer routing
+# ---------------------------------------------------------------------------
+
+def test_map_image_classification(dirs):
+    src, dest = dirs
+    _seed(src, "images", "cat.jpg")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.IMAGE_CLASSIFICATION, {"filename": "cat"}, {"extension": ".jpg"}
+    )
+    assert rec is not None
+
+
+def test_map_object_detection_atomic_success(dirs):
+    src, dest = dirs
+    _seed(src, "images", "x.jpg")
+    _seed(src, "annotations", "x.xml", b"<a/>")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.OBJECT_DETECTION, {"filename": "x"}, {"extension": ".jpg"}
+    )
+    assert rec is not None
+    assert (dest / "x.jpg").exists()
+    assert (dest / "x.xml").exists()
+
+
+def test_map_object_detection_missing_annotation_returns_none(dirs):
+    src, _ = dirs
+    _seed(src, "images", "x.jpg")  # no annotation
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.OBJECT_DETECTION, {"filename": "x"}, {"extension": ".jpg"}
+    )
+    assert rec is None
+
+
+def test_map_object_detection_missing_filename_returns_none(dirs):
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.OBJECT_DETECTION, {}, {"extension": ".jpg"}
+    )
+    assert rec is None
+
+
+def test_map_semantic_segmentation_success(dirs):
+    src, dest = dirs
+    _seed(src, "images", "x.jpg")
+    _seed(src, "masks", "m.png")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        {"filename": "x", "mask_id": "m"}, {"extension": ".jpg"},
+    )
+    assert rec is not None
+    assert (dest / "m.png").exists()
+
+
+def test_map_semantic_segmentation_missing_mask_id_returns_none(dirs):
+    src, _ = dirs
+    _seed(src, "images", "x.jpg")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.SEMANTIC_SEGMENTATION, {"filename": "x"}, {"extension": ".jpg"}
+    )
+    assert rec is None
+
+
+def test_map_mlm_copies_tokenizer(dirs):
+    src, dest = dirs
+    _seed(src, "sequences", "seq.txt", b"tokens")
+    (src / "tokenizer.json").write_text("{}")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.MASKED_LANGUAGE_MODELING, {"filename": "seq"}, {"extension": ".txt"}
+    )
+    assert rec is not None
+    assert (dest / "tokenizer.json").exists()
+
+
+def test_map_keypoint_detection(dirs):
+    src, dest = dirs
+    _seed(src, "images", "p.jpg")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.KEYPOINT_DETECTION, {"filename": "p"}, {"extension": ".jpg"}
+    )
+    assert rec is not None
+
+
+def test_map_unknown_category_returns_none(dirs):
+    assert file_transfer.map_file_transfer("weird", {"filename": "x"}, {}) is None

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -1,0 +1,243 @@
+"""Tests for BaseIngestor: record processing, batch handling, validation, ingest flow.
+
+We use a tiny concrete subclass and MagicMock Database/APIClient. The
+SQLAlchemy Session is patched out so no real engine is touched.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Generator, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor, IngestionSummary
+from tracebloc_ingestor.validators.base import ValidationResult
+
+
+class FakeIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source: Any) -> Generator[Dict[str, Any], None, None]:
+        yield from self._records
+
+
+def make_ingestor(records=None, **overrides):
+    db = MagicMock(name="Database")
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
+    db.get_table_schema.return_value = {"a": "INT"}
+    api = MagicMock(name="APIClient")
+    api.send_batch.return_value = True
+    api.send_generate_edge_label_meta.return_value = True
+    api.send_global_meta_meta.return_value = True
+    api.prepare_dataset.return_value = True
+    api.create_dataset.return_value = {"id": 1}
+
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=None,
+    )
+    kwargs.update(overrides)
+    return FakeIngestor(records or [], **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# IngestionSummary.has_failures
+# ---------------------------------------------------------------------------
+
+def test_summary_clean_run_no_failures():
+    s = IngestionSummary("id", 10, 10, 10, 10, 0, 0, 0)
+    assert s.has_failures is False
+
+
+@pytest.mark.parametrize("kwargs", [
+    dict(failed_records=1),
+    dict(file_transfer_failures=1),
+    dict(inserted_records=9),       # < total
+    dict(api_sent_records=9),       # < inserted
+])
+def test_summary_has_failures(kwargs):
+    base = dict(ingestor_id="id", total_records=10, processed_records=10,
+                inserted_records=10, api_sent_records=10, failed_records=0,
+                skipped_records=0, file_transfer_failures=0)
+    base.update(kwargs)
+    assert IngestionSummary(**base).has_failures is True
+
+
+# ---------------------------------------------------------------------------
+# __init__ schema cleaning
+# ---------------------------------------------------------------------------
+
+def test_init_strips_label_annotation_unique_from_schema():
+    ing = make_ingestor(
+        schema={"a": "INT", "lbl": "VARCHAR", "ann": "TEXT", "uid": "VARCHAR"},
+        label_column="lbl", annotation_column="ann", unique_id_column="uid",
+        category=None,
+    )
+    # The cleaned table schema passed to create_table excludes the special cols.
+    table_schema = ing.database.create_table.call_args[0][1]
+    assert "lbl" not in table_schema and "ann" not in table_schema and "uid" not in table_schema
+    assert "a" in table_schema
+
+
+def test_init_injects_number_of_columns_for_tabular():
+    from tracebloc_ingestor.utils.constants import TaskCategory
+    ing = make_ingestor(
+        schema={"a": "INT", "b": "FLOAT"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    assert ing.file_options["number_of_columns"] == 2
+
+
+# ---------------------------------------------------------------------------
+# process_record / _map_unique_id
+# ---------------------------------------------------------------------------
+
+def test_process_record_generates_uuid_data_id():
+    ing = make_ingestor(category=None, label_column="a")
+    rec = ing.process_record({"a": "cat", "filename": "x", "extension": ".jpg"})
+    assert rec["label"] == "cat"
+    assert rec["data_intent"] == "train"
+    assert rec["data_id"]  # uuid string
+    assert rec["ingestor_id"] == ing.ingestor_id
+
+
+def test_process_record_uses_unique_id_column():
+    ing = make_ingestor(schema={"a": "INT"}, unique_id_column="uid", category=None)
+    rec = ing.process_record({"a": "1", "uid": "  abc  ", "filename": "f"})
+    assert rec["data_id"] == "abc"
+
+
+def test_process_record_invalid_intent_returns_none():
+    ing = make_ingestor(intent="bogus", category=None)
+    assert ing.process_record({"a": "1"}) is None
+
+
+def test_process_record_missing_unique_id_returns_none():
+    ing = make_ingestor(unique_id_column="uid", category=None)
+    assert ing.process_record({"a": "1", "uid": "   "}) is None
+
+
+def test_process_record_applies_bucket_label_policy():
+    from tracebloc_ingestor.utils.label_policy import BUCKET
+    ing = make_ingestor(label_column="a", label_policy=BUCKET, category=None)
+    rec = ing.process_record({"a": "12345", "filename": "f"})
+    # bucket policy hashes the raw value -> not equal to the raw value
+    assert rec["label"] != "12345"
+
+
+# ---------------------------------------------------------------------------
+# _process_batch
+# ---------------------------------------------------------------------------
+
+def test_process_batch_success():
+    ing = make_ingestor()
+    session = MagicMock()
+    ids, api_success, db_failures = ing._process_batch([{"data_id": "a"}], session)
+    assert ids == [1, 2]
+    assert api_success is True
+    assert db_failures == []
+
+
+def test_process_batch_no_ids_skips_api():
+    ing = make_ingestor()
+    ing.database.insert_batch.return_value = ([], [{"err": "x"}])
+    session = MagicMock()
+    ids, api_success, db_failures = ing._process_batch([{"data_id": "a"}], session)
+    assert ids == []
+    assert api_success is False
+    ing.api_client.send_batch.assert_not_called()
+
+
+def test_process_batch_reraises_on_insert_error():
+    ing = make_ingestor()
+    err = RuntimeError("db down")
+    err.response = MagicMock(text="detail")
+    ing.database.insert_batch.side_effect = err
+    with pytest.raises(RuntimeError):
+        ing._process_batch([{"data_id": "a"}], MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# validate_data
+# ---------------------------------------------------------------------------
+
+def test_validate_data_no_validators_passes():
+    ing = make_ingestor(category=None)
+    assert ing.validate_data("src") is True
+
+
+def test_validate_data_raises_when_validator_fails():
+    ing = make_ingestor(category=None)
+    bad = MagicMock()
+    bad.name = "Bad"
+    bad.validate.return_value = ValidationResult(False, ["nope"], [], {})
+    with patch.object(base_mod, "map_validators", return_value=[bad]):
+        with pytest.raises(ValueError):
+            ing.validate_data("src")
+
+
+def test_validate_data_validator_exception_raises():
+    ing = make_ingestor(category=None)
+    bad = MagicMock()
+    bad.name = "Boom"
+    bad.validate.side_effect = RuntimeError("kaboom")
+    with patch.object(base_mod, "map_validators", return_value=[bad]):
+        with pytest.raises(ValueError):
+            ing.validate_data("src")
+
+
+# ---------------------------------------------------------------------------
+# ingest (full flow, Session patched)
+# ---------------------------------------------------------------------------
+
+def test_ingest_happy_path():
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=None)
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+    assert failed == []
+    ing.database.insert_batch.assert_called()
+    ing.api_client.create_dataset.assert_called_once()
+
+
+def test_ingest_skips_records_that_fail_processing():
+    # invalid intent -> process_record returns None -> counted as skipped
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=None, intent="bogus")
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+    assert failed == []
+    ing.database.insert_batch.assert_not_called()
+
+
+def test_ingest_reraises_on_session_error():
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=None)
+    ing.database.insert_batch.side_effect = RuntimeError("boom")
+    with patch.object(base_mod, "Session") as Sess:
+        session = MagicMock()
+        Sess.return_value.__enter__.return_value = session
+        # final batch processing failure is caught; but make commit raise to hit rollback
+        session.commit.side_effect = RuntimeError("commit fail")
+        with pytest.raises(RuntimeError):
+            ing.ingest("src", batch_size=10)
+        session.rollback.assert_called()
+
+
+def test_context_manager_protocol():
+    ing = make_ingestor()
+    with ing as x:
+        assert x is ing

--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -1,0 +1,108 @@
+"""Tests for JSONIngestor: read_data (object/array), record validation, counting."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tracebloc_ingestor.ingestors.json_ingestor import JSONIngestor
+
+
+def make_json_ingestor(schema=None, **overrides):
+    db = MagicMock()
+    db.create_table.return_value = MagicMock()
+    api = MagicMock()
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema=schema if schema is not None else {"a": "INT"},
+        intent="train",
+        category=None,
+    )
+    kwargs.update(overrides)
+    return JSONIngestor(**kwargs)
+
+
+def _write_json(tmp_path, obj, name="d.json"):
+    p = tmp_path / name
+    p.write_text(json.dumps(obj))
+    return p
+
+
+def test_read_data_array(tmp_path):
+    p = _write_json(tmp_path, [{"a": 1}, {"a": 2}])
+    ing = make_json_ingestor(schema={"a": "INT"})
+    records = list(ing.read_data(str(p)))
+    assert len(records) == 2
+
+
+def test_read_data_single_object(tmp_path):
+    p = _write_json(tmp_path, {"a": 1})
+    ing = make_json_ingestor(schema={"a": "INT"})
+    records = list(ing.read_data(str(p)))
+    assert records == [{"a": 1}]
+
+
+def test_read_data_missing_file_raises():
+    ing = make_json_ingestor()
+    with pytest.raises(FileNotFoundError):
+        list(ing.read_data("/no/such.json"))
+
+
+def test_read_data_invalid_top_level_type_raises(tmp_path):
+    p = _write_json(tmp_path, 42)  # neither dict nor list
+    ing = make_json_ingestor(schema={"a": "INT"})
+    with pytest.raises(ValueError):
+        list(ing.read_data(str(p)))
+
+
+def test_read_data_skips_non_dict_items(tmp_path):
+    p = _write_json(tmp_path, [{"a": 1}, "not-a-dict", {"a": 2}])
+    ing = make_json_ingestor(schema={"a": "INT"})
+    records = list(ing.read_data(str(p)))
+    assert len(records) == 2
+
+
+def test_read_data_skips_records_failing_validation(tmp_path):
+    # record missing unique_id_column -> _validate_record raises -> skipped
+    p = _write_json(tmp_path, [{"a": 1}, {"a": 2, "uid": "x"}])
+    ing = make_json_ingestor(schema={"a": "INT"}, unique_id_column="uid")
+    records = list(ing.read_data(str(p)))
+    assert records == [{"a": 2, "uid": "x"}]
+
+
+def test_read_data_malformed_json_raises(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text("{not json")
+    ing = make_json_ingestor()
+    with pytest.raises(json.JSONDecodeError):
+        list(ing.read_data(str(p)))
+
+
+def test_validate_record_type_error_raises():
+    ing = make_json_ingestor(schema={"n": "INT"})
+    with pytest.raises(ValueError, match="Data type validation failed"):
+        ing._validate_record({"n": "not-an-int"})
+
+
+def test_validate_record_allows_empty_string():
+    ing = make_json_ingestor(schema={"n": "INT"})
+    # empty string is allowed (treated as None) -> no raise
+    ing._validate_record({"n": ""})
+
+
+def test_count_records_array(tmp_path):
+    p = _write_json(tmp_path, [{"a": 1}, {"a": 2}, {"a": 3}])
+    assert make_json_ingestor()._count_records(str(p)) == 3
+
+
+def test_count_records_object(tmp_path):
+    p = _write_json(tmp_path, {"a": 1})
+    assert make_json_ingestor()._count_records(str(p)) == 1
+
+
+def test_count_records_bad_path_returns_none():
+    assert make_json_ingestor()._count_records("/no/such.json") is None

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -1,0 +1,124 @@
+"""Tests for map_validators — the per-category validator factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.utils.validators_mapping import map_validators
+from tracebloc_ingestor.utils.constants import TaskCategory, FileExtension
+from tracebloc_ingestor.validators.file_validator import FileTypeValidator
+from tracebloc_ingestor.validators.image_validator import ImageResolutionValidator
+from tracebloc_ingestor.validators.data_validator import DataValidator
+from tracebloc_ingestor.validators.table_name_validator import TableNameValidator
+from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
+from tracebloc_ingestor.validators.xml_validator import PascalVOCXMLValidator
+from tracebloc_ingestor.validators.time_to_event_validator import TimeToEventValidator
+from tracebloc_ingestor.validators.time_format_validator import TimeFormatValidator
+from tracebloc_ingestor.validators.numeric_columns_validator import NumericColumnsValidator
+from tracebloc_ingestor.validators.keypoint_annotation_validator import KeypointAnnotationValidator
+from tracebloc_ingestor.validators.keypoint_visibility_validator import KeypointVisibilityValidator
+from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
+
+
+IMAGE_OPTS = {"extension": FileExtension.JPG, "target_size": [224, 224]}
+
+
+def _types(validators):
+    return [type(v) for v in validators]
+
+
+def test_image_classification():
+    v = map_validators(TaskCategory.IMAGE_CLASSIFICATION, IMAGE_OPTS)
+    assert _types(v) == [
+        FileTypeValidator, ImageResolutionValidator, TableNameValidator, DuplicateValidator
+    ]
+
+
+def test_object_detection_includes_xml_validator():
+    v = map_validators(TaskCategory.OBJECT_DETECTION, IMAGE_OPTS)
+    types = _types(v)
+    assert PascalVOCXMLValidator in types
+    # two FileTypeValidators: images + annotations
+    assert types.count(FileTypeValidator) == 2
+
+
+def test_semantic_segmentation():
+    v = map_validators(TaskCategory.SEMANTIC_SEGMENTATION, IMAGE_OPTS)
+    types = _types(v)
+    assert types.count(FileTypeValidator) == 2
+    assert ImageResolutionValidator in types
+
+
+def test_keypoint_detection_includes_keypoint_validators():
+    v = map_validators(TaskCategory.KEYPOINT_DETECTION, IMAGE_OPTS)
+    types = _types(v)
+    assert KeypointAnnotationValidator in types
+    assert KeypointVisibilityValidator in types
+
+
+def test_tabular_classification_with_schema():
+    v = map_validators(TaskCategory.TABULAR_CLASSIFICATION, {"schema": {"a": "INT"}})
+    types = _types(v)
+    assert DataValidator in types
+    assert types[-2:] == [TableNameValidator, DuplicateValidator]
+
+
+def test_tabular_classification_without_schema_omits_data_validator():
+    v = map_validators(TaskCategory.TABULAR_CLASSIFICATION, {})
+    assert DataValidator not in _types(v)
+
+
+def test_tabular_regression_with_schema():
+    v = map_validators(TaskCategory.TABULAR_REGRESSION, {"schema": {"x": "FLOAT"}})
+    assert DataValidator in _types(v)
+
+
+def test_text_classification_defaults_extension():
+    v = map_validators(TaskCategory.TEXT_CLASSIFICATION, {})
+    assert _types(v)[0] is FileTypeValidator
+
+
+def test_time_series_forecasting_validator_set():
+    v = map_validators(
+        TaskCategory.TIME_SERIES_FORECASTING,
+        {"schema": {"timestamp": "TIMESTAMP", "value": "FLOAT"}},
+    )
+    types = _types(v)
+    assert TimeFormatValidator in types
+    assert NumericColumnsValidator in types
+    # schema minus timestamp is non-empty -> a DataValidator is added
+    assert DataValidator in types
+
+
+def test_time_series_forecasting_timestamp_only_schema_no_data_validator():
+    v = map_validators(
+        TaskCategory.TIME_SERIES_FORECASTING,
+        {"schema": {"timestamp": "TIMESTAMP"}},
+    )
+    assert DataValidator not in _types(v)
+
+
+def test_time_to_event_with_schema():
+    v = map_validators(
+        TaskCategory.TIME_TO_EVENT_PREDICTION,
+        {"schema": {"time": "INT"}, "time_column": "time"},
+    )
+    types = _types(v)
+    assert TimeToEventValidator in types
+    assert DataValidator in types
+
+
+def test_time_to_event_without_schema():
+    v = map_validators(TaskCategory.TIME_TO_EVENT_PREDICTION, {})
+    types = _types(v)
+    assert TimeToEventValidator in types
+    assert DataValidator not in types
+
+
+def test_masked_language_modeling_includes_tokenizer():
+    v = map_validators(TaskCategory.MASKED_LANGUAGE_MODELING, {})
+    assert TokenizerValidator in _types(v)
+
+
+def test_unknown_category_returns_empty():
+    assert map_validators("not_a_category", {}) == []


### PR DESCRIPTION
## Summary

Phase 3 of the 90% coverage effort (Phase 1 #126 merged; Phase 2 #127 open). Covers the mocking-heavy modules: ingestors, file transfer, API client, and the validator factory.

- `validators_mapping` — asserts the validator set returned per `TaskCategory` (image/detection/segmentation/keypoint/tabular/text/time-series/time-to-event/MLM + unknown).
- `api/client` — `send_batch`, `send_global_meta_meta`, `send_generate_edge_label_meta`, `prepare_dataset`, `create_dataset`: success / HTTP-error / local-mode branches, plus the `authenticate()` error path. Session `get`/`post` are patched; client built with `BACKEND_TOKEN` so `__init__` does no network call.
- `ingestors/base` — `process_record`/`_map_unique_id` (UUID vs column id, intent/label-policy), `_process_batch`, `validate_data` (pass + validator-failure raise), schema cleaning, and the full `ingest()` flow with mocked Database/APIClient and a patched `Session`.
- `csv_ingestor` / `json_ingestor` — `read_data` (chunking, object/array, skips), schema type validation, record counting, error paths.
- `file_transfer` — successful copy paths and the multi-file `map_file_transfer` branches (object detection, semantic segmentation, MLM tokenizer copy, keypoint).

**Coverage: 73% → 87%.** Per module: validators_mapping 98%, api/client 94%, file_transfer 88%, base 87%, csv 87%, json 83%.

## Phased plan (remaining)

- **Phase 4** — `database.py` via mocked SQLAlchemy (the last big gap; should land the repo at ~90%).

## Test plan

- [ ] CI green on Python 3.11 + 3.12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with mocked I/O; no runtime or security behavior changes.
> 
> **Overview**
> Phase 3 adds **six new test modules** (~1k lines) to raise repo coverage toward 90%, with **no production code changes**.
> 
> **`test_validators_mapping.py`** asserts the validator class list returned by `map_validators` for each `TaskCategory` (image, detection, segmentation, keypoint, tabular, text, time series, time-to-event, MLM) and unknown categories.
> 
> **`test_api_client_methods.py`** exercises `APIClient` HTTP helpers (`send_batch`, global meta, edge labels, `prepare_dataset`, `create_dataset`) plus auth failure, with session `get`/`post` patched and `BACKEND_TOKEN` set so init stays offline; covers success, HTTP errors, and `EDGE_ENV=local` no-op paths.
> 
> **`test_ingestor_base.py`** drives `BaseIngestor` via a fake subclass with mocked DB/API and patched `Session`: `IngestionSummary`, schema stripping, `process_record`, batches, `validate_data`, and full `ingest()`.
> 
> **`test_csv_ingestor.py`** and **`test_json_ingestor.py`** cover `read_data`, schema/validation errors, counting, and tabular NA handling (CSV) or array/object JSON shapes (JSON).
> 
> **`test_file_transfer_transfers.py`** complements existing summary tests with successful copies, `_find_src` / mask helpers, and `map_file_transfer` routing (object detection, segmentation, MLM tokenizer, keypoint).
> 
> Per the PR description, overall coverage moves **73% → 87%** on these modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5290f106c3bf239b42018f6063c3002a6106dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->