### PR TITLE
fix(#24): build the ingestor image multi-arch (amd64 + arm64)

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -51,6 +51,12 @@ jobs:
           # cosign + buildkit reproducibility benefit from full history.
           fetch-depth: 0
 
+      - name: Set up QEMU
+        # Registers binfmt handlers so the arm64 layers can be built
+        # under emulation on the amd64 runner. Without this, the
+        # multi-arch build below silently degrades to amd64-only.
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -119,6 +125,15 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          # Multi-arch (#24). Without `platforms`, build-push-action
+          # builds for the runner's arch only (amd64) — which is exactly
+          # why earlier ingestor digests couldn't be pulled on arm64
+          # nodes/clusters (jobs-manager spawns the ingestor Job by
+          # digest; arm64 kubelets ImagePullBackOff on an amd64-only
+          # manifest). The pushed digest becomes a manifest-list index
+          # spanning both arches; downstream (the chart's
+          # images.ingestor.digest) pins that index digest.
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
`release-image.yml`'s build step had no `platforms:`, so `docker/build-push-action` built for the runner's arch only — **amd64**. jobs-manager spawns the ingestor Job *by digest* (`ghcr.io/tracebloc/ingestor@sha256:...`), and an **arm64 kubelet can't pull an amd64-only manifest** → ImagePullBackOff. That blocks ingestion on arm64 nodes/clusters (and Apple-Silicon dev clusters) entirely — the only workaround is hand-importing the image into the node's containerd.

## Changes
- Add `docker/setup-qemu-action` (binfmt handlers for cross-arch emulation on the amd64 runner).
- Add `platforms: linux/amd64,linux/arm64` to `docker/build-push-action`.

The pushed digest becomes a **manifest-list index** spanning both arches, so the single digest the chart pins (`images.ingestor.digest` → jobs-manager's `INGESTOR_IMAGE_DIGEST`) works on both architectures. cosign signs the index digest as before.

## Rollout
Takes effect on the next `vX.Y.Z` release tag (the workflow's trigger). When that release is cut, the chart's `images.ingestor.digest` should bump to the new multi-arch index digest.

## Test plan
- YAML validated. The real proof is the next release build producing a 2-arch manifest — verify with `docker buildx imagetools inspect ghcr.io/tracebloc/ingestor@<digest>` (expect `linux/amd64` + `linux/arm64`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)