### PR TITLE
fix(validator): stop reporting missing values as "non-numeric" (and show sample bad values)

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -95,6 +95,41 @@ def test_float_non_numeric_fails():
 
 
 # ---------------------------------------------------------------------------
+# Missing values are NULL, not "non-numeric" (regression)
+# ---------------------------------------------------------------------------
+
+def test_int_with_missing_values_is_valid():
+    # NaN/empty in an INT column is a missing value (stored as NULL), not a
+    # non-numeric one — and not a "non-integer" one either.
+    df = pd.DataFrame({"n": [1, None, 3]})
+    assert DataValidator(schema={"n": "INT"}).validate(df).is_valid
+
+
+def test_float_with_missing_values_is_valid():
+    # Regression: a float column with genuine NaN was wrongly reported as
+    # containing "non-numeric values" — and inserting NaN could never clear it.
+    df = pd.DataFrame({"x": [1.5, None, 2.25]})
+    assert DataValidator(schema={"x": "FLOAT"}).validate(df).is_valid
+
+
+def test_missing_values_do_not_mask_real_non_numeric():
+    # Only the genuinely unparseable value is flagged; the NaN is ignored.
+    df = pd.DataFrame({"x": [1.5, None, "oops"]})
+    result = DataValidator(schema={"x": "FLOAT"}).validate(df)
+    assert not result.is_valid
+    assert "1 non-numeric" in result.errors[0]
+    assert "oops" in result.errors[0]  # the offending value is surfaced
+
+
+def test_non_numeric_error_includes_sample_values():
+    df = pd.DataFrame({"x": ["abc", "def"]})
+    result = DataValidator(schema={"x": "FLOAT"}).validate(df)
+    assert not result.is_valid
+    assert "Sample invalid values" in result.errors[0]
+    assert "abc" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
 # VARCHAR / CHAR / TEXT
 # ---------------------------------------------------------------------------
 

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -342,18 +342,27 @@ class DataValidator(BaseValidator):
         errors = []
         warnings = []
 
-        # Try to convert to numeric
+        # Coerce to numeric; only values that were *present* but unparseable are
+        # "non-numeric". Genuine missing values (NaN/empty) are NOT non-numeric —
+        # the ingestor stores them as NULL — so they must not be conflated, or a
+        # user can never clear the error (inserting NaN doesn't help). See
+        # NumericColumnsValidator, which makes the same distinction.
         numeric_series = pd.to_numeric(series, errors="coerce")
-        non_numeric_count = numeric_series.isnull().sum()
+        non_numeric_mask = numeric_series.isna() & series.notna()
+        non_numeric_count = int(non_numeric_mask.sum())
 
         if non_numeric_count > 0:
+            sample = series[non_numeric_mask].head(5).tolist()
             errors.append(
-                f"Column '{column_name}' contains {non_numeric_count} non-numeric values"
+                f"Column '{column_name}' contains {non_numeric_count} non-numeric value(s). "
+                f"Sample invalid values: {sample}"
             )
 
-        # Check for integer values
+        # Check for integer values among the parsed, non-null numbers only
+        # (a NaN would otherwise be miscounted as "non-integer" via NaN % 1).
         if non_numeric_count == 0:
-            non_integer_count = (numeric_series % 1 != 0).sum()
+            non_integer_mask = numeric_series.notna() & (numeric_series % 1 != 0)
+            non_integer_count = int(non_integer_mask.sum())
             if non_integer_count > 0:
                 errors.append(
                     f"Column '{column_name}' contains {non_integer_count} non-integer values"
@@ -392,13 +401,20 @@ class DataValidator(BaseValidator):
         errors = []
         warnings = []
 
-        # Try to convert to numeric
+        # Coerce to numeric; only values that were *present* but unparseable are
+        # "non-numeric". Genuine missing values (NaN/empty) are valid for a float
+        # column (stored as NULL), so they must not be counted here — otherwise a
+        # user can never clear the error (inserting NaN doesn't help). See
+        # NumericColumnsValidator, which makes the same distinction.
         numeric_series = pd.to_numeric(series, errors="coerce")
-        non_numeric_count = numeric_series.isnull().sum()
+        non_numeric_mask = numeric_series.isna() & series.notna()
+        non_numeric_count = int(non_numeric_mask.sum())
 
         if non_numeric_count > 0:
+            sample = series[non_numeric_mask].head(5).tolist()
             errors.append(
-                f"Column '{column_name}' contains {non_numeric_count} non-numeric values"
+                f"Column '{column_name}' contains {non_numeric_count} non-numeric value(s). "
+                f"Sample invalid values: {sample}"
             )
 
         return {"is_valid": len(errors) == 0, "errors": errors, "warnings": warnings}


### PR DESCRIPTION
## Summary

`DataValidator` is the schema-type check that runs for every tabular-family ingestion — tabular classification/regression, time-series forecasting, time-to-event (see `validators_mapping.py`). Its numeric checks counted **every** NaN as a "non-numeric" value:

```python
numeric_series = pd.to_numeric(series, errors="coerce")
non_numeric_count = numeric_series.isnull().sum()   # <- genuine NaN counts too
```

So a numeric (`INT`/`FLOAT`/`DOUBLE`/`DECIMAL`/`BIGINT`) column with legitimate **missing values** failed with:

> Column 'X' contains N non-numeric values

— a misleading error the user **cannot clear by inserting NaN** (NaN still counts as null). The ingestor itself stores NaN as `NULL` (`csv_ingestor._validate_csv`), so missing values are valid input; only *present-but-unparseable* values are genuinely non-numeric.

## Fix

Mirror the distinction `NumericColumnsValidator` already makes:

```python
non_numeric_mask = numeric_series.isna() & series.notna()   # present but unparseable
```

- **Missing values (NaN/empty) no longer fail** numeric validation (they're stored as NULL).
- **Genuine non-numeric values still fail** — now with up to **5 sample invalid values** in the message, so the user can see *what's* wrong (e.g. comma decimals `"1,23"`, sentinels like `"<LOD"` / `"n.d."`, stray text). Previously the error gave no examples.
- Also fixes the parallel `INT` "non-integer" check, which miscounted `NaN` via `NaN % 1 != 0`.

Example — `FLOAT` column `[1.5, NaN, "oops"]`:
- **before:** `contains 2 non-numeric values` (the NaN is miscounted; no hint what's wrong)
- **after:** `contains 1 non-numeric value(s). Sample invalid values: ['oops']`

## Tests

4 new regression tests (missing-values-valid for INT/FLOAT; missing doesn't mask a real non-numeric; sample values surfaced). Full suite green: **611 passed**.
