### PR TITLE
fix(ingest): MLM tokenizer + relax PascalVOC difficult + reserved-id guard (#137, #135)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,55 @@
+name: E2E ingestion
+
+# Real end-to-end ingestion: runs the engine against the bundled templates into
+# a real MySQL (service container) with an in-process mock backend. Complements
+# the unit suite (tests.yml), which mocks the DB + API. See e2e/README.md.
+
+on:
+  pull_request:
+    branches: [develop, master, main]
+  push:
+    branches: [develop, master, main]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: e2e (real MySQL)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: training_test_datasets
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -uroot -proot"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install package + deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Run e2e ingestion suite
+        env:
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_PORT: '3306'
+          DB_USER: root
+          DB_PASSWORD: root
+          DB_NAME: training_test_datasets
+        run: pytest e2e/ -v

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,34 @@
+# End-to-end ingestion suite
+
+Runs the **real `tracebloc-ingest` engine** against each bundled `templates/`
+dataset, into a **real MySQL**, with an in-process mock backend
+(`CLIENT_ENV=local`). It proves the *"every shipped config ingests its bundled
+data"* guarantee — the gap that let **8/10 modalities fail first-try** when a
+config is copied onto the matching template data (#134).
+
+Unlike the unit suite (which mocks the DB + API), this exercises the full
+validate → file-transfer → MySQL insert path end to end.
+
+## Run locally
+
+```bash
+docker compose -f e2e/docker-compose.yml up -d        # MySQL on :3306
+pip install -r requirements.txt && pip install -e .
+MYSQL_HOST=127.0.0.1 MYSQL_PORT=3306 DB_USER=root DB_PASSWORD=root \
+  DB_NAME=training_test_datasets pytest e2e/ -v
+docker compose -f e2e/docker-compose.yml down -v
+```
+
+The suite **auto-skips when no MySQL is reachable**, so the default `pytest`
+(unit) run is unaffected. CI runs it with a MySQL service in
+`.github/workflows/e2e.yml`.
+
+## Known gaps (currently `xfail`)
+
+| Modality | Why | Ticket |
+|---|---|---|
+| object_detection | bundled VisDrone XML uses `difficult=2`; validator only accepts `0/1` | #135 |
+| semantic_segmentation | mask sidecar column not wired through the declarative path | #136 |
+| masked_language_modeling | template missing the required `tokenizer.json` | #137 |
+
+When a fix lands, the corresponding test XPASSes — drop the `xfail` mark.

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,83 @@
+"""Pytest config for the end-to-end ingestion suite.
+
+These tests run the REAL ``tracebloc-ingest`` engine against the bundled
+``templates/`` datasets, into a REAL MySQL, with an in-process mock backend
+(``CLIENT_ENV=local`` pins the APIClient at ``http://localhost:8000``). They
+are skipped unless a MySQL is reachable (``MYSQL_HOST`` / ``MYSQL_PORT``), so
+the default unit ``pytest`` run is unaffected.
+
+Local run::
+
+    docker compose -f e2e/docker-compose.yml up -d
+    MYSQL_HOST=127.0.0.1 DB_USER=root DB_PASSWORD=root pytest e2e/ -v
+
+CI: ``.github/workflows/e2e.yml`` (MySQL service).
+"""
+import json
+import os
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+
+def _mysql_reachable() -> bool:
+    host = os.environ.get("MYSQL_HOST", "127.0.0.1")
+    port = int(os.environ.get("MYSQL_PORT", "3306"))
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+# Don't even collect the e2e tests unless a MySQL is reachable — keeps the
+# default `pytest` (unit) run green when run without a database.
+collect_ignore_glob = [] if _mysql_reachable() else ["test_*.py"]
+
+
+class _MockBackend(BaseHTTPRequestHandler):
+    """200 + permissive JSON for every endpoint the APIClient calls (auth token,
+    batch send, metadata, prepare/create dataset)."""
+
+    def _ok(self):
+        body = json.dumps({
+            "token": "mock", "key": "mock", "id": 1, "status": "ok",
+            "success": True, "data_id": "mock", "dataset_key": "mock",
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    do_GET = do_POST = do_PUT = do_PATCH = lambda self: self._ok()
+
+    def log_message(self, *_a):  # silence the default access log
+        pass
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_backend():
+    srv = HTTPServer(("127.0.0.1", 8000), _MockBackend)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield
+    srv.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def engine_env(tmp_path, monkeypatch):
+    # /data/shared (the hardcoded sidecar destination) isn't writable in CI;
+    # redirect it to a per-test tmp dir. STORAGE_PATH is a class constant.
+    from tracebloc_ingestor.config import Config
+    shared = tmp_path / "shared"
+    shared.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Config, "STORAGE_PATH", str(shared))
+
+    monkeypatch.setenv("CLIENT_ENV", "local")  # bypass backend auth; point at the mock
+    monkeypatch.setenv("MYSQL_HOST", os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    monkeypatch.setenv("MYSQL_PORT", os.environ.get("MYSQL_PORT", "3306"))
+    monkeypatch.setenv("DB_USER", os.environ.get("DB_USER", "root"))
+    monkeypatch.setenv("DB_PASSWORD", os.environ.get("DB_PASSWORD", "root"))
+    monkeypatch.setenv("DB_NAME", os.environ.get("DB_NAME", "training_test_datasets"))

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,17 @@
+# Local MySQL for the e2e ingestion suite.  Usage:
+#   docker compose -f e2e/docker-compose.yml up -d
+#   MYSQL_HOST=127.0.0.1 DB_USER=root DB_PASSWORD=root pytest e2e/ -v
+#   docker compose -f e2e/docker-compose.yml down -v
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: training_test_datasets
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 3s
+      retries: 20

--- a/e2e/test_ingest_e2e.py
+++ b/e2e/test_ingest_e2e.py
@@ -1,0 +1,144 @@
+"""End-to-end ingestion equivalence: every modality's bundled template ingests.
+
+For each modality we build an ``ingest.yaml`` matched to the bundled
+``templates/`` dataset, run the real engine into MySQL, and assert it succeeds
+with rows. Modalities with known engine/template gaps are ``xfail``'d against
+their tracking ticket — when the fix lands the test XPASSes and the xfail can be
+removed.
+
+The matched configs here are deliberately the *correct* configs for the bundled
+data — several differ from the shipped ``examples/yaml`` (which don't match the
+templates) and that mismatch is exactly what this suite guards against (#134).
+"""
+import os
+from pathlib import Path
+
+import mysql.connector
+import pytest
+import yaml
+
+from tracebloc_ingestor.cli import run
+
+REPO = Path(__file__).resolve().parents[1]
+T = REPO / "templates"
+
+
+def _cfg(**kw):
+    base = {"apiVersion": "tracebloc.io/v1", "kind": "IngestConfig", "intent": "train"}
+    base.update(kw)
+    return base
+
+
+CASES = [
+    pytest.param(_cfg(
+        table="e2e_text", category="text_classification",
+        csv=str(T / "text_classification/data/labels_file_sample.csv"),
+        texts=str(T / "text_classification/data/texts"), label="label",
+    ), id="text_classification"),
+
+    pytest.param(_cfg(
+        table="e2e_tte", category="time_to_event_prediction",
+        csv=str(T / "time_to_event_prediction/time_to_event_prediction_sample_in_csv_format.csv"),
+        time_column="time",
+        schema={"age": "INT", "anaemia": "INT", "creatinine_phosphokinase": "INT",
+                "diabetes": "INT", "ejection_fraction": "INT", "high_blood_pressure": "INT",
+                "platelets": "FLOAT", "serum_creatinine": "FLOAT", "serum_sodium": "INT",
+                "sex": "INT", "smoking": "INT", "time": "INT", "DEATH_EVENT": "INT"},
+        label={"column": "DEATH_EVENT", "policy": "bucket"},
+    ), id="time_to_event_prediction"),
+
+    pytest.param(_cfg(
+        table="e2e_tabclf", category="tabular_classification",
+        csv=str(T / "tabular_classification/tabular_classification_sample_in_csv_format.csv"),
+        schema={"feature_00": "FLOAT", "feature_01": "FLOAT", "feature_02": "FLOAT", "label": "INT"},
+        label="label",
+    ), id="tabular_classification"),
+
+    pytest.param(_cfg(
+        table="e2e_tabreg", category="tabular_regression",
+        csv=str(T / "tabular_regression/tabular_regression_sample_in_csv_format.csv"),
+        schema={"square_feet": "FLOAT", "bedrooms": "INT", "age": "INT", "price": "FLOAT"},
+        label={"column": "price", "policy": "bucket"},
+    ), id="tabular_regression"),
+
+    pytest.param(_cfg(
+        table="e2e_img", category="image_classification",
+        csv=str(T / "image_classification/data/labels_file_sample.csv"),
+        images=str(T / "image_classification/data/images"), label="label",
+        spec={"file_options": {"extension": ".jpeg", "target_size": [256, 256]}},
+    ), id="image_classification"),
+
+    pytest.param(_cfg(
+        table="e2e_tsf", category="time_series_forecasting",
+        csv=str(T / "time_series_forecasting/time_series_forecasting_sample_in_csv_format.csv"),
+        schema={"timestamp": "TIMESTAMP", "day_of_week": "INT", "month": "INT",
+                "day_of_month": "INT", "week_of_year": "INT", "is_weekend": "INT", "value": "FLOAT"},
+        label={"column": "value", "policy": "bucket"},
+    ), id="time_series_forecasting"),
+
+    pytest.param(_cfg(
+        table="e2e_kp", category="keypoint_detection",
+        csv=str(T / "keypoint_detection/data/labels_file_sample.csv"),
+        images=str(T / "keypoint_detection/data/images"), label="image_label",
+        target_size=[448, 448], number_of_keypoints=9,
+    ), id="keypoint_detection"),
+
+    # ── known gaps (xfail → tracking ticket; XPASS signals the fix landed) ──
+    pytest.param(_cfg(
+        table="e2e_od", category="object_detection",
+        csv=str(T / "object_detection/data/labels_file_sample.csv"),
+        images=str(T / "object_detection/data/images"),
+        annotations=str(T / "object_detection/data/annotations"), label="image_label",
+    ), id="object_detection",
+        marks=pytest.mark.xfail(reason="bundled VisDrone XML difficult=2 rejected (#135)", strict=False)),
+
+    pytest.param(_cfg(
+        table="e2e_seg", category="semantic_segmentation",
+        csv=str(T / "semantic_segmentation/semantic_data/labels_file_sample.csv"),
+        images=str(T / "semantic_segmentation/semantic_data/images"),
+        masks=str(T / "semantic_segmentation/semantic_data/masks"), label="image_label",
+    ), id="semantic_segmentation",
+        marks=pytest.mark.xfail(reason="mask sidecar not wired in declarative path (#136)", strict=False)),
+
+    pytest.param(_cfg(
+        table="e2e_mlm", category="masked_language_modeling",
+        csv=str(T / "masked_language_modeling/data/labels_file_sample.csv"),
+        sequences=str(T / "masked_language_modeling/data/sequences"),
+    ), id="masked_language_modeling",
+        marks=pytest.mark.xfail(reason="template missing tokenizer.json (#137)", strict=False)),
+]
+
+
+def _connect():
+    return mysql.connector.connect(
+        host=os.environ["MYSQL_HOST"], port=int(os.environ["MYSQL_PORT"]),
+        user=os.environ["DB_USER"], password=os.environ["DB_PASSWORD"],
+        database=os.environ["DB_NAME"],
+    )
+
+
+def _drop(table):
+    conn = _connect(); cur = conn.cursor()
+    cur.execute(f"DROP TABLE IF EXISTS `{table}`")
+    conn.commit(); cur.close(); conn.close()
+
+
+def _rows(table):
+    conn = _connect(); cur = conn.cursor()
+    cur.execute(f"SELECT COUNT(*) FROM `{table}`")
+    n = cur.fetchone()[0]
+    cur.close(); conn.close()
+    return n
+
+
+@pytest.mark.parametrize("cfg", CASES)
+def test_modality_ingests_its_template(cfg, tmp_path, monkeypatch):
+    table = cfg["table"]
+    _drop(table)  # clean slate so the row assertion is deterministic on re-runs
+    config_path = tmp_path / "ingest.yaml"
+    config_path.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("INGEST_CONFIG", str(config_path))
+
+    rc = run.main()
+    assert rc == 0, f"ingest exited {rc} for {cfg['category']}"
+    assert _rows(table) > 0, f"no rows ingested for {cfg['category']}"

--- a/e2e/test_ingest_e2e.py
+++ b/e2e/test_ingest_e2e.py
@@ -83,15 +83,25 @@ CASES = [
         target_size=[448, 448], number_of_keypoints=9,
     ), id="keypoint_detection"),
 
-    # ── known gaps (xfail → tracking ticket; XPASS signals the fix landed) ──
+    # object_detection: now ingests after relaxing the PascalVOC `difficult`
+    # validator (#135a); target_size matched to the bundled VisDrone image.
     pytest.param(_cfg(
         table="e2e_od", category="object_detection",
         csv=str(T / "object_detection/data/labels_file_sample.csv"),
         images=str(T / "object_detection/data/images"),
         annotations=str(T / "object_detection/data/annotations"), label="image_label",
-    ), id="object_detection",
-        marks=pytest.mark.xfail(reason="bundled VisDrone XML difficult=2 rejected (#135)", strict=False)),
+        target_size=[1920, 1080],
+    ), id="object_detection"),
 
+    # masked_language_modeling: now ingests after adding the template's
+    # tokenizer.json (#137).
+    pytest.param(_cfg(
+        table="e2e_mlm", category="masked_language_modeling",
+        csv=str(T / "masked_language_modeling/data/labels_file_sample.csv"),
+        sequences=str(T / "masked_language_modeling/data/sequences"),
+    ), id="masked_language_modeling"),
+
+    # ── known gap (xfail → tracking ticket; XPASS signals the fix landed) ──
     pytest.param(_cfg(
         table="e2e_seg", category="semantic_segmentation",
         csv=str(T / "semantic_segmentation/semantic_data/labels_file_sample.csv"),
@@ -99,13 +109,6 @@ CASES = [
         masks=str(T / "semantic_segmentation/semantic_data/masks"), label="image_label",
     ), id="semantic_segmentation",
         marks=pytest.mark.xfail(reason="mask sidecar not wired in declarative path (#136)", strict=False)),
-
-    pytest.param(_cfg(
-        table="e2e_mlm", category="masked_language_modeling",
-        csv=str(T / "masked_language_modeling/data/labels_file_sample.csv"),
-        sequences=str(T / "masked_language_modeling/data/sequences"),
-    ), id="masked_language_modeling",
-        marks=pytest.mark.xfail(reason="template missing tokenizer.json (#137)", strict=False)),
 ]
 
 

--- a/templates/masked_language_modeling/data/tokenizer.json
+++ b/templates/masked_language_modeling/data/tokenizer.json
@@ -1,0 +1,31 @@
+{
+  "version": "1.0",
+  "model": {
+    "type": "WordLevel",
+    "unk_token": "[UNK]",
+    "vocab": {
+      "[PAD]": 0,
+      "[UNK]": 1,
+      "[CLS]": 2,
+      "[SEP]": 3,
+      "[MASK]": 4,
+      "the": 5,
+      "a": 6,
+      "is": 7,
+      "of": 8,
+      "and": 9,
+      "to": 10,
+      "in": 11,
+      "protein": 12,
+      "gene": 13,
+      "disease": 14
+    }
+  },
+  "added_tokens": [
+    {"id": 0, "content": "[PAD]", "special": true},
+    {"id": 1, "content": "[UNK]", "special": true},
+    {"id": 2, "content": "[CLS]", "special": true},
+    {"id": 3, "content": "[SEP]", "special": true},
+    {"id": 4, "content": "[MASK]", "special": true}
+  ]
+}

--- a/tests/test_coverage_gaps2.py
+++ b/tests/test_coverage_gaps2.py
@@ -350,8 +350,19 @@ def test_object_truncated_missing(v):
 
 
 def test_object_difficult_bad_value(v):
-    res = v._validate_single_object(_obj(difficult="9"), 0)
+    # Non-integer (or negative) difficult is still rejected; the message changed
+    # from strict 0/1 to "non-negative integer" when we relaxed the validator
+    # for VisDrone-style data (#135a).
+    res = v._validate_single_object(_obj(difficult="abc"), 0)
     assert any("Difficult element must be" in e for e in res["errors"])
+
+
+def test_object_difficult_high_value_accepted(v):
+    # VisDrone uses difficult=2; it's now accepted (with a warning) rather than
+    # an error, so the bundled OD sample ingests (#135a).
+    res = v._validate_single_object(_obj(difficult="2"), 0)
+    assert not any("Difficult" in e for e in res["errors"])
+    assert any("Difficult=2" in w for w in res["warnings"])
 
 
 def test_object_difficult_missing(v):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -223,3 +223,20 @@ def test_get_table_schema(db):
     assert schema["name"] == "VARCHAR(255)"
     # unknown SQLAlchemy type falls back to VARCHAR
     assert schema["weird"] == "VARCHAR"
+
+
+def test_create_table_rejects_reserved_column():
+    """A user schema column colliding with a reserved/internal column (e.g.
+    'id') fails fast with a clear ValueError, not a cryptic DuplicateColumnError.
+    The guard runs before any DB I/O, so no live connection is needed."""
+    db = Database.__new__(Database)
+    with pytest.raises(ValueError, match="reserved"):
+        db.create_table("some_table", {"id": "INT", "feature_0": "FLOAT"})
+
+
+def test_create_table_allows_label_in_schema():
+    """`label` is the user-facing label column (mapped onto the standard
+    column), so it must NOT be treated as a reserved collision."""
+    db = Database.__new__(Database)
+    db.tables = {"t": "sentinel"}  # short-circuit before any engine use
+    assert db.create_table("t", {"feature_0": "FLOAT", "label": "INT"}) == "sentinel"

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -113,7 +113,29 @@ class Database:
 
         Returns:
             SQLAlchemy Table object
+
+        Raises:
+            ValueError: if a schema column collides with a reserved/internal
+                column (e.g. a user CSV with its own ``id``), which would
+                otherwise surface as a cryptic SQLAlchemy DuplicateColumnError.
         """
+        # Fail fast on reserved-column collisions before any DB I/O. `label`
+        # is intentionally excluded — it's the user-facing label column the
+        # framework maps onto the standard `label` column.
+        _RESERVED = {
+            "id", "created_at", "updated_at", "status", "data_intent",
+            "data_id", "filename", "extension", "annotation", "ingestor_id",
+        }
+        _collisions = sorted(_RESERVED & set(schema))
+        if _collisions:
+            raise ValueError(
+                f"Schema column(s) {_collisions} collide with reserved tracebloc "
+                f"columns. The framework manages its own row id, timestamps, status, "
+                f"data_id and sidecar metadata — rename these column(s) in your "
+                f"CSV/schema. (To use your own `id` as the record identifier, set "
+                f"data_id.strategy=column instead.)"
+            )
+
         # Return existing table if already created
         if table_name in self.tables:
             return self.tables[table_name]

--- a/tracebloc_ingestor/validators/xml_validator.py
+++ b/tracebloc_ingestor/validators/xml_validator.py
@@ -527,15 +527,30 @@ class PascalVOCXMLValidator(BaseValidator):
         elif "truncated" in self.required_object_elements:
             errors.append(f"Object {index}: Missing required 'truncated' element")
 
-        # Validate difficult element
+        # Validate difficult element. Pascal VOC officially uses 0/1, but
+        # real-world detection datasets (e.g. VisDrone — our bundled OD sample)
+        # use higher difficulty levels. Accept any non-negative integer; flag
+        # non-standard values as a warning rather than failing ingestion.
         difficult_elem = obj.find("difficult")
         if difficult_elem is not None:
-            if difficult_elem.text not in ["0", "1"]:
+            try:
+                difficult_val = (
+                    int(difficult_elem.text) if difficult_elem.text is not None else None
+                )
+            except (ValueError, TypeError):
+                difficult_val = None
+            if difficult_val is None or difficult_val < 0:
                 errors.append(
-                    f"Object {index}: Difficult element must be '0' or '1', found: {difficult_elem.text}"
+                    f"Object {index}: Difficult element must be a non-negative integer, "
+                    f"found: {difficult_elem.text}"
                 )
             else:
-                metadata["difficult"] = int(difficult_elem.text)
+                metadata["difficult"] = difficult_val
+                if difficult_val not in (0, 1):
+                    warnings.append(
+                        f"Object {index}: Difficult={difficult_val} is outside the standard "
+                        f"Pascal VOC 0/1 (accepted; e.g. VisDrone uses 0/1/2)"
+                    )
         elif "difficult" in self.required_object_elements:
             errors.append(f"Object {index}: Missing required 'difficult' element")
 


### PR DESCRIPTION
> 🔗 **Stacked on #138** (the e2e equivalence suite — the xfail flips edit its test file). Until #138 merges, this PR's range includes its commits — review commit `090bbcb` / the files below, and **merge #138 first**.

## Summary
Implements **#137** and the two xfail-flipping items of **#135**, turning two e2e modalities from `xfail` to passing in the equivalence suite (#138) and adding a friendly error for a common ingestion footgun. Part of epic tracebloc/backend#597.

## Changes
- **#137 — MLM template `tokenizer.json`.** The template couldn't ingest itself — `TokenizerValidator` requires a `tokenizer.json` with `[MASK]`/`[PAD]` alongside the sequences. Added a minimal valid WordLevel tokenizer. MLM now ingests.
- **#135a — relax PascalVOC `difficult`** (`validators/xml_validator.py`). Official Pascal VOC uses `0/1`, but real datasets (VisDrone — our bundled OD sample) use higher levels. Now accepts any non-negative integer, **warns** on non-standard values, errors only on non-integer/negative. The bundled OD sample ingests.
- **#135b — reserved-column guard** (`database.py`). A user schema/CSV column colliding with a reserved internal column (e.g. `id`) used to surface as a cryptic `sqlalchemy DuplicateColumnError`; now a clear `ValueError` raised before any DB I/O. `label` is excluded (it's the mapped label column).
- **e2e harness**: removed the OD + MLM xfails (OD with `target_size` matched to the bundled image).

## Results
- **e2e: 9 passed / 1 xfailed** — only `semantic_segmentation` remains (mask sidecars, #136).
- **unit: 602 passed, 98.5% coverage** (≥95 gate); `xml_validator.py` + `tokenizer_validator.py` at 100%. Updated `test_object_difficult_bad_value`, added a high-value-accepted test + two reserved-column-guard tests.

## Deferred (kept open in #135)
Image default-extension flexibility, and time-series leading-`NaN` handling (the latter needs a training-side decision on whether ingestion should accept nulls).

## Type of change
- [x] Bug fix
- [x] Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
