### PR TITLE
chore(release): bump version to 0.3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="tracebloc_ingestor",
-    version="0.3.2",
+    version="0.3.3",
     author="Tracebloc",
     author_email="support@tracebloc.com",
     description="A flexible data ingestion library for various file formats",

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -17,7 +17,7 @@ from .validators import (
     TableNameValidator,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.3.3"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
Version bump ahead of the **v0.3.3** patch release. Companion sync PR (`sync/develop-to-master-v0.3.3`) will follow.

Bumps `setup.py` 0.3.2 → 0.3.3 and aligns the stale `tracebloc_ingestor.__version__` (left at 0.3.0 since 0.3.1/0.3.2 only bumped setup.py) to match.

Release tracked in #152. Ships #150 (customer-facing DataValidator missing-values fix) plus already-merged #147 and #145.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string updates only; no behavioral or security-sensitive code changes.
> 
> **Overview**
> Prepares the **v0.3.3** patch release by bumping the package version in `setup.py` from **0.3.2** to **0.3.3** and aligning `tracebloc_ingestor.__version__` from the stale **0.3.0** to **0.3.3** so runtime version reporting matches what setuptools publishes.
> 
> No application logic changes in this PR; it is release metadata only ahead of the develop→master sync and the tagged image/PyPI publish described in the release notes (#152).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7933313f6c6436eeb9ee443130c499a9e745efff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->