### PR TITLE
docs: fix declarative-ingest path/column drift (issue #131 A-series)

### DIFF
--- a/examples/yaml/custom_processor.yaml
+++ b/examples/yaml/custom_processor.yaml
@@ -17,7 +17,7 @@ kind: IngestConfig
 table: phi_records_train
 intent: train
 category: tabular_classification
-csv: /data/records.csv
+csv: /data/shared/phi-records/records.csv
 schema:
   patient_id: VARCHAR(255)
   age: INT

--- a/examples/yaml/image_classification.yaml
+++ b/examples/yaml/image_classification.yaml
@@ -4,12 +4,14 @@
 #   - default file_options: target_size [512, 512], extension .jpg
 #   - default validators: [FileTypeValidator(images), ImageResolutionValidator,
 #                         TableNameValidator, DuplicateValidator]
-#   - default columns: image_id (data_id source), label (the column you set below)
+#   - required CSV columns: `filename` (image filename, with or without
+#     extension — the default extension above is appended if missing), and
+#     the label column you set below.
 apiVersion: tracebloc.io/v1
 kind: IngestConfig
 table: chest_xrays_train
 intent: train
 category: image_classification
-csv: /data/labels.csv
-images: /data/images/
+csv: /data/shared/chest-xrays/labels.csv
+images: /data/shared/chest-xrays/images/
 label: image_label

--- a/examples/yaml/keypoint_detection.yaml
+++ b/examples/yaml/keypoint_detection.yaml
@@ -10,8 +10,8 @@ kind: IngestConfig
 table: pose_train
 intent: train
 category: keypoint_detection
-csv: /data/labels.csv
-images: /data/images/
+csv: /data/shared/pose/labels.csv
+images: /data/shared/pose/images/
 label: image_label
 target_size: [256, 256]      # height, width — must match your pose model's input
 number_of_keypoints: 9        # e.g. 17 for COCO pose, 9 for the upper-body sample

--- a/examples/yaml/masked_language_modeling.yaml
+++ b/examples/yaml/masked_language_modeling.yaml
@@ -6,5 +6,5 @@ kind: IngestConfig
 table: primekg_mlm_train
 intent: train
 category: masked_language_modeling
-csv: /data/labels_file.csv
-sequences: /data/sequences/
+csv: /data/shared/primekg-mlm/labels_file.csv
+sequences: /data/shared/primekg-mlm/sequences/

--- a/examples/yaml/object_detection.yaml
+++ b/examples/yaml/object_detection.yaml
@@ -6,7 +6,7 @@ kind: IngestConfig
 table: visdrone_train
 intent: train
 category: object_detection
-csv: /data/labels.csv
-images: /data/images/
-annotations: /data/annotations/
+csv: /data/shared/visdrone/labels.csv
+images: /data/shared/visdrone/images/
+annotations: /data/shared/visdrone/annotations/
 label: image_label

--- a/examples/yaml/semantic_segmentation.yaml
+++ b/examples/yaml/semantic_segmentation.yaml
@@ -6,7 +6,7 @@ kind: IngestConfig
 table: tumors_train
 intent: train
 category: semantic_segmentation
-csv: /data/labels.csv
-images: /data/images/
-masks: /data/masks/
+csv: /data/shared/tumors/labels.csv
+images: /data/shared/tumors/images/
+masks: /data/shared/tumors/masks/
 label: image_label

--- a/examples/yaml/tabular_classification.yaml
+++ b/examples/yaml/tabular_classification.yaml
@@ -5,7 +5,7 @@ kind: IngestConfig
 table: churn_train
 intent: train
 category: tabular_classification
-csv: /data/customers.csv
+csv: /data/shared/churn/customers.csv
 schema:
   age: INT
   tenure_months: INT

--- a/examples/yaml/tabular_regression.yaml
+++ b/examples/yaml/tabular_regression.yaml
@@ -7,7 +7,7 @@ kind: IngestConfig
 table: house_prices_train
 intent: train
 category: tabular_regression
-csv: /data/houses.csv
+csv: /data/shared/house-prices/houses.csv
 schema:
   square_feet: FLOAT
   bedrooms: INT

--- a/examples/yaml/text_classification.yaml
+++ b/examples/yaml/text_classification.yaml
@@ -6,8 +6,8 @@ kind: IngestConfig
 table: support_tickets_train
 intent: train
 category: text_classification
-csv: /data/labels.csv
-texts: /data/texts/
+csv: /data/shared/support-tickets/labels.csv
+texts: /data/shared/support-tickets/texts/
 schema:
   text_id: VARCHAR(255)
   label: VARCHAR(64)

--- a/examples/yaml/time_series_forecasting.yaml
+++ b/examples/yaml/time_series_forecasting.yaml
@@ -6,7 +6,7 @@ kind: IngestConfig
 table: energy_demand_train
 intent: train
 category: time_series_forecasting
-csv: /data/demand.csv
+csv: /data/shared/energy-demand/demand.csv
 schema:
   timestamp: VARCHAR(64)
   region: VARCHAR(32)

--- a/examples/yaml/time_to_event_prediction.yaml
+++ b/examples/yaml/time_to_event_prediction.yaml
@@ -6,7 +6,7 @@ kind: IngestConfig
 table: customer_churn_survival_train
 intent: train
 category: time_to_event_prediction
-csv: /data/survival.csv
+csv: /data/shared/customer-churn-survival/survival.csv
 time_column: tenure_days
 schema:
   customer_id: VARCHAR(64)

--- a/templates/image_classification/README.md
+++ b/templates/image_classification/README.md
@@ -61,7 +61,7 @@ image_classification/
 
 ### CSV Labels File
 The CSV contains the following columns:
-- `filename`: Image filename with extension, e.g. `cat1.jpeg`
+- `filename`: Image filename (with or without extension — the configured extension is appended if missing). E.g. `cat1.jpeg` or `cat1`.
 - `label`: Class label for the image, e.g. `cat`, `dog`
 
 ## Advanced: custom processor script

--- a/templates/image_classification/image_classification.py
+++ b/templates/image_classification/image_classification.py
@@ -68,7 +68,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
+                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/image_classification/image_classification.py
+++ b/templates/image_classification/image_classification.py
@@ -68,7 +68,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('image_id', 'Unknown')}"
+                        f"Failed record: {record.get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/keypoint_detection/README.md
+++ b/templates/keypoint_detection/README.md
@@ -56,7 +56,7 @@ keypoint_detection/
 
 ### CSV Labels File
 The CSV file contains the following columns:
-- `filename`: Name of the image file (without extension)
+- `filename`: Image filename (with or without extension — the configured extension is appended if missing)
 - `Annotation`: JSON string with keypoint coordinates as `{"joint_name": [x, y]}` pairs
 - `Visibility`: JSON string with per-keypoint visibility flags as `{"joint_name": 0|1}` (1=visible, 0=occluded/out-of-frame)
 - `image_label`: Class label for the image

--- a/templates/keypoint_detection/keypoint_detection.py
+++ b/templates/keypoint_detection/keypoint_detection.py
@@ -92,7 +92,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('image_id', 'Unknown')}"
+                        f"Failed record: {record.get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/keypoint_detection/keypoint_detection.py
+++ b/templates/keypoint_detection/keypoint_detection.py
@@ -92,7 +92,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
+                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/masked_language_modeling/README.md
+++ b/templates/masked_language_modeling/README.md
@@ -34,6 +34,12 @@ helm install my-mlm-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
+> **If install fails with `'masked_language_modeling' is not one of [...]` or `Additional properties are not allowed ('sequences' was unexpected)`:** your local Helm chart cache is stale. Refresh it and retry:
+>
+> ```bash
+> helm repo update
+> ```
+
 MLM is unsupervised — no `label:` field; the tokenizer validator checks that sequences match the configured vocabulary. Canonical example: [`examples/yaml/masked_language_modeling.yaml`](../../examples/yaml/masked_language_modeling.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure

--- a/templates/masked_language_modeling/README.md
+++ b/templates/masked_language_modeling/README.md
@@ -8,9 +8,9 @@ Ingest with ~7 lines of YAML using the official ingestor image (`ghcr.io/tracebl
 
 > **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
-**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `sequences/` subdirectory holding the per-record `.txt` sequence files.
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `sequences/` subdirectory holding the per-record `.txt` sequence files, plus a `tokenizer.json` at the prefix root (sibling of `sequences/`, **not** inside it). The ingestor auto-discovers the tokenizer by joining `SRC_PATH/tokenizer.json` — `SRC_PATH` is derived as the parent of the `sequences:` directory below, so the location is implicit. See [Tokenizer Requirements](#tokenizer-requirements) for the format rules (must be a HuggingFace tokenizer with `[MASK]` and `[PAD]` in its vocab).
 
-**2. Write `ingest.yaml`:**
+**2. Write `ingest.yaml`** — note there is **no** `tokenizer:` field; the file is discovered automatically:
 
 ```yaml
 apiVersion: tracebloc.io/v1
@@ -18,8 +18,8 @@ kind: IngestConfig
 category: masked_language_modeling
 table: primekg_mlm_train
 intent: train
-csv: /data/shared/primekg/labels_file.csv
-sequences: /data/shared/primekg/sequences/
+csv: /data/shared/primekg-mlm/labels_file.csv
+sequences: /data/shared/primekg-mlm/sequences/
 ```
 
 **3. Install:**
@@ -45,7 +45,8 @@ masked_language_modeling/
     │   ├── seq_0000003.txt
     │   ├── seq_0000004.txt
     │   └── seq_0000005.txt
-    └── labels_file_sample.csv    # CSV manifest mapping filenames to extensions
+    ├── labels_file_sample.csv    # CSV manifest mapping filenames to extensions
+    └── tokenizer.json            # REQUIRED — HuggingFace tokenizer (must include [MASK] and [PAD])
 ```
 
 ## Data Format
@@ -60,6 +61,28 @@ masked_language_modeling/
 MLM is **self-supervised** — no label column is needed. The CSV contains:
 - `filename`: Base name of the text file, without extension (e.g. `seq_0000001`)
 - `extension`: File extension as a quoted string (e.g. `'.txt'`)
+
+## Tokenizer Requirements
+
+MLM ingestion requires a `tokenizer.json` placed at the dataset **root** (sibling of `sequences/`, **not** inside it). The ingestor copies it once from `SRC_PATH` ([`file_transfer.py:369`](../../tracebloc_ingestor/file_transfer.py)), and the training client loads it automatically.
+
+Hard rules (enforced — failing any of these blocks ingestion or training):
+
+- Must be a valid HuggingFace `tokenizer.json`, loadable via `tokenizers.Tokenizer.from_file()`.
+- Must contain **both `[MASK]` and `[PAD]`** in its vocabulary (`model.vocab` or `added_tokens`).
+- These tokens **cannot be added dynamically** — doing so would create token IDs beyond the model's embedding size (`vocab_size`) and crash training with an `IndexError`.
+
+Validation runs twice:
+1. **At ingestion** — [`TokenizerValidator`](../../tracebloc_ingestor/validators/tokenizer_validator.py) checks the file exists, parses as JSON, and contains the required tokens.
+2. **At training load** — the MLM client re-checks `mask_token`/`pad_token` and raises a `ValueError` if either is missing.
+
+### Troubleshooting validation failures
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `tokenizer.json not found` | File missing or not at dataset root | Place `tokenizer.json` alongside `sequences/` |
+| `Invalid JSON in tokenizer.json` | Corrupt / non-JSON file | Regenerate the tokenizer; verify it loads with `Tokenizer.from_file()` |
+| `Tokenizer is missing required special tokens: [MASK], [PAD]` | Tokens absent from vocab | Add `[MASK]` and `[PAD]` to the vocabulary **before** saving the tokenizer |
 
 ## Preprocessing
 
@@ -118,4 +141,12 @@ The script uses the following configuration:
 
 - The `filename` column does **not** include the extension — that's supplied separately via the `extension` column.
 - No `label` column is needed because MLM training is self-supervised (masking is applied on-the-fly by the training client).
-- A `tokenizer.json` file should be placed alongside the data on the dataset path. The MLM client will load it automatically. See the preprocessing scripts for tokenizer generation.
+- `tokenizer.json` must sit at the dataset **root** (sibling of `sequences/`), not inside `sequences/`. See [Tokenizer Requirements](#tokenizer-requirements).
+- Generate the tokenizer with the preprocessing scripts in the `tracebloc-client` repo. After generating, confirm the special tokens are present:
+
+  ```python
+  from tokenizers import Tokenizer
+  tok = Tokenizer.from_file("tokenizer.json")
+  vocab = tok.get_vocab()
+  assert "[MASK]" in vocab and "[PAD]" in vocab, "Missing required special tokens"
+  ```

--- a/templates/masked_language_modeling/README.md
+++ b/templates/masked_language_modeling/README.md
@@ -8,7 +8,11 @@ Ingest with ~7 lines of YAML using the official ingestor image (`ghcr.io/tracebl
 
 > **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
-**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `sequences/` subdirectory holding the per-record `.txt` sequence files, plus a `tokenizer.json` at the prefix root (sibling of `sequences/`, **not** inside it). The ingestor auto-discovers the tokenizer by joining `SRC_PATH/tokenizer.json` — `SRC_PATH` is derived as the parent of the `sequences:` directory below, so the location is implicit. See [Tokenizer Requirements](#tokenizer-requirements) for the format rules (must be a HuggingFace tokenizer with `[MASK]` and `[PAD]` in its vocab).
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with:
+- a `sequences/` subdirectory holding the per-record `.txt` sequence files, and
+- **`tokenizer.json` placed in the same folder as your labels CSV** (the prefix root, not inside `sequences/`).
+
+The ingestor auto-discovers `tokenizer.json` from that folder — there is no YAML field for it. See [Tokenizer Requirements](#tokenizer-requirements) for the format rules (must be a HuggingFace tokenizer with `[MASK]` and `[PAD]` in its vocab).
 
 **2. Write `ingest.yaml`** — note there is **no** `tokenizer:` field; the file is discovered automatically:
 
@@ -46,7 +50,7 @@ masked_language_modeling/
     │   ├── seq_0000004.txt
     │   └── seq_0000005.txt
     ├── labels_file_sample.csv    # CSV manifest mapping filenames to extensions
-    └── tokenizer.json            # REQUIRED — HuggingFace tokenizer (must include [MASK] and [PAD])
+    └── tokenizer.json            # REQUIRED — same folder as the labels CSV; HuggingFace tokenizer with [MASK] and [PAD]
 ```
 
 ## Data Format
@@ -64,7 +68,7 @@ MLM is **self-supervised** — no label column is needed. The CSV contains:
 
 ## Tokenizer Requirements
 
-MLM ingestion requires a `tokenizer.json` placed at the dataset **root** (sibling of `sequences/`, **not** inside it). The ingestor copies it once from `SRC_PATH` ([`file_transfer.py:369`](../../tracebloc_ingestor/file_transfer.py)), and the training client loads it automatically.
+MLM ingestion requires a `tokenizer.json` placed **in the same folder as your labels CSV** (the dataset prefix root — not inside `sequences/`). The ingestor copies it once from there ([`file_transfer.py:369`](../../tracebloc_ingestor/file_transfer.py)), and the training client loads it automatically.
 
 Hard rules (enforced — failing any of these blocks ingestion or training):
 
@@ -80,7 +84,7 @@ Validation runs twice:
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `tokenizer.json not found` | File missing or not at dataset root | Place `tokenizer.json` alongside `sequences/` |
+| `tokenizer.json not found` | File missing or in the wrong folder | Place `tokenizer.json` in the same folder as your labels CSV |
 | `Invalid JSON in tokenizer.json` | Corrupt / non-JSON file | Regenerate the tokenizer; verify it loads with `Tokenizer.from_file()` |
 | `Tokenizer is missing required special tokens: [MASK], [PAD]` | Tokens absent from vocab | Add `[MASK]` and `[PAD]` to the vocabulary **before** saving the tokenizer |
 
@@ -141,7 +145,7 @@ The script uses the following configuration:
 
 - The `filename` column does **not** include the extension — that's supplied separately via the `extension` column.
 - No `label` column is needed because MLM training is self-supervised (masking is applied on-the-fly by the training client).
-- `tokenizer.json` must sit at the dataset **root** (sibling of `sequences/`), not inside `sequences/`. See [Tokenizer Requirements](#tokenizer-requirements).
+- `tokenizer.json` must sit **in the same folder as your labels CSV** (not inside `sequences/`). See [Tokenizer Requirements](#tokenizer-requirements).
 - Generate the tokenizer with the preprocessing scripts in the `tracebloc-client` repo. After generating, confirm the special tokens are present:
 
   ```python

--- a/templates/object_detection/README.md
+++ b/templates/object_detection/README.md
@@ -67,7 +67,7 @@ object_detection/
 ### CSV Labels File
 The CSV file contains the following columns:
 - `object_id`: Unique identifier for each object (format: `{image_name}_obj_{index}`)
-- `image_id`: Name of the image file (without extension)
+- `filename`: Image filename (with or without extension — the configured extension is appended if missing)
 - `image_label`: Class label of the object
 - `object_count`: Number of objects in the image (always 1 for individual objects)
 

--- a/templates/object_detection/object_detection.py
+++ b/templates/object_detection/object_detection.py
@@ -73,7 +73,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('image_id', 'Unknown')}"
+                        f"Failed record: {record.get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/object_detection/object_detection.py
+++ b/templates/object_detection/object_detection.py
@@ -73,7 +73,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
+                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/semantic_segmentation/README.md
+++ b/templates/semantic_segmentation/README.md
@@ -71,8 +71,8 @@ semantic_segmentation/
 
 ### CSV Labels File
 The CSV file contains the following columns:
-- `filename`: Name of the image file (without extension)
-- `mask_id`: Name of the corresponding mask file (without extension)
+- `filename`: Image filename (with or without extension — the configured extension is appended if missing)
+- `mask_id`: Corresponding mask filename (with or without extension — `.png` is appended if missing)
 - `image_label`: Class label present in the image (one row per class per image)
 
 Example:

--- a/templates/semantic_segmentation/semantic_segmentation.py
+++ b/templates/semantic_segmentation/semantic_segmentation.py
@@ -77,7 +77,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('image_id', 'Unknown')}"
+                        f"Failed record: {record.get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/semantic_segmentation/semantic_segmentation.py
+++ b/templates/semantic_segmentation/semantic_segmentation.py
@@ -77,7 +77,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
+                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -164,7 +164,7 @@ def test_csv_happy_path(clean_env, mock_runtime, monkeypatch):
     csv_instance = mock_runtime["CSVIngestor"].return_value
     csv_instance.ingest.assert_called_once()
     args, kwargs = csv_instance.ingest.call_args
-    assert args[0] == "/data/labels.csv"
+    assert args[0] == "/data/shared/chest-xrays/labels.csv"
     assert kwargs.get("batch_size") == 4000
 
 
@@ -364,10 +364,10 @@ def test_legacy_env_vars_set_before_config_construction(
     main()
 
     assert captured_env["TABLE_NAME"] == "chest_xrays_train"
-    assert captured_env["LABEL_FILE"] == "/data/labels.csv"
+    assert captured_env["LABEL_FILE"] == "/data/shared/chest-xrays/labels.csv"
     # SRC_PATH = parent of `images:` dir, since file_transfer.py joins
     # SRC_PATH/images/<filename>.
-    assert captured_env["SRC_PATH"] == "/data"
+    assert captured_env["SRC_PATH"] == "/data/shared/chest-xrays"
 
 
 def test_file_transfer_config_reads_env_lazily(clean_env, mock_runtime, monkeypatch):
@@ -395,8 +395,8 @@ def test_file_transfer_config_reads_env_lazily(clean_env, mock_runtime, monkeypa
     main()
 
     assert file_transfer.config.TABLE_NAME == "chest_xrays_train"
-    assert file_transfer.config.LABEL_FILE == "/data/labels.csv"
-    assert file_transfer.config.SRC_PATH == "/data"
+    assert file_transfer.config.LABEL_FILE == "/data/shared/chest-xrays/labels.csv"
+    assert file_transfer.config.SRC_PATH == "/data/shared/chest-xrays"
     # DEST_PATH is derived from STORAGE_PATH/<table> via property — no
     # in-place patching needed.
     assert file_transfer.config.DEST_PATH == os.path.join(storage_path, "chest_xrays_train")

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -77,14 +77,14 @@ def test_image_classification_data_format():
     r = resolve(_load("image_classification.yaml"))
     assert r.data_format == DataFormat.IMAGE
     assert r.source_type == "csv"
-    assert r.source_path == "/data/labels.csv"
-    assert r.images == "/data/images/"
+    assert r.source_path == "/data/shared/chest-xrays/labels.csv"
+    assert r.images == "/data/shared/chest-xrays/images/"
 
 
 def test_text_classification_data_format():
     r = resolve(_load("text_classification.yaml"))
     assert r.data_format == DataFormat.TEXT
-    assert r.texts == "/data/texts/"
+    assert r.texts == "/data/shared/support-tickets/texts/"
 
 
 def test_tabular_classification_data_format():
@@ -100,16 +100,16 @@ def test_time_series_data_format_is_tabular():
 
 def test_object_detection_sidecars_set():
     r = resolve(_load("object_detection.yaml"))
-    assert r.images == "/data/images/"
-    assert r.annotations == "/data/annotations/"
+    assert r.images == "/data/shared/visdrone/images/"
+    assert r.annotations == "/data/shared/visdrone/annotations/"
     assert r.masks is None
     assert r.texts is None
 
 
 def test_semantic_segmentation_sidecars_set():
     r = resolve(_load("semantic_segmentation.yaml"))
-    assert r.images == "/data/images/"
-    assert r.masks == "/data/masks/"
+    assert r.images == "/data/shared/tumors/images/"
+    assert r.masks == "/data/shared/tumors/masks/"
     assert r.annotations is None
 
 


### PR DESCRIPTION
## Summary

Resolves the **code-verified A-series defects** from [#131](https://github.com/tracebloc/data-ingestors/issues/131). These were the items most likely to break a first-time declarative-YAML ingest.

- **A1** — All 11 `examples/yaml/*.yaml` repointed from `/data/` to `/data/shared/<prefix>/`, matching the actual PVC mount documented in the repo README and per-template READMEs. Prefix per example tracks the YAML's `table:` name (`chest-xrays/`, `visdrone/`, `tumors/`, etc.).
- **A2** — `templates/object_detection/README.md` claimed the image column was `image_id`. The ingestor only ever reads `record.get("filename")` ([`file_transfer.py:135`](../blob/develop/tracebloc_ingestor/file_transfer.py#L135)); `image_id` appears nowhere in the package. A CSV built from that README would have failed. Renamed to `filename`.
- **A3** — Image-family READMEs disagreed on the same column: `image_classification` said "with extension", `semantic_segmentation`/`keypoint_detection` said "without extension", `object_detection` used a different column entirely. Code truth ([`file_transfer.py:154`](../blob/develop/tracebloc_ingestor/file_transfer.py#L154), `os.path.splitext`) is that the value works with or without extension. All four READMEs now say the same thing.
- **A4** — `examples/yaml/image_classification.yaml`'s header comment described default columns as `image_id (data_id source), label`. `data_id` is an auto-generated UUID ([`base.py:262-269`](../blob/develop/tracebloc_ingestor/ingestors/base.py#L262-L269)) unrelated to the filename. Replaced with the actual required columns.

### Bonus — same root cause
The four template `.py` scripts logged `record.get('image_id', 'Unknown')` on failure, which always returned `'Unknown'` (real key is `filename`). Fixed in `image_classification.py`, `object_detection.py`, `semantic_segmentation.py`, `keypoint_detection.py`.

### Not in this PR (out of scope)
- **B1/B2** — canonical staging recipe; needs maintainer decision on `kubectl cp` vs host-path `cp`.
- **B3** — `object_id` / `object_count` rows still listed in `object_detection/README.md`. Sample CSV is `filename,image_label` only and code has no reference to those columns, but the issue marks this as needing detection-path expertise.
- **C-series** — README polish (credentials in declarative path, namespace/workspace wording, intent defaults, run-twice rule).

Closes A-series checkboxes in #131.

## Test plan
- [ ] Pick one `examples/yaml/*.yaml` (recommend `image_classification.yaml`), stage matching data at `/data/shared/chest-xrays/`, and run `helm install ... --set-file ingestConfig=...` end-to-end against a real client install.
- [ ] Confirm a failing record now logs `Failed record: <actual-filename>` instead of `Failed record: Unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, example YAML paths, and template logging only—no ingestor runtime logic changes.
> 
> **Overview**
> Aligns declarative ingest docs and examples with how the ingestor actually resolves paths and CSV columns, fixing first-run failures from issue #131 (A-series).
> 
> All **11** `examples/yaml/*.yaml` files now use **`/data/shared/<dataset-prefix>/`** paths (e.g. `chest-xrays`, `visdrone`) instead of generic `/data/...`, matching the shared PVC staging docs. **`test_conventions.py`** and **`test_cli_run.py`** expectations were updated to match.
> 
> Image-task **READMEs** are unified on the **`filename`** column (with or without extension); **object detection** no longer documents **`image_id`**. The **image classification** example comment now lists **`filename`** plus the label column instead of **`image_id`**. Four template **`.py`** scripts log failed rows via **`record['record']['filename']`** instead of a nonexistent **`image_id`**.
> 
> The **masked language modeling** README adds **`tokenizer.json`** placement (next to the labels CSV, auto-discovered), **`[MASK]`/``** requirements, troubleshooting, and a **`helm repo update`** note; example paths use the **`primekg-mlm`** prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7262eae30ec0cd388c0b92a51c80c916495afe94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->