### PR TITLE
ci: add fr-gate caller workflow

### DIFF
--- a/.github/workflows/fr-gate-caller.yml
+++ b/.github/workflows/fr-gate-caller.yml
@@ -1,0 +1,15 @@
+name: FR gate
+
+# Per-repo caller. Blocks merges to staging/main/master unless every contained
+# kanban item is in "Ready for staging" or "Ready for prod" respectively.
+# All logic lives in tracebloc/.github/.github/workflows/fr-gate.yml.
+
+on:
+  pull_request:
+    branches: [staging, main, master]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+
+jobs:
+  gate:
+    uses: tracebloc/.github/.github/workflows/fr-gate.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Wires this repo into the `fr-gate` workflow that blocks merges to `staging` / `main` / `master` unless every contained kanban item is in the right column (`Ready for staging` or `Ready for prod`).

This caller was missing — surfaced during a pre-promotion audit before the Mon Jun 1 (`develop → staging`) and Tue Jun 2 (`staging → main/master`) pushes. 4 active repos had the gap (this one + 3 others getting parallel PRs).

## Effect

- PRs targeting `staging` / `main` / `master` now trigger `fr-gate` from `tracebloc/.github`.
- PRs targeting `develop` (the normal case) are unaffected.
- No runtime/code changes — pure CI wiring.

## Reference

12-line content matching the canonical caller already deployed in `backend`, `tracebloc-client`, `client`, `client-runtime`, `frontend-app`, `tracebloc-website`, `tracebloc-py-package`, `docs`, `cli`.
