### PR TITLE
chore(release): bump version to 0.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="tracebloc_ingestor",
-    version="0.3.1",
+    version="0.3.2",
     author="Tracebloc",
     author_email="support@tracebloc.com",
     description="A flexible data ingestion library for various file formats",


### PR DESCRIPTION
Bumps `tracebloc_ingestor` **0.3.1 → 0.3.2** in `setup.py` ahead of the v0.3.2 release.

## Why
PyPI already has `0.3.1` (it's the current latest), so the next `develop`→`master` sync would run `twine upload` of `0.3.1` and **fail with "file already exists"**. Bumping the version unblocks that publish. (Flagged by @-colleague.)

## Scope / safety
- One-line change to `setup.py` only.
- Merging to `develop` triggers `publish-dev.yml`, which **builds + smoke-tests but does not upload** — so this PR ships nothing on its own.
- The actual PyPI publish happens later on the `develop`→`master` sync; the multi-arch image publish happens on the `v0.3.2` tag (the auto-rollout step). Neither is triggered by this PR.

Per RELEASING.md step 2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version bump in packaging metadata with no runtime or security impact.
> 
> **Overview**
> Bumps the **`tracebloc_ingestor`** package version in **`setup.py`** from **`0.3.1`** to **`0.3.2`** so the next release publish to PyPI does not collide with the version already on the index.
> 
> No application or library code changes—release housekeeping only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83258f27564d103ec9f6d68aa60a66ceb84a889f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->