### PR TITLE
harden(image): distinct reasons for unreadable images (empty / corrupt / bomb)

### DIFF
--- a/tests/test_image_validator_flow.py
+++ b/tests/test_image_validator_flow.py
@@ -122,3 +122,23 @@ def test_validate_image_resolutions_unprocessable(tmp_path):
     res = ImageResolutionValidator(expected_resolution=(10, 10))._validate_image_resolutions([bad])
     assert not res.is_valid
     assert any("could not be processed" in e for e in res.errors)
+    # the per-file reason is now surfaced, not just the bare path
+    assert any("not a valid image" in e for e in res.errors)
+
+
+# --- _diagnose_image_error: distinct, actionable reasons --------------------
+
+def test_diagnose_empty_file(tmp_path):
+    p = tmp_path / "empty.jpg"
+    p.write_bytes(b"")
+    assert "empty file" in ImageResolutionValidator._diagnose_image_error(p)
+
+
+def test_diagnose_corrupt_file(tmp_path):
+    p = tmp_path / "corrupt.jpg"
+    p.write_bytes(b"this is definitely not an image")
+    assert "not a valid image" in ImageResolutionValidator._diagnose_image_error(p)
+
+
+def test_diagnose_missing_file(tmp_path):
+    assert "not found" in ImageResolutionValidator._diagnose_image_error(tmp_path / "nope.jpg")

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -12,12 +12,13 @@ from tracebloc_ingestor.config import Config
 from tracebloc_ingestor.utils.logging import setup_logging
 
 try:
-    from PIL import Image
+    from PIL import Image, UnidentifiedImageError
 
     PIL_AVAILABLE = True
 except ImportError:
     PIL_AVAILABLE = False
     Image = None
+    UnidentifiedImageError = Exception
 
 from .base import BaseValidator, ValidationResult
 
@@ -199,6 +200,30 @@ class ImageResolutionValidator(BaseValidator):
             logger.warning(f"Could not get resolution for {image_path}: {str(e)}")
             return None
 
+    @staticmethod
+    def _diagnose_image_error(image_path: Path) -> str:
+        """Return a human-readable reason an image could not be read, turning the
+        generic "could not be processed" into an actionable cause: empty file,
+        corrupt/unsupported format, or decompression bomb."""
+        try:
+            p = Path(image_path)
+            if not p.exists():
+                return "file not found"
+            if p.stat().st_size == 0:
+                return "empty file (0 bytes)"
+        except OSError as exc:
+            return f"unreadable ({exc.__class__.__name__})"
+        try:
+            with Image.open(image_path) as img:
+                img.verify()  # integrity check without a full decode
+            return "unreadable image"
+        except UnidentifiedImageError:
+            return "not a valid image (corrupt or unsupported format)"
+        except Image.DecompressionBombError:
+            return "exceeds the safe pixel limit (possible decompression bomb)"
+        except Exception as exc:
+            return f"{exc.__class__.__name__}: {exc}"
+
     def _validate_image_resolutions(self, image_files: List[Path]) -> ValidationResult:
         """Validate image resolutions for uniformity.
 
@@ -237,7 +262,9 @@ class ImageResolutionValidator(BaseValidator):
                 try:
                     resolution = self._get_image_resolution(image_path)
                     if resolution is None:
-                        invalid_files.append(str(image_path))
+                        invalid_files.append(
+                            f"{image_path}: {self._diagnose_image_error(image_path)}"
+                        )
                         continue
 
                     resolutions_found.add(resolution)


### PR DESCRIPTION
## Summary

**Tier 2.4 of the ingestion-hardening audit — image file integrity.**

`ImageResolutionValidator` reported every file it couldn't open under a single generic error:

```
Files that could not be processed: ['a.jpg', 'b.png', 'c.jpg']
```

`_get_image_resolution` swallowed the underlying exception into `None`, so the *reason* (empty file? corrupt? wrong format? decompression bomb?) was lost and the user had no idea what to fix.

## Fix

A `_diagnose_image_error()` helper classifies the cause, surfaced per file:

```
Files that could not be processed:
  ['a.jpg: empty file (0 bytes)',
   'b.png: not a valid image (corrupt or unsupported format)',
   'c.jpg: exceeds the safe pixel limit (possible decompression bomb)']
```

Cheap (only runs on the files that already failed) and safe (`img.verify()` checks integrity without a full decode; `UnidentifiedImageError` / `DecompressionBombError` are handled explicitly, with a graceful PIL-missing fallback).

## Tests (`test_image_validator_flow.py`)

- empty (0-byte) file → "empty file"
- corrupt / non-image bytes → "not a valid image"
- missing file → "not found"
- the resolution-flow test now asserts the per-file reason is surfaced

Full suite green: **614 passed**.

## Scope / follow-up

This covers the **integrity / "why can't this open"** half of the image gaps. The other half — **image ↔ mask/annotation pairing** (a file with no counterpart, which currently fails *mid-training* with a `FileNotFoundError` instead of at validation) — is the next PR. Independent of the other open hardening PRs; touches `image_validator.py` only.
