### PR TITLE
Develop to prod

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -143,9 +143,17 @@ docker run --rm --entrypoint python ${IMAGE}@${DIGEST} \
   -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
 ```
 
-## 7. Pin the new digest downstream
+## 7. (Optional) Bump the greenfield baseline in `tracebloc/client`
 
-The Helm subchart in [`tracebloc/client`](https://github.com/tracebloc/client) reads the digest out of these release notes and bakes it into its values. Open a follow-up PR there pinning to the new digest. (Pull by digest, not tag — that's the whole point of signing.)
+**Live clusters roll themselves forward — this step is not required for rollout.** Since [`tracebloc/client#159`](https://github.com/tracebloc/client/pull/159) (the [#158](https://github.com/tracebloc/client/issues/158) auto-refresh feature), the chart ships `images.ingestor.autoRefresh: true` with a floating tag (`images.ingestor.tag: "0.3"`). An image-refresh CronJob polls `ghcr.io/tracebloc/ingestor:0.3` and rewrites the live deployment's `INGESTOR_IMAGE_DIGEST` within ~15 min of a new image push — no chart change, no `helm upgrade`. Every existing install converges on its own, as long as the new image matches the chart's floating tag. (Authoritative explanation: the comment block around `images.ingestor` in [`client/values.yaml`](https://github.com/tracebloc/client/blob/develop/client/values.yaml).)
+
+The pinned `images.ingestor.digest` in the chart only sets the **greenfield baseline** — the digest a brand-new install lands on before its first refresh tick. Bumping it is a deliberate, optional chart release, not a release step. Do it when you want fresh installs to start on the version you just shipped:
+
+- Bump `images.ingestor.digest` to the new digest **and** `client/Chart.yaml`'s `version` + `appVersion` in lockstep (the chart's own SemVer, independent of the ingestor's).
+- Open the PR against **`develop`**, like any other client change — this is not a `master`-targeting release PR.
+- Precedent: [`client#161`](https://github.com/tracebloc/client/pull/161) (baseline v0.3.0 → v0.3.1) and [`client#185`](https://github.com/tracebloc/client/pull/185) (v0.3.1 → v0.3.2, tracking [#184](https://github.com/tracebloc/client/issues/184)).
+
+(When you do pin, pull by digest, not tag — that's the whole point of signing.)
 
 ## Manual fallback (workflow_dispatch)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="tracebloc_ingestor",
-    version="0.3.2",
+    version="0.3.3",
     author="Tracebloc",
     author_email="support@tracebloc.com",
     description="A flexible data ingestion library for various file formats",

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -95,6 +95,41 @@ def test_float_non_numeric_fails():
 
 
 # ---------------------------------------------------------------------------
+# Missing values are NULL, not "non-numeric" (regression)
+# ---------------------------------------------------------------------------
+
+def test_int_with_missing_values_is_valid():
+    # NaN/empty in an INT column is a missing value (stored as NULL), not a
+    # non-numeric one — and not a "non-integer" one either.
+    df = pd.DataFrame({"n": [1, None, 3]})
+    assert DataValidator(schema={"n": "INT"}).validate(df).is_valid
+
+
+def test_float_with_missing_values_is_valid():
+    # Regression: a float column with genuine NaN was wrongly reported as
+    # containing "non-numeric values" — and inserting NaN could never clear it.
+    df = pd.DataFrame({"x": [1.5, None, 2.25]})
+    assert DataValidator(schema={"x": "FLOAT"}).validate(df).is_valid
+
+
+def test_missing_values_do_not_mask_real_non_numeric():
+    # Only the genuinely unparseable value is flagged; the NaN is ignored.
+    df = pd.DataFrame({"x": [1.5, None, "oops"]})
+    result = DataValidator(schema={"x": "FLOAT"}).validate(df)
+    assert not result.is_valid
+    assert "1 non-numeric" in result.errors[0]
+    assert "oops" in result.errors[0]  # the offending value is surfaced
+
+
+def test_non_numeric_error_includes_sample_values():
+    df = pd.DataFrame({"x": ["abc", "def"]})
+    result = DataValidator(schema={"x": "FLOAT"}).validate(df)
+    assert not result.is_valid
+    assert "Sample invalid values" in result.errors[0]
+    assert "abc" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
 # VARCHAR / CHAR / TEXT
 # ---------------------------------------------------------------------------
 

--- a/tests/test_keypoint_annotation_validator.py
+++ b/tests/test_keypoint_annotation_validator.py
@@ -107,3 +107,75 @@ def test_inconsistent_keypoint_names_fail(validator):
     result = validator.validate(df)
     assert not result.is_valid
     assert any("differ from first record" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# num_keypoints — per-row count must match the dataset's declared K
+# ---------------------------------------------------------------------------
+
+
+def test_num_keypoints_match_passes():
+    """When every row has exactly the declared K, validation passes."""
+    v = KeypointAnnotationValidator(num_keypoints=2)
+    df = _df([
+        {"nose": [1, 2], "eye": [3, 4]},
+        {"nose": [5, 6], "eye": [7, 8]},
+    ])
+    result = v.validate(df)
+    assert result.is_valid
+
+
+def test_num_keypoints_mismatch_fails():
+    """Reproduces the staging incident — dataset declared K=14 but rows
+    name only 4 keypoints. Pre-fix this passed ingest silently and
+    crashed the runtime mid-training; post-fix the ingest rejects with
+    a clear error pointing the dataset author at the right line."""
+    v = KeypointAnnotationValidator(num_keypoints=14)
+    df = _df([
+        {"a": [1, 2], "b": [3, 4], "c": [5, 6], "d": [7, 8]},
+    ])
+    result = v.validate(df)
+    assert not result.is_valid
+    err = next(e for e in result.errors if "4 keypoint" in e)
+    assert "num_keypoints=14" in err
+    assert "mismatched counts cause silent shape crashes" in err
+
+
+def test_num_keypoints_mismatch_reports_every_offending_row():
+    """Mismatches surface per-row so the dataset author can fix them
+    in one pass — not just the first one."""
+    v = KeypointAnnotationValidator(num_keypoints=3)
+    df = _df([
+        {"a": [1, 2], "b": [3, 4]},                     # row 1: 2 kp (bad)
+        {"a": [1, 2], "b": [3, 4], "c": [5, 6]},        # row 2: 3 kp (ok)
+        {"a": [1, 2]},                                  # row 3: 1 kp (bad)
+    ])
+    result = v.validate(df)
+    assert not result.is_valid
+    count_errs = [e for e in result.errors if "num_keypoints=3" in e]
+    assert len(count_errs) == 2  # rows 1 and 3
+    assert any("Row 1" in e and "2 keypoint" in e for e in count_errs)
+    assert any("Row 3" in e and "1 keypoint" in e for e in count_errs)
+
+
+def test_num_keypoints_none_preserves_legacy_behavior():
+    """When ``num_keypoints`` isn't set we skip the count check —
+    matches the pre-fix behavior for ingests that haven't yet declared
+    a count."""
+    v = KeypointAnnotationValidator(num_keypoints=None)
+    df = _df([{"a": [1, 2], "b": [3, 4]}])
+    result = v.validate(df)
+    assert result.is_valid
+
+
+def test_num_keypoints_check_compounds_with_coordinate_errors():
+    """A mismatched count shouldn't suppress per-keypoint coordinate
+    errors — operator sees both kinds in one pass."""
+    v = KeypointAnnotationValidator(num_keypoints=3)
+    df = _df([
+        {"a": [-1, 2], "b": [3, 4]},  # wrong count AND a negative coord
+    ])
+    result = v.validate(df)
+    assert not result.is_valid
+    assert any("num_keypoints=3" in e for e in result.errors)
+    assert any("negative coordinates" in e for e in result.errors)

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -17,7 +17,7 @@ from .validators import (
     TableNameValidator,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.3.3"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -130,10 +130,18 @@ def map_validators(
             DuplicateValidator(),
         ]
     elif task_category == TaskCategory.KEYPOINT_DETECTION:
+        # ``number_of_keypoints`` is required by the ingest schema for
+        # keypoint_detection (see ``schema/ingest.v1.json``) and
+        # plumbed into ``file_options`` by ``cli/conventions.py``.
+        # Passing it to ``KeypointAnnotationValidator`` enables the
+        # per-row count check that rejects datasets whose annotations
+        # drift from the declared K.
         validators = [
             FileTypeValidator(allowed_extension=options["extension"], path="images"),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
-            KeypointAnnotationValidator(),
+            KeypointAnnotationValidator(
+                num_keypoints=options.get("number_of_keypoints")
+            ),
             KeypointVisibilityValidator(),
             TableNameValidator(),
             DuplicateValidator(),

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -342,18 +342,27 @@ class DataValidator(BaseValidator):
         errors = []
         warnings = []
 
-        # Try to convert to numeric
+        # Coerce to numeric; only values that were *present* but unparseable are
+        # "non-numeric". Genuine missing values (NaN/empty) are NOT non-numeric —
+        # the ingestor stores them as NULL — so they must not be conflated, or a
+        # user can never clear the error (inserting NaN doesn't help). See
+        # NumericColumnsValidator, which makes the same distinction.
         numeric_series = pd.to_numeric(series, errors="coerce")
-        non_numeric_count = numeric_series.isnull().sum()
+        non_numeric_mask = numeric_series.isna() & series.notna()
+        non_numeric_count = int(non_numeric_mask.sum())
 
         if non_numeric_count > 0:
+            sample = series[non_numeric_mask].head(5).tolist()
             errors.append(
-                f"Column '{column_name}' contains {non_numeric_count} non-numeric values"
+                f"Column '{column_name}' contains {non_numeric_count} non-numeric value(s). "
+                f"Sample invalid values: {sample}"
             )
 
-        # Check for integer values
+        # Check for integer values among the parsed, non-null numbers only
+        # (a NaN would otherwise be miscounted as "non-integer" via NaN % 1).
         if non_numeric_count == 0:
-            non_integer_count = (numeric_series % 1 != 0).sum()
+            non_integer_mask = numeric_series.notna() & (numeric_series % 1 != 0)
+            non_integer_count = int(non_integer_mask.sum())
             if non_integer_count > 0:
                 errors.append(
                     f"Column '{column_name}' contains {non_integer_count} non-integer values"
@@ -392,13 +401,20 @@ class DataValidator(BaseValidator):
         errors = []
         warnings = []
 
-        # Try to convert to numeric
+        # Coerce to numeric; only values that were *present* but unparseable are
+        # "non-numeric". Genuine missing values (NaN/empty) are valid for a float
+        # column (stored as NULL), so they must not be counted here — otherwise a
+        # user can never clear the error (inserting NaN doesn't help). See
+        # NumericColumnsValidator, which makes the same distinction.
         numeric_series = pd.to_numeric(series, errors="coerce")
-        non_numeric_count = numeric_series.isnull().sum()
+        non_numeric_mask = numeric_series.isna() & series.notna()
+        non_numeric_count = int(non_numeric_mask.sum())
 
         if non_numeric_count > 0:
+            sample = series[non_numeric_mask].head(5).tolist()
             errors.append(
-                f"Column '{column_name}' contains {non_numeric_count} non-numeric values"
+                f"Column '{column_name}' contains {non_numeric_count} non-numeric value(s). "
+                f"Sample invalid values: {sample}"
             )
 
         return {"is_valid": len(errors) == 0, "errors": errors, "warnings": warnings}

--- a/tracebloc_ingestor/validators/keypoint_annotation_validator.py
+++ b/tracebloc_ingestor/validators/keypoint_annotation_validator.py
@@ -28,17 +28,35 @@ class KeypointAnnotationValidator(BaseValidator):
     positive width and height. Checks keypoint name consistency across
     all records.
 
+    When ``num_keypoints`` is provided (the dataset author's declared
+    ``number_of_keypoints``), also enforces that every per-row
+    annotation carries exactly that many keypoints. Without this check
+    a dataset can declare K=14 in metadata while shipping rows that
+    only name a subset (e.g. 4) — downstream training silently
+    mis-shapes placeholders / heatmap targets and crashes on the
+    client side, where the only signal back to the operator is an
+    inscrutable ``torch.cat`` / ``broadcast_tensors`` failure inside
+    the runtime. Catching the drift at ingest time turns that into a
+    clear "your dataset is inconsistent with your declared keypoint
+    count" error against the dataset author.
+
     Attributes:
         annotation_column: Name of the annotation column in CSV
+        num_keypoints: Optional expected count from the dataset's
+            declared ``number_of_keypoints``. ``None`` skips the
+            check (preserves legacy behavior for ingests that don't
+            yet declare a count).
     """
 
     def __init__(
         self,
         annotation_column: str = "Annotation",
+        num_keypoints: Optional[int] = None,
         name: str = "Keypoint Annotation",
     ):
         super().__init__(name)
         self.annotation_column = annotation_column
+        self.num_keypoints = num_keypoints
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         try:
@@ -99,6 +117,29 @@ class KeypointAnnotationValidator(BaseValidator):
                 f"got {type(annotation).__name__}"
             )
             return errors
+
+        # 1b. Enforce declared num_keypoints, if set.
+        # We compare against ``len(annotation)`` (the number of named
+        # keypoints in the row's JSON dict) — not against any later
+        # coordinate-shape derivative — because the on-disk annotation
+        # is the source of truth that downstream consumers
+        # (``rescale_keypoints``, ``_generate_heatmaps``) actually
+        # iterate. A mismatch here is exactly the condition that
+        # produces runtime ``Sizes of tensors must match`` and
+        # ``broadcast_tensors`` crashes; failing the ingest is far
+        # kinder than letting the dataset land and then debug it
+        # from pod logs three weeks later.
+        if self.num_keypoints is not None and len(annotation) != self.num_keypoints:
+            errors.append(
+                f"{row_label}: annotation has {len(annotation)} keypoint(s) "
+                f"but the dataset declared num_keypoints={self.num_keypoints}. "
+                f"Every row's annotation JSON must name exactly the declared "
+                f"number of keypoints — mismatched counts cause silent shape "
+                f"crashes during client-side training."
+            )
+            # Continue into per-keypoint validation so the operator
+            # sees coordinate-level errors in the same pass instead of
+            # having to re-ingest to find them.
 
         # 2. Validate each keypoint coordinate
         x_coords = []


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ingest rejection rules for tabular numeric columns and keypoint datasets (stricter when declared K mismatches rows); behavior is intentional but may block datasets that previously passed silently.
> 
> **Overview**
> **v0.3.3** release sync with ingest validation fixes and updated release guidance.
> 
> **Data validation:** `DataValidator` no longer treats missing values (NaN/empty) as non-numeric or non-integer for INT/FLOAT columns—only present but unparseable cells fail. Non-numeric errors now include sample invalid values.
> 
> **Keypoint detection:** `KeypointAnnotationValidator` accepts optional `num_keypoints` and rejects rows whose annotation JSON key count differs from the dataset’s declared `number_of_keypoints`. Keypoint detection ingests pass `options["number_of_keypoints"]` from the ingest schema via `validators_mapping`.
> 
> **Docs:** `RELEASING.md` clarifies that bumping the pinned digest in `tracebloc/client` is optional for rollout (auto-refresh on floating tags); it only affects greenfield install baselines.
> 
> **Version:** `setup.py` and `tracebloc_ingestor.__version__` bumped to **0.3.3**, with regression tests for the above behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 272625a91dfe61c81d3abbb9a578ee2b3bd5bf29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->