### PR TITLE
harden(validator): reject non-finite (inf) numerics + realistic messy-data scenario tests

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -127,6 +128,53 @@ def test_non_numeric_error_includes_sample_values():
     assert not result.is_valid
     assert "Sample invalid values" in result.errors[0]
     assert "abc" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Non-finite (inf) + realistic messy-data scenarios
+# ---------------------------------------------------------------------------
+
+def test_float_infinity_is_rejected():
+    # inf survives pd.to_numeric (it is "numeric") but flows through the training
+    # scaler unchanged and produces a NaN loss — so the gate must reject it.
+    df = pd.DataFrame({"x": [1.0, np.inf, -np.inf]})
+    result = DataValidator(schema={"x": "FLOAT"}).validate(df)
+    assert not result.is_valid
+    assert "non-finite" in result.errors[0]
+
+
+def test_int_infinity_is_rejected():
+    df = pd.DataFrame({"n": [1.0, np.inf, 3.0]})
+    result = DataValidator(schema={"n": "INT"}).validate(df)
+    assert not result.is_valid
+    assert "non-finite" in result.errors[0]
+
+
+def test_eu_comma_decimal_rejected_with_sample():
+    # German/EU exports write "1,5" for 1.5 — non-numeric to pandas. It is
+    # correctly rejected, and the sample value shows the user what to fix.
+    df = pd.DataFrame({"x": ["1,5", "2,3"]})
+    result = DataValidator(schema={"x": "FLOAT"}).validate(df)
+    assert not result.is_valid
+    assert "1,5" in result.errors[0]
+
+
+def test_thousands_separator_rejected():
+    df = pd.DataFrame({"n": ["1,234", "5,678"]})
+    assert not DataValidator(schema={"n": "INT"}).validate(df).is_valid
+
+
+def test_units_in_numeric_rejected_with_sample():
+    df = pd.DataFrame({"x": ["95%", "3kg"]})
+    result = DataValidator(schema={"x": "FLOAT"}).validate(df)
+    assert not result.is_valid
+    assert "95%" in result.errors[0] or "3kg" in result.errors[0]
+
+
+def test_scientific_notation_is_valid():
+    # Mass-spec / proteomics intensities are commonly in scientific notation.
+    df = pd.DataFrame({"x": ["1.23E+08", "4.5e7"]})
+    assert DataValidator(schema={"x": "FLOAT"}).validate(df).is_valid
 
 
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, List, Dict, Optional, Union
 from datetime import datetime
 
+import numpy as np
 import pandas as pd
 
 from .base import BaseValidator, ValidationResult
@@ -326,6 +327,25 @@ class DataValidator(BaseValidator):
 
         return {"is_valid": len(errors) == 0, "errors": errors, "warnings": warnings}
 
+    @staticmethod
+    def _non_finite_error(series, numeric_series, column_name):
+        """Return an error string if a numeric column has inf/-inf values.
+
+        ``pd.to_numeric`` treats inf/-inf as valid numbers, so they slip past
+        the non-numeric check — but they are not valid finite input: they flow
+        through the training preprocessor's scaling unchanged and produce a NaN
+        loss. Reject them at the gate, showing the offending values.
+        """
+        mask = numeric_series.notna() & ~np.isfinite(numeric_series)
+        count = int(mask.sum())
+        if count == 0:
+            return None
+        sample = series[mask].head(5).tolist()
+        return (
+            f"Column '{column_name}' contains {count} non-finite value(s) "
+            f"(inf/-inf): {sample}"
+        )
+
     def _validate_int(
         self, series: pd.Series, column_name: str, expected_type: str
     ) -> Dict[str, Any]:
@@ -358,10 +378,15 @@ class DataValidator(BaseValidator):
                 f"Sample invalid values: {sample}"
             )
 
-        # Check for integer values among the parsed, non-null numbers only
-        # (a NaN would otherwise be miscounted as "non-integer" via NaN % 1).
+        non_finite = self._non_finite_error(series, numeric_series, column_name)
+        if non_finite:
+            errors.append(non_finite)
+
+        # Check for integer values among the parsed, finite, non-null numbers only
+        # (NaN/inf would otherwise be miscounted as "non-integer" via NaN % 1).
         if non_numeric_count == 0:
-            non_integer_mask = numeric_series.notna() & (numeric_series % 1 != 0)
+            finite = numeric_series.notna() & np.isfinite(numeric_series)
+            non_integer_mask = finite & (numeric_series % 1 != 0)
             non_integer_count = int(non_integer_mask.sum())
             if non_integer_count > 0:
                 errors.append(
@@ -416,6 +441,10 @@ class DataValidator(BaseValidator):
                 f"Column '{column_name}' contains {non_numeric_count} non-numeric value(s). "
                 f"Sample invalid values: {sample}"
             )
+
+        non_finite = self._non_finite_error(series, numeric_series, column_name)
+        if non_finite:
+            errors.append(non_finite)
 
         return {"is_valid": len(errors) == 0, "errors": errors, "warnings": warnings}
 


### PR DESCRIPTION
## Summary

Proactive hardening of the tabular ingestion gate, prompted by the class of real-world messy-data bugs the `DataValidator` missing-value fix (#150) exposed. This PR closes the most clear-cut, end-to-end-proven gap: **non-finite values**.

`inf` / `-inf` survive `pd.to_numeric` (they *are* numeric), so they sailed through both numeric validators. But on the training side (`tracebloc-client`) they flow **unchanged** through `MissingValueImputationStep` (only fills NaN) and `StandardScalingStep` (only guards `std == 0`, not `inf`) straight into the model → **NaN loss, silently**. So a CSV with an `inf` cell passes ingestion and quietly poisons training.

## Changes

- `_validate_int` / `_validate_float` now reject non-finite values via a shared `_non_finite_error` helper, surfacing the offending values:
  `Column 'x' contains 2 non-finite value(s) (inf/-inf): [inf, -inf]`
- The INT "non-integer" check is now gated on finiteness (`np.isfinite`), so `inf` isn't double-reported as both non-finite and non-integer.

## Tests

Adds a realistic messy-data scenario block to `test_data_validator.py`:

| scenario | expected |
|---|---|
| `inf` / `-inf` in FLOAT and INT | **rejected** (new) |
| EU comma decimals `"1,5"` | rejected, sample value shown |
| thousands separators `"1,234"` | rejected |
| units `"95%"`, `"3kg"` | rejected, sample value shown |
| scientific notation `"1.23E+08"` | valid (mass-spec intensities) |

Full suite green: **617 passed**.

## Stacking

Stacks on **#150** (base = `fix/data-validator-missing-values-not-non-numeric`). Retarget to `develop` once #150 merges.

## Not in this PR (follow-ups from the same audit — see the findings summary)

- **Validator↔ingestor NA-token mismatch** (a file with text `NaN`/`N/A`/`null` passes `DataValidator` but `CSVIngestor._validate_csv` then raises) — needs a policy decision on aligning the two readers.
- **Column-name length > 64** (the customer contact's Problem B) — no preflight; explodes at `CREATE TABLE`.
- **Non-UTF-8 (Latin-1) files** and **`;`-delimited German CSVs** — crash / cryptic error.
- **Training-side** (`tracebloc-client`): NaN-in-label, single-class label, high-cardinality one-hot — break with no guard/test.
