### PR TITLE
harden(time-series): reject locale-ambiguous timestamps (silent mis-parse guard)

### DIFF
--- a/tests/test_time_validators.py
+++ b/tests/test_time_validators.py
@@ -66,6 +66,31 @@ def test_format_schema_timestamp_with_precision_passes(make_csv):
     assert result.is_valid
 
 
+# --- locale-ambiguous dates (silent-corruption guard) ----------------------
+
+def test_format_ambiguous_eu_dates_rejected(make_csv):
+    # "03.04.2026" is Apr 3 (day-first/EU) or Mar 4 (month-first/US); pandas'
+    # format='mixed' would silently pick one. Both interpretations are valid but
+    # different, so reject as ambiguous instead of corrupting the series.
+    path = make_csv({"timestamp": ["03.04.2026", "07.08.2026"], "v": [1, 2]})
+    result = TimeFormatValidator().validate(str(path))
+    assert not result.is_valid
+    assert "ambiguous" in result.errors[0].lower()
+
+
+def test_format_iso_dates_not_ambiguous(make_csv):
+    # ISO 8601 is unambiguous and must pass cleanly.
+    path = make_csv({"timestamp": ["2024-01-03", "2024-04-05"], "v": [1, 2]})
+    assert TimeFormatValidator().validate(str(path)).is_valid
+
+
+def test_format_unambiguous_dates_not_flagged(make_csv):
+    # day > 12 has only one valid interpretation (here month-first), so it is
+    # NOT ambiguous and must not be falsely rejected.
+    path = make_csv({"timestamp": ["01/25/2024", "02/26/2024"], "v": [1, 2]})
+    assert TimeFormatValidator().validate(str(path)).is_valid
+
+
 # ---------------------------------------------------------------------------
 # TimeOrderedValidator
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/validators/time_format_validator.py
+++ b/tracebloc_ingestor/validators/time_format_validator.py
@@ -72,9 +72,30 @@ class TimeFormatValidator(BaseValidator):
                     errors=[f"Required column 'timestamp' not found. Available: {list(df.columns)}"],
                 )
 
-            # Parse timestamps
+            # Parse timestamps (month-first by default).
             timestamps = pd.to_datetime(df["timestamp"], format='mixed', errors="coerce")
             metadata = {"rows_checked": len(df)}
+
+            # Locale-ambiguity guard. "03.04.2026" is Apr 3 read day-first (EU)
+            # but Mar 4 read month-first (US); format='mixed' silently picks one
+            # and corrupts the whole series with no error. If a value parses
+            # successfully BOTH ways but to different dates, it is ambiguous —
+            # reject it and steer the user to unambiguous ISO 8601.
+            day_first = pd.to_datetime(
+                df["timestamp"], format='mixed', dayfirst=True, errors="coerce"
+            )
+            ambiguous_mask = (
+                timestamps.notna() & day_first.notna() & (timestamps != day_first)
+            )
+            if ambiguous_mask.any():
+                ambiguous_count = int(ambiguous_mask.sum())
+                samples = df["timestamp"][ambiguous_mask].astype(str).head(5).tolist()
+                errors.append(
+                    f"Found {ambiguous_count} ambiguous date(s) in 'timestamp' that parse "
+                    f"differently day-first vs month-first (e.g. {samples}). Use ISO 8601 "
+                    f"(YYYY-MM-DD or YYYY-MM-DD HH:MM:SS) to remove the ambiguity."
+                )
+                metadata["ambiguous_timestamps"] = ambiguous_count
 
             # Check for invalid/missing timestamps
             invalid_mask = timestamps.isna()

--- a/tracebloc_ingestor/validators/time_format_validator.py
+++ b/tracebloc_ingestor/validators/time_format_validator.py
@@ -81,11 +81,19 @@ class TimeFormatValidator(BaseValidator):
             # and corrupts the whole series with no error. If a value parses
             # successfully BOTH ways but to different dates, it is ambiguous —
             # reject it and steer the user to unambiguous ISO 8601.
+            #
+            # Exempt ISO-8601 values (YYYY-…): pandas with dayfirst=True still
+            # swaps their components, which would falsely flag every ISO date.
             day_first = pd.to_datetime(
                 df["timestamp"], format='mixed', dayfirst=True, errors="coerce"
             )
+            ts_str = df["timestamp"].astype(str)
+            iso_like = ts_str.str.match(r"^\d{4}-")
             ambiguous_mask = (
-                timestamps.notna() & day_first.notna() & (timestamps != day_first)
+                timestamps.notna()
+                & day_first.notna()
+                & (timestamps != day_first)
+                & ~iso_like
             )
             if ambiguous_mask.any():
                 ambiguous_count = int(ambiguous_mask.sum())


### PR DESCRIPTION
## Summary

**Tier 1 of the ingestion-hardening audit — silent data corruption.**

`TimeFormatValidator` parsed time-series timestamps with `pd.to_datetime(df["timestamp"], format='mixed', errors="coerce")`. `format='mixed'` resolves ambiguous dates **by locale, silently**:

- `03.04.2026` → **Mar 4** read month-first (US default) or **Apr 3** read day-first (EU)

No error is raised — a German/EU user's entire series is silently shifted. This is the most dangerous class of bug in the audit because nothing fails; the model just trains on wrong timestamps.

## Fix

An ambiguity guard in `TimeFormatValidator`: parse the column both day-first and month-first, and if a value is valid **both** ways but yields **different** dates, reject it with a clear message and the offending samples:

```
Found 2 ambiguous date(s) in 'timestamp' that parse differently day-first vs
month-first (e.g. ['03.04.2026', '07.08.2026']). Use ISO 8601 (YYYY-MM-DD or
YYYY-MM-DD HH:MM:SS) to remove the ambiguity.
```

Unambiguous inputs are unaffected: ISO 8601 parses identically both ways, and a value with day > 12 has only one valid interpretation.

## Tests

- ambiguous EU dates (`03.04.2026`) → rejected
- ISO dates → pass
- unambiguous (day > 12) dates → pass

Full suite green: **614 passed**.

## Scope / follow-ups (same audit)

- This guards the **silent-corruption** case (ambiguous dates). A *separate* face of the same locale issue: an unambiguous day-first date like `25.12.2026` (day > 12) is still flagged as an "invalid timestamp" under month-first parsing — it fails (not silent) but with a misleading message. Cleanest long-term fix for both is an explicit per-dataset date-format / `dayfirst` field in the ingest schema; tracked separately.
- The same `format='mixed'` parsing is used for `DATE`-typed columns in tabular ingestion (`csv_ingestor.py`, `DataValidator._validate_date`) — lower frequency, noted for a follow-up.

Independent of #150 (merged) / #151 / #155 — touches `time_format_validator.py` only.
