### PR TITLE
harden(ingestion): align tabular NA parsing with validator + reject over-long column names

### DIFF
--- a/tests/test_csv_na_values.py
+++ b/tests/test_csv_na_values.py
@@ -48,6 +48,10 @@ def test_tabular_family_uses_wider_na_values(category, tmp_path):
 
     _, kwargs = mock_read.call_args
     assert kwargs["na_values"] == ["", "NA", "NULL", "None"]
+    # keep_default_na=True for tabular so pandas' full NA set (NaN/N/A/null/...)
+    # is recognised — matching the validators' read, which closes the gate-lie
+    # where a file passes validation but crashes the ingestor's type-conversion.
+    assert kwargs["keep_default_na"] is True
 
 
 def test_non_tabular_keeps_narrow_na_values(tmp_path):
@@ -61,3 +65,25 @@ def test_non_tabular_keeps_narrow_na_values(tmp_path):
 
     _, kwargs = mock_read.call_args
     assert kwargs["na_values"] == [""]
+    assert kwargs["keep_default_na"] is False
+
+
+def test_tabular_na_token_in_numeric_column_does_not_crash(tmp_path):
+    """A 'NaN'/'N/A' cell in a numeric column used to PASS the validator but then
+    crash the ingestor's numeric type-conversion (the validator read it as NaN,
+    the ingestor kept it as text). With keep_default_na=True both agree: the cell
+    parses as NaN, read_data succeeds, and the value is missing."""
+    csv_path = tmp_path / "x.csv"
+    csv_path.write_text("x,label\n1.5,a\nNaN,b\nN/A,c\n")
+    ing = CSVIngestor(
+        database=MagicMock(),
+        api_client=MagicMock(),
+        table_name="t",
+        schema={"x": "FLOAT", "label": "str"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+        label_column="label",
+    )
+    records = list(ing.read_data(str(csv_path)))  # must not raise
+    xs = [r["x"] for r in records]
+    assert xs[0] == 1.5
+    assert pd.isna(xs[1]) and pd.isna(xs[2])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -240,3 +240,13 @@ def test_create_table_allows_label_in_schema():
     db = Database.__new__(Database)
     db.tables = {"t": "sentinel"}  # short-circuit before any engine use
     assert db.create_table("t", {"feature_0": "FLOAT", "label": "INT"}) == "sentinel"
+
+
+def test_create_table_rejects_overlong_column_name():
+    """Column names over MySQL's 64-char identifier limit fail fast with a clear
+    error naming the offenders, instead of a raw MySQL 1059 at CREATE TABLE.
+    Like the reserved-column guard, this runs before any DB I/O."""
+    db = Database.__new__(Database)
+    long_name = "Protein_" + "X" * 70  # 78 chars, > 64
+    with pytest.raises(ValueError, match="64-character"):
+        db.create_table("t", {long_name: "FLOAT", "feature_0": "FLOAT"})

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -136,6 +136,20 @@ class Database:
                 f"data_id.strategy=column instead.)"
             )
 
+        # Fail fast on column names longer than MySQL's 64-char identifier limit,
+        # before CREATE TABLE turns it into a raw MySQL 1059 error. CSV headers are
+        # used verbatim as column names, so long proteomics/genomics headers (e.g. a
+        # semicolon-joined isoform list) blow the limit; name the offenders clearly.
+        _MAX_IDENTIFIER = 64
+        _too_long = sorted(c for c in schema if len(str(c)) > _MAX_IDENTIFIER)
+        if _too_long:
+            preview = "; ".join(f"'{c[:40]}…' ({len(c)} chars)" for c in _too_long[:5])
+            more = "" if len(_too_long) <= 5 else f" (and {len(_too_long) - 5} more)"
+            raise ValueError(
+                f"{len(_too_long)} column name(s) exceed the {_MAX_IDENTIFIER}-character "
+                f"database column-name limit and must be shortened: {preview}{more}"
+            )
+
         # Return existing table if already created
         if table_name in self.tables:
             return self.tables[table_name]

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -171,19 +171,20 @@ class CSVIngestor(BaseIngestor):
         try:
             chunk_size = self.csv_options.pop("chunk_size", 1000)
 
-            # Wider null sentinel for tabular-family categories — matches the
-            # legacy templates and prevents "NA"/"NULL"/"None" string cells
-            # from being stored verbatim instead of as NaN.
-            na_values = (
-                _TABULAR_NA_VALUES
-                if self.category in _TABULAR_FAMILY_CATEGORIES
-                else [""]
-            )
+            # NA handling. Tabular-family CSVs use pandas' full default NA set
+            # (keep_default_na=True) so every common missing sentinel — ""/NaN/
+            # "N/A"/"null"/"NA"/"NULL"/"None" — parses as NaN. Crucially this
+            # MATCHES how the validators read the file (plain pd.read_csv with
+            # defaults), so a file that passes validation can't then crash the
+            # numeric type-conversion below on an unrecognised NA token. Other
+            # categories keep the conservative empty-only behaviour.
+            is_tabular = self.category in _TABULAR_FAMILY_CATEGORIES
+            na_values = _TABULAR_NA_VALUES if is_tabular else [""]
 
             # Enhanced default options for pandas
             default_options = {
                 "dtype": None,  # Let pandas infer types initially
-                "keep_default_na": False,
+                "keep_default_na": is_tabular,
                 "na_values": na_values,
                 "encoding": "utf-8",
                 "on_bad_lines": "warn",


### PR DESCRIPTION
## Summary

Two real-world ingestion **seams** found in the messy-data hardening audit (the same audit that produced #150 / #151). Both are cases where the gate lets bad data through and it bites later.

### 1. NA-token gate-lie (validator says OK → ingestor crashes)

The validators read CSVs with **plain `pd.read_csv` defaults**, so `NaN` / `N/A` / `null` / `nan` cells become `NaN`. But `CSVIngestor.read_data` used `keep_default_na=False` with a narrow `na_values=["", "NA", "NULL", "None"]`, so those same cells stayed as **text**. Result, proven in the audit:

```
DataValidator:            PASS
CSVIngestor._validate_csv: RAISES ValueError: Unable to parse string "NaN"
```

A file passes validation, then the ingestor's numeric type-conversion crashes on a token the validator treated as missing. **Fix:** tabular-family reads now use `keep_default_na=True`, so the ingestor's NA interpretation matches the validator's — what validates is what ingests. (Non-tabular categories keep the conservative empty-only behaviour.)

### 2. Column names over MySQL's 64-char limit (the customer contact's "Problem B")

CSV headers are used **verbatim** as MySQL column names (`create_table`), which are capped at 64 characters. Long proteomics/genomics headers (a semicolon-joined isoform list) exploded at `CREATE TABLE` with a raw **MySQL 1059** error. **Fix:** `create_table` now fails fast with a clear message naming the offending columns, before any DB I/O — mirroring the existing reserved-column guard.

```
3 column name(s) exceed the 64-character database column-name limit and must be
shortened: 'Protein_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX…' (78 chars); ...
```

## Tests

- `test_csv_na_values.py`: assert `keep_default_na` per category + a behavioral test that a `NaN`/`N/A` cell in a numeric column no longer crashes `read_data` (parses as missing).
- `test_database.py`: `create_table` rejects an over-long column name with a clear error (no DB needed — runs before any I/O).

Full suite green: **613 passed**.

## Context

Independent of #150 (merged) and #151 (inf guard, open) — touches `csv_ingestor.py` + `database.py` only. Part of the broader ingestion-hardening program; remaining items (cross-cutting UTF-8/encoding handling, time-series date-locale parsing, image-pairing, training-side guards) tracked separately.
