### PR TITLE
ci: gate coverage at --cov-fail-under=95

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,8 @@ name: Tests
 
 # Runs the pytest suite on every PR + push to develop/master/main.
 # Matrix: Python 3.11 + 3.12 (matches setup.py: python_requires=">=3.11").
-# Coverage is gated at --cov-fail-under=90 (the suite currently sits at ~99%);
-# CI fails if total coverage regresses below 90%.
+# Coverage is gated at --cov-fail-under=95 (the suite currently sits at ~99%);
+# CI fails if total coverage regresses below 95%.
 #
 # After this lands and stabilizes:
 #   - 'pytest (3.11)' + 'pytest (3.12)' become required status checks via
@@ -53,7 +53,7 @@ jobs:
             --cov-report=term \
             --cov-report=xml \
             --cov-report=html \
-            --cov-fail-under=90
+            --cov-fail-under=95
 
       - name: Coverage summary
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,8 @@ name: Tests
 
 # Runs the pytest suite on every PR + push to develop/master/main.
 # Matrix: Python 3.11 + 3.12 (matches setup.py: python_requires=">=3.11").
-# Coverage measured but not yet gated by --cov-fail-under; lock that in once
-# the baseline number is recorded.
+# Coverage is gated at --cov-fail-under=90 (the suite currently sits at ~99%);
+# CI fails if total coverage regresses below 90%.
 #
 # After this lands and stabilizes:
 #   - 'pytest (3.11)' + 'pytest (3.12)' become required status checks via
@@ -52,7 +52,8 @@ jobs:
             --cov=tracebloc_ingestor \
             --cov-report=term \
             --cov-report=xml \
-            --cov-report=html
+            --cov-report=html \
+            --cov-fail-under=90
 
       - name: Coverage summary
         if: always()


### PR DESCRIPTION
## Summary

Adds `--cov-fail-under=95` to the pytest CI step so coverage can't silently regress. Closes the follow-up noted in the original test-workflow PR (#124).

Full-suite run: **98.51% total** — above the 95% floor, with a small buffer.

## Why 95

The suite sits at ~99% after the Phase 1–4 test work (all merged). The gate is set at **95** to leave a little headroom — new feature code can land slightly below the current peak without tripping CI, while still catching a real regression.

## Test plan

- [ ] CI green on Python 3.11 + 3.12 with the gate active
- [ ] Coverage summary still posts to the job summary

## Follow-up

- Make `pytest (3.11)` + `pytest (3.12)` required status checks via branch protection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only pytest flag and comment updates; no runtime or application code changes.
> 
> **Overview**
> CI now **enforces a minimum total coverage** on the pytest matrix job instead of only reporting it.
> 
> The workflow adds `--cov-fail-under=95` to the existing coverage run and updates the header comment so **pytest fails when `tracebloc_ingestor` coverage drops below 95%** (with ~99% called out as the current baseline). Coverage reports and the job summary step are unchanged aside from that gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c046b71da9806ecee946ccd679f2cd17a0f2c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->