### PR TITLE
Release: develop → master (33 commits — coverage, fr-gate, bug fixes, docs)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,55 @@
+name: E2E ingestion
+
+# Real end-to-end ingestion: runs the engine against the bundled templates into
+# a real MySQL (service container) with an in-process mock backend. Complements
+# the unit suite (tests.yml), which mocks the DB + API. See e2e/README.md.
+
+on:
+  pull_request:
+    branches: [develop, master, main]
+  push:
+    branches: [develop, master, main]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: e2e (real MySQL)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: training_test_datasets
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -uroot -proot"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install package + deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Run e2e ingestion suite
+        env:
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_PORT: '3306'
+          DB_USER: root
+          DB_PASSWORD: root
+          DB_NAME: training_test_datasets
+        run: pytest e2e/ -v

--- a/.github/workflows/fr-gate-caller.yml
+++ b/.github/workflows/fr-gate-caller.yml
@@ -1,0 +1,15 @@
+name: FR gate
+
+# Per-repo caller. Blocks merges to staging/main/master unless every contained
+# kanban item is in "Ready for staging" or "Ready for prod" respectively.
+# All logic lives in tracebloc/.github/.github/workflows/fr-gate.yml.
+
+on:
+  pull_request:
+    branches: [staging, main, master]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+
+jobs:
+  gate:
+    uses: tracebloc/.github/.github/workflows/fr-gate.yml@main
+    secrets: inherit

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -51,6 +51,12 @@ jobs:
           # cosign + buildkit reproducibility benefit from full history.
           fetch-depth: 0
 
+      - name: Set up QEMU
+        # Registers binfmt handlers so the arm64 layers can be built
+        # under emulation on the amd64 runner. Without this, the
+        # multi-arch build below silently degrades to amd64-only.
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -119,6 +125,15 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          # Multi-arch (#24). Without `platforms`, build-push-action
+          # builds for the runner's arch only (amd64) — which is exactly
+          # why earlier ingestor digests couldn't be pulled on arm64
+          # nodes/clusters (jobs-manager spawns the ingestor Job by
+          # digest; arm64 kubelets ImagePullBackOff on an amd64-only
+          # manifest). The pushed digest becomes a manifest-list index
+          # spanning both arches; downstream (the chart's
+          # images.ingestor.digest) pins that index digest.
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,74 @@
+name: Tests
+
+# Runs the pytest suite on every PR + push to develop/master/main.
+# Matrix: Python 3.11 + 3.12 (matches setup.py: python_requires=">=3.11").
+# Coverage measured but not yet gated by --cov-fail-under; lock that in once
+# the baseline number is recorded.
+#
+# After this lands and stabilizes:
+#   - 'pytest (3.11)' + 'pytest (3.12)' become required status checks via
+#     branch protection.
+
+on:
+  pull_request:
+    branches: [develop, master, main]
+  push:
+    branches: [develop, master, main]
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.11', '3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+
+      - name: Install package + test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Run pytest with coverage
+        run: |
+          pytest \
+            --cov=tracebloc_ingestor \
+            --cov-report=term \
+            --cov-report=xml \
+            --cov-report=html
+
+      - name: Coverage summary
+        if: always()
+        run: |
+          if [ -f .coverage ]; then
+            echo "## Coverage (Python ${{ matrix.python }})" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            coverage report >> "$GITHUB_STEP_SUMMARY" || true
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload coverage HTML
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html-py${{ matrix.python }}
+          path: htmlcov/
+          retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,8 @@ name: Tests
 
 # Runs the pytest suite on every PR + push to develop/master/main.
 # Matrix: Python 3.11 + 3.12 (matches setup.py: python_requires=">=3.11").
-# Coverage measured but not yet gated by --cov-fail-under; lock that in once
-# the baseline number is recorded.
+# Coverage is gated at --cov-fail-under=95 (the suite currently sits at ~99%);
+# CI fails if total coverage regresses below 95%.
 #
 # After this lands and stabilizes:
 #   - 'pytest (3.11)' + 'pytest (3.12)' become required status checks via
@@ -52,7 +52,8 @@ jobs:
             --cov=tracebloc_ingestor \
             --cov-report=term \
             --cov-report=xml \
-            --cov-report=html
+            --cov-report=html \
+            --cov-fail-under=95
 
       - name: Coverage summary
         if: always()

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,34 @@
+# End-to-end ingestion suite
+
+Runs the **real `tracebloc-ingest` engine** against each bundled `templates/`
+dataset, into a **real MySQL**, with an in-process mock backend
+(`CLIENT_ENV=local`). It proves the *"every shipped config ingests its bundled
+data"* guarantee — the gap that let **8/10 modalities fail first-try** when a
+config is copied onto the matching template data (#134).
+
+Unlike the unit suite (which mocks the DB + API), this exercises the full
+validate → file-transfer → MySQL insert path end to end.
+
+## Run locally
+
+```bash
+docker compose -f e2e/docker-compose.yml up -d        # MySQL on :3306
+pip install -r requirements.txt && pip install -e .
+MYSQL_HOST=127.0.0.1 MYSQL_PORT=3306 DB_USER=root DB_PASSWORD=root \
+  DB_NAME=training_test_datasets pytest e2e/ -v
+docker compose -f e2e/docker-compose.yml down -v
+```
+
+The suite **auto-skips when no MySQL is reachable**, so the default `pytest`
+(unit) run is unaffected. CI runs it with a MySQL service in
+`.github/workflows/e2e.yml`.
+
+## Known gaps (currently `xfail`)
+
+| Modality | Why | Ticket |
+|---|---|---|
+| object_detection | bundled VisDrone XML uses `difficult=2`; validator only accepts `0/1` | #135 |
+| semantic_segmentation | mask sidecar column not wired through the declarative path | #136 |
+| masked_language_modeling | template missing the required `tokenizer.json` | #137 |
+
+When a fix lands, the corresponding test XPASSes — drop the `xfail` mark.

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,83 @@
+"""Pytest config for the end-to-end ingestion suite.
+
+These tests run the REAL ``tracebloc-ingest`` engine against the bundled
+``templates/`` datasets, into a REAL MySQL, with an in-process mock backend
+(``CLIENT_ENV=local`` pins the APIClient at ``http://localhost:8000``). They
+are skipped unless a MySQL is reachable (``MYSQL_HOST`` / ``MYSQL_PORT``), so
+the default unit ``pytest`` run is unaffected.
+
+Local run::
+
+    docker compose -f e2e/docker-compose.yml up -d
+    MYSQL_HOST=127.0.0.1 DB_USER=root DB_PASSWORD=root pytest e2e/ -v
+
+CI: ``.github/workflows/e2e.yml`` (MySQL service).
+"""
+import json
+import os
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+
+def _mysql_reachable() -> bool:
+    host = os.environ.get("MYSQL_HOST", "127.0.0.1")
+    port = int(os.environ.get("MYSQL_PORT", "3306"))
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+# Don't even collect the e2e tests unless a MySQL is reachable — keeps the
+# default `pytest` (unit) run green when run without a database.
+collect_ignore_glob = [] if _mysql_reachable() else ["test_*.py"]
+
+
+class _MockBackend(BaseHTTPRequestHandler):
+    """200 + permissive JSON for every endpoint the APIClient calls (auth token,
+    batch send, metadata, prepare/create dataset)."""
+
+    def _ok(self):
+        body = json.dumps({
+            "token": "mock", "key": "mock", "id": 1, "status": "ok",
+            "success": True, "data_id": "mock", "dataset_key": "mock",
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    do_GET = do_POST = do_PUT = do_PATCH = lambda self: self._ok()
+
+    def log_message(self, *_a):  # silence the default access log
+        pass
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_backend():
+    srv = HTTPServer(("127.0.0.1", 8000), _MockBackend)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield
+    srv.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def engine_env(tmp_path, monkeypatch):
+    # /data/shared (the hardcoded sidecar destination) isn't writable in CI;
+    # redirect it to a per-test tmp dir. STORAGE_PATH is a class constant.
+    from tracebloc_ingestor.config import Config
+    shared = tmp_path / "shared"
+    shared.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Config, "STORAGE_PATH", str(shared))
+
+    monkeypatch.setenv("CLIENT_ENV", "local")  # bypass backend auth; point at the mock
+    monkeypatch.setenv("MYSQL_HOST", os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    monkeypatch.setenv("MYSQL_PORT", os.environ.get("MYSQL_PORT", "3306"))
+    monkeypatch.setenv("DB_USER", os.environ.get("DB_USER", "root"))
+    monkeypatch.setenv("DB_PASSWORD", os.environ.get("DB_PASSWORD", "root"))
+    monkeypatch.setenv("DB_NAME", os.environ.get("DB_NAME", "training_test_datasets"))

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,17 @@
+# Local MySQL for the e2e ingestion suite.  Usage:
+#   docker compose -f e2e/docker-compose.yml up -d
+#   MYSQL_HOST=127.0.0.1 DB_USER=root DB_PASSWORD=root pytest e2e/ -v
+#   docker compose -f e2e/docker-compose.yml down -v
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: training_test_datasets
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 3s
+      retries: 20

--- a/e2e/test_ingest_e2e.py
+++ b/e2e/test_ingest_e2e.py
@@ -1,0 +1,144 @@
+"""End-to-end ingestion equivalence: every modality's bundled template ingests.
+
+For each modality we build an ``ingest.yaml`` matched to the bundled
+``templates/`` dataset, run the real engine into MySQL, and assert it succeeds
+with rows. Modalities with known engine/template gaps are ``xfail``'d against
+their tracking ticket — when the fix lands the test XPASSes and the xfail can be
+removed.
+
+The matched configs here are deliberately the *correct* configs for the bundled
+data — several differ from the shipped ``examples/yaml`` (which don't match the
+templates) and that mismatch is exactly what this suite guards against (#134).
+"""
+import os
+from pathlib import Path
+
+import mysql.connector
+import pytest
+import yaml
+
+from tracebloc_ingestor.cli import run
+
+REPO = Path(__file__).resolve().parents[1]
+T = REPO / "templates"
+
+
+def _cfg(**kw):
+    base = {"apiVersion": "tracebloc.io/v1", "kind": "IngestConfig", "intent": "train"}
+    base.update(kw)
+    return base
+
+
+CASES = [
+    pytest.param(_cfg(
+        table="e2e_text", category="text_classification",
+        csv=str(T / "text_classification/data/labels_file_sample.csv"),
+        texts=str(T / "text_classification/data/texts"), label="label",
+    ), id="text_classification"),
+
+    pytest.param(_cfg(
+        table="e2e_tte", category="time_to_event_prediction",
+        csv=str(T / "time_to_event_prediction/time_to_event_prediction_sample_in_csv_format.csv"),
+        time_column="time",
+        schema={"age": "INT", "anaemia": "INT", "creatinine_phosphokinase": "INT",
+                "diabetes": "INT", "ejection_fraction": "INT", "high_blood_pressure": "INT",
+                "platelets": "FLOAT", "serum_creatinine": "FLOAT", "serum_sodium": "INT",
+                "sex": "INT", "smoking": "INT", "time": "INT", "DEATH_EVENT": "INT"},
+        label={"column": "DEATH_EVENT", "policy": "bucket"},
+    ), id="time_to_event_prediction"),
+
+    pytest.param(_cfg(
+        table="e2e_tabclf", category="tabular_classification",
+        csv=str(T / "tabular_classification/tabular_classification_sample_in_csv_format.csv"),
+        schema={"feature_00": "FLOAT", "feature_01": "FLOAT", "feature_02": "FLOAT", "label": "INT"},
+        label="label",
+    ), id="tabular_classification"),
+
+    pytest.param(_cfg(
+        table="e2e_tabreg", category="tabular_regression",
+        csv=str(T / "tabular_regression/tabular_regression_sample_in_csv_format.csv"),
+        schema={"square_feet": "FLOAT", "bedrooms": "INT", "age": "INT", "price": "FLOAT"},
+        label={"column": "price", "policy": "bucket"},
+    ), id="tabular_regression"),
+
+    pytest.param(_cfg(
+        table="e2e_img", category="image_classification",
+        csv=str(T / "image_classification/data/labels_file_sample.csv"),
+        images=str(T / "image_classification/data/images"), label="label",
+        spec={"file_options": {"extension": ".jpeg", "target_size": [256, 256]}},
+    ), id="image_classification"),
+
+    pytest.param(_cfg(
+        table="e2e_tsf", category="time_series_forecasting",
+        csv=str(T / "time_series_forecasting/time_series_forecasting_sample_in_csv_format.csv"),
+        schema={"timestamp": "TIMESTAMP", "day_of_week": "INT", "month": "INT",
+                "day_of_month": "INT", "week_of_year": "INT", "is_weekend": "INT", "value": "FLOAT"},
+        label={"column": "value", "policy": "bucket"},
+    ), id="time_series_forecasting"),
+
+    pytest.param(_cfg(
+        table="e2e_kp", category="keypoint_detection",
+        csv=str(T / "keypoint_detection/data/labels_file_sample.csv"),
+        images=str(T / "keypoint_detection/data/images"), label="image_label",
+        target_size=[448, 448], number_of_keypoints=9,
+    ), id="keypoint_detection"),
+
+    # ── known gaps (xfail → tracking ticket; XPASS signals the fix landed) ──
+    pytest.param(_cfg(
+        table="e2e_od", category="object_detection",
+        csv=str(T / "object_detection/data/labels_file_sample.csv"),
+        images=str(T / "object_detection/data/images"),
+        annotations=str(T / "object_detection/data/annotations"), label="image_label",
+    ), id="object_detection",
+        marks=pytest.mark.xfail(reason="bundled VisDrone XML difficult=2 rejected (#135)", strict=False)),
+
+    pytest.param(_cfg(
+        table="e2e_seg", category="semantic_segmentation",
+        csv=str(T / "semantic_segmentation/semantic_data/labels_file_sample.csv"),
+        images=str(T / "semantic_segmentation/semantic_data/images"),
+        masks=str(T / "semantic_segmentation/semantic_data/masks"), label="image_label",
+    ), id="semantic_segmentation",
+        marks=pytest.mark.xfail(reason="mask sidecar not wired in declarative path (#136)", strict=False)),
+
+    pytest.param(_cfg(
+        table="e2e_mlm", category="masked_language_modeling",
+        csv=str(T / "masked_language_modeling/data/labels_file_sample.csv"),
+        sequences=str(T / "masked_language_modeling/data/sequences"),
+    ), id="masked_language_modeling",
+        marks=pytest.mark.xfail(reason="template missing tokenizer.json (#137)", strict=False)),
+]
+
+
+def _connect():
+    return mysql.connector.connect(
+        host=os.environ["MYSQL_HOST"], port=int(os.environ["MYSQL_PORT"]),
+        user=os.environ["DB_USER"], password=os.environ["DB_PASSWORD"],
+        database=os.environ["DB_NAME"],
+    )
+
+
+def _drop(table):
+    conn = _connect(); cur = conn.cursor()
+    cur.execute(f"DROP TABLE IF EXISTS `{table}`")
+    conn.commit(); cur.close(); conn.close()
+
+
+def _rows(table):
+    conn = _connect(); cur = conn.cursor()
+    cur.execute(f"SELECT COUNT(*) FROM `{table}`")
+    n = cur.fetchone()[0]
+    cur.close(); conn.close()
+    return n
+
+
+@pytest.mark.parametrize("cfg", CASES)
+def test_modality_ingests_its_template(cfg, tmp_path, monkeypatch):
+    table = cfg["table"]
+    _drop(table)  # clean slate so the row assertion is deterministic on re-runs
+    config_path = tmp_path / "ingest.yaml"
+    config_path.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("INGEST_CONFIG", str(config_path))
+
+    rc = run.main()
+    assert rc == 0, f"ingest exited {rc} for {cfg['category']}"
+    assert _rows(table) > 0, f"no rows ingested for {cfg['category']}"

--- a/e2e/test_ingest_e2e.py
+++ b/e2e/test_ingest_e2e.py
@@ -83,15 +83,25 @@ CASES = [
         target_size=[448, 448], number_of_keypoints=9,
     ), id="keypoint_detection"),
 
-    # ── known gaps (xfail → tracking ticket; XPASS signals the fix landed) ──
+    # object_detection: now ingests after relaxing the PascalVOC `difficult`
+    # validator (#135a); target_size matched to the bundled VisDrone image.
     pytest.param(_cfg(
         table="e2e_od", category="object_detection",
         csv=str(T / "object_detection/data/labels_file_sample.csv"),
         images=str(T / "object_detection/data/images"),
         annotations=str(T / "object_detection/data/annotations"), label="image_label",
-    ), id="object_detection",
-        marks=pytest.mark.xfail(reason="bundled VisDrone XML difficult=2 rejected (#135)", strict=False)),
+        target_size=[1920, 1080],
+    ), id="object_detection"),
 
+    # masked_language_modeling: now ingests after adding the template's
+    # tokenizer.json (#137).
+    pytest.param(_cfg(
+        table="e2e_mlm", category="masked_language_modeling",
+        csv=str(T / "masked_language_modeling/data/labels_file_sample.csv"),
+        sequences=str(T / "masked_language_modeling/data/sequences"),
+    ), id="masked_language_modeling"),
+
+    # ── known gap (xfail → tracking ticket; XPASS signals the fix landed) ──
     pytest.param(_cfg(
         table="e2e_seg", category="semantic_segmentation",
         csv=str(T / "semantic_segmentation/semantic_data/labels_file_sample.csv"),
@@ -99,13 +109,6 @@ CASES = [
         masks=str(T / "semantic_segmentation/semantic_data/masks"), label="image_label",
     ), id="semantic_segmentation",
         marks=pytest.mark.xfail(reason="mask sidecar not wired in declarative path (#136)", strict=False)),
-
-    pytest.param(_cfg(
-        table="e2e_mlm", category="masked_language_modeling",
-        csv=str(T / "masked_language_modeling/data/labels_file_sample.csv"),
-        sequences=str(T / "masked_language_modeling/data/sequences"),
-    ), id="masked_language_modeling",
-        marks=pytest.mark.xfail(reason="template missing tokenizer.json (#137)", strict=False)),
 ]
 
 

--- a/examples/yaml/custom_processor.yaml
+++ b/examples/yaml/custom_processor.yaml
@@ -17,7 +17,7 @@ kind: IngestConfig
 table: phi_records_train
 intent: train
 category: tabular_classification
-csv: /data/records.csv
+csv: /data/shared/phi-records/records.csv
 schema:
   patient_id: VARCHAR(255)
   age: INT

--- a/examples/yaml/image_classification.yaml
+++ b/examples/yaml/image_classification.yaml
@@ -4,12 +4,14 @@
 #   - default file_options: target_size [512, 512], extension .jpg
 #   - default validators: [FileTypeValidator(images), ImageResolutionValidator,
 #                         TableNameValidator, DuplicateValidator]
-#   - default columns: image_id (data_id source), label (the column you set below)
+#   - required CSV columns: `filename` (image filename, with or without
+#     extension — the default extension above is appended if missing), and
+#     the label column you set below.
 apiVersion: tracebloc.io/v1
 kind: IngestConfig
 table: chest_xrays_train
 intent: train
 category: image_classification
-csv: /data/labels.csv
-images: /data/images/
+csv: /data/shared/chest-xrays/labels.csv
+images: /data/shared/chest-xrays/images/
 label: image_label

--- a/examples/yaml/keypoint_detection.yaml
+++ b/examples/yaml/keypoint_detection.yaml
@@ -10,8 +10,8 @@ kind: IngestConfig
 table: pose_train
 intent: train
 category: keypoint_detection
-csv: /data/labels.csv
-images: /data/images/
+csv: /data/shared/pose/labels.csv
+images: /data/shared/pose/images/
 label: image_label
 target_size: [256, 256]      # height, width — must match your pose model's input
 number_of_keypoints: 9        # e.g. 17 for COCO pose, 9 for the upper-body sample

--- a/examples/yaml/masked_language_modeling.yaml
+++ b/examples/yaml/masked_language_modeling.yaml
@@ -6,5 +6,5 @@ kind: IngestConfig
 table: primekg_mlm_train
 intent: train
 category: masked_language_modeling
-csv: /data/labels_file.csv
-sequences: /data/sequences/
+csv: /data/shared/primekg-mlm/labels_file.csv
+sequences: /data/shared/primekg-mlm/sequences/

--- a/examples/yaml/object_detection.yaml
+++ b/examples/yaml/object_detection.yaml
@@ -6,7 +6,7 @@ kind: IngestConfig
 table: visdrone_train
 intent: train
 category: object_detection
-csv: /data/labels.csv
-images: /data/images/
-annotations: /data/annotations/
+csv: /data/shared/visdrone/labels.csv
+images: /data/shared/visdrone/images/
+annotations: /data/shared/visdrone/annotations/
 label: image_label

--- a/examples/yaml/semantic_segmentation.yaml
+++ b/examples/yaml/semantic_segmentation.yaml
@@ -6,7 +6,7 @@ kind: IngestConfig
 table: tumors_train
 intent: train
 category: semantic_segmentation
-csv: /data/labels.csv
-images: /data/images/
-masks: /data/masks/
+csv: /data/shared/tumors/labels.csv
+images: /data/shared/tumors/images/
+masks: /data/shared/tumors/masks/
 label: image_label

--- a/examples/yaml/tabular_classification.yaml
+++ b/examples/yaml/tabular_classification.yaml
@@ -5,7 +5,7 @@ kind: IngestConfig
 table: churn_train
 intent: train
 category: tabular_classification
-csv: /data/customers.csv
+csv: /data/shared/churn/customers.csv
 schema:
   age: INT
   tenure_months: INT

--- a/examples/yaml/tabular_regression.yaml
+++ b/examples/yaml/tabular_regression.yaml
@@ -7,7 +7,7 @@ kind: IngestConfig
 table: house_prices_train
 intent: train
 category: tabular_regression
-csv: /data/houses.csv
+csv: /data/shared/house-prices/houses.csv
 schema:
   square_feet: FLOAT
   bedrooms: INT

--- a/examples/yaml/text_classification.yaml
+++ b/examples/yaml/text_classification.yaml
@@ -6,8 +6,8 @@ kind: IngestConfig
 table: support_tickets_train
 intent: train
 category: text_classification
-csv: /data/labels.csv
-texts: /data/texts/
+csv: /data/shared/support-tickets/labels.csv
+texts: /data/shared/support-tickets/texts/
 schema:
   text_id: VARCHAR(255)
   label: VARCHAR(64)

--- a/examples/yaml/time_series_forecasting.yaml
+++ b/examples/yaml/time_series_forecasting.yaml
@@ -6,7 +6,7 @@ kind: IngestConfig
 table: energy_demand_train
 intent: train
 category: time_series_forecasting
-csv: /data/demand.csv
+csv: /data/shared/energy-demand/demand.csv
 schema:
   timestamp: VARCHAR(64)
   region: VARCHAR(32)

--- a/examples/yaml/time_to_event_prediction.yaml
+++ b/examples/yaml/time_to_event_prediction.yaml
@@ -6,7 +6,7 @@ kind: IngestConfig
 table: customer_churn_survival_train
 intent: train
 category: time_to_event_prediction
-csv: /data/survival.csv
+csv: /data/shared/customer-churn-survival/survival.csv
 time_column: tenure_days
 schema:
   customer_id: VARCHAR(64)

--- a/templates/image_classification/README.md
+++ b/templates/image_classification/README.md
@@ -61,7 +61,7 @@ image_classification/
 
 ### CSV Labels File
 The CSV contains the following columns:
-- `filename`: Image filename with extension, e.g. `cat1.jpeg`
+- `filename`: Image filename (with or without extension — the configured extension is appended if missing). E.g. `cat1.jpeg` or `cat1`.
 - `label`: Class label for the image, e.g. `cat`, `dog`
 
 ## Advanced: custom processor script

--- a/templates/image_classification/image_classification.py
+++ b/templates/image_classification/image_classification.py
@@ -68,7 +68,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
+                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/image_classification/image_classification.py
+++ b/templates/image_classification/image_classification.py
@@ -68,7 +68,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('image_id', 'Unknown')}"
+                        f"Failed record: {record.get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/keypoint_detection/README.md
+++ b/templates/keypoint_detection/README.md
@@ -56,7 +56,7 @@ keypoint_detection/
 
 ### CSV Labels File
 The CSV file contains the following columns:
-- `filename`: Name of the image file (without extension)
+- `filename`: Image filename (with or without extension — the configured extension is appended if missing)
 - `Annotation`: JSON string with keypoint coordinates as `{"joint_name": [x, y]}` pairs
 - `Visibility`: JSON string with per-keypoint visibility flags as `{"joint_name": 0|1}` (1=visible, 0=occluded/out-of-frame)
 - `image_label`: Class label for the image

--- a/templates/keypoint_detection/keypoint_detection.py
+++ b/templates/keypoint_detection/keypoint_detection.py
@@ -92,7 +92,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('image_id', 'Unknown')}"
+                        f"Failed record: {record.get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/keypoint_detection/keypoint_detection.py
+++ b/templates/keypoint_detection/keypoint_detection.py
@@ -92,7 +92,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
+                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/masked_language_modeling/README.md
+++ b/templates/masked_language_modeling/README.md
@@ -34,6 +34,12 @@ helm install my-mlm-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
+> **If install fails with `'masked_language_modeling' is not one of [...]` or `Additional properties are not allowed ('sequences' was unexpected)`:** your local Helm chart cache is stale. Refresh it and retry:
+>
+> ```bash
+> helm repo update
+> ```
+
 MLM is unsupervised — no `label:` field; the tokenizer validator checks that sequences match the configured vocabulary. Canonical example: [`examples/yaml/masked_language_modeling.yaml`](../../examples/yaml/masked_language_modeling.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure

--- a/templates/masked_language_modeling/README.md
+++ b/templates/masked_language_modeling/README.md
@@ -8,9 +8,9 @@ Ingest with ~7 lines of YAML using the official ingestor image (`ghcr.io/tracebl
 
 > **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
-**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `sequences/` subdirectory holding the per-record `.txt` sequence files.
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `sequences/` subdirectory holding the per-record `.txt` sequence files, plus a `tokenizer.json` at the prefix root (sibling of `sequences/`, **not** inside it). The ingestor auto-discovers the tokenizer by joining `SRC_PATH/tokenizer.json` — `SRC_PATH` is derived as the parent of the `sequences:` directory below, so the location is implicit. See [Tokenizer Requirements](#tokenizer-requirements) for the format rules (must be a HuggingFace tokenizer with `[MASK]` and `[PAD]` in its vocab).
 
-**2. Write `ingest.yaml`:**
+**2. Write `ingest.yaml`** — note there is **no** `tokenizer:` field; the file is discovered automatically:
 
 ```yaml
 apiVersion: tracebloc.io/v1
@@ -18,8 +18,8 @@ kind: IngestConfig
 category: masked_language_modeling
 table: primekg_mlm_train
 intent: train
-csv: /data/shared/primekg/labels_file.csv
-sequences: /data/shared/primekg/sequences/
+csv: /data/shared/primekg-mlm/labels_file.csv
+sequences: /data/shared/primekg-mlm/sequences/
 ```
 
 **3. Install:**
@@ -45,7 +45,8 @@ masked_language_modeling/
     │   ├── seq_0000003.txt
     │   ├── seq_0000004.txt
     │   └── seq_0000005.txt
-    └── labels_file_sample.csv    # CSV manifest mapping filenames to extensions
+    ├── labels_file_sample.csv    # CSV manifest mapping filenames to extensions
+    └── tokenizer.json            # REQUIRED — HuggingFace tokenizer (must include [MASK] and [PAD])
 ```
 
 ## Data Format
@@ -60,6 +61,28 @@ masked_language_modeling/
 MLM is **self-supervised** — no label column is needed. The CSV contains:
 - `filename`: Base name of the text file, without extension (e.g. `seq_0000001`)
 - `extension`: File extension as a quoted string (e.g. `'.txt'`)
+
+## Tokenizer Requirements
+
+MLM ingestion requires a `tokenizer.json` placed at the dataset **root** (sibling of `sequences/`, **not** inside it). The ingestor copies it once from `SRC_PATH` ([`file_transfer.py:369`](../../tracebloc_ingestor/file_transfer.py)), and the training client loads it automatically.
+
+Hard rules (enforced — failing any of these blocks ingestion or training):
+
+- Must be a valid HuggingFace `tokenizer.json`, loadable via `tokenizers.Tokenizer.from_file()`.
+- Must contain **both `[MASK]` and `[PAD]`** in its vocabulary (`model.vocab` or `added_tokens`).
+- These tokens **cannot be added dynamically** — doing so would create token IDs beyond the model's embedding size (`vocab_size`) and crash training with an `IndexError`.
+
+Validation runs twice:
+1. **At ingestion** — [`TokenizerValidator`](../../tracebloc_ingestor/validators/tokenizer_validator.py) checks the file exists, parses as JSON, and contains the required tokens.
+2. **At training load** — the MLM client re-checks `mask_token`/`pad_token` and raises a `ValueError` if either is missing.
+
+### Troubleshooting validation failures
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `tokenizer.json not found` | File missing or not at dataset root | Place `tokenizer.json` alongside `sequences/` |
+| `Invalid JSON in tokenizer.json` | Corrupt / non-JSON file | Regenerate the tokenizer; verify it loads with `Tokenizer.from_file()` |
+| `Tokenizer is missing required special tokens: [MASK], [PAD]` | Tokens absent from vocab | Add `[MASK]` and `[PAD]` to the vocabulary **before** saving the tokenizer |
 
 ## Preprocessing
 
@@ -118,4 +141,12 @@ The script uses the following configuration:
 
 - The `filename` column does **not** include the extension — that's supplied separately via the `extension` column.
 - No `label` column is needed because MLM training is self-supervised (masking is applied on-the-fly by the training client).
-- A `tokenizer.json` file should be placed alongside the data on the dataset path. The MLM client will load it automatically. See the preprocessing scripts for tokenizer generation.
+- `tokenizer.json` must sit at the dataset **root** (sibling of `sequences/`), not inside `sequences/`. See [Tokenizer Requirements](#tokenizer-requirements).
+- Generate the tokenizer with the preprocessing scripts in the `tracebloc-client` repo. After generating, confirm the special tokens are present:
+
+  ```python
+  from tokenizers import Tokenizer
+  tok = Tokenizer.from_file("tokenizer.json")
+  vocab = tok.get_vocab()
+  assert "[MASK]" in vocab and "[PAD]" in vocab, "Missing required special tokens"
+  ```

--- a/templates/masked_language_modeling/README.md
+++ b/templates/masked_language_modeling/README.md
@@ -8,7 +8,11 @@ Ingest with ~7 lines of YAML using the official ingestor image (`ghcr.io/tracebl
 
 > **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
 
-**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `sequences/` subdirectory holding the per-record `.txt` sequence files, plus a `tokenizer.json` at the prefix root (sibling of `sequences/`, **not** inside it). The ingestor auto-discovers the tokenizer by joining `SRC_PATH/tokenizer.json` — `SRC_PATH` is derived as the parent of the `sequences:` directory below, so the location is implicit. See [Tokenizer Requirements](#tokenizer-requirements) for the format rules (must be a HuggingFace tokenizer with `[MASK]` and `[PAD]` in its vocab).
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with:
+- a `sequences/` subdirectory holding the per-record `.txt` sequence files, and
+- **`tokenizer.json` placed in the same folder as your labels CSV** (the prefix root, not inside `sequences/`).
+
+The ingestor auto-discovers `tokenizer.json` from that folder — there is no YAML field for it. See [Tokenizer Requirements](#tokenizer-requirements) for the format rules (must be a HuggingFace tokenizer with `[MASK]` and `[PAD]` in its vocab).
 
 **2. Write `ingest.yaml`** — note there is **no** `tokenizer:` field; the file is discovered automatically:
 
@@ -46,7 +50,7 @@ masked_language_modeling/
     │   ├── seq_0000004.txt
     │   └── seq_0000005.txt
     ├── labels_file_sample.csv    # CSV manifest mapping filenames to extensions
-    └── tokenizer.json            # REQUIRED — HuggingFace tokenizer (must include [MASK] and [PAD])
+    └── tokenizer.json            # REQUIRED — same folder as the labels CSV; HuggingFace tokenizer with [MASK] and [PAD]
 ```
 
 ## Data Format
@@ -64,7 +68,7 @@ MLM is **self-supervised** — no label column is needed. The CSV contains:
 
 ## Tokenizer Requirements
 
-MLM ingestion requires a `tokenizer.json` placed at the dataset **root** (sibling of `sequences/`, **not** inside it). The ingestor copies it once from `SRC_PATH` ([`file_transfer.py:369`](../../tracebloc_ingestor/file_transfer.py)), and the training client loads it automatically.
+MLM ingestion requires a `tokenizer.json` placed **in the same folder as your labels CSV** (the dataset prefix root — not inside `sequences/`). The ingestor copies it once from there ([`file_transfer.py:369`](../../tracebloc_ingestor/file_transfer.py)), and the training client loads it automatically.
 
 Hard rules (enforced — failing any of these blocks ingestion or training):
 
@@ -80,7 +84,7 @@ Validation runs twice:
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `tokenizer.json not found` | File missing or not at dataset root | Place `tokenizer.json` alongside `sequences/` |
+| `tokenizer.json not found` | File missing or in the wrong folder | Place `tokenizer.json` in the same folder as your labels CSV |
 | `Invalid JSON in tokenizer.json` | Corrupt / non-JSON file | Regenerate the tokenizer; verify it loads with `Tokenizer.from_file()` |
 | `Tokenizer is missing required special tokens: [MASK], [PAD]` | Tokens absent from vocab | Add `[MASK]` and `[PAD]` to the vocabulary **before** saving the tokenizer |
 
@@ -141,7 +145,7 @@ The script uses the following configuration:
 
 - The `filename` column does **not** include the extension — that's supplied separately via the `extension` column.
 - No `label` column is needed because MLM training is self-supervised (masking is applied on-the-fly by the training client).
-- `tokenizer.json` must sit at the dataset **root** (sibling of `sequences/`), not inside `sequences/`. See [Tokenizer Requirements](#tokenizer-requirements).
+- `tokenizer.json` must sit **in the same folder as your labels CSV** (not inside `sequences/`). See [Tokenizer Requirements](#tokenizer-requirements).
 - Generate the tokenizer with the preprocessing scripts in the `tracebloc-client` repo. After generating, confirm the special tokens are present:
 
   ```python

--- a/templates/masked_language_modeling/data/tokenizer.json
+++ b/templates/masked_language_modeling/data/tokenizer.json
@@ -1,0 +1,31 @@
+{
+  "version": "1.0",
+  "model": {
+    "type": "WordLevel",
+    "unk_token": "[UNK]",
+    "vocab": {
+      "[PAD]": 0,
+      "[UNK]": 1,
+      "[CLS]": 2,
+      "[SEP]": 3,
+      "[MASK]": 4,
+      "the": 5,
+      "a": 6,
+      "is": 7,
+      "of": 8,
+      "and": 9,
+      "to": 10,
+      "in": 11,
+      "protein": 12,
+      "gene": 13,
+      "disease": 14
+    }
+  },
+  "added_tokens": [
+    {"id": 0, "content": "[PAD]", "special": true},
+    {"id": 1, "content": "[UNK]", "special": true},
+    {"id": 2, "content": "[CLS]", "special": true},
+    {"id": 3, "content": "[SEP]", "special": true},
+    {"id": 4, "content": "[MASK]", "special": true}
+  ]
+}

--- a/templates/object_detection/README.md
+++ b/templates/object_detection/README.md
@@ -67,7 +67,7 @@ object_detection/
 ### CSV Labels File
 The CSV file contains the following columns:
 - `object_id`: Unique identifier for each object (format: `{image_name}_obj_{index}`)
-- `image_id`: Name of the image file (without extension)
+- `filename`: Image filename (with or without extension — the configured extension is appended if missing)
 - `image_label`: Class label of the object
 - `object_count`: Number of objects in the image (always 1 for individual objects)
 

--- a/templates/object_detection/object_detection.py
+++ b/templates/object_detection/object_detection.py
@@ -73,7 +73,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('image_id', 'Unknown')}"
+                        f"Failed record: {record.get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/object_detection/object_detection.py
+++ b/templates/object_detection/object_detection.py
@@ -73,7 +73,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
+                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/semantic_segmentation/README.md
+++ b/templates/semantic_segmentation/README.md
@@ -71,8 +71,8 @@ semantic_segmentation/
 
 ### CSV Labels File
 The CSV file contains the following columns:
-- `filename`: Name of the image file (without extension)
-- `mask_id`: Name of the corresponding mask file (without extension)
+- `filename`: Image filename (with or without extension — the configured extension is appended if missing)
+- `mask_id`: Corresponding mask filename (with or without extension — `.png` is appended if missing)
 - `image_label`: Class label present in the image (one row per class per image)
 
 Example:

--- a/templates/semantic_segmentation/semantic_segmentation.py
+++ b/templates/semantic_segmentation/semantic_segmentation.py
@@ -77,7 +77,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('image_id', 'Unknown')}"
+                        f"Failed record: {record.get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/templates/semantic_segmentation/semantic_segmentation.py
+++ b/templates/semantic_segmentation/semantic_segmentation.py
@@ -77,7 +77,7 @@ def main():
                 logger.warning(f"Failed to process {len(failed_records)} records")
                 for record in failed_records:
                     logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
+                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
                     )
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,167 @@
+"""Shared fixtures for the test suite.
+
+Validators and ingestors snapshot ``config = Config()`` at import time but
+read ``os.environ`` lazily on each property access, so tests set env vars via
+``monkeypatch.setenv`` and the module-level config picks them up. The
+``clean_env`` fixture strips the env vars these tests touch so a developer's
+shell environment can't leak into a run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+
+_ENV_VARS = (
+    "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
+    "BACKEND_TOKEN", "CLIENT_ID", "CLIENT_PASSWORD",
+    "CLIENT_ENV", "LOG_LEVEL", "BATCH_SIZE",
+    "MYSQL_HOST", "MYSQL_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Strip env vars the ingestor config reads, so the host shell can't leak in."""
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+@pytest.fixture
+def make_csv(tmp_path):
+    """Write rows to a temp CSV and return its path.
+
+    Accepts either a pandas DataFrame or a list-of-dicts. ``name`` lets a
+    single test create several distinct files.
+    """
+
+    def _make(rows, name: str = "data.csv") -> Path:
+        df = rows if isinstance(rows, pd.DataFrame) else pd.DataFrame(rows)
+        path = tmp_path / name
+        df.to_csv(path, index=False)
+        return path
+
+    return _make
+
+
+@pytest.fixture
+def make_voc_xml(tmp_path):
+    """Write a Pascal VOC annotation XML and return its path.
+
+    ``objects`` is a list of dicts with keys: name, xmin, ymin, xmax, ymax.
+    Pass ``raw=`` to write arbitrary XML text instead (for malformed cases).
+    """
+
+    def _make(
+        objects: Optional[Sequence[Dict[str, Any]]] = None,
+        *,
+        filename: str = "img.jpg",
+        width: int = 640,
+        height: int = 480,
+        depth: int = 3,
+        name: str = "ann.xml",
+        raw: Optional[str] = None,
+    ) -> Path:
+        path = tmp_path / name
+        if raw is not None:
+            path.write_text(raw, encoding="utf-8")
+            return path
+
+        obj_xml = ""
+        for obj in objects or []:
+            obj_xml += f"""
+  <object>
+    <name>{obj['name']}</name>
+    <bndbox>
+      <xmin>{obj['xmin']}</xmin>
+      <ymin>{obj['ymin']}</ymin>
+      <xmax>{obj['xmax']}</xmax>
+      <ymax>{obj['ymax']}</ymax>
+    </bndbox>
+  </object>"""
+
+        xml = f"""<annotation>
+  <filename>{filename}</filename>
+  <size>
+    <width>{width}</width>
+    <height>{height}</height>
+    <depth>{depth}</depth>
+  </size>{obj_xml}
+</annotation>"""
+        path.write_text(xml, encoding="utf-8")
+        return path
+
+    return _make
+
+
+@pytest.fixture
+def make_tokenizer(tmp_path):
+    """Write a HuggingFace-style tokenizer.json into a dir, return that dir.
+
+    ``vocab`` is the model.vocab token list; ``added`` is the added_tokens
+    content list. Pass ``raw=`` to write invalid JSON.
+    """
+
+    def _make(
+        vocab: Optional[Sequence[str]] = ("hello", "world", "[MASK]", "[PAD]"),
+        added: Optional[Sequence[str]] = None,
+        *,
+        subdir: str = "src",
+        raw: Optional[str] = None,
+    ) -> Path:
+        src = tmp_path / subdir
+        src.mkdir(parents=True, exist_ok=True)
+        path = src / "tokenizer.json"
+        if raw is not None:
+            path.write_text(raw, encoding="utf-8")
+            return src
+
+        body: Dict[str, Any] = {"model": {}}
+        if vocab is not None:
+            body["model"]["vocab"] = {tok: i for i, tok in enumerate(vocab)}
+        if added is not None:
+            body["added_tokens"] = [{"content": t} for t in added]
+        path.write_text(json.dumps(body), encoding="utf-8")
+        return src
+
+    return _make
+
+
+@pytest.fixture
+def make_image(tmp_path):
+    """Write a solid-color image of a given size and return its path."""
+    from PIL import Image
+
+    def _make(
+        size=(64, 64),
+        *,
+        name: str = "img.jpg",
+        color=(128, 128, 128),
+        mode: str = "RGB",
+    ) -> Path:
+        path = tmp_path / name
+        Image.new(mode, size, color).save(path)
+        return path
+
+    return _make
+
+
+@pytest.fixture
+def mock_database():
+    """A MagicMock standing in for tracebloc_ingestor.database.Database."""
+    db = MagicMock(name="Database")
+    return db
+
+
+@pytest.fixture
+def mock_api_client():
+    """A MagicMock standing in for tracebloc_ingestor.api.client.APIClient."""
+    api = MagicMock(name="APIClient")
+    return api

--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -19,8 +19,10 @@ from tracebloc_ingestor.utils.constants import TaskCategory
 
 
 def _client(**overrides):
+    # TITLE=None by default so create_dataset's title-generation path is
+    # deterministic regardless of any TITLE exported in the host/CI env.
     defaults = dict(BACKEND_TOKEN="tok", CLIENT_USERNAME=None,
-                    CLIENT_PASSWORD=None, EDGE_ENV="prod")
+                    CLIENT_PASSWORD=None, EDGE_ENV="prod", TITLE=None)
     defaults.update(overrides)
     return APIClient(Config(**defaults))
 

--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -28,7 +28,7 @@ def _client(**overrides):
 def _resp(status=200, json_body=None, text=""):
     r = MagicMock()
     r.status_code = status
-    r.json.return_value = json_body or {}
+    r.json.return_value = json_body if json_body is not None else {}
     r.text = text
     return r
 

--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -1,0 +1,208 @@
+"""Tests for APIClient request methods (send_batch, metadata, prepare, create).
+
+Auth boot paths are covered in test_api_client_auth.py. Here we build a client
+with BACKEND_TOKEN set (so __init__ does no network call) and patch the
+session's get/post to exercise each method's success / error / local-mode path.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.api.client import APIClient
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+def _client(**overrides):
+    defaults = dict(BACKEND_TOKEN="tok", CLIENT_USERNAME=None,
+                    CLIENT_PASSWORD=None, EDGE_ENV="prod")
+    defaults.update(overrides)
+    return APIClient(Config(**defaults))
+
+
+def _resp(status=200, json_body=None, text=""):
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = json_body or {}
+    r.text = text
+    return r
+
+
+# ---------------------------------------------------------------------------
+# authenticate() error path
+# ---------------------------------------------------------------------------
+
+def test_authenticate_http_error_raises():
+    cfg = Config(BACKEND_TOKEN=None, CLIENT_USERNAME="u",
+                 CLIENT_PASSWORD="p", EDGE_ENV="prod")
+    with patch("requests.Session.post", return_value=_resp(403, text="forbidden")):
+        with pytest.raises(ValueError) as exc:
+            APIClient(cfg)
+    # The manually-raised HTTPError carries no .response, so the client
+    # falls through to the generic "Error response" branch.
+    assert "403" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# send_batch
+# ---------------------------------------------------------------------------
+
+def test_send_batch_success():
+    client = _client()
+    records = [(1, {"data_id": "a", "label": "cat"}), (2, {"data_id": "b"})]
+    with patch.object(client.session, "post", return_value=_resp(200)) as post:
+        assert client.send_batch(records, "tbl", ingestor_id="ing") is True
+    post.assert_called_once()
+    assert "/global_meta/tbl/" in post.call_args[0][0]
+
+
+def test_send_batch_http_error_returns_false():
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(500, text="boom")):
+        assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+
+
+def test_send_batch_local_mode_skips_network():
+    client = _client(EDGE_ENV="local")
+    with patch.object(client.session, "post") as post:
+        assert client.send_batch([(1, {})], "tbl", "ing") is True
+    post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# send_global_meta_meta
+# ---------------------------------------------------------------------------
+
+def test_send_global_meta_success():
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(200, {"ok": 1})):
+        assert client.send_global_meta_meta("tbl", {"a": "INT"}, {"k": "v"}) is True
+
+
+def test_send_global_meta_error_returns_false():
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(400, text="bad")):
+        assert client.send_global_meta_meta("tbl", {}, {}) is False
+
+
+def test_send_global_meta_local_mode():
+    client = _client(EDGE_ENV="local")
+    with patch.object(client.session, "post") as post:
+        assert client.send_global_meta_meta("tbl", {}, {}) is True
+    post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# send_generate_edge_label_meta
+# ---------------------------------------------------------------------------
+
+def test_generate_edge_label_success():
+    client = _client()
+    with patch.object(client.session, "get", return_value=_resp(200)) as get:
+        assert client.send_generate_edge_label_meta("tbl", "ing", "train") is True
+    assert "generate-edge-labels-meta" in get.call_args[0][0]
+
+
+def test_generate_edge_label_error_returns_false():
+    client = _client()
+    with patch.object(client.session, "get", return_value=_resp(503, text="down")):
+        assert client.send_generate_edge_label_meta("tbl", "ing", "train") is False
+
+
+def test_generate_edge_label_local_mode():
+    client = _client(EDGE_ENV="local")
+    with patch.object(client.session, "get") as get:
+        assert client.send_generate_edge_label_meta("tbl", "ing", "train") is True
+    get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# prepare_dataset
+# ---------------------------------------------------------------------------
+
+def test_prepare_dataset_success():
+    client = _client()
+    with patch.object(client.session, "get", return_value=_resp(200, {"ok": 1})):
+        assert client.prepare_dataset(
+            TaskCategory.IMAGE_CLASSIFICATION, "ing", "image", "train"
+        ) is True
+
+
+def test_prepare_dataset_invalid_category_returns_false():
+    client = _client()
+    with patch.object(client.session, "get") as get:
+        assert client.prepare_dataset("nonsense", "ing", "image", "train") is False
+    get.assert_not_called()
+
+
+def test_prepare_dataset_error_returns_false():
+    client = _client()
+    with patch.object(client.session, "get", return_value=_resp(500, text="x")):
+        assert client.prepare_dataset(
+            TaskCategory.IMAGE_CLASSIFICATION, "ing", "image", "train"
+        ) is False
+
+
+def test_prepare_dataset_local_mode():
+    client = _client(EDGE_ENV="local")
+    with patch.object(client.session, "get") as get:
+        assert client.prepare_dataset("anything", "ing", "image", "train") is True
+    get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# create_dataset
+# ---------------------------------------------------------------------------
+
+def test_create_dataset_success_generates_title():
+    client = _client()
+    captured = {}
+
+    def fake_post(url, data=None, headers=None, timeout=None):
+        captured["data"] = data
+        return _resp(200, {"id": 7})
+
+    with patch.object(client.session, "post", side_effect=fake_post):
+        result = client.create_dataset(
+            ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
+        )
+    assert result == {"id": 7}
+    assert "image_classification_ing" in captured["data"]
+
+
+def test_create_dataset_tabular_allows_feature_modification():
+    client = _client()
+    captured = {}
+    with patch.object(client.session, "post",
+                      side_effect=lambda url, data=None, **k: captured.update(data=data) or _resp(200, {"id": 1})):
+        client.create_dataset(ingestor_id="ing", category=TaskCategory.TABULAR_CLASSIFICATION)
+    assert '"allow_feature_modification": true' in captured["data"]
+
+
+def test_create_dataset_uses_config_title():
+    client = _client(TITLE="My Title")
+    captured = {}
+    with patch.object(client.session, "post",
+                      side_effect=lambda url, data=None, **k: captured.update(data=data) or _resp(200, {"id": 1})):
+        client.create_dataset(ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION)
+    assert "My Title" in captured["data"]
+
+
+def test_create_dataset_error_raises():
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(500, text="err")):
+        with pytest.raises(requests.exceptions.RequestException):
+            client.create_dataset(ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION)
+
+
+def test_create_dataset_local_mode():
+    client = _client(EDGE_ENV="local")
+    with patch.object(client.session, "post") as post:
+        result = client.create_dataset(ingestor_id="ing", category="x")
+    assert result["id"] == "mock_dataset_id"
+    post.assert_not_called()

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -164,7 +164,7 @@ def test_csv_happy_path(clean_env, mock_runtime, monkeypatch):
     csv_instance = mock_runtime["CSVIngestor"].return_value
     csv_instance.ingest.assert_called_once()
     args, kwargs = csv_instance.ingest.call_args
-    assert args[0] == "/data/labels.csv"
+    assert args[0] == "/data/shared/chest-xrays/labels.csv"
     assert kwargs.get("batch_size") == 4000
 
 
@@ -364,10 +364,10 @@ def test_legacy_env_vars_set_before_config_construction(
     main()
 
     assert captured_env["TABLE_NAME"] == "chest_xrays_train"
-    assert captured_env["LABEL_FILE"] == "/data/labels.csv"
+    assert captured_env["LABEL_FILE"] == "/data/shared/chest-xrays/labels.csv"
     # SRC_PATH = parent of `images:` dir, since file_transfer.py joins
     # SRC_PATH/images/<filename>.
-    assert captured_env["SRC_PATH"] == "/data"
+    assert captured_env["SRC_PATH"] == "/data/shared/chest-xrays"
 
 
 def test_file_transfer_config_reads_env_lazily(clean_env, mock_runtime, monkeypatch):
@@ -395,8 +395,8 @@ def test_file_transfer_config_reads_env_lazily(clean_env, mock_runtime, monkeypa
     main()
 
     assert file_transfer.config.TABLE_NAME == "chest_xrays_train"
-    assert file_transfer.config.LABEL_FILE == "/data/labels.csv"
-    assert file_transfer.config.SRC_PATH == "/data"
+    assert file_transfer.config.LABEL_FILE == "/data/shared/chest-xrays/labels.csv"
+    assert file_transfer.config.SRC_PATH == "/data/shared/chest-xrays"
     # DEST_PATH is derived from STORAGE_PATH/<table> via property — no
     # in-place patching needed.
     assert file_transfer.config.DEST_PATH == os.path.join(storage_path, "chest_xrays_train")

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -77,14 +77,14 @@ def test_image_classification_data_format():
     r = resolve(_load("image_classification.yaml"))
     assert r.data_format == DataFormat.IMAGE
     assert r.source_type == "csv"
-    assert r.source_path == "/data/labels.csv"
-    assert r.images == "/data/images/"
+    assert r.source_path == "/data/shared/chest-xrays/labels.csv"
+    assert r.images == "/data/shared/chest-xrays/images/"
 
 
 def test_text_classification_data_format():
     r = resolve(_load("text_classification.yaml"))
     assert r.data_format == DataFormat.TEXT
-    assert r.texts == "/data/texts/"
+    assert r.texts == "/data/shared/support-tickets/texts/"
 
 
 def test_tabular_classification_data_format():
@@ -100,16 +100,16 @@ def test_time_series_data_format_is_tabular():
 
 def test_object_detection_sidecars_set():
     r = resolve(_load("object_detection.yaml"))
-    assert r.images == "/data/images/"
-    assert r.annotations == "/data/annotations/"
+    assert r.images == "/data/shared/visdrone/images/"
+    assert r.annotations == "/data/shared/visdrone/annotations/"
     assert r.masks is None
     assert r.texts is None
 
 
 def test_semantic_segmentation_sidecars_set():
     r = resolve(_load("semantic_segmentation.yaml"))
-    assert r.images == "/data/images/"
-    assert r.masks == "/data/masks/"
+    assert r.images == "/data/shared/tumors/images/"
+    assert r.masks == "/data/shared/tumors/masks/"
     assert r.annotations is None
 
 

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -1,0 +1,499 @@
+"""Targeted tests closing the long tail of exception / edge branches.
+
+These exist to exercise defensive error paths and small helpers that the
+behavioural tests don't reach, pushing module coverage toward 100%.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+import requests
+from requests.packages.urllib3.util.retry import Retry
+
+from tracebloc_ingestor.utils.constants import DataFormat, TaskCategory
+from tracebloc_ingestor.utils.logging import setup_logging
+from tracebloc_ingestor.config import Config
+
+
+# ===========================================================================
+# utils: constants, logging
+# ===========================================================================
+
+def test_dataformat_helpers():
+    formats = DataFormat.get_all_formats()
+    assert DataFormat.IMAGE in formats
+    assert DataFormat.is_valid_format(DataFormat.TABULAR) is True
+    assert DataFormat.is_valid_format("nonsense") is False
+
+
+def test_setup_logging_without_config():
+    setup_logging(None)  # exercises the default-level else branch
+    assert logging.getLogger().handlers
+
+
+def test_config_log_level_string_override():
+    assert Config(LOG_LEVEL="DEBUG").LOG_LEVEL == logging.DEBUG
+
+
+# ===========================================================================
+# cli: conventions, run
+# ===========================================================================
+
+def test_data_format_for_unknown_raises():
+    from tracebloc_ingestor.cli.conventions import _data_format_for
+    with pytest.raises(ValueError):
+        _data_format_for("not_a_category")
+
+
+def test_build_ingestor_unknown_source_type_raises():
+    from tracebloc_ingestor.cli import run as run_mod
+    from tracebloc_ingestor.cli.conventions import ResolvedConfig
+    resolved = ResolvedConfig(
+        category=None, table_name="t", intent="train",
+        data_format="image", source_type="parquet", source_path="/x",
+    )
+    with pytest.raises(ValueError, match="Unknown source_type"):
+        run_mod._build_ingestor(MagicMock(), MagicMock(), resolved)
+
+
+# ===========================================================================
+# validators/base: BaseValidator helpers
+# ===========================================================================
+
+from tracebloc_ingestor.validators.base import BaseValidator, ValidationResult
+
+
+class _Concrete(BaseValidator):
+    def validate(self, data, **kwargs):
+        return self._create_result(True)
+
+
+def test_base_validator_load_data_dataframe_passthrough():
+    v = _Concrete("x")
+    df = pd.DataFrame({"a": [1]})
+    assert v._load_data(df) is df
+
+
+def test_base_validator_load_data_reads_csv(make_csv):
+    v = _Concrete("x")
+    path = make_csv({"a": [1, 2]})
+    loaded = v._load_data(str(path))
+    assert len(loaded) == 2
+
+
+def test_base_validator_load_data_unsupported_returns_none():
+    assert _Concrete("x")._load_data(12345) is None
+
+
+def test_base_validator_load_data_bad_path_returns_none():
+    assert _Concrete("x")._load_data("/no/such/file.csv") is None
+
+
+def test_base_validator_parse_json_valid():
+    v = _Concrete("x")
+    assert v._parse_json({"c": '{"a": 1}'}, "c") == {"a": 1}
+
+
+def test_base_validator_parse_json_nan_returns_none():
+    v = _Concrete("x")
+    assert v._parse_json({"c": float("nan")}, "c") is None
+
+
+def test_base_validator_parse_json_bad_returns_none():
+    v = _Concrete("x")
+    assert v._parse_json({"c": "{bad"}, "c") is None
+
+
+def test_base_validator_str_and_repr():
+    v = _Concrete("My Validator")
+    assert "My Validator" in str(v)
+    assert "my_validator_validator" in repr(v)
+
+
+# ===========================================================================
+# validators_mapping: schema branches
+# ===========================================================================
+
+def test_text_classification_with_schema_adds_data_validator():
+    from tracebloc_ingestor.utils.validators_mapping import map_validators
+    from tracebloc_ingestor.validators.data_validator import DataValidator
+    v = map_validators(TaskCategory.TEXT_CLASSIFICATION, {"schema": {"a": "INT"}})
+    assert any(isinstance(x, DataValidator) for x in v)
+
+
+def test_mlm_with_schema_adds_data_validator():
+    from tracebloc_ingestor.utils.validators_mapping import map_validators
+    from tracebloc_ingestor.validators.data_validator import DataValidator
+    v = map_validators(TaskCategory.MASKED_LANGUAGE_MODELING, {"schema": {"a": "INT"}})
+    assert any(isinstance(x, DataValidator) for x in v)
+
+
+# ===========================================================================
+# data_validator: edge branches
+# ===========================================================================
+
+from tracebloc_ingestor.validators.data_validator import DataValidator
+
+
+def test_data_validator_load_non_csv_returns_none():
+    assert DataValidator(schema={"a": "INT"})._load_data("/x.parquet", 100) is None
+
+
+def test_data_validator_load_bad_path_returns_none():
+    # .csv path that doesn't exist -> read raises -> None
+    assert DataValidator(schema={"a": "INT"})._load_data("/no/such.csv", 100) is None
+
+
+def test_data_validator_validate_exception_path():
+    v = DataValidator(schema={"a": "INT"})
+    # _load_data raising bubbles into the outer except.
+    with patch.object(v, "_load_data", side_effect=RuntimeError("boom")):
+        result = v.validate(pd.DataFrame({"a": [1]}))
+    assert not result.is_valid
+    assert "validation error" in result.errors[0].lower()
+
+
+def test_data_validator_boolean_other_dtype():
+    # datetime dtype hits the catch-all boolean branch.
+    df = pd.DataFrame({"b": pd.to_datetime(["2024-01-01", "2024-01-02"])})
+    result = DataValidator(schema={"b": "BOOLEAN"}).validate(df)
+    assert not result.is_valid
+
+
+def test_data_validator_date_exception(monkeypatch):
+    v = DataValidator(schema={"d": "DATE"})
+    with patch("tracebloc_ingestor.validators.data_validator.pd.to_datetime",
+               side_effect=RuntimeError("bad")):
+        res = v._validate_date(pd.Series(["2024-01-01"]), "d", "DATE")
+    assert not res["is_valid"]
+
+
+# ===========================================================================
+# duplicate_validator: exception fallbacks
+# ===========================================================================
+
+from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
+
+
+def test_duplicate_validate_exception(monkeypatch):
+    v = DuplicateValidator(dest_path="/x")
+    with patch.object(v, "_check_directory_exists", side_effect=RuntimeError("boom")):
+        res = v.validate(None)
+    assert not res.is_valid
+    assert "Duplicate validation error" in res.errors[0]
+
+
+def test_duplicate_check_directory_exists_exception():
+    v = DuplicateValidator(dest_path="/x")
+    with patch("tracebloc_ingestor.validators.duplicate_validator.Path",
+               side_effect=RuntimeError("boom")):
+        assert v._check_directory_exists() is False
+
+
+def test_duplicate_create_directory_exception():
+    v = DuplicateValidator(dest_path="/x")
+    with patch("tracebloc_ingestor.validators.duplicate_validator.Path",
+               side_effect=RuntimeError("boom")):
+        assert v._create_directory_if_needed() is False
+
+
+# ===========================================================================
+# table_name / tokenizer / keypoint / numeric: outer except
+# ===========================================================================
+
+def test_table_name_validate_exception():
+    from tracebloc_ingestor.validators.table_name_validator import TableNameValidator
+    v = TableNameValidator()
+    with patch.object(v, "_validate_table_names", side_effect=RuntimeError("boom")):
+        res = v.validate(None)
+    assert not res.is_valid
+
+
+def test_tokenizer_validate_generic_exception(clean_env, make_tokenizer):
+    from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
+    src = make_tokenizer(vocab=["[MASK]", "[PAD]"])
+    clean_env.setenv("SRC_PATH", str(src))
+    v = TokenizerValidator()
+    with patch.object(v, "_extract_vocab", side_effect=RuntimeError("boom")):
+        res = v.validate(None)
+    assert not res.is_valid
+
+
+def test_keypoint_annotation_validate_exception():
+    from tracebloc_ingestor.validators.keypoint_annotation_validator import (
+        KeypointAnnotationValidator,
+    )
+    v = KeypointAnnotationValidator()
+    with patch.object(v, "_load_data", side_effect=RuntimeError("boom")):
+        res = v.validate("x")
+    assert not res.is_valid
+
+
+def test_keypoint_visibility_validate_exception():
+    from tracebloc_ingestor.validators.keypoint_visibility_validator import (
+        KeypointVisibilityValidator,
+    )
+    v = KeypointVisibilityValidator()
+    with patch.object(v, "_load_data", side_effect=RuntimeError("boom")):
+        res = v.validate("x")
+    assert not res.is_valid
+
+
+def test_numeric_columns_validate_exception():
+    from tracebloc_ingestor.validators.numeric_columns_validator import (
+        NumericColumnsValidator,
+    )
+    v = NumericColumnsValidator(schema={"a": "INT"})
+    with patch.object(v, "_load_data", side_effect=RuntimeError("boom")):
+        res = v.validate("x")
+    assert not res.is_valid
+
+
+def test_numeric_columns_load_bad_path_returns_none():
+    from tracebloc_ingestor.validators.numeric_columns_validator import (
+        NumericColumnsValidator,
+    )
+    assert NumericColumnsValidator()._load_data("/no/such.csv") is None
+
+
+# ===========================================================================
+# time validators: outer except + _load_data None paths
+# ===========================================================================
+
+@pytest.mark.parametrize("modname,clsname", [
+    ("time_format_validator", "TimeFormatValidator"),
+    ("time_ordered_validator", "TimeOrderedValidator"),
+    ("time_before_today_validator", "TimeBeforeTodayValidator"),
+])
+def test_time_validators_generic_exception(make_csv, modname, clsname):
+    mod = importlib.import_module(f"tracebloc_ingestor.validators.{modname}")
+    cls = getattr(mod, clsname)
+    v = cls()
+    path = make_csv({"timestamp": ["2024-01-01"]})
+    with patch.object(v, "_load_data", side_effect=RuntimeError("boom")):
+        res = v.validate(str(path))
+    assert not res.is_valid
+
+
+@pytest.mark.parametrize("modname,clsname", [
+    ("time_format_validator", "TimeFormatValidator"),
+    ("time_ordered_validator", "TimeOrderedValidator"),
+    ("time_before_today_validator", "TimeBeforeTodayValidator"),
+])
+def test_time_validators_load_non_csv_none(modname, clsname):
+    mod = importlib.import_module(f"tracebloc_ingestor.validators.{modname}")
+    v = getattr(mod, clsname)()
+    assert v._load_data("/x.parquet") is None
+
+
+def test_time_before_today_empty_after_dropna(make_csv):
+    from tracebloc_ingestor.validators.time_before_today_validator import (
+        TimeBeforeTodayValidator,
+    )
+    # all-invalid timestamps -> valid set empty -> skips future check, stays valid
+    path = make_csv({"timestamp": ["not-a-date", "also-bad"]})
+    res = TimeBeforeTodayValidator().validate(str(path))
+    assert res.is_valid
+
+
+def test_time_to_event_load_unsupported_type():
+    from tracebloc_ingestor.validators.time_to_event_validator import TimeToEventValidator
+    assert TimeToEventValidator()._load_data(12345, None) is None
+
+
+def test_time_to_event_load_non_csv():
+    from tracebloc_ingestor.validators.time_to_event_validator import TimeToEventValidator
+    assert TimeToEventValidator()._load_data("/x.parquet", None) is None
+
+
+def test_time_to_event_generic_exception():
+    from tracebloc_ingestor.validators.time_to_event_validator import TimeToEventValidator
+    v = TimeToEventValidator()
+    with patch.object(v, "_load_data", side_effect=RuntimeError("boom")):
+        res = v.validate(pd.DataFrame({"time": [1]}))
+    assert not res.is_valid
+
+
+# ===========================================================================
+# image_validator: PIL-not-available + small branches
+# ===========================================================================
+
+def test_image_validator_pil_unavailable(monkeypatch, clean_env):
+    from tracebloc_ingestor.validators import image_validator as iv
+    monkeypatch.setattr(iv, "PIL_AVAILABLE", False)
+    clean_env.setenv("SRC_PATH", "/tmp")
+    res = iv.ImageResolutionValidator().validate(None)
+    assert not res.is_valid
+    assert any("PIL" in e for e in res.errors)
+
+
+def test_image_validator_list_with_non_image(tmp_path):
+    from tracebloc_ingestor.validators.image_validator import ImageResolutionValidator
+    txt = tmp_path / "a.txt"
+    txt.write_text("x")
+    v = ImageResolutionValidator()
+    # a list with a non-image file -> warning branch, returns empty list
+    assert v._get_image_files([str(txt)], True, True) == []
+
+
+def test_image_validator_list_with_non_path_item():
+    from tracebloc_ingestor.validators.image_validator import ImageResolutionValidator
+    v = ImageResolutionValidator()
+    assert v._get_image_files([123], True, True) == []
+
+
+# ===========================================================================
+# api/client: error-response branches + LoggingRetry
+# ===========================================================================
+
+from tracebloc_ingestor.api.client import APIClient, LoggingRetry
+
+
+def _client(**ov):
+    d = dict(BACKEND_TOKEN="tok", CLIENT_USERNAME=None, CLIENT_PASSWORD=None, EDGE_ENV="prod")
+    d.update(ov)
+    return APIClient(Config(**d))
+
+
+def _err_with_response():
+    err = requests.exceptions.HTTPError("boom")
+    err.response = MagicMock(text="server detail")
+    return err
+
+
+def test_logging_retry_increment():
+    with patch.object(Retry, "increment", return_value=MagicMock(total=1)):
+        r = LoggingRetry(total=3)
+        r.increment(method="GET", url="http://x")
+
+
+def test_authenticate_error_with_response_text():
+    cfg = Config(BACKEND_TOKEN=None, CLIENT_USERNAME="u", CLIENT_PASSWORD="p", EDGE_ENV="prod")
+    with patch("requests.Session.post", side_effect=_err_with_response()):
+        with pytest.raises(ValueError, match="Authentication failed"):
+            APIClient(cfg)
+
+
+def test_send_batch_error_with_response_text():
+    client = _client()
+    with patch.object(client.session, "post", side_effect=_err_with_response()):
+        assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+
+
+def test_send_global_meta_error_with_response_text():
+    client = _client()
+    with patch.object(client.session, "post", side_effect=_err_with_response()):
+        assert client.send_global_meta_meta("tbl", {}, {}) is False
+
+
+def test_generate_edge_label_error_with_response_text():
+    client = _client()
+    with patch.object(client.session, "get", side_effect=_err_with_response()):
+        assert client.send_generate_edge_label_meta("tbl", "ing", "train") is False
+
+
+def test_prepare_dataset_error_with_response_text():
+    client = _client()
+    with patch.object(client.session, "get", side_effect=_err_with_response()):
+        assert client.prepare_dataset(
+            TaskCategory.IMAGE_CLASSIFICATION, "ing", "image", "train"
+        ) is False
+
+
+def test_create_dataset_error_with_response_text():
+    client = _client()
+    with patch.object(client.session, "post", side_effect=_err_with_response()):
+        with pytest.raises(requests.exceptions.RequestException):
+            client.create_dataset(ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION)
+
+
+# ===========================================================================
+# file_transfer: copy-failure except branches
+# ===========================================================================
+
+from tracebloc_ingestor import file_transfer
+
+
+@pytest.fixture
+def ft_dirs(tmp_path, monkeypatch):
+    src = tmp_path / "src"
+    storage = tmp_path / "storage"
+    src.mkdir()
+    storage.mkdir()
+    monkeypatch.setenv("SRC_PATH", str(src))
+    monkeypatch.setenv("TABLE_NAME", "tbl")
+    monkeypatch.setattr(file_transfer.config, "STORAGE_PATH", str(storage))
+    return src, storage / "tbl"
+
+
+def _seed(src, sub, name):
+    d = src / sub
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_bytes(b"x")
+    return d / name
+
+
+def test_image_transfer_copy_failure_raises(ft_dirs):
+    src, _ = ft_dirs
+    _seed(src, "images", "a.jpg")
+    with patch.object(file_transfer, "_copy_file_with_retry", side_effect=OSError("disk")):
+        with pytest.raises(ValueError):
+            file_transfer.image_transfer({"filename": "a"}, {"extension": ".jpg"})
+
+
+def test_annotation_transfer_copy_failure_raises(ft_dirs):
+    src, _ = ft_dirs
+    s = _seed(src, "annotations", "a.xml")
+    with patch.object(file_transfer, "_copy_file_with_retry", side_effect=OSError("disk")):
+        with pytest.raises(ValueError):
+            file_transfer.annotation_transfer({"filename": "a"}, {}, ".xml", str(s), "a.xml")
+
+
+def test_text_transfer_copy_failure_raises(ft_dirs):
+    src, _ = ft_dirs
+    _seed(src, "texts", "a.txt")
+    with patch.object(file_transfer, "_copy_file_with_retry", side_effect=OSError("disk")):
+        with pytest.raises(ValueError):
+            file_transfer.text_transfer({"filename": "a"}, {"extension": ".txt"})
+
+
+def test_mask_transfer_copy_failure_raises(ft_dirs):
+    src, _ = ft_dirs
+    s = _seed(src, "masks", "m.png")
+    with patch.object(file_transfer, "_copy_file_with_retry", side_effect=OSError("disk")):
+        with pytest.raises(ValueError):
+            file_transfer.mask_transfer({"filename": "x"}, str(s), ".png", "m")
+
+
+def test_annotation_transfer_missing_filename_returns_none(ft_dirs):
+    assert file_transfer.annotation_transfer({}, {}, ".xml") is None
+
+
+def test_image_transfer_missing_filename_returns_none(ft_dirs):
+    assert file_transfer.image_transfer({}, {"extension": ".jpg"}) is None
+
+
+def test_map_object_detection_missing_image_returns_none(ft_dirs):
+    # no image seeded -> image-not-found branch in map_file_transfer
+    assert file_transfer.map_file_transfer(
+        TaskCategory.OBJECT_DETECTION, {"filename": "ghost"}, {"extension": ".jpg"}
+    ) is None
+
+
+def test_map_semantic_segmentation_missing_image_returns_none(ft_dirs):
+    assert file_transfer.map_file_transfer(
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        {"filename": "ghost", "mask_id": "m"}, {"extension": ".jpg"},
+    ) is None
+
+
+def test_map_semantic_segmentation_missing_filename_returns_none(ft_dirs):
+    assert file_transfer.map_file_transfer(
+        TaskCategory.SEMANTIC_SEGMENTATION, {}, {"extension": ".jpg"}
+    ) is None

--- a/tests/test_coverage_gaps2.py
+++ b/tests/test_coverage_gaps2.py
@@ -1,0 +1,384 @@
+"""Second batch of gap-closing tests: BaseIngestor branches, CSV/JSON ingest
+methods, and XML validator sub-element branches."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor
+from tracebloc_ingestor.validators.base import ValidationResult
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+# ===========================================================================
+# BaseIngestor branches
+# ===========================================================================
+
+class FakeIngestor(BaseIngestor):
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source):
+        yield from self._records
+
+
+def make_ingestor(records=None, **overrides):
+    db = MagicMock()
+    db.create_table.return_value = MagicMock()
+    db.insert_batch.return_value = ([1], [])
+    db.get_table_schema.return_value = {"a": "INT"}
+    api = MagicMock()
+    api.send_batch.return_value = True
+    api.send_generate_edge_label_meta.return_value = True
+    api.send_global_meta_meta.return_value = True
+    api.prepare_dataset.return_value = True
+    api.create_dataset.return_value = {"id": 1}
+    kwargs = dict(database=db, api_client=api, table_name="tbl",
+                  schema={"a": "INT"}, intent="train", category=None)
+    kwargs.update(overrides)
+    return FakeIngestor(records or [], **kwargs)
+
+
+def test_map_unique_id_warns_on_missing_label_column():
+    ing = make_ingestor(label_column="missing", category=None)
+    rec = ing.process_record({"a": "1", "filename": "f"})
+    # missing label column logs a warning but still produces a record with a uuid
+    assert rec is not None
+    assert rec["data_id"]
+
+
+def test_process_record_sets_annotation():
+    ing = make_ingestor(schema={"a": "INT", "ann": "TEXT"},
+                        annotation_column="ann", category=None)
+    rec = ing.process_record({"a": "1", "ann": "boxdata", "filename": "f"})
+    assert rec["annotation"] == "boxdata"
+
+
+def test_process_record_excludes_unique_id_from_payload():
+    ing = make_ingestor(schema={"a": "INT", "uid": "VARCHAR(10)"},
+                        unique_id_column="uid", category=None)
+    rec = ing.process_record({"a": "1", "uid": "id7", "filename": "f"})
+    assert rec["data_id"] == "id7"
+    assert "uid" not in rec
+
+
+def test_process_record_exception_returns_none():
+    ing = make_ingestor(category=None)
+    with patch.object(ing, "_map_unique_id", side_effect=RuntimeError("boom")):
+        assert ing.process_record({"a": "1"}) is None
+
+
+def test_count_records_exception_returns_none():
+    ing = make_ingestor()
+    with patch.object(ing, "read_data", side_effect=RuntimeError("boom")):
+        assert ing._count_records("x") is None
+
+
+def test_validate_data_passing_validator_with_warning():
+    ing = make_ingestor(category=None)
+    good = MagicMock()
+    good.name = "Good"
+    good.validate.return_value = ValidationResult(True, [], ["a warning"], {})
+    with patch.object(base_mod, "map_validators", return_value=[good]):
+        assert ing.validate_data("src") is True
+
+
+def test_ingest_reraises_validation_error():
+    ing = make_ingestor(records=[{"a": "1", "filename": "f"}], category=None)
+    bad = MagicMock()
+    bad.name = "Bad"
+    bad.validate.return_value = ValidationResult(False, ["nope"], [], {})
+    with patch.object(base_mod, "map_validators", return_value=[bad]):
+        with pytest.raises(ValueError):
+            ing.ingest("src")
+
+
+def test_ingest_image_category_batches_in_loop():
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=TaskCategory.IMAGE_CLASSIFICATION)
+    ing.database.insert_batch.return_value = ([1], [])
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(base_mod, "map_file_transfer", side_effect=lambda c, r, o: r), \
+         patch.object(base_mod, "map_validators", return_value=[]):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=1)
+    assert failed == []
+    # batch_size=1 -> _process_batch invoked inside the loop
+    assert ing.database.insert_batch.call_count >= 2
+
+
+def test_ingest_records_db_failures():
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=None)
+    ing.database.insert_batch.return_value = ([], [{"record": {}, "error": "dup"}])
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(base_mod, "map_validators", return_value=[]):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+    assert any(f.get("error") == "dup" for f in failed)
+
+
+def test_ingest_processing_error_in_loop():
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=None)
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(base_mod, "map_validators", return_value=[]), \
+         patch.object(ing, "process_record", side_effect=RuntimeError("boom")):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+    assert len(failed) == 1
+    assert "boom" in failed[0]["error"]
+
+
+# ===========================================================================
+# CSV / JSON ingestor .ingest() methods + edge branches
+# ===========================================================================
+
+def _csv_ingestor(schema=None, **ov):
+    from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+    db = MagicMock(); db.create_table.return_value = MagicMock()
+    db.insert_batch.return_value = ([1], [])
+    db.get_table_schema.return_value = {}
+    api = MagicMock()
+    for m in ("send_batch", "send_generate_edge_label_meta",
+              "send_global_meta_meta", "prepare_dataset"):
+        getattr(api, m).return_value = True
+    api.create_dataset.return_value = {"id": 1}
+    kw = dict(database=db, api_client=api, table_name="tbl",
+              schema=schema if schema is not None else {"a": "INT"},
+              intent="train", category=None)
+    kw.update(ov)
+    return CSVIngestor(**kw)
+
+
+def test_csv_validate_type_error_raises():
+    ing = _csv_ingestor(schema={"n": "INT"})
+    df = pd.DataFrame({"n": ["abc", "def"]})  # not numeric -> raises
+    with pytest.raises(ValueError, match="validation failed"):
+        ing._validate_csv(df)
+
+
+def test_csv_ingest_method(make_csv):
+    path = make_csv({"a": [1, 2]})
+    ing = _csv_ingestor(schema={"a": "INT"})
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(base_mod, "map_validators", return_value=[]):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest(str(path), batch_size=10)
+    assert failed == []
+
+
+def test_csv_ingest_method_propagates_error():
+    ing = _csv_ingestor(schema={"a": "INT"})
+    with pytest.raises(FileNotFoundError):
+        ing.ingest("/no/such.csv")
+
+
+def _json_ingestor(schema=None, **ov):
+    from tracebloc_ingestor.ingestors.json_ingestor import JSONIngestor
+    db = MagicMock(); db.create_table.return_value = MagicMock()
+    db.insert_batch.return_value = ([1], [])
+    db.get_table_schema.return_value = {}
+    api = MagicMock()
+    for m in ("send_batch", "send_generate_edge_label_meta",
+              "send_global_meta_meta", "prepare_dataset"):
+        getattr(api, m).return_value = True
+    api.create_dataset.return_value = {"id": 1}
+    kw = dict(database=db, api_client=api, table_name="tbl",
+              schema=schema if schema is not None else {"a": "INT"},
+              intent="train", category=None)
+    kw.update(ov)
+    return JSONIngestor(**kw)
+
+
+def test_json_ingestor_log_level_set():
+    ing = _json_ingestor(log_level=10)
+    assert ing.json_options == {}
+
+
+def test_json_validate_record_warns_missing_fields():
+    ing = _json_ingestor(schema={"a": "INT", "b": "INT"})
+    # 'b' missing -> warning branch, no raise
+    ing._validate_record({"a": 1})
+
+
+def test_json_validate_record_float_and_bool():
+    ing = _json_ingestor(schema={"f": "FLOAT", "b": "BOOL"})
+    ing._validate_record({"f": "1.5", "b": "true"})
+
+
+def test_json_count_records_scalar_returns_none(tmp_path):
+    p = tmp_path / "n.json"
+    p.write_text("42")
+    assert _json_ingestor()._count_records(str(p)) is None
+
+
+def test_json_ingest_method(tmp_path):
+    import json
+    p = tmp_path / "d.json"
+    p.write_text(json.dumps([{"a": 1}, {"a": 2}]))
+    ing = _json_ingestor(schema={"a": "INT"})
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(base_mod, "map_validators", return_value=[]):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest(str(p), batch_size=10)
+    assert failed == []
+
+
+def test_json_ingest_method_propagates_error():
+    with pytest.raises(FileNotFoundError):
+        _json_ingestor().ingest("/no/such.json")
+
+
+# ===========================================================================
+# XML validator: sub-element branches (called directly on crafted elements)
+# ===========================================================================
+
+from tracebloc_ingestor.validators.xml_validator import PascalVOCXMLValidator
+
+
+def _obj(name=True, pose=True, truncated="0", difficult="0", bndbox=True,
+         xmin=10, ymin=10, xmax=100, ymax=100):
+    parts = ["<object>"]
+    if name is not None:
+        parts.append(f"<name>{'cat' if name else ''}</name>")
+    if pose is not None:
+        parts.append(f"<pose>{'Unspecified' if pose else ''}</pose>")
+    if truncated is not None:
+        parts.append(f"<truncated>{truncated}</truncated>")
+    if difficult is not None:
+        parts.append(f"<difficult>{difficult}</difficult>")
+    if bndbox:
+        parts.append(
+            f"<bndbox><xmin>{xmin}</xmin><ymin>{ymin}</ymin>"
+            f"<xmax>{xmax}</xmax><ymax>{ymax}</ymax></bndbox>"
+        )
+    parts.append("</object>")
+    return ET.fromstring("".join(parts))
+
+
+@pytest.fixture
+def v():
+    return PascalVOCXMLValidator()
+
+
+def test_get_xml_files_list_non_path_item(v):
+    assert v._get_xml_files([123], True, True) == []
+
+
+def test_validate_xml_files_empty(v):
+    res = v._validate_xml_files([])
+    assert not res.is_valid
+
+
+def test_validate_single_xml_generic_error(v, tmp_path):
+    f = tmp_path / "a.xml"
+    f.write_text("<annotation></annotation>")
+    with patch.object(base_mod, "Session"):
+        with patch("xml.etree.ElementTree.parse", side_effect=RuntimeError("boom")):
+            res = v._validate_single_xml(f)
+    assert not res.is_valid
+    assert "Unexpected error" in res.errors[0]
+
+
+def test_root_folder_empty(v):
+    root = ET.fromstring("<annotation><folder></folder></annotation>")
+    res = v._validate_root_elements(root)
+    assert any("Folder element must have non-empty" in e for e in res["errors"])
+
+
+def test_root_filename_missing(v):
+    root = ET.fromstring("<annotation><folder>x</folder></annotation>")
+    res = v._validate_root_elements(root)
+    assert any("Missing required 'filename'" in e for e in res["errors"])
+
+
+def test_root_segmented_missing(v):
+    root = ET.fromstring("<annotation><folder>x</folder></annotation>")
+    res = v._validate_root_elements(root)
+    assert any("Missing required 'segmented'" in e for e in res["errors"])
+
+
+def test_source_missing_database_and_annotation(v):
+    root = ET.fromstring("<annotation><source></source></annotation>")
+    res = v._validate_source_element(root)
+    assert any("Missing required source elements" in e for e in res["errors"])
+
+
+def test_source_empty_annotation(v):
+    root = ET.fromstring(
+        "<annotation><source><database>x</database><annotation></annotation></source></annotation>"
+    )
+    res = v._validate_source_element(root)
+    assert any("Annotation element must have non-empty" in e for e in res["errors"])
+
+
+def test_size_missing_height_depth(v):
+    root = ET.fromstring("<annotation><size><width>10</width></size></annotation>")
+    res = v._validate_size_element(root)
+    assert any("Missing required size elements" in e for e in res["errors"])
+
+
+def test_object_name_empty(v):
+    res = v._validate_single_object(_obj(name=False), 0)
+    assert any("Name element must have non-empty" in e for e in res["errors"])
+
+
+def test_object_name_missing(v):
+    res = v._validate_single_object(_obj(name=None), 0)
+    assert any("Missing required 'name'" in e for e in res["errors"])
+
+
+def test_object_pose_empty(v):
+    res = v._validate_single_object(_obj(pose=False), 0)
+    assert any("Pose element must have non-empty" in e for e in res["errors"])
+
+
+def test_object_pose_missing(v):
+    res = v._validate_single_object(_obj(pose=None), 0)
+    assert any("Missing required 'pose'" in e for e in res["errors"])
+
+
+def test_object_truncated_missing(v):
+    res = v._validate_single_object(_obj(truncated=None), 0)
+    assert any("Missing required 'truncated'" in e for e in res["errors"])
+
+
+def test_object_difficult_bad_value(v):
+    res = v._validate_single_object(_obj(difficult="9"), 0)
+    assert any("Difficult element must be" in e for e in res["errors"])
+
+
+def test_object_difficult_missing(v):
+    res = v._validate_single_object(_obj(difficult=None), 0)
+    assert any("Missing required 'difficult'" in e for e in res["errors"])
+
+
+def test_bndbox_missing_coord(v):
+    obj = ET.fromstring(
+        "<object><bndbox><xmin>1</xmin><ymin>1</ymin><xmax>5</xmax></bndbox></object>"
+    )
+    res = v._validate_bndbox_element(obj, 0)
+    assert any("Missing required 'ymax'" in e or "Missing required bndbox" in e
+               for e in res["errors"])
+
+
+def test_bndbox_ymin_ge_ymax(v):
+    res = v._validate_bndbox_element(_obj(ymin=100, ymax=50), 0)
+    assert any("must be less than ymax" in e for e in res["errors"])
+
+
+def test_bndbox_zero_area(v):
+    # equal x's and y's via valid coords producing zero area is caught by
+    # the < checks first; use xmin<xmax but ymin==ymax-handled; here force
+    # zero width through xmin<xmax but xmax-xmin * ... = 0 isn't possible.
+    # Instead: a 0-area box where xmin<xmax and ymin<ymax can't be zero, so
+    # exercise the small-area warning path via a 1x1 box.
+    res = v._validate_bndbox_element(_obj(xmin=0, ymin=0, xmax=1, ymax=1), 0)
+    assert any("Very small bounding box" in w for w in res["warnings"])

--- a/tests/test_coverage_gaps2.py
+++ b/tests/test_coverage_gaps2.py
@@ -350,8 +350,19 @@ def test_object_truncated_missing(v):
 
 
 def test_object_difficult_bad_value(v):
-    res = v._validate_single_object(_obj(difficult="9"), 0)
+    # Non-integer (or negative) difficult is still rejected; the message changed
+    # from strict 0/1 to "non-negative integer" when we relaxed the validator
+    # for VisDrone-style data (#135a).
+    res = v._validate_single_object(_obj(difficult="abc"), 0)
     assert any("Difficult element must be" in e for e in res["errors"])
+
+
+def test_object_difficult_high_value_accepted(v):
+    # VisDrone uses difficult=2; it's now accepted (with a warning) rather than
+    # an error, so the bundled OD sample ingests (#135a).
+    res = v._validate_single_object(_obj(difficult="2"), 0)
+    assert not any("Difficult" in e for e in res["errors"])
+    assert any("Difficult=2" in w for w in res["warnings"])
 
 
 def test_object_difficult_missing(v):

--- a/tests/test_coverage_gaps2.py
+++ b/tests/test_coverage_gaps2.py
@@ -280,9 +280,8 @@ def test_validate_xml_files_empty(v):
 def test_validate_single_xml_generic_error(v, tmp_path):
     f = tmp_path / "a.xml"
     f.write_text("<annotation></annotation>")
-    with patch.object(base_mod, "Session"):
-        with patch("xml.etree.ElementTree.parse", side_effect=RuntimeError("boom")):
-            res = v._validate_single_xml(f)
+    with patch("xml.etree.ElementTree.parse", side_effect=RuntimeError("boom")):
+        res = v._validate_single_xml(f)
     assert not res.is_valid
     assert "Unexpected error" in res.errors[0]
 

--- a/tests/test_coverage_gaps3.py
+++ b/tests/test_coverage_gaps3.py
@@ -1,0 +1,82 @@
+"""Third batch of cheap gap-closers: non-string type checks and _load_data
+exception fallbacks across validators."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.data_validator import DataValidator
+
+
+# ---- data_validator non-string type checks -------------------------------
+
+def test_varchar_non_string_values_flagged():
+    df = pd.DataFrame({"s": [1, 2]})  # ints under VARCHAR -> non-string
+    res = DataValidator(schema={"s": "VARCHAR(10)"}).validate(df)
+    assert not res.is_valid
+    assert any("non-string" in e for e in res.errors)
+
+
+def test_char_non_string_values_flagged():
+    df = pd.DataFrame({"s": [1, 2]})
+    res = DataValidator(schema={"s": "CHAR(1)"}).validate(df)
+    assert not res.is_valid
+
+
+def test_text_non_string_values_flagged():
+    df = pd.DataFrame({"s": [1, 2]})
+    res = DataValidator(schema={"s": "TEXT"}).validate(df)
+    assert not res.is_valid
+    assert any("non-string" in e for e in res.errors)
+
+
+def test_data_validator_load_data_exception(make_csv):
+    v = DataValidator(schema={"a": "INT"})
+    path = make_csv({"a": [1]})
+    with patch("tracebloc_ingestor.validators.data_validator.pd.read_csv",
+               side_effect=RuntimeError("boom")):
+        assert v._load_data(str(path), 100) is None
+
+
+# ---- numeric_columns _load_data exception ---------------------------------
+
+def test_numeric_columns_load_data_exception(make_csv):
+    from tracebloc_ingestor.validators.numeric_columns_validator import (
+        NumericColumnsValidator,
+    )
+    path = make_csv({"a": [1]})
+    v = NumericColumnsValidator(schema={"a": "INT"})
+    with patch("tracebloc_ingestor.validators.numeric_columns_validator.pd.read_csv",
+               side_effect=RuntimeError("boom")):
+        assert v._load_data(str(path)) is None
+
+
+# ---- time validators: _load_data exception fallback -----------------------
+
+@pytest.mark.parametrize("modname,clsname", [
+    ("time_format_validator", "TimeFormatValidator"),
+    ("time_ordered_validator", "TimeOrderedValidator"),
+    ("time_before_today_validator", "TimeBeforeTodayValidator"),
+])
+def test_time_validators_load_data_read_exception(make_csv, modname, clsname):
+    mod = importlib.import_module(f"tracebloc_ingestor.validators.{modname}")
+    v = getattr(mod, clsname)()
+    path = make_csv({"timestamp": ["2024-01-01"]})
+    with patch(f"tracebloc_ingestor.validators.{modname}.pd.read_csv",
+               side_effect=RuntimeError("boom")):
+        assert v._load_data(str(path)) is None
+
+
+def test_time_before_today_empty_dataframe(tmp_path):
+    from tracebloc_ingestor.validators.time_before_today_validator import (
+        TimeBeforeTodayValidator,
+    )
+    p = tmp_path / "e.csv"
+    p.write_text("timestamp\n")  # header only -> empty df
+    res = TimeBeforeTodayValidator().validate(str(p))
+    assert not res.is_valid
+    assert "No data found" in res.errors[0]

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -1,0 +1,108 @@
+"""Tests for CSVIngestor: read_data chunking, schema type validation, counting."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+def make_csv_ingestor(schema=None, **overrides):
+    db = MagicMock()
+    db.create_table.return_value = MagicMock()
+    api = MagicMock()
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema=schema if schema is not None else {"a": "INT"},
+        intent="train",
+        category=None,
+    )
+    kwargs.update(overrides)
+    return CSVIngestor(**kwargs)
+
+
+def test_read_data_yields_records(make_csv):
+    path = make_csv({"a": [1, 2], "b": ["x", "y"]})
+    ing = make_csv_ingestor(schema={"a": "INT", "b": "VARCHAR(10)"})
+    records = list(ing.read_data(str(path)))
+    assert len(records) == 2
+    assert records[0]["a"] == 1
+    assert records[0]["b"] == "x"
+
+
+def test_read_data_missing_file_raises():
+    ing = make_csv_ingestor()
+    with pytest.raises(FileNotFoundError):
+        list(ing.read_data("/no/such/file.csv"))
+
+
+def test_read_data_strips_column_whitespace(make_csv, tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text(" a , b \n1,2\n")
+    ing = make_csv_ingestor(schema={"a": "INT", "b": "INT"})
+    records = list(ing.read_data(str(p)))
+    assert "a" in records[0] and "b" in records[0]
+
+
+def test_read_data_schema_column_missing_raises(make_csv):
+    path = make_csv({"a": [1]})
+    ing = make_csv_ingestor(schema={"a": "INT", "missing": "INT"})
+    with pytest.raises(ValueError, match="Schema columns not present"):
+        list(ing.read_data(str(path)))
+
+
+def test_read_data_unique_id_column_missing_raises(make_csv):
+    path = make_csv({"a": [1]})
+    ing = make_csv_ingestor(schema={"a": "INT"}, unique_id_column="uid")
+    with pytest.raises(ValueError, match="unique_id_column"):
+        list(ing.read_data(str(path)))
+
+
+def test_read_data_empty_file_returns_nothing(tmp_path):
+    p = tmp_path / "empty.csv"
+    p.write_text("")
+    ing = make_csv_ingestor(schema={})
+    assert list(ing.read_data(str(p))) == []
+
+
+def test_validate_csv_type_coercion():
+    ing = make_csv_ingestor(schema={"n": "INT", "f": "FLOAT", "b": "BOOLEAN", "d": "DATE"})
+    df = pd.DataFrame({
+        "n": ["1", "2"],
+        "f": ["1.5", "2.5"],
+        "b": [True, False],
+        "d": ["2024-01-01", "2024-02-02"],
+    })
+    # Should not raise; coerces in place.
+    ing._validate_csv(df)
+    assert str(df["d"].dtype).startswith("datetime")
+
+
+def test_count_records(make_csv):
+    path = make_csv({"a": [1, 2, 3, 4]})
+    ing = make_csv_ingestor(schema={"a": "INT"})
+    assert ing._count_records(str(path)) == 4
+
+
+def test_count_records_bad_path_returns_none():
+    ing = make_csv_ingestor()
+    assert ing._count_records("/no/such.csv") is None
+
+
+def test_tabular_na_values_applied(tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("a,b\n1,NA\n2,NULL\n")
+    ing = make_csv_ingestor(
+        schema={"a": "INT", "b": "VARCHAR(10)"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    records = list(ing.read_data(str(p)))
+    # "NA"/"NULL" should be parsed as NaN for tabular categories.
+    assert pd.isna(records[0]["b"])
+    assert pd.isna(records[1]["b"])

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -42,7 +42,7 @@ def test_read_data_missing_file_raises():
         list(ing.read_data("/no/such/file.csv"))
 
 
-def test_read_data_strips_column_whitespace(make_csv, tmp_path):
+def test_read_data_strips_column_whitespace(tmp_path):
     p = tmp_path / "d.csv"
     p.write_text(" a , b \n1,2\n")
     ing = make_csv_ingestor(schema={"a": "INT", "b": "INT"})

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -1,0 +1,211 @@
+"""Tests for DataValidator — per-type schema compliance checks."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.data_validator import DataValidator
+
+
+# ---------------------------------------------------------------------------
+# validate() top-level flow
+# ---------------------------------------------------------------------------
+
+def test_no_schema_passes_with_warning():
+    result = DataValidator().validate(pd.DataFrame({"a": [1]}))
+    assert result.is_valid
+    assert result.metadata["schema_provided"] is False
+
+
+def test_empty_dataframe_fails():
+    result = DataValidator(schema={"a": "INT"}).validate(pd.DataFrame())
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_non_csv_path_returns_no_data():
+    result = DataValidator(schema={"a": "INT"}).validate("/nope.parquet")
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_loads_from_csv(make_csv):
+    path = make_csv({"age": [1, 2, 3]})
+    result = DataValidator(schema={"age": "INT"}).validate(str(path))
+    assert result.is_valid
+
+
+def test_unknown_type_fails():
+    df = pd.DataFrame({"a": [1]})
+    result = DataValidator(schema={"a": "WEIRDTYPE"}).validate(df)
+    assert not result.is_valid
+    assert "Unknown data type" in result.errors[0]
+
+
+def test_schema_column_not_in_df_is_ignored():
+    df = pd.DataFrame({"a": [1]})
+    result = DataValidator(schema={"b": "INT"}).validate(df)
+    # 'b' isn't in df.columns, so nothing is validated -> valid.
+    assert result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# INT / BIGINT
+# ---------------------------------------------------------------------------
+
+def test_int_valid():
+    df = pd.DataFrame({"n": [1, 2, 3]})
+    assert DataValidator(schema={"n": "INT"}).validate(df).is_valid
+
+
+def test_int_non_numeric_fails():
+    df = pd.DataFrame({"n": ["a", "b"]})
+    result = DataValidator(schema={"n": "INT"}).validate(df)
+    assert not result.is_valid
+    assert "non-numeric" in result.errors[0]
+
+
+def test_int_non_integer_float_fails():
+    df = pd.DataFrame({"n": [1.5, 2.0]})
+    result = DataValidator(schema={"n": "INT"}).validate(df)
+    assert not result.is_valid
+    assert "non-integer" in result.errors[0]
+
+
+def test_bigint_delegates_to_int():
+    df = pd.DataFrame({"n": [10_000_000_000]})
+    assert DataValidator(schema={"n": "BIGINT"}).validate(df).is_valid
+
+
+# ---------------------------------------------------------------------------
+# FLOAT / DOUBLE / DECIMAL
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("dtype", ["FLOAT", "DOUBLE", "DECIMAL(10,2)"])
+def test_float_family_valid(dtype):
+    df = pd.DataFrame({"x": [1.5, 2.25]})
+    assert DataValidator(schema={"x": dtype}).validate(df).is_valid
+
+
+def test_float_non_numeric_fails():
+    df = pd.DataFrame({"x": ["a", "b"]})
+    result = DataValidator(schema={"x": "FLOAT"}).validate(df)
+    assert not result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# VARCHAR / CHAR / TEXT
+# ---------------------------------------------------------------------------
+
+def test_varchar_valid():
+    df = pd.DataFrame({"s": ["abc", "de"]})
+    assert DataValidator(schema={"s": "VARCHAR(255)"}).validate(df).is_valid
+
+
+def test_varchar_too_long_fails():
+    df = pd.DataFrame({"s": ["abcdef", "gh"]})
+    result = DataValidator(schema={"s": "VARCHAR(3)"}).validate(df)
+    assert not result.is_valid
+    assert "exceeding max length" in result.errors[0]
+
+
+def test_char_wrong_length_fails():
+    df = pd.DataFrame({"s": ["ab", "cde"]})
+    result = DataValidator(schema={"s": "CHAR(2)"}).validate(df)
+    assert not result.is_valid
+    assert "length !=" in result.errors[0]
+
+
+def test_text_valid():
+    df = pd.DataFrame({"s": ["any length text here"]})
+    assert DataValidator(schema={"s": "TEXT"}).validate(df).is_valid
+
+
+# ---------------------------------------------------------------------------
+# BOOLEAN across dtypes
+# ---------------------------------------------------------------------------
+
+def test_boolean_bool_dtype_valid():
+    df = pd.DataFrame({"b": [True, False]})
+    assert DataValidator(schema={"b": "BOOLEAN"}).validate(df).is_valid
+
+
+def test_boolean_int_valid():
+    df = pd.DataFrame({"b": [0, 1, 1]})
+    assert DataValidator(schema={"b": "BOOL"}).validate(df).is_valid
+
+
+def test_boolean_int_out_of_range_fails():
+    df = pd.DataFrame({"b": [0, 2]})
+    result = DataValidator(schema={"b": "BOOLEAN"}).validate(df)
+    assert not result.is_valid
+    assert "non-boolean" in result.errors[0]
+
+
+def test_boolean_string_valid():
+    df = pd.DataFrame({"b": ["true", "no", "1", "False"]})
+    assert DataValidator(schema={"b": "BOOLEAN"}).validate(df).is_valid
+
+
+def test_boolean_string_invalid_fails():
+    df = pd.DataFrame({"b": ["maybe", "true"]})
+    result = DataValidator(schema={"b": "BOOLEAN"}).validate(df)
+    assert not result.is_valid
+
+
+def test_boolean_all_null_valid():
+    df = pd.DataFrame({"b": pd.Series([None, None], dtype="object")})
+    assert DataValidator(schema={"b": "BOOLEAN"}).validate(df).is_valid
+
+
+def test_boolean_float_valid():
+    df = pd.DataFrame({"b": [0.0, 1.0]})
+    assert DataValidator(schema={"b": "BOOLEAN"}).validate(df).is_valid
+
+
+def test_boolean_float_invalid_fails():
+    df = pd.DataFrame({"b": [0.0, 0.5]})
+    result = DataValidator(schema={"b": "BOOLEAN"}).validate(df)
+    assert not result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# DATE / DATETIME / TIMESTAMP / TIME
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("dtype", ["DATE", "DATETIME", "TIMESTAMP", "TIME"])
+def test_date_family_valid(dtype):
+    df = pd.DataFrame({"d": ["2024-01-01", "2024-02-02"]})
+    assert DataValidator(schema={"d": dtype}).validate(df).is_valid
+
+
+def test_date_invalid_fails():
+    df = pd.DataFrame({"d": ["not-a-date", "2024-01-01"]})
+    result = DataValidator(schema={"d": "DATE"}).validate(df)
+    assert not result.is_valid
+    assert "invalid date" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# type parsing + auto-detect helper
+# ---------------------------------------------------------------------------
+
+def test_constraints_are_stripped_from_type():
+    df = pd.DataFrame({"n": [1, 2]})
+    # "INT NOT NULL" should resolve to the INT validator.
+    assert DataValidator(schema={"n": "INT NOT NULL"}).validate(df).is_valid
+
+
+@pytest.mark.parametrize(
+    "series,expected",
+    [
+        (pd.Series([True, False]), "BOOLEAN"),
+        (pd.Series([1, 2, 3]), "INT"),
+        (pd.Series([1.0, 2.5]), "FLOAT"),
+        (pd.Series(pd.to_datetime(["2024-01-01"])), "DATETIME"),
+        (pd.Series(["x", "y"]), "VARCHAR(255)"),
+    ],
+)
+def test_detect_column_type(series, expected):
+    assert DataValidator()._detect_column_type(series) == expected

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -135,9 +135,12 @@ def _seed_table(db):
         db.create_table("tbl", {"feat": "INT"})
 
 
-def test_insert_batch_empty_returns_dict(db):
-    result = db.insert_batch("tbl", [])
-    assert result == {"success_ids": [], "failures": []}
+def test_insert_batch_empty_returns_empty_tuple(db):
+    # Empty input returns the same (success_ids, failures) tuple shape as the
+    # non-empty path, so callers can unconditionally unpack two values.
+    ids, failures = db.insert_batch("tbl", [])
+    assert ids == []
+    assert failures == []
 
 
 def test_insert_batch_success(db, mock_engine_factory):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -223,3 +223,20 @@ def test_get_table_schema(db):
     assert schema["name"] == "VARCHAR(255)"
     # unknown SQLAlchemy type falls back to VARCHAR
     assert schema["weird"] == "VARCHAR"
+
+
+def test_create_table_rejects_reserved_column():
+    """A user schema column colliding with a reserved/internal column (e.g.
+    'id') fails fast with a clear ValueError, not a cryptic DuplicateColumnError.
+    The guard runs before any DB I/O, so no live connection is needed."""
+    db = Database.__new__(Database)
+    with pytest.raises(ValueError, match="reserved"):
+        db.create_table("some_table", {"id": "INT", "feature_0": "FLOAT"})
+
+
+def test_create_table_allows_label_in_schema():
+    """`label` is the user-facing label column (mapped onto the standard
+    column), so it must NOT be treated as a reserved collision."""
+    db = Database.__new__(Database)
+    db.tables = {"t": "sentinel"}  # short-circuit before any engine use
+    assert db.create_table("t", {"feature_0": "FLOAT", "label": "INT"}) == "sentinel"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,222 @@
+"""Tests for Database with SQLAlchemy mocked at the engine/inspect boundary.
+
+We never touch a real MySQL. ``create_engine`` is patched so ``__init__`` /
+``_create_engine`` build a mock engine; ``inspect`` and ``metadata.create_all`` /
+``metadata.reflect`` are patched per-test so table operations run without a DB.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import Integer, String, BigInteger, Column, Table
+
+from tracebloc_ingestor import database as db_mod
+from tracebloc_ingestor.database import Database
+from tracebloc_ingestor.config import Config
+
+
+@pytest.fixture
+def mock_engine_factory():
+    """Patch create_engine so Database.__init__ builds a mock engine."""
+    with patch.object(db_mod, "create_engine") as ce:
+        engine = MagicMock(name="engine")
+        # engine.connect() is a context manager yielding a mock connection.
+        conn = MagicMock(name="connection")
+        engine.connect.return_value.__enter__.return_value = conn
+        ce.return_value = engine
+        yield ce, engine, conn
+
+
+@pytest.fixture
+def db(mock_engine_factory):
+    return Database(Config(EDGE_ENV="local"))
+
+
+# ---------------------------------------------------------------------------
+# __init__ / _create_engine
+# ---------------------------------------------------------------------------
+
+def test_init_builds_engine(db, mock_engine_factory):
+    ce, engine, conn = mock_engine_factory
+    assert db.engine is engine
+    # create_engine called twice: server-level then db-specific.
+    assert ce.call_count == 2
+    # CREATE DATABASE issued + committed during _create_engine.
+    conn.execute.assert_called()
+    conn.commit.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _get_sqlalchemy_type (pure)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mysql_type,expected_cls", [
+    ("INT", Integer),
+    ("INTEGER", Integer),
+    ("BIGINT", BigInteger),
+    ("TEXT", db_mod.Text),
+    ("FLOAT", db_mod.Float),
+    ("BOOLEAN", db_mod.Boolean),
+    ("DATE", db_mod.Date),
+    ("DATETIME", db_mod.DateTime),
+    ("TIMESTAMP", db_mod.DateTime),
+    ("TIME", db_mod.Time),
+])
+def test_get_sqlalchemy_type_mapping(db, mysql_type, expected_cls):
+    result = db._get_sqlalchemy_type(mysql_type)
+    # result may be a class or an instance depending on length handling.
+    assert isinstance(result, expected_cls) or result is expected_cls
+
+
+def test_get_sqlalchemy_type_varchar_length(db):
+    result = db._get_sqlalchemy_type("VARCHAR(128)")
+    assert isinstance(result, String)
+    assert result.length == 128
+
+
+def test_get_sqlalchemy_type_bad_length_ignored(db):
+    result = db._get_sqlalchemy_type("VARCHAR(abc)")
+    assert isinstance(result, String) or result is String
+
+
+def test_get_sqlalchemy_type_unsupported_raises(db):
+    with pytest.raises(ValueError, match="Unsupported MySQL type"):
+        db._get_sqlalchemy_type("GEOMETRY")
+
+
+# ---------------------------------------------------------------------------
+# create_table
+# ---------------------------------------------------------------------------
+
+def test_create_table_new(db):
+    db.metadata.create_all = MagicMock()
+    inspector = MagicMock()
+    inspector.get_table_names.return_value = []
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        table = db.create_table("new_tbl", {"feat": "INT"})
+    assert "new_tbl" in db.tables
+    assert "feat" in table.c
+    # standard columns present
+    assert "data_id" in table.c
+    db.metadata.create_all.assert_called_once()
+
+
+def test_create_table_cached(db):
+    sentinel = MagicMock(name="cached_table")
+    db.tables["t"] = sentinel
+    assert db.create_table("t", {}) is sentinel
+
+
+def test_create_table_existing_in_db_reflects(db):
+    inspector = MagicMock()
+    inspector.get_table_names.return_value = ["existing"]
+
+    def fake_reflect(engine, only=None):
+        Table("existing", db.metadata, Column("id", BigInteger, primary_key=True))
+
+    db.metadata.reflect = MagicMock(side_effect=fake_reflect)
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        table = db.create_table("existing", {})
+    assert db.tables["existing"] is table
+    db.metadata.reflect.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# insert_batch
+# ---------------------------------------------------------------------------
+
+def _seed_table(db):
+    db.metadata.create_all = MagicMock()
+    inspector = MagicMock()
+    inspector.get_table_names.return_value = []
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        db.create_table("tbl", {"feat": "INT"})
+
+
+def test_insert_batch_empty_returns_dict(db):
+    result = db.insert_batch("tbl", [])
+    assert result == {"success_ids": [], "failures": []}
+
+
+def test_insert_batch_success(db, mock_engine_factory):
+    ce, engine, conn = mock_engine_factory
+    _seed_table(db)
+    rows = [MagicMock(id=1), MagicMock(id=2)]
+    conn.execute.return_value.fetchall.return_value = rows
+    ids, failures = db.insert_batch(
+        "tbl", [{"data_id": "a", "feat": 1}, {"data_id": "b", "feat": 2}]
+    )
+    assert ids == [1, 2]
+    assert failures == []
+    conn.commit.assert_called()
+
+
+def test_insert_batch_falls_back_to_individual(db, mock_engine_factory):
+    ce, engine, conn = mock_engine_factory
+    _seed_table(db)
+
+    calls = {"n": 0}
+
+    def execute_side_effect(stmt, *a, **k):
+        calls["n"] += 1
+        # First call is the bulk insert -> fail to trigger the per-record path.
+        if calls["n"] == 1:
+            raise RuntimeError("bulk failed")
+        result = MagicMock()
+        result.fetchone.return_value = MagicMock(id=99)
+        result.fetchall.return_value = [MagicMock(id=99)]
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    ids, failures = db.insert_batch("tbl", [{"data_id": "a", "feat": 1}])
+    # Individual insert path succeeded for the single record.
+    assert ids == [99]
+    assert failures == []
+
+
+def test_insert_batch_individual_failure_recorded(db, mock_engine_factory):
+    ce, engine, conn = mock_engine_factory
+    _seed_table(db)
+
+    def execute_side_effect(stmt, *a, **k):
+        raise RuntimeError("always fails")
+
+    conn.execute.side_effect = execute_side_effect
+    ids, failures = db.insert_batch("tbl", [{"data_id": "a", "feat": 1}])
+    assert ids == []
+    assert len(failures) == 1
+    assert "always fails" in failures[0]["error"]
+
+
+def test_insert_batch_connection_error(db, mock_engine_factory):
+    ce, engine, conn = mock_engine_factory
+    _seed_table(db)
+    engine.connect.side_effect = RuntimeError("no connection")
+    ids, failures = db.insert_batch("tbl", [{"data_id": "a", "feat": 1}])
+    assert ids == []
+    assert len(failures) == 1
+    assert "Database connection error" in failures[0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_table_schema
+# ---------------------------------------------------------------------------
+
+def test_get_table_schema(db):
+    inspector = MagicMock()
+    class Weird:  # unknown SQLAlchemy type, no 'length' attribute
+        pass
+
+    inspector.get_columns.return_value = [
+        {"name": "id", "type": Integer()},
+        {"name": "name", "type": String(255)},
+        {"name": "weird", "type": Weird()},
+    ]
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        schema = db.get_table_schema("tbl")
+    assert schema["id"] == "INT"
+    assert schema["name"] == "VARCHAR(255)"
+    # unknown SQLAlchemy type falls back to VARCHAR
+    assert schema["weird"] == "VARCHAR"

--- a/tests/test_duplicate_validator_extra.py
+++ b/tests/test_duplicate_validator_extra.py
@@ -1,0 +1,52 @@
+"""Supplementary DuplicateValidator coverage: parent-dir warnings, dir
+creation, and the error-handling fallbacks not exercised by
+test_duplicate_validator.py."""
+
+from __future__ import annotations
+
+from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
+
+
+def test_missing_parent_directory_warns(tmp_path):
+    dest = tmp_path / "missing_parent" / "table"
+    result = DuplicateValidator(dest_path=str(dest)).validate(None)
+    assert result.is_valid
+    assert any("Parent directory" in w for w in result.warnings)
+    assert result.metadata["parent_directory_exists"] is False
+
+
+def test_check_directory_exists_true(tmp_path):
+    d = tmp_path / "existing"
+    d.mkdir()
+    assert DuplicateValidator(dest_path=str(d))._check_directory_exists() is True
+
+
+def test_check_directory_exists_false_for_file(tmp_path):
+    f = tmp_path / "a_file"
+    f.write_text("x")
+    # A file is not a directory.
+    assert DuplicateValidator(dest_path=str(f))._check_directory_exists() is False
+
+
+def test_is_directory_empty_true(tmp_path):
+    d = tmp_path / "empty"
+    d.mkdir()
+    assert DuplicateValidator(dest_path=str(d))._is_directory_empty() is True
+
+
+def test_is_directory_empty_handles_missing(tmp_path):
+    # iterdir on a nonexistent dir raises -> caught -> returns False.
+    assert DuplicateValidator(dest_path=str(tmp_path / "nope"))._is_directory_empty() is False
+
+
+def test_create_directory_if_needed(tmp_path):
+    dest = tmp_path / "to_create" / "nested"
+    v = DuplicateValidator(dest_path=str(dest))
+    assert v._create_directory_if_needed() is True
+    assert dest.exists()
+
+
+def test_create_directory_if_needed_existing(tmp_path):
+    dest = tmp_path / "already"
+    dest.mkdir()
+    assert DuplicateValidator(dest_path=str(dest))._create_directory_if_needed() is True

--- a/tests/test_file_transfer_transfers.py
+++ b/tests/test_file_transfer_transfers.py
@@ -1,0 +1,225 @@
+"""Tests for the file_transfer copy functions and map_file_transfer routing.
+
+The 'missing source returns None' paths are covered in
+test_file_transfer_summary.py; here we cover the successful-copy paths,
+source resolution helpers, and the multi-file map_file_transfer branches.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tracebloc_ingestor import file_transfer
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+@pytest.fixture
+def dirs(tmp_path, monkeypatch):
+    """Point file_transfer's Config at tmp src + storage dirs.
+
+    SRC_PATH is env-backed; DEST_PATH derives from STORAGE_PATH / TABLE_NAME,
+    so override STORAGE_PATH on the live module-level Config and set TABLE_NAME.
+    """
+    src = tmp_path / "src"
+    storage = tmp_path / "storage"
+    src.mkdir()
+    storage.mkdir()
+    monkeypatch.setenv("SRC_PATH", str(src))
+    monkeypatch.setenv("TABLE_NAME", "tbl")
+    monkeypatch.setattr(file_transfer.config, "STORAGE_PATH", str(storage))
+    dest = storage / "tbl"
+    return src, dest
+
+
+def _seed(src, subdir, name, content=b"data"):
+    d = src / subdir
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_bytes(content)
+    return d / name
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def test_find_src_with_extension(dirs):
+    src, _ = dirs
+    _seed(src, "images", "cat.jpg")
+    path, fname = file_transfer._find_src("images", "cat.jpg", ".jpg")
+    assert path is not None and fname == "cat.jpg"
+
+
+def test_find_src_appends_extension(dirs):
+    src, _ = dirs
+    _seed(src, "images", "cat.jpg")
+    path, fname = file_transfer._find_src("images", "cat", ".jpg")
+    assert path is not None and fname == "cat.jpg"
+
+
+def test_find_src_missing(dirs):
+    path, fname = file_transfer._find_src("images", "ghost", ".jpg")
+    assert path is None and fname == "ghost.jpg"
+
+
+def test_find_mask_src_tries_extensions(dirs):
+    src, _ = dirs
+    _seed(src, "masks", "m1.png")
+    path, ext, name = file_transfer._find_mask_src("m1")
+    assert path is not None and ext == ".png" and name == "m1"
+
+
+def test_find_mask_src_missing(dirs):
+    path, ext, name = file_transfer._find_mask_src("nope")
+    assert path is None and ext is None and name == "nope"
+
+
+def test_copy_file_with_retry_overwrites(dirs, tmp_path):
+    src, dest = dirs
+    s = _seed(src, "images", "a.jpg", b"new")
+    dest.mkdir(parents=True, exist_ok=True)
+    target = dest / "a.jpg"
+    target.write_bytes(b"old")
+    file_transfer._copy_file_with_retry(str(s), str(target))
+    assert target.read_bytes() == b"new"
+
+
+# ---------------------------------------------------------------------------
+# image_transfer / text_transfer / annotation / mask success
+# ---------------------------------------------------------------------------
+
+def test_image_transfer_success(dirs):
+    src, dest = dirs
+    _seed(src, "images", "cat.jpg")
+    rec = file_transfer.image_transfer({"filename": "cat"}, {"extension": ".jpg"})
+    assert rec is not None
+    assert rec["filename"] == "cat"
+    assert rec["extension"] == ".jpg"
+    assert (dest / "cat.jpg").exists()
+
+
+def test_text_transfer_success(dirs):
+    src, dest = dirs
+    _seed(src, "texts", "doc.txt", b"hello")
+    rec = file_transfer.text_transfer({"filename": "doc"}, {"extension": ".txt"})
+    assert rec is not None
+    assert (dest / "doc.txt").exists()
+
+
+def test_text_transfer_custom_subdir(dirs):
+    src, dest = dirs
+    _seed(src, "sequences", "seq.txt", b"tokens")
+    rec = file_transfer.text_transfer(
+        {"filename": "seq"}, {"extension": ".txt"}, src_subdir="sequences"
+    )
+    assert rec is not None
+    assert (dest / "seq.txt").exists()
+
+
+def test_text_transfer_missing_filename_returns_none(dirs):
+    assert file_transfer.text_transfer({}, {"extension": ".txt"}) is None
+
+
+def test_annotation_transfer_success(dirs):
+    src, dest = dirs
+    s = _seed(src, "annotations", "img.xml", b"<x/>")
+    rec = file_transfer.annotation_transfer(
+        {"filename": "img"}, {}, ".xml", str(s), "img.xml"
+    )
+    assert rec is not None
+    assert (dest / "img.xml").exists()
+
+
+def test_mask_transfer_success(dirs):
+    src, dest = dirs
+    s = _seed(src, "masks", "m.png")
+    rec = file_transfer.mask_transfer({"filename": "x"}, str(s), ".png", "m")
+    assert rec is not None
+    assert (dest / "m.png").exists()
+
+
+# ---------------------------------------------------------------------------
+# map_file_transfer routing
+# ---------------------------------------------------------------------------
+
+def test_map_image_classification(dirs):
+    src, dest = dirs
+    _seed(src, "images", "cat.jpg")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.IMAGE_CLASSIFICATION, {"filename": "cat"}, {"extension": ".jpg"}
+    )
+    assert rec is not None
+
+
+def test_map_object_detection_atomic_success(dirs):
+    src, dest = dirs
+    _seed(src, "images", "x.jpg")
+    _seed(src, "annotations", "x.xml", b"<a/>")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.OBJECT_DETECTION, {"filename": "x"}, {"extension": ".jpg"}
+    )
+    assert rec is not None
+    assert (dest / "x.jpg").exists()
+    assert (dest / "x.xml").exists()
+
+
+def test_map_object_detection_missing_annotation_returns_none(dirs):
+    src, _ = dirs
+    _seed(src, "images", "x.jpg")  # no annotation
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.OBJECT_DETECTION, {"filename": "x"}, {"extension": ".jpg"}
+    )
+    assert rec is None
+
+
+def test_map_object_detection_missing_filename_returns_none(dirs):
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.OBJECT_DETECTION, {}, {"extension": ".jpg"}
+    )
+    assert rec is None
+
+
+def test_map_semantic_segmentation_success(dirs):
+    src, dest = dirs
+    _seed(src, "images", "x.jpg")
+    _seed(src, "masks", "m.png")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        {"filename": "x", "mask_id": "m"}, {"extension": ".jpg"},
+    )
+    assert rec is not None
+    assert (dest / "m.png").exists()
+
+
+def test_map_semantic_segmentation_missing_mask_id_returns_none(dirs):
+    src, _ = dirs
+    _seed(src, "images", "x.jpg")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.SEMANTIC_SEGMENTATION, {"filename": "x"}, {"extension": ".jpg"}
+    )
+    assert rec is None
+
+
+def test_map_mlm_copies_tokenizer(dirs):
+    src, dest = dirs
+    _seed(src, "sequences", "seq.txt", b"tokens")
+    (src / "tokenizer.json").write_text("{}")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.MASKED_LANGUAGE_MODELING, {"filename": "seq"}, {"extension": ".txt"}
+    )
+    assert rec is not None
+    assert (dest / "tokenizer.json").exists()
+
+
+def test_map_keypoint_detection(dirs):
+    src, dest = dirs
+    _seed(src, "images", "p.jpg")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.KEYPOINT_DETECTION, {"filename": "p"}, {"extension": ".jpg"}
+    )
+    assert rec is not None
+
+
+def test_map_unknown_category_returns_none(dirs):
+    assert file_transfer.map_file_transfer("weird", {"filename": "x"}, {}) is None

--- a/tests/test_file_validator.py
+++ b/tests/test_file_validator.py
@@ -1,0 +1,109 @@
+"""Tests for FileTypeValidator — extension uniformity under config.SRC_PATH/<path>."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tracebloc_ingestor.validators.file_validator import FileTypeValidator
+
+
+def test_invalid_allowed_extension_raises():
+    with pytest.raises(ValueError):
+        FileTypeValidator(allowed_extension=".gif")
+
+
+def test_uniform_extension_passes(clean_env, tmp_path):
+    images = tmp_path / "images"
+    images.mkdir()
+    (images / "a.jpg").write_bytes(b"x")
+    (images / "b.jpg").write_bytes(b"y")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = FileTypeValidator(allowed_extension=".jpg").validate(None)
+    assert result.is_valid, result.errors
+    assert result.metadata["uniform_extension"] == ".jpg"
+
+
+def test_mixed_extensions_fail(clean_env, tmp_path):
+    images = tmp_path / "images"
+    images.mkdir()
+    (images / "a.jpg").write_bytes(b"x")
+    (images / "b.png").write_bytes(b"y")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = FileTypeValidator(allowed_extension=".jpg").validate(None)
+    assert not result.is_valid
+    assert any("Multiple file extensions" in e for e in result.errors)
+
+
+def test_invalid_extension_in_strict_mode_fails(clean_env, tmp_path):
+    images = tmp_path / "images"
+    images.mkdir()
+    (images / "a.png").write_bytes(b"x")
+    (images / "b.png").write_bytes(b"y")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = FileTypeValidator(allowed_extension=".jpg").validate(None)
+    assert not result.is_valid
+    assert any("invalid extensions" in e for e in result.errors)
+
+
+def test_no_files_fails(clean_env, tmp_path):
+    (tmp_path / "images").mkdir()
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = FileTypeValidator(allowed_extension=".jpg").validate(None)
+    assert not result.is_valid
+    assert "No files found" in result.errors[0]
+
+
+def test_nonexistent_path_fails(clean_env, tmp_path):
+    clean_env.setenv("SRC_PATH", str(tmp_path))  # no "images" subdir
+    result = FileTypeValidator(allowed_extension=".jpg").validate(None)
+    assert not result.is_valid
+
+
+def test_custom_subpath(clean_env, tmp_path):
+    texts = tmp_path / "texts"
+    texts.mkdir()
+    (texts / "a.txt").write_text("hi")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = FileTypeValidator(allowed_extension=".txt", path="texts").validate(None)
+    assert result.is_valid
+
+
+# ---- helpers --------------------------------------------------------------
+
+def test_get_files_single_file(tmp_path):
+    p = tmp_path / "a.jpg"
+    p.write_bytes(b"x")
+    v = FileTypeValidator(allowed_extension=".jpg")
+    assert v._get_files_to_validate(str(p), True, True) == [p]
+
+
+def test_get_files_list(tmp_path):
+    p = tmp_path / "a.jpg"
+    p.write_bytes(b"x")
+    v = FileTypeValidator(allowed_extension=".jpg")
+    files = v._get_files_to_validate([str(p), str(tmp_path / "missing.jpg")], True, True)
+    assert files == [p]
+
+
+def test_get_files_unsupported_type_raises():
+    v = FileTypeValidator(allowed_extension=".jpg")
+    with pytest.raises(ValueError):
+        v._get_files_to_validate(123, True, True)
+
+
+def test_get_files_ignores_hidden(tmp_path):
+    (tmp_path / ".h.jpg").write_bytes(b"x")
+    visible = tmp_path / "v.jpg"
+    visible.write_bytes(b"x")
+    v = FileTypeValidator(allowed_extension=".jpg")
+    files = v._get_files_to_validate(str(tmp_path), True, True)
+    assert visible in files
+    assert all(not p.name.startswith(".") for p in files)
+
+
+def test_validate_file_extensions_empty():
+    v = FileTypeValidator(allowed_extension=".jpg")
+    res = v._validate_file_extensions([])
+    assert not res.is_valid

--- a/tests/test_image_validator_flow.py
+++ b/tests/test_image_validator_flow.py
@@ -1,0 +1,124 @@
+"""Tests for ImageResolutionValidator's validate() flow and helpers.
+
+The resolution-matching unit tests live in test_image_validator_resolution.py;
+this file covers the file-discovery + uniformity flow, which reads images from
+``config.SRC_PATH/images``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from tracebloc_ingestor.validators.image_validator import ImageResolutionValidator
+
+
+@pytest.fixture
+def images_dir(tmp_path):
+    """Return a factory that creates <tmp>/images/<name> at a given size."""
+    d = tmp_path / "images"
+    d.mkdir()
+
+    def _add(name, size=(64, 64), color=(120, 120, 120)):
+        Image.new("RGB", size, color).save(d / name)
+        return d / name
+
+    return tmp_path, _add
+
+
+def test_uniform_images_pass(clean_env, images_dir):
+    src, add = images_dir
+    add("a.jpg", (64, 64))
+    add("b.jpg", (64, 64))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert result.is_valid, result.errors
+    assert result.metadata["files_checked"] == 2
+
+
+def test_mixed_resolutions_fail(clean_env, images_dir):
+    src, add = images_dir
+    add("a.jpg", (64, 64))
+    add("b.jpg", (32, 32))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+    assert any("Multiple image resolutions" in e for e in result.errors)
+
+
+def test_no_images_fails(clean_env, tmp_path):
+    (tmp_path / "images").mkdir()
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+    assert "No image files found" in result.errors[0]
+
+
+def test_explicit_resolution_mismatch_fails(clean_env, images_dir):
+    src, add = images_dir
+    add("a.jpg", (64, 64))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator(expected_resolution=(128, 128)).validate(None)
+    assert not result.is_valid
+    assert any("incorrect resolution" in e for e in result.errors)
+
+
+def test_nonexistent_src_path_fails(clean_env):
+    clean_env.setenv("SRC_PATH", "/no/such/dir")
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+
+
+# ---- helpers --------------------------------------------------------------
+
+def test_is_image_file():
+    v = ImageResolutionValidator()
+    assert v._is_image_file(Path("a.JPG"))
+    assert v._is_image_file(Path("a.png"))
+    assert not v._is_image_file(Path("a.txt"))
+
+
+def test_get_image_files_single(tmp_path):
+    p = tmp_path / "a.jpg"
+    Image.new("RGB", (10, 10)).save(p)
+    v = ImageResolutionValidator()
+    assert v._get_image_files(str(p), True, True) == [p]
+
+
+def test_get_image_files_list(tmp_path):
+    p = tmp_path / "a.png"
+    Image.new("RGB", (10, 10)).save(p)
+    v = ImageResolutionValidator()
+    files = v._get_image_files([str(p), str(tmp_path / "b.txt")], True, True)
+    assert files == [p]
+
+
+def test_get_image_files_unsupported_type_raises():
+    with pytest.raises(ValueError):
+        ImageResolutionValidator()._get_image_files(123, True, True)
+
+
+def test_get_image_files_missing_path_raises(tmp_path):
+    with pytest.raises(ValueError):
+        ImageResolutionValidator()._get_image_files(str(tmp_path / "nope"), True, True)
+
+
+def test_get_image_resolution_bad_file(tmp_path):
+    bad = tmp_path / "a.jpg"
+    bad.write_text("not an image")
+    assert ImageResolutionValidator()._get_image_resolution(bad) is None
+
+
+def test_validate_image_resolutions_empty_list():
+    res = ImageResolutionValidator()._validate_image_resolutions([])
+    assert not res.is_valid
+
+
+def test_validate_image_resolutions_unprocessable(tmp_path):
+    bad = tmp_path / "a.jpg"
+    bad.write_text("nope")
+    res = ImageResolutionValidator(expected_resolution=(10, 10))._validate_image_resolutions([bad])
+    assert not res.is_valid
+    assert any("could not be processed" in e for e in res.errors)

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -1,0 +1,243 @@
+"""Tests for BaseIngestor: record processing, batch handling, validation, ingest flow.
+
+We use a tiny concrete subclass and MagicMock Database/APIClient. The
+SQLAlchemy Session is patched out so no real engine is touched.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Generator, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor, IngestionSummary
+from tracebloc_ingestor.validators.base import ValidationResult
+
+
+class FakeIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source: Any) -> Generator[Dict[str, Any], None, None]:
+        yield from self._records
+
+
+def make_ingestor(records=None, **overrides):
+    db = MagicMock(name="Database")
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
+    db.get_table_schema.return_value = {"a": "INT"}
+    api = MagicMock(name="APIClient")
+    api.send_batch.return_value = True
+    api.send_generate_edge_label_meta.return_value = True
+    api.send_global_meta_meta.return_value = True
+    api.prepare_dataset.return_value = True
+    api.create_dataset.return_value = {"id": 1}
+
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=None,
+    )
+    kwargs.update(overrides)
+    return FakeIngestor(records or [], **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# IngestionSummary.has_failures
+# ---------------------------------------------------------------------------
+
+def test_summary_clean_run_no_failures():
+    s = IngestionSummary("id", 10, 10, 10, 10, 0, 0, 0)
+    assert s.has_failures is False
+
+
+@pytest.mark.parametrize("kwargs", [
+    dict(failed_records=1),
+    dict(file_transfer_failures=1),
+    dict(inserted_records=9),       # < total
+    dict(api_sent_records=9),       # < inserted
+])
+def test_summary_has_failures(kwargs):
+    base = dict(ingestor_id="id", total_records=10, processed_records=10,
+                inserted_records=10, api_sent_records=10, failed_records=0,
+                skipped_records=0, file_transfer_failures=0)
+    base.update(kwargs)
+    assert IngestionSummary(**base).has_failures is True
+
+
+# ---------------------------------------------------------------------------
+# __init__ schema cleaning
+# ---------------------------------------------------------------------------
+
+def test_init_strips_label_annotation_unique_from_schema():
+    ing = make_ingestor(
+        schema={"a": "INT", "lbl": "VARCHAR", "ann": "TEXT", "uid": "VARCHAR"},
+        label_column="lbl", annotation_column="ann", unique_id_column="uid",
+        category=None,
+    )
+    # The cleaned table schema passed to create_table excludes the special cols.
+    table_schema = ing.database.create_table.call_args[0][1]
+    assert "lbl" not in table_schema and "ann" not in table_schema and "uid" not in table_schema
+    assert "a" in table_schema
+
+
+def test_init_injects_number_of_columns_for_tabular():
+    from tracebloc_ingestor.utils.constants import TaskCategory
+    ing = make_ingestor(
+        schema={"a": "INT", "b": "FLOAT"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    assert ing.file_options["number_of_columns"] == 2
+
+
+# ---------------------------------------------------------------------------
+# process_record / _map_unique_id
+# ---------------------------------------------------------------------------
+
+def test_process_record_generates_uuid_data_id():
+    ing = make_ingestor(category=None, label_column="a")
+    rec = ing.process_record({"a": "cat", "filename": "x", "extension": ".jpg"})
+    assert rec["label"] == "cat"
+    assert rec["data_intent"] == "train"
+    assert rec["data_id"]  # uuid string
+    assert rec["ingestor_id"] == ing.ingestor_id
+
+
+def test_process_record_uses_unique_id_column():
+    ing = make_ingestor(schema={"a": "INT"}, unique_id_column="uid", category=None)
+    rec = ing.process_record({"a": "1", "uid": "  abc  ", "filename": "f"})
+    assert rec["data_id"] == "abc"
+
+
+def test_process_record_invalid_intent_returns_none():
+    ing = make_ingestor(intent="bogus", category=None)
+    assert ing.process_record({"a": "1"}) is None
+
+
+def test_process_record_missing_unique_id_returns_none():
+    ing = make_ingestor(unique_id_column="uid", category=None)
+    assert ing.process_record({"a": "1", "uid": "   "}) is None
+
+
+def test_process_record_applies_bucket_label_policy():
+    from tracebloc_ingestor.utils.label_policy import BUCKET
+    ing = make_ingestor(label_column="a", label_policy=BUCKET, category=None)
+    rec = ing.process_record({"a": "12345", "filename": "f"})
+    # bucket policy hashes the raw value -> not equal to the raw value
+    assert rec["label"] != "12345"
+
+
+# ---------------------------------------------------------------------------
+# _process_batch
+# ---------------------------------------------------------------------------
+
+def test_process_batch_success():
+    ing = make_ingestor()
+    session = MagicMock()
+    ids, api_success, db_failures = ing._process_batch([{"data_id": "a"}], session)
+    assert ids == [1, 2]
+    assert api_success is True
+    assert db_failures == []
+
+
+def test_process_batch_no_ids_skips_api():
+    ing = make_ingestor()
+    ing.database.insert_batch.return_value = ([], [{"err": "x"}])
+    session = MagicMock()
+    ids, api_success, db_failures = ing._process_batch([{"data_id": "a"}], session)
+    assert ids == []
+    assert api_success is False
+    ing.api_client.send_batch.assert_not_called()
+
+
+def test_process_batch_reraises_on_insert_error():
+    ing = make_ingestor()
+    err = RuntimeError("db down")
+    err.response = MagicMock(text="detail")
+    ing.database.insert_batch.side_effect = err
+    with pytest.raises(RuntimeError):
+        ing._process_batch([{"data_id": "a"}], MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# validate_data
+# ---------------------------------------------------------------------------
+
+def test_validate_data_no_validators_passes():
+    ing = make_ingestor(category=None)
+    assert ing.validate_data("src") is True
+
+
+def test_validate_data_raises_when_validator_fails():
+    ing = make_ingestor(category=None)
+    bad = MagicMock()
+    bad.name = "Bad"
+    bad.validate.return_value = ValidationResult(False, ["nope"], [], {})
+    with patch.object(base_mod, "map_validators", return_value=[bad]):
+        with pytest.raises(ValueError):
+            ing.validate_data("src")
+
+
+def test_validate_data_validator_exception_raises():
+    ing = make_ingestor(category=None)
+    bad = MagicMock()
+    bad.name = "Boom"
+    bad.validate.side_effect = RuntimeError("kaboom")
+    with patch.object(base_mod, "map_validators", return_value=[bad]):
+        with pytest.raises(ValueError):
+            ing.validate_data("src")
+
+
+# ---------------------------------------------------------------------------
+# ingest (full flow, Session patched)
+# ---------------------------------------------------------------------------
+
+def test_ingest_happy_path():
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=None)
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+    assert failed == []
+    ing.database.insert_batch.assert_called()
+    ing.api_client.create_dataset.assert_called_once()
+
+
+def test_ingest_skips_records_that_fail_processing():
+    # invalid intent -> process_record returns None -> counted as skipped
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=None, intent="bogus")
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+    assert failed == []
+    ing.database.insert_batch.assert_not_called()
+
+
+def test_ingest_reraises_on_session_error():
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=None)
+    ing.database.insert_batch.side_effect = RuntimeError("boom")
+    with patch.object(base_mod, "Session") as Sess:
+        session = MagicMock()
+        Sess.return_value.__enter__.return_value = session
+        # final batch processing failure is caught; but make commit raise to hit rollback
+        session.commit.side_effect = RuntimeError("commit fail")
+        with pytest.raises(RuntimeError):
+            ing.ingest("src", batch_size=10)
+        session.rollback.assert_called()
+
+
+def test_context_manager_protocol():
+    ing = make_ingestor()
+    with ing as x:
+        assert x is ing

--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -1,0 +1,108 @@
+"""Tests for JSONIngestor: read_data (object/array), record validation, counting."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tracebloc_ingestor.ingestors.json_ingestor import JSONIngestor
+
+
+def make_json_ingestor(schema=None, **overrides):
+    db = MagicMock()
+    db.create_table.return_value = MagicMock()
+    api = MagicMock()
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema=schema if schema is not None else {"a": "INT"},
+        intent="train",
+        category=None,
+    )
+    kwargs.update(overrides)
+    return JSONIngestor(**kwargs)
+
+
+def _write_json(tmp_path, obj, name="d.json"):
+    p = tmp_path / name
+    p.write_text(json.dumps(obj))
+    return p
+
+
+def test_read_data_array(tmp_path):
+    p = _write_json(tmp_path, [{"a": 1}, {"a": 2}])
+    ing = make_json_ingestor(schema={"a": "INT"})
+    records = list(ing.read_data(str(p)))
+    assert len(records) == 2
+
+
+def test_read_data_single_object(tmp_path):
+    p = _write_json(tmp_path, {"a": 1})
+    ing = make_json_ingestor(schema={"a": "INT"})
+    records = list(ing.read_data(str(p)))
+    assert records == [{"a": 1}]
+
+
+def test_read_data_missing_file_raises():
+    ing = make_json_ingestor()
+    with pytest.raises(FileNotFoundError):
+        list(ing.read_data("/no/such.json"))
+
+
+def test_read_data_invalid_top_level_type_raises(tmp_path):
+    p = _write_json(tmp_path, 42)  # neither dict nor list
+    ing = make_json_ingestor(schema={"a": "INT"})
+    with pytest.raises(ValueError):
+        list(ing.read_data(str(p)))
+
+
+def test_read_data_skips_non_dict_items(tmp_path):
+    p = _write_json(tmp_path, [{"a": 1}, "not-a-dict", {"a": 2}])
+    ing = make_json_ingestor(schema={"a": "INT"})
+    records = list(ing.read_data(str(p)))
+    assert len(records) == 2
+
+
+def test_read_data_skips_records_failing_validation(tmp_path):
+    # record missing unique_id_column -> _validate_record raises -> skipped
+    p = _write_json(tmp_path, [{"a": 1}, {"a": 2, "uid": "x"}])
+    ing = make_json_ingestor(schema={"a": "INT"}, unique_id_column="uid")
+    records = list(ing.read_data(str(p)))
+    assert records == [{"a": 2, "uid": "x"}]
+
+
+def test_read_data_malformed_json_raises(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text("{not json")
+    ing = make_json_ingestor()
+    with pytest.raises(json.JSONDecodeError):
+        list(ing.read_data(str(p)))
+
+
+def test_validate_record_type_error_raises():
+    ing = make_json_ingestor(schema={"n": "INT"})
+    with pytest.raises(ValueError, match="Data type validation failed"):
+        ing._validate_record({"n": "not-an-int"})
+
+
+def test_validate_record_allows_empty_string():
+    ing = make_json_ingestor(schema={"n": "INT"})
+    # empty string is allowed (treated as None) -> no raise
+    ing._validate_record({"n": ""})
+
+
+def test_count_records_array(tmp_path):
+    p = _write_json(tmp_path, [{"a": 1}, {"a": 2}, {"a": 3}])
+    assert make_json_ingestor()._count_records(str(p)) == 3
+
+
+def test_count_records_object(tmp_path):
+    p = _write_json(tmp_path, {"a": 1})
+    assert make_json_ingestor()._count_records(str(p)) == 1
+
+
+def test_count_records_bad_path_returns_none():
+    assert make_json_ingestor()._count_records("/no/such.json") is None

--- a/tests/test_keypoint_annotation_validator.py
+++ b/tests/test_keypoint_annotation_validator.py
@@ -1,0 +1,109 @@
+"""Tests for KeypointAnnotationValidator — JSON structure / coordinate checks."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.keypoint_annotation_validator import (
+    KeypointAnnotationValidator,
+)
+
+
+@pytest.fixture
+def validator():
+    return KeypointAnnotationValidator()
+
+
+def _df(annotations):
+    return pd.DataFrame({"Annotation": [json.dumps(a) for a in annotations]})
+
+
+def test_valid_keypoints_pass(validator):
+    df = _df([
+        {"nose": [10, 20], "eye": [30, 40]},
+        {"nose": [11, 21], "eye": [31, 41]},
+    ])
+    result = validator.validate(df)
+    assert result.is_valid
+    assert result.metadata["rows_checked"] == 2
+
+
+def test_dict_coordinate_form_passes(validator):
+    df = _df([{"nose": {"x": 1, "y": 2}, "eye": {"x": 3, "y": 4}}])
+    result = validator.validate(df)
+    assert result.is_valid
+
+
+def test_empty_dataframe_fails(validator):
+    result = validator.validate(pd.DataFrame())
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_missing_column_fails(validator):
+    result = validator.validate(pd.DataFrame({"other": [1]}))
+    assert not result.is_valid
+    assert "Missing required column" in result.errors[0]
+
+
+def test_invalid_json_fails(validator):
+    df = pd.DataFrame({"Annotation": ["{not json"]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "Invalid JSON" in result.errors[0]
+
+
+def test_non_dict_annotation_fails(validator):
+    df = pd.DataFrame({"Annotation": [json.dumps([1, 2, 3])]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "must be a JSON object" in result.errors[0]
+
+
+def test_wrong_coordinate_count_fails(validator):
+    df = _df([{"nose": [1, 2, 3]}])
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "exactly" in result.errors[0]
+
+
+def test_non_numeric_coordinates_fail(validator):
+    df = _df([{"nose": ["a", "b"], "eye": [1, 2]}])
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("must be numeric" in e for e in result.errors)
+
+
+def test_negative_coordinates_fail(validator):
+    df = _df([{"nose": [-1, 2], "eye": [3, 4]}])
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("negative coordinates" in e for e in result.errors)
+
+
+def test_malformed_keypoint_value_fails(validator):
+    df = _df([{"nose": 5}])  # neither list nor x/y dict
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("[x, y] list" in e for e in result.errors)
+
+
+def test_degenerate_bounding_box_fails(validator):
+    # All keypoints share the same coordinates -> zero width/height.
+    df = _df([{"a": [5, 5], "b": [5, 5]}])
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("degenerate bounding box" in e for e in result.errors)
+
+
+def test_inconsistent_keypoint_names_fail(validator):
+    df = _df([
+        {"nose": [1, 2], "eye": [3, 4]},
+        {"nose": [1, 2], "ear": [3, 4]},  # different key set
+    ])
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("differ from first record" in e for e in result.errors)

--- a/tests/test_keypoint_visibility_validator.py
+++ b/tests/test_keypoint_visibility_validator.py
@@ -1,0 +1,85 @@
+"""Tests for KeypointVisibilityValidator — visibility 0/1 + key consistency."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.keypoint_visibility_validator import (
+    KeypointVisibilityValidator,
+)
+
+
+@pytest.fixture
+def validator():
+    return KeypointVisibilityValidator()
+
+
+def test_valid_visibility_passes(validator):
+    df = pd.DataFrame({
+        "Annotation": [json.dumps({"nose": [1, 2], "eye": [3, 4]})],
+        "Visibility": [json.dumps({"nose": 1, "eye": 0})],
+    })
+    result = validator.validate(df)
+    assert result.is_valid
+
+
+def test_visibility_without_annotation_column_passes(validator):
+    df = pd.DataFrame({"Visibility": [json.dumps({"nose": 1})]})
+    result = validator.validate(df)
+    assert result.is_valid
+
+
+def test_empty_dataframe_fails(validator):
+    result = validator.validate(pd.DataFrame())
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_missing_visibility_column_fails(validator):
+    result = validator.validate(pd.DataFrame({"Annotation": ["{}"]}))
+    assert not result.is_valid
+    assert "Missing required column" in result.errors[0]
+
+
+def test_invalid_json_fails(validator):
+    df = pd.DataFrame({"Visibility": ["{bad"]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "Invalid JSON" in result.errors[0]
+
+
+def test_non_dict_visibility_fails(validator):
+    df = pd.DataFrame({"Visibility": [json.dumps([1, 0])]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "must be a JSON object" in result.errors[0]
+
+
+def test_out_of_range_value_fails(validator):
+    df = pd.DataFrame({"Visibility": [json.dumps({"nose": 2})]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("must be 0 or 1" in e for e in result.errors)
+
+
+def test_missing_keys_vs_annotation_fails(validator):
+    df = pd.DataFrame({
+        "Annotation": [json.dumps({"nose": [1, 2], "eye": [3, 4]})],
+        "Visibility": [json.dumps({"nose": 1})],  # missing "eye"
+    })
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("missing keys" in e for e in result.errors)
+
+
+def test_extra_keys_vs_annotation_fails(validator):
+    df = pd.DataFrame({
+        "Annotation": [json.dumps({"nose": [1, 2]})],
+        "Visibility": [json.dumps({"nose": 1, "eye": 0})],  # extra "eye"
+    })
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("extra keys" in e for e in result.errors)

--- a/tests/test_numeric_columns_validator.py
+++ b/tests/test_numeric_columns_validator.py
@@ -1,0 +1,76 @@
+"""Tests for NumericColumnsValidator — non-timestamp schema columns must be numeric/non-null."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.validators.numeric_columns_validator import (
+    NumericColumnsValidator,
+)
+
+
+SCHEMA = {"timestamp": "TIMESTAMP", "value": "FLOAT", "count": "INT"}
+
+
+def test_all_numeric_passes(make_csv):
+    path = make_csv({
+        "timestamp": ["2024-01-01", "2024-01-02"],
+        "value": [1.0, 2.0],
+        "count": [3, 4],
+    })
+    result = NumericColumnsValidator(schema=SCHEMA).validate(str(path))
+    assert result.is_valid
+    assert result.metadata["columns_to_validate"] == 2
+
+
+def test_null_value_fails(make_csv):
+    path = make_csv({
+        "timestamp": ["2024-01-01", "2024-01-02"],
+        "value": [1.0, None],
+        "count": [3, 4],
+    })
+    result = NumericColumnsValidator(schema=SCHEMA).validate(str(path))
+    assert not result.is_valid
+    assert any("null/missing" in e for e in result.errors)
+
+
+def test_non_numeric_fails(make_csv):
+    path = make_csv({
+        "timestamp": ["2024-01-01", "2024-01-02"],
+        "value": ["x", "y"],
+        "count": [3, 4],
+    })
+    result = NumericColumnsValidator(schema=SCHEMA).validate(str(path))
+    assert not result.is_valid
+    assert any("non-numeric" in e for e in result.errors)
+
+
+def test_timestamp_column_excluded(make_csv):
+    # timestamp is non-numeric but must be skipped.
+    path = make_csv({
+        "timestamp": ["2024-01-01", "2024-01-02"],
+        "value": [1.0, 2.0],
+    })
+    result = NumericColumnsValidator(schema={"timestamp": "TIMESTAMP", "value": "FLOAT"}).validate(str(path))
+    assert result.is_valid
+
+
+def test_no_schema_skips_validation(make_csv):
+    path = make_csv({"value": ["anything"]})
+    result = NumericColumnsValidator().validate(str(path))
+    assert result.is_valid
+    assert "No schema provided" in result.metadata["message"]
+
+
+def test_no_overlapping_columns_passes(make_csv):
+    # Schema columns aren't present in the CSV (besides timestamp) -> nothing to check.
+    path = make_csv({"timestamp": ["2024-01-01"], "other": [1]})
+    result = NumericColumnsValidator(schema={"timestamp": "TIMESTAMP", "value": "FLOAT"}).validate(str(path))
+    assert result.is_valid
+    assert "No schema columns to validate" in result.metadata["message"]
+
+
+def test_no_data_for_non_csv():
+    result = NumericColumnsValidator(schema=SCHEMA).validate("/missing.csv")
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]

--- a/tests/test_table_name_validator.py
+++ b/tests/test_table_name_validator.py
@@ -1,0 +1,77 @@
+"""Tests for TableNameValidator — regex naming rules read from config.TABLE_NAME."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.validators.table_name_validator import TableNameValidator
+
+
+@pytest.fixture
+def validator():
+    return TableNameValidator()
+
+
+def test_valid_name_passes(clean_env, validator):
+    clean_env.setenv("TABLE_NAME", "cats_dogs_train")
+    result = validator.validate(None)
+    assert result.is_valid
+    assert result.errors == []
+    assert result.metadata["table_names_checked"] == 1
+
+
+def test_missing_table_name_fails(clean_env, validator):
+    # TABLE_NAME unset -> config returns "" -> the no-name branch.
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert "No table name found" in result.errors[0]
+    assert result.metadata["table_names_checked"] == 0
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "1table",         # starts with a digit
+        "my-table",       # hyphen
+        "my table",       # space
+        "table$",         # symbol
+        "_leading",       # underscore start (pattern requires a letter)
+    ],
+)
+def test_invalid_characters_fail(clean_env, validator, bad_name):
+    clean_env.setenv("TABLE_NAME", bad_name)
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert any("invalid characters" in e for e in result.errors)
+    assert result.metadata["invalid_names"]
+
+
+def test_reserved_keyword_warns_but_passes(clean_env, validator):
+    clean_env.setenv("TABLE_NAME", "select")
+    result = validator.validate(None)
+    assert result.is_valid
+    assert any("reserved keyword" in w for w in result.warnings)
+
+
+def test_validate_table_names_empty_list(validator):
+    result = validator._validate_table_names([])
+    assert not result.is_valid
+    assert "No table names to validate" in result.errors[0]
+
+
+def test_validate_table_names_non_string(validator):
+    result = validator._validate_table_names([123])
+    assert not result.is_valid
+    assert any("not a string" in e for e in result.errors)
+
+
+def test_validate_table_names_whitespace_only(validator):
+    result = validator._validate_table_names(["   "])
+    assert not result.is_valid
+    assert any("empty table name" in e for e in result.errors)
+
+
+def test_is_reserved_keyword_case_insensitive(validator):
+    assert validator._is_reserved_keyword("SELECT")
+    assert validator._is_reserved_keyword("from")
+    assert not validator._is_reserved_keyword("customers")

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -222,6 +222,31 @@ CASES = [
     ),
 
     # -----------------------------------------------------------------------
+    # masked_language_modeling — self-supervised: no label_column. Template
+    # uses data_format=TEXT, extension=.txt, intent=TRAIN.
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.MASKED_LANGUAGE_MODELING,
+            table="masked_language_modeling_train",
+            intent="train",
+            csv="/data/labels.csv",
+            sequences="/data/sequences/",
+        ),
+        {
+            "category": TaskCategory.MASKED_LANGUAGE_MODELING,
+            "data_format": DataFormat.TEXT,
+            "intent": Intent.TRAIN,
+            "label_column": "",
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"extension": FileExtension.TXT},
+        },
+        id="masked_language_modeling",
+    ),
+
+    # -----------------------------------------------------------------------
     # tabular_classification — template label_column="name"
     # -----------------------------------------------------------------------
     pytest.param(

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -222,6 +222,33 @@ CASES = [
     ),
 
     # -----------------------------------------------------------------------
+    # masked_language_modeling — self-supervised, no label column. CSV manifest
+    # points at .txt sidecar files containing space-separated token sequences;
+    # the MLM client masks tokens on-the-fly during training. Sidecar dir is
+    # ``sequences/`` (not ``texts/``) to signal it's pre-tokenized, not raw text.
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.MASKED_LANGUAGE_MODELING,
+            table="masked_language_modeling_train",
+            intent="train",
+            csv="/data/labels.csv",
+            sequences="/data/sequences/",
+        ),
+        {
+            "category": TaskCategory.MASKED_LANGUAGE_MODELING,
+            "data_format": DataFormat.TEXT,
+            "intent": Intent.TRAIN,
+            "label_column": "",  # self-supervised — no label
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"extension": FileExtension.TXT},
+        },
+        id="masked_language_modeling",
+    ),
+
+    # -----------------------------------------------------------------------
     # tabular_classification — template label_column="name"
     # -----------------------------------------------------------------------
     pytest.param(

--- a/tests/test_time_validators.py
+++ b/tests/test_time_validators.py
@@ -1,0 +1,189 @@
+"""Tests for the time-series validators: format, ordering, before-today, to-event."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.time_format_validator import TimeFormatValidator
+from tracebloc_ingestor.validators.time_ordered_validator import TimeOrderedValidator
+from tracebloc_ingestor.validators.time_before_today_validator import (
+    TimeBeforeTodayValidator,
+)
+from tracebloc_ingestor.validators.time_to_event_validator import TimeToEventValidator
+
+
+# ---------------------------------------------------------------------------
+# TimeFormatValidator
+# ---------------------------------------------------------------------------
+
+def test_format_valid_timestamps_pass(make_csv):
+    path = make_csv({"timestamp": ["2024-01-01", "2024-01-02"], "v": [1, 2]})
+    result = TimeFormatValidator().validate(str(path))
+    assert result.is_valid
+    assert result.metadata["rows_checked"] == 2
+
+
+def test_format_invalid_timestamp_fails(make_csv):
+    path = make_csv({"timestamp": ["2024-01-01", "not-a-date"], "v": [1, 2]})
+    result = TimeFormatValidator().validate(str(path))
+    assert not result.is_valid
+    assert "invalid timestamp" in result.errors[0]
+    assert result.metadata["invalid_timestamps"] == 1
+
+
+def test_format_missing_column_fails(make_csv):
+    path = make_csv({"ts": ["2024-01-01"], "v": [1]})
+    result = TimeFormatValidator().validate(str(path))
+    assert not result.is_valid
+    assert "not found" in result.errors[0]
+
+
+def test_format_no_data_when_path_not_csv():
+    result = TimeFormatValidator().validate("/nonexistent/path.txt")
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_format_schema_missing_timestamp_fails():
+    v = TimeFormatValidator(schema={"value": "FLOAT"})
+    result = v.validate("ignored")
+    assert not result.is_valid
+    assert "must contain a 'timestamp' column" in result.errors[0]
+
+
+def test_format_schema_wrong_type_fails():
+    v = TimeFormatValidator(schema={"timestamp": "DATE"})
+    result = v.validate("ignored")
+    assert not result.is_valid
+    assert "must be of type 'TIMESTAMP'" in result.errors[0]
+
+
+def test_format_schema_timestamp_with_precision_passes(make_csv):
+    path = make_csv({"timestamp": ["2024-01-01"], "v": [1]})
+    v = TimeFormatValidator(schema={"timestamp": "TIMESTAMP(6)"})
+    result = v.validate(str(path))
+    assert result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# TimeOrderedValidator
+# ---------------------------------------------------------------------------
+
+def test_ordered_monotonic_passes(make_csv):
+    path = make_csv({"timestamp": ["2024-01-01", "2024-01-02", "2024-01-03"]})
+    result = TimeOrderedValidator().validate(str(path))
+    assert result.is_valid
+    assert result.metadata["is_ordered"] is True
+
+
+def test_ordered_out_of_order_fails(make_csv):
+    path = make_csv({"timestamp": ["2024-01-03", "2024-01-01"]})
+    result = TimeOrderedValidator().validate(str(path))
+    assert not result.is_valid
+    assert "out-of-order" in result.errors[0]
+    assert result.metadata["out_of_order_pairs"] == 1
+
+
+def test_ordered_missing_column_fails(make_csv):
+    path = make_csv({"ts": ["2024-01-01"]})
+    result = TimeOrderedValidator().validate(str(path))
+    assert not result.is_valid
+    assert "not found" in result.errors[0]
+
+
+def test_ordered_no_data_for_non_csv():
+    result = TimeOrderedValidator().validate("/nope.parquet")
+    assert not result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# TimeBeforeTodayValidator
+# ---------------------------------------------------------------------------
+
+def test_before_today_past_passes(make_csv):
+    path = make_csv({"timestamp": ["2000-01-01", "2001-01-01"]})
+    result = TimeBeforeTodayValidator().validate(str(path))
+    assert result.is_valid
+    assert "earliest" in result.metadata
+
+
+def test_before_today_future_fails(make_csv):
+    future = (pd.Timestamp.now() + pd.Timedelta(days=365)).strftime("%Y-%m-%d")
+    path = make_csv({"timestamp": ["2000-01-01", future]})
+    result = TimeBeforeTodayValidator().validate(str(path))
+    assert not result.is_valid
+    assert "not before today" in result.errors[0]
+    assert result.metadata["future_timestamps"] == 1
+
+
+def test_before_today_missing_column_fails(make_csv):
+    path = make_csv({"ts": ["2000-01-01"]})
+    result = TimeBeforeTodayValidator().validate(str(path))
+    assert not result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# TimeToEventValidator (accepts DataFrames directly)
+# ---------------------------------------------------------------------------
+
+def test_to_event_valid_passes():
+    df = pd.DataFrame({"time": [0, 1.5, 10], "event": [1, 0, 1]})
+    result = TimeToEventValidator().validate(df)
+    assert result.is_valid
+    assert result.metadata["min_time"] == 0.0
+    assert result.metadata["max_time"] == 10.0
+
+
+def test_to_event_missing_column_fails():
+    df = pd.DataFrame({"duration": [1, 2]})
+    result = TimeToEventValidator().validate(df)
+    assert not result.is_valid
+    assert "Required time column 'time' not found" in result.errors[0]
+
+
+def test_to_event_non_numeric_fails():
+    df = pd.DataFrame({"time": [1, "abc", 3]})
+    result = TimeToEventValidator().validate(df)
+    assert not result.is_valid
+    assert "non-numeric" in result.errors[0]
+    assert result.metadata["non_numeric_count"] == 1
+
+
+def test_to_event_negative_fails():
+    df = pd.DataFrame({"time": [1, -2, 3]})
+    result = TimeToEventValidator().validate(df)
+    assert not result.is_valid
+    assert "negative" in result.errors[0]
+    assert result.metadata["negative_count"] == 1
+
+
+def test_to_event_null_warns_but_can_pass():
+    df = pd.DataFrame({"time": [1.0, None, 3.0]})
+    result = TimeToEventValidator().validate(df)
+    assert result.is_valid
+    assert any("null/missing" in w for w in result.warnings)
+
+
+def test_to_event_empty_dataframe_fails():
+    result = TimeToEventValidator().validate(pd.DataFrame())
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_to_event_custom_column_name():
+    df = pd.DataFrame({"duration": [1, 2, 3]})
+    result = TimeToEventValidator(time_column="duration").validate(df)
+    assert result.is_valid
+
+
+def test_to_event_loads_from_csv(make_csv):
+    path = make_csv({"time": [1, 2, 3]})
+    result = TimeToEventValidator().validate(str(path))
+    assert result.is_valid
+
+
+def test_to_event_sample_size_limits_rows():
+    df = pd.DataFrame({"time": list(range(100))})
+    result = TimeToEventValidator().validate(df, sample_size=10)
+    assert result.metadata["rows_checked"] == 10

--- a/tests/test_tokenizer_validator.py
+++ b/tests/test_tokenizer_validator.py
@@ -1,0 +1,81 @@
+"""Tests for TokenizerValidator — checks tokenizer.json at config.SRC_PATH."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
+
+
+@pytest.fixture
+def validator():
+    return TokenizerValidator()
+
+
+def test_passes_when_required_tokens_present(clean_env, validator, make_tokenizer):
+    src = make_tokenizer(vocab=["a", "b", "[MASK]", "[PAD]"])
+    clean_env.setenv("SRC_PATH", str(src))
+    result = validator.validate(None)
+    assert result.is_valid
+    assert result.metadata["vocab_size"] == 4
+
+
+def test_missing_file_fails(clean_env, validator, tmp_path):
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert "tokenizer.json not found" in result.errors[0]
+
+
+def test_missing_required_token_fails(clean_env, validator, make_tokenizer):
+    src = make_tokenizer(vocab=["a", "b", "[PAD]"])  # no [MASK]
+    clean_env.setenv("SRC_PATH", str(src))
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert "[MASK]" in result.errors[0]
+    assert result.metadata["missing_tokens"] == ["[MASK]"]
+
+
+def test_tokens_from_added_tokens_section(clean_env, validator, make_tokenizer):
+    # vocab lacks the special tokens; added_tokens supplies them.
+    src = make_tokenizer(vocab=["a", "b"], added=["[MASK]", "[PAD]"])
+    clean_env.setenv("SRC_PATH", str(src))
+    result = validator.validate(None)
+    assert result.is_valid
+
+
+def test_unrecognized_structure_fails(clean_env, validator, make_tokenizer):
+    src = make_tokenizer(vocab=None)  # empty model, no added_tokens
+    clean_env.setenv("SRC_PATH", str(src))
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert "Could not extract vocabulary" in result.errors[0]
+
+
+def test_invalid_json_fails(clean_env, validator, make_tokenizer):
+    src = make_tokenizer(raw="{not valid json")
+    clean_env.setenv("SRC_PATH", str(src))
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert "not valid JSON" in result.errors[0]
+
+
+def test_extract_vocab_unigram_list_form():
+    data = {"model": {"vocab": [["[MASK]", -1.0], ["[PAD]", -2.0]]}}
+    vocab = TokenizerValidator._extract_vocab(data)
+    assert vocab == {"[MASK]", "[PAD]"}
+
+
+def test_extract_vocab_added_tokens_string_form():
+    data = {"added_tokens": ["[MASK]", "[PAD]"]}
+    vocab = TokenizerValidator._extract_vocab(data)
+    assert vocab == {"[MASK]", "[PAD]"}
+
+
+def test_extract_vocab_returns_none_when_empty():
+    assert TokenizerValidator._extract_vocab({}) is None
+
+
+def test_custom_required_tokens():
+    v = TokenizerValidator(required_tokens=("[CLS]",))
+    assert v.required_tokens == {"[CLS]"}

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -1,0 +1,124 @@
+"""Tests for map_validators — the per-category validator factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.utils.validators_mapping import map_validators
+from tracebloc_ingestor.utils.constants import TaskCategory, FileExtension
+from tracebloc_ingestor.validators.file_validator import FileTypeValidator
+from tracebloc_ingestor.validators.image_validator import ImageResolutionValidator
+from tracebloc_ingestor.validators.data_validator import DataValidator
+from tracebloc_ingestor.validators.table_name_validator import TableNameValidator
+from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
+from tracebloc_ingestor.validators.xml_validator import PascalVOCXMLValidator
+from tracebloc_ingestor.validators.time_to_event_validator import TimeToEventValidator
+from tracebloc_ingestor.validators.time_format_validator import TimeFormatValidator
+from tracebloc_ingestor.validators.numeric_columns_validator import NumericColumnsValidator
+from tracebloc_ingestor.validators.keypoint_annotation_validator import KeypointAnnotationValidator
+from tracebloc_ingestor.validators.keypoint_visibility_validator import KeypointVisibilityValidator
+from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
+
+
+IMAGE_OPTS = {"extension": FileExtension.JPG, "target_size": [224, 224]}
+
+
+def _types(validators):
+    return [type(v) for v in validators]
+
+
+def test_image_classification():
+    v = map_validators(TaskCategory.IMAGE_CLASSIFICATION, IMAGE_OPTS)
+    assert _types(v) == [
+        FileTypeValidator, ImageResolutionValidator, TableNameValidator, DuplicateValidator
+    ]
+
+
+def test_object_detection_includes_xml_validator():
+    v = map_validators(TaskCategory.OBJECT_DETECTION, IMAGE_OPTS)
+    types = _types(v)
+    assert PascalVOCXMLValidator in types
+    # two FileTypeValidators: images + annotations
+    assert types.count(FileTypeValidator) == 2
+
+
+def test_semantic_segmentation():
+    v = map_validators(TaskCategory.SEMANTIC_SEGMENTATION, IMAGE_OPTS)
+    types = _types(v)
+    assert types.count(FileTypeValidator) == 2
+    assert ImageResolutionValidator in types
+
+
+def test_keypoint_detection_includes_keypoint_validators():
+    v = map_validators(TaskCategory.KEYPOINT_DETECTION, IMAGE_OPTS)
+    types = _types(v)
+    assert KeypointAnnotationValidator in types
+    assert KeypointVisibilityValidator in types
+
+
+def test_tabular_classification_with_schema():
+    v = map_validators(TaskCategory.TABULAR_CLASSIFICATION, {"schema": {"a": "INT"}})
+    types = _types(v)
+    assert DataValidator in types
+    assert types[-2:] == [TableNameValidator, DuplicateValidator]
+
+
+def test_tabular_classification_without_schema_omits_data_validator():
+    v = map_validators(TaskCategory.TABULAR_CLASSIFICATION, {})
+    assert DataValidator not in _types(v)
+
+
+def test_tabular_regression_with_schema():
+    v = map_validators(TaskCategory.TABULAR_REGRESSION, {"schema": {"x": "FLOAT"}})
+    assert DataValidator in _types(v)
+
+
+def test_text_classification_defaults_extension():
+    v = map_validators(TaskCategory.TEXT_CLASSIFICATION, {})
+    assert _types(v)[0] is FileTypeValidator
+
+
+def test_time_series_forecasting_validator_set():
+    v = map_validators(
+        TaskCategory.TIME_SERIES_FORECASTING,
+        {"schema": {"timestamp": "TIMESTAMP", "value": "FLOAT"}},
+    )
+    types = _types(v)
+    assert TimeFormatValidator in types
+    assert NumericColumnsValidator in types
+    # schema minus timestamp is non-empty -> a DataValidator is added
+    assert DataValidator in types
+
+
+def test_time_series_forecasting_timestamp_only_schema_no_data_validator():
+    v = map_validators(
+        TaskCategory.TIME_SERIES_FORECASTING,
+        {"schema": {"timestamp": "TIMESTAMP"}},
+    )
+    assert DataValidator not in _types(v)
+
+
+def test_time_to_event_with_schema():
+    v = map_validators(
+        TaskCategory.TIME_TO_EVENT_PREDICTION,
+        {"schema": {"time": "INT"}, "time_column": "time"},
+    )
+    types = _types(v)
+    assert TimeToEventValidator in types
+    assert DataValidator in types
+
+
+def test_time_to_event_without_schema():
+    v = map_validators(TaskCategory.TIME_TO_EVENT_PREDICTION, {})
+    types = _types(v)
+    assert TimeToEventValidator in types
+    assert DataValidator not in types
+
+
+def test_masked_language_modeling_includes_tokenizer():
+    v = map_validators(TaskCategory.MASKED_LANGUAGE_MODELING, {})
+    assert TokenizerValidator in _types(v)
+
+
+def test_unknown_category_returns_empty():
+    assert map_validators("not_a_category", {}) == []

--- a/tests/test_xml_validator.py
+++ b/tests/test_xml_validator.py
@@ -1,0 +1,276 @@
+"""Tests for PascalVOCXMLValidator — full VOC structure compliance."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from tracebloc_ingestor.validators.xml_validator import PascalVOCXMLValidator
+
+
+# ---------------------------------------------------------------------------
+# Builders for valid / customizable VOC XML.
+# ---------------------------------------------------------------------------
+
+def _object_xml(
+    name="cat", pose="Unspecified", truncated="0", difficult="0",
+    xmin=10, ymin=10, xmax=100, ymax=100,
+):
+    return f"""
+  <object>
+    <name>{name}</name>
+    <pose>{pose}</pose>
+    <truncated>{truncated}</truncated>
+    <difficult>{difficult}</difficult>
+    <bndbox>
+      <xmin>{xmin}</xmin>
+      <ymin>{ymin}</ymin>
+      <xmax>{xmax}</xmax>
+      <ymax>{ymax}</ymax>
+    </bndbox>
+  </object>"""
+
+
+def _voc_xml(objects=None, width=640, height=480, depth=3, segmented="0"):
+    if objects is None:
+        objects = [_object_xml()]
+    return f"""<annotation>
+  <folder>images</folder>
+  <filename>img.jpg</filename>
+  <source>
+    <database>Unknown</database>
+    <annotation>PASCAL VOC</annotation>
+  </source>
+  <size>
+    <width>{width}</width>
+    <height>{height}</height>
+    <depth>{depth}</depth>
+  </size>
+  <segmented>{segmented}</segmented>
+{"".join(objects)}
+</annotation>"""
+
+
+@pytest.fixture
+def write_xml(tmp_path):
+    """Write XML text into SRC_PATH and point config at it via env."""
+
+    def _write(xml_text, *, name="ann.xml", monkeypatch=None):
+        path = tmp_path / name
+        path.write_text(xml_text, encoding="utf-8")
+        return path
+
+    return _write
+
+
+@pytest.fixture
+def validator():
+    return PascalVOCXMLValidator()
+
+
+# ---------------------------------------------------------------------------
+# validate() flow (reads config.SRC_PATH directory)
+# ---------------------------------------------------------------------------
+
+def test_valid_file_passes(clean_env, tmp_path, validator):
+    (tmp_path / "ann.xml").write_text(_voc_xml(), encoding="utf-8")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(None)
+    assert result.is_valid, result.errors
+    assert result.metadata["valid_files"] == 1
+
+
+def test_no_xml_files_fails(clean_env, tmp_path, validator):
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert "No XML files found" in result.errors[0]
+
+
+def test_invalid_file_reports_errors(clean_env, tmp_path, validator):
+    bad = _voc_xml(objects=[_object_xml(xmin=100, xmax=100)])  # zero width box
+    (tmp_path / "ann.xml").write_text(bad, encoding="utf-8")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(None)
+    assert not result.is_valid
+    assert result.metadata["invalid_files"] == 1
+
+
+def test_nonexistent_src_path_fails(clean_env, validator):
+    clean_env.setenv("SRC_PATH", "/definitely/not/here")
+    result = validator.validate(None)
+    assert not result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# _get_xml_files
+# ---------------------------------------------------------------------------
+
+def test_get_xml_files_single_file(tmp_path, validator):
+    f = tmp_path / "a.xml"
+    f.write_text(_voc_xml(), encoding="utf-8")
+    files = validator._get_xml_files(str(f), True, True)
+    assert files == [f]
+
+
+def test_get_xml_files_list_input(tmp_path, validator):
+    f = tmp_path / "a.xml"
+    f.write_text(_voc_xml(), encoding="utf-8")
+    files = validator._get_xml_files([str(f), str(tmp_path / "missing.xml")], True, True)
+    assert files == [f]
+
+
+def test_get_xml_files_unsupported_type_raises(validator):
+    with pytest.raises(ValueError):
+        validator._get_xml_files(123, True, True)
+
+
+def test_get_xml_files_ignores_hidden(tmp_path, validator):
+    (tmp_path / ".hidden.xml").write_text(_voc_xml(), encoding="utf-8")
+    visible = tmp_path / "v.xml"
+    visible.write_text(_voc_xml(), encoding="utf-8")
+    files = validator._get_xml_files(str(tmp_path), True, True)
+    assert visible in files
+    assert all(not p.name.startswith(".") for p in files)
+
+
+# ---------------------------------------------------------------------------
+# _validate_single_xml + sub-validators
+# ---------------------------------------------------------------------------
+
+def test_single_xml_valid(tmp_path, validator):
+    f = tmp_path / "a.xml"
+    f.write_text(_voc_xml(), encoding="utf-8")
+    result = validator._validate_single_xml(f)
+    assert result.is_valid, result.errors
+
+
+def test_wrong_root_tag_fails(tmp_path, validator):
+    f = tmp_path / "a.xml"
+    f.write_text("<dataset></dataset>", encoding="utf-8")
+    result = validator._validate_single_xml(f)
+    assert not result.is_valid
+    assert "Root element must be 'annotation'" in result.errors[0]
+
+
+def test_parse_error_fails(tmp_path, validator):
+    f = tmp_path / "a.xml"
+    f.write_text("<annotation><unclosed>", encoding="utf-8")
+    result = validator._validate_single_xml(f)
+    assert not result.is_valid
+    assert "XML parsing error" in result.errors[0]
+
+
+def _root(xml_text):
+    return ET.fromstring(xml_text)
+
+
+def test_root_elements_missing():
+    v = PascalVOCXMLValidator()
+    root = _root("<annotation><filename>x.jpg</filename></annotation>")
+    res = v._validate_root_elements(root)
+    assert any("Missing required root elements" in e for e in res["errors"])
+
+
+def test_root_empty_filename_fails():
+    v = PascalVOCXMLValidator()
+    root = _root(_voc_xml().replace("<filename>img.jpg</filename>", "<filename></filename>"))
+    res = v._validate_root_elements(root)
+    assert any("Filename element must have non-empty" in e for e in res["errors"])
+
+
+def test_root_bad_segmented_fails():
+    v = PascalVOCXMLValidator()
+    root = _root(_voc_xml(segmented="2"))
+    res = v._validate_root_elements(root)
+    assert any("Segmented element must be" in e for e in res["errors"])
+
+
+def test_source_missing_fails():
+    v = PascalVOCXMLValidator()
+    root = _root("<annotation></annotation>")
+    res = v._validate_source_element(root)
+    assert any("Missing required 'source'" in e for e in res["errors"])
+
+
+def test_source_empty_database_fails():
+    v = PascalVOCXMLValidator()
+    root = _root(_voc_xml().replace("<database>Unknown</database>", "<database></database>"))
+    res = v._validate_source_element(root)
+    assert any("Database element must have non-empty" in e for e in res["errors"])
+
+
+def test_size_missing_fails():
+    v = PascalVOCXMLValidator()
+    root = _root("<annotation></annotation>")
+    res = v._validate_size_element(root)
+    assert any("Missing required 'size'" in e for e in res["errors"])
+
+
+def test_size_non_positive_fails():
+    v = PascalVOCXMLValidator()
+    root = _root(_voc_xml(width=0))
+    res = v._validate_size_element(root)
+    assert any("width must be a positive integer" in e for e in res["errors"])
+
+
+def test_size_non_integer_fails():
+    v = PascalVOCXMLValidator()
+    root = _root(_voc_xml().replace("<width>640</width>", "<width>abc</width>"))
+    res = v._validate_size_element(root)
+    assert any("width must be a valid integer" in e for e in res["errors"])
+
+
+def test_objects_none_warns():
+    v = PascalVOCXMLValidator()
+    root = _root(_voc_xml(objects=[]))
+    res = v._validate_objects(root)
+    assert res["errors"] == []
+    assert any("No objects found" in w for w in res["warnings"])
+
+
+def test_object_missing_bndbox_fails():
+    v = PascalVOCXMLValidator()
+    obj = _root("""
+      <object>
+        <name>cat</name><pose>Unspecified</pose>
+        <truncated>0</truncated><difficult>0</difficult>
+      </object>""")
+    res = v._validate_single_object(obj, 0)
+    assert any("Missing required 'bndbox'" in e for e in res["errors"])
+
+
+def test_object_bad_truncated_fails():
+    v = PascalVOCXMLValidator()
+    obj = _root(_object_xml(truncated="5"))
+    res = v._validate_single_object(obj, 0)
+    assert any("Truncated element must be" in e for e in res["errors"])
+
+
+def test_bndbox_xmin_ge_xmax_fails():
+    v = PascalVOCXMLValidator()
+    obj = _root(_object_xml(xmin=100, xmax=50))
+    res = v._validate_bndbox_element(obj, 0)
+    assert any("must be less than xmax" in e for e in res["errors"])
+
+
+def test_bndbox_negative_coord_fails():
+    v = PascalVOCXMLValidator()
+    obj = _root(_object_xml(xmin=-5))
+    res = v._validate_bndbox_element(obj, 0)
+    assert any("must be non-negative" in e for e in res["errors"])
+
+
+def test_bndbox_non_integer_coord_fails():
+    v = PascalVOCXMLValidator()
+    obj = _root(_object_xml().replace("<xmin>10</xmin>", "<xmin>abc</xmin>"))
+    res = v._validate_bndbox_element(obj, 0)
+    assert any("must be a valid integer" in e for e in res["errors"])
+
+
+def test_bndbox_small_area_warns():
+    v = PascalVOCXMLValidator()
+    obj = _root(_object_xml(xmin=10, ymin=10, xmax=12, ymax=12))  # area 4 < 10
+    res = v._validate_bndbox_element(obj, 0)
+    assert any("Very small bounding box" in w for w in res["warnings"])

--- a/tests/test_xml_validator.py
+++ b/tests/test_xml_validator.py
@@ -53,18 +53,6 @@ def _voc_xml(objects=None, width=640, height=480, depth=3, segmented="0"):
 
 
 @pytest.fixture
-def write_xml(tmp_path):
-    """Write XML text into SRC_PATH and point config at it via env."""
-
-    def _write(xml_text, *, name="ann.xml", monkeypatch=None):
-        path = tmp_path / name
-        path.write_text(xml_text, encoding="utf-8")
-        return path
-
-    return _write
-
-
-@pytest.fixture
 def validator():
     return PascalVOCXMLValidator()
 

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -178,7 +178,10 @@ class Database:
             - failures: List of dictionaries containing failed records and their error messages
         """
         if not records:
-            return {"success_ids": [], "failures": []}
+            # Return the same (success_ids, failures) tuple shape as the
+            # non-empty path so callers can always unpack two values —
+            # BaseIngestor._process_batch does ``ids, failures = insert_batch(...)``.
+            return [], []
 
         table = self.tables[table_name]
         result = {"success_ids": [], "failures": []}

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -113,7 +113,29 @@ class Database:
 
         Returns:
             SQLAlchemy Table object
+
+        Raises:
+            ValueError: if a schema column collides with a reserved/internal
+                column (e.g. a user CSV with its own ``id``), which would
+                otherwise surface as a cryptic SQLAlchemy DuplicateColumnError.
         """
+        # Fail fast on reserved-column collisions before any DB I/O. `label`
+        # is intentionally excluded — it's the user-facing label column the
+        # framework maps onto the standard `label` column.
+        _RESERVED = {
+            "id", "created_at", "updated_at", "status", "data_intent",
+            "data_id", "filename", "extension", "annotation", "ingestor_id",
+        }
+        _collisions = sorted(_RESERVED & set(schema))
+        if _collisions:
+            raise ValueError(
+                f"Schema column(s) {_collisions} collide with reserved tracebloc "
+                f"columns. The framework manages its own row id, timestamps, status, "
+                f"data_id and sidecar metadata — rename these column(s) in your "
+                f"CSV/schema. (To use your own `id` as the record identifier, set "
+                f"data_id.strategy=column instead.)"
+            )
+
         # Return existing table if already created
         if table_name in self.tables:
             return self.tables[table_name]

--- a/tracebloc_ingestor/validators/xml_validator.py
+++ b/tracebloc_ingestor/validators/xml_validator.py
@@ -527,15 +527,30 @@ class PascalVOCXMLValidator(BaseValidator):
         elif "truncated" in self.required_object_elements:
             errors.append(f"Object {index}: Missing required 'truncated' element")
 
-        # Validate difficult element
+        # Validate difficult element. Pascal VOC officially uses 0/1, but
+        # real-world detection datasets (e.g. VisDrone — our bundled OD sample)
+        # use higher difficulty levels. Accept any non-negative integer; flag
+        # non-standard values as a warning rather than failing ingestion.
         difficult_elem = obj.find("difficult")
         if difficult_elem is not None:
-            if difficult_elem.text not in ["0", "1"]:
+            try:
+                difficult_val = (
+                    int(difficult_elem.text) if difficult_elem.text is not None else None
+                )
+            except (ValueError, TypeError):
+                difficult_val = None
+            if difficult_val is None or difficult_val < 0:
                 errors.append(
-                    f"Object {index}: Difficult element must be '0' or '1', found: {difficult_elem.text}"
+                    f"Object {index}: Difficult element must be a non-negative integer, "
+                    f"found: {difficult_elem.text}"
                 )
             else:
-                metadata["difficult"] = int(difficult_elem.text)
+                metadata["difficult"] = difficult_val
+                if difficult_val not in (0, 1):
+                    warnings.append(
+                        f"Object {index}: Difficult={difficult_val} is outside the standard "
+                        f"Pascal VOC 0/1 (accepted; e.g. VisDrone uses 0/1/2)"
+                    )
         elif "difficult" in self.required_object_elements:
             errors.append(f"Object {index}: Missing required 'difficult' element")
 


### PR DESCRIPTION
## Summary

Release: `develop → master`. 33 commits, including the items below (all FR-passed and in Ready for prod).

Note: data-ingestors has no `staging` branch (it's a 2-stage repo). Per the kanban model, items in this PR moved from "Ready for staging" → "Ready for prod" (the correct column for a 2-stage repo's items awaiting promotion to master).

## Contained items

The full list will be visible in the PR commits. Highlights:

- **CI hardening**: pytest test workflow (#124), fr-gate caller (#132), coverage gate at `--cov-fail-under=95` (#130)
- **Test coverage**: phases 2/3/4 — pandas/file validators, ingestors/transfer/api, database.py + gap closure to ~99% (#127, #128, #129)
- **Bug fixes**: MLM tokenizer + PascalVOC + reserved-id guard (#139), multi-arch ingestor image (#140, closes #24)
- **End-to-end test**: ingestion equivalence suite across modalities, real MySQL (#138)
- **Docs**: declarative-ingest drift fix (#133), release procedure (#118)
- **Release chore**: v0.3.1 version bump (#121)

## Why now

- 33 commits of accumulated develop work + all individual PRs already reviewed + FR-passed.
- The fr-gate caller (#132) just landed today — first release going through the gate.

## Test plan

- [x] All individual PRs passed `--cov-fail-under` gates
- [x] All individual PRs passed e2e ingestion equivalence
- [ ] fr-gate green on this PR (all items confirmed in `Ready for prod`)
- [ ] After merge: `advance-deploy-env` advances all items to `Prod` automatically
