### PR TITLE
harden(ingestion): clear error for non-UTF-8 CSVs (one pre-flight gate)

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -241,3 +241,29 @@ def test_context_manager_protocol():
     ing = make_ingestor()
     with ing as x:
         assert x is ing
+
+
+# ---------------------------------------------------------------------------
+# CSV encoding pre-flight (validate_data)
+# ---------------------------------------------------------------------------
+
+def test_check_csv_encoding_rejects_non_utf8(tmp_path):
+    # A Latin-1 export (German umlauts) used to surface as a misleading
+    # "No data found"; now it fails fast with a clear UTF-8 message.
+    bad = tmp_path / "umlaut.csv"
+    bad.write_bytes("Größe,label\n1,a\n".encode("latin-1"))
+    with pytest.raises(ValueError, match="UTF-8"):
+        BaseIngestor._check_csv_encoding(str(bad))
+
+
+def test_check_csv_encoding_accepts_utf8(tmp_path):
+    good = tmp_path / "ok.csv"
+    good.write_text("Größe,label\n1,a\n", encoding="utf-8")
+    BaseIngestor._check_csv_encoding(str(good))  # must not raise
+
+
+def test_check_csv_encoding_skips_non_csv_sources(tmp_path):
+    # Non-CSV / non-path / missing sources are left to the validators.
+    BaseIngestor._check_csv_encoding(str(tmp_path))                   # a directory
+    BaseIngestor._check_csv_encoding(None)                            # not a path
+    BaseIngestor._check_csv_encoding(str(tmp_path / "missing.csv"))   # nonexistent

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -5,6 +5,7 @@ from sqlalchemy.engine import Engine
 import logging
 from tqdm import tqdm
 import uuid
+from pathlib import Path
 
 from ..database import Database
 from ..api.client import APIClient
@@ -307,6 +308,30 @@ class BaseIngestor(ABC):
             logger.error(f"Error processing record: {str(e)}")
             return None
 
+    @staticmethod
+    def _check_csv_encoding(source: Any) -> None:
+        """Fail fast with a clear message if a CSV source is not valid UTF-8.
+
+        Every validator reads CSVs as UTF-8 and swallows decode errors into a
+        misleading "No data found"; a non-UTF-8 export (e.g. a Latin-1/Windows
+        CSV with umlauts) would otherwise crash or mislead. Probe once, up front.
+        """
+        if not isinstance(source, (str, Path)):
+            return
+        path = Path(source)
+        if path.suffix.lower() != ".csv" or not path.exists():
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                while fh.read(1 << 20):  # decode in 1 MB chunks; raises on a bad byte
+                    pass
+        except UnicodeDecodeError as exc:
+            raise ValueError(
+                f"{RED}'{path.name}' is not valid UTF-8 — a non-UTF-8 byte was found at "
+                f"byte {exc.start}. Re-save the file as UTF-8 (in Excel: Save As → "
+                f"'CSV UTF-8 (Comma delimited)'), then re-ingest.{RESET}"
+            ) from exc
+
     def validate_data(self, source: Any) -> bool:
         """Validate data before ingestion using configured validators.
 
@@ -319,6 +344,10 @@ class BaseIngestor(ABC):
         Raises:
             ValueError: If validation fails
         """
+        # Pre-flight: a non-UTF-8 CSV otherwise surfaces as a misleading
+        # "No data found" (validators read UTF-8 and swallow decode errors).
+        # Catch it once here with a clear, actionable message.
+        self._check_csv_encoding(source)
 
         validators = map_validators(self.category, self.file_options)
         logger.info(f"Running {len(validators)} validator(s) on data source")


### PR DESCRIPTION
## Summary

**Tier 2 of the ingestion-hardening audit — cross-cutting encoding.**

Every CSV-reading validator opens the file with `encoding="utf-8"` inside a `try/except Exception: return None`, and `validate()` turns that `None` into **"No data found to validate"**. So a Latin-1 / Windows-1252 export — routine for German/EU lab data with umlauts (`Größe`) and accents — fails with a misleading message that points the user at the wrong problem (or, at the ingestion read, a raw `UnicodeDecodeError` traceback).

## Fix

One pre-flight UTF-8 probe in `BaseIngestor.validate_data` — the single orchestrator (`ingestors/base.py:310`) that runs **every** validator for **every** category. It decodes the CSV in 1 MB chunks before the validator loop and, on a decode error, fails fast with an actionable message:

```
'umlaut.csv' is not valid UTF-8 — a non-UTF-8 byte was found at byte 4.
Re-save the file as UTF-8 (in Excel: Save As → 'CSV UTF-8 (Comma delimited)'),
then re-ingest.
```

One chokepoint covers all categories — no per-validator edits, and **no silent latin-1 fallback** (that would mojibake umlauts and corrupt data, against the whole point of the audit). Non-CSV / missing / non-path sources are skipped and left to the validators.

## Tests (`test_ingestor_base.py`)

- Latin-1 file → rejected with a UTF-8 message
- UTF-8 file → passes
- directory / `None` / nonexistent path → skipped (no false positive)

Full suite green: **614 passed**.

## Scope

The same `encoding="utf-8"` is hardcoded in the **text/NLP dataset loaders in `tracebloc-client`** (`text_classification_dataset.py`, `masked_language_modeling_dataset.py`) — same class of bug, separate repo; tracked as a follow-up. Independent of #150/#151/#155/#156 — touches `ingestors/base.py` only.
