### PR TITLE
docs(releasing): reframe step 7 as optional greenfield-baseline bump

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -143,9 +143,17 @@ docker run --rm --entrypoint python ${IMAGE}@${DIGEST} \
   -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
 ```
 
-## 7. Pin the new digest downstream
+## 7. (Optional) Bump the greenfield baseline in `tracebloc/client`
 
-The Helm subchart in [`tracebloc/client`](https://github.com/tracebloc/client) reads the digest out of these release notes and bakes it into its values. Open a follow-up PR there pinning to the new digest. (Pull by digest, not tag — that's the whole point of signing.)
+**Live clusters roll themselves forward — this step is not required for rollout.** Since [`tracebloc/client#159`](https://github.com/tracebloc/client/pull/159) (the [#158](https://github.com/tracebloc/client/issues/158) auto-refresh feature), the chart ships `images.ingestor.autoRefresh: true` with a floating tag (`images.ingestor.tag: "0.3"`). An image-refresh CronJob polls `ghcr.io/tracebloc/ingestor:0.3` and rewrites the live deployment's `INGESTOR_IMAGE_DIGEST` within ~15 min of a new image push — no chart change, no `helm upgrade`. Every existing install converges on its own, as long as the new image matches the chart's floating tag. (Authoritative explanation: the comment block around `images.ingestor` in [`client/values.yaml`](https://github.com/tracebloc/client/blob/develop/client/values.yaml).)
+
+The pinned `images.ingestor.digest` in the chart only sets the **greenfield baseline** — the digest a brand-new install lands on before its first refresh tick. Bumping it is a deliberate, optional chart release, not a release step. Do it when you want fresh installs to start on the version you just shipped:
+
+- Bump `images.ingestor.digest` to the new digest **and** `client/Chart.yaml`'s `version` + `appVersion` in lockstep (the chart's own SemVer, independent of the ingestor's).
+- Open the PR against **`develop`**, like any other client change — this is not a `master`-targeting release PR.
+- Precedent: [`client#161`](https://github.com/tracebloc/client/pull/161) (baseline v0.3.0 → v0.3.1) and [`client#185`](https://github.com/tracebloc/client/pull/185) (v0.3.1 → v0.3.2, tracking [#184](https://github.com/tracebloc/client/issues/184)).
+
+(When you do pin, pull by digest, not tag — that's the whole point of signing.)
 
 ## Manual fallback (workflow_dispatch)
 


### PR DESCRIPTION
## What

Revises `RELEASING.md` **step 7** (formerly "Pin the new digest downstream"). It presented the `tracebloc/client` Helm-chart digest pin as a **required** release step — that's been stale since the auto-refresh feature shipped.

## Why

After [`tracebloc/client#159`](https://github.com/tracebloc/client/pull/159) (the [#158](https://github.com/tracebloc/client/issues/158) "auto-refresh ingestor image digest without chart release" feature), live clusters converge on a new ingestor release **automatically**:

- `client/values.yaml` ships `images.ingestor.autoRefresh: true` with float tag `images.ingestor.tag: "0.3"`.
- An image-refresh CronJob polls `ghcr.io/tracebloc/ingestor:0.3` and rewrites the live deployment's `INGESTOR_IMAGE_DIGEST` within ~15 min of a new image push — no chart change, no `helm upgrade`.

The chart's pinned `images.ingestor.digest` now only sets the **greenfield-install baseline**. Bumping it is a deliberate, **optional** chart release — not a mandatory release step.

## Change

Step 7 now:

1. States that live-cluster rollout is automatic via image-refresh and needs no chart change.
2. Reframes the `tracebloc/client` PR as the optional greenfield-baseline bump — bump `images.ingestor.digest` + `client/Chart.yaml`'s `version`/`appVersion` in lockstep, PR'd to `develop`. Precedents: [`client#161`](https://github.com/tracebloc/client/pull/161), [`client#185`](https://github.com/tracebloc/client/pull/185).

Rest of the doc is untouched (single-section edit, +10/−2).

Closes #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to maintainer release instructions; no runtime, auth, or deployment code is modified.
> 
> **Overview**
> **Release doc update only:** `RELEASING.md` step 7 is renamed and expanded so it no longer reads as a mandatory downstream digest pin.
> 
> It now explains that **existing clusters** pick up new ingestor images via the client chart’s auto-refresh CronJob (~15 min after push), without a chart change or `helm upgrade`. The optional follow-up is bumping **`images.ingestor.digest`** in `tracebloc/client` for **greenfield** installs, with bullets for digest + `Chart.yaml` version/`appVersion`, PR target **`develop`**, and precedent PRs; the digest-not-tag reminder is kept in parentheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 196ababf24a71e607961acafc56ad8155f3f2018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->