### PR TITLE
harden(image): validate image↔annotation/mask pairing at ingestion (not mid-training)

### DIFF
--- a/tests/test_file_pairing_validator.py
+++ b/tests/test_file_pairing_validator.py
@@ -1,0 +1,57 @@
+"""Tests for FilePairingValidator — image <-> sidecar (annotation/mask) pairing.
+
+The validator reads directories under ``config.SRC_PATH`` (``<src>/images`` and
+``<src>/annotations`` or ``<src>/masks``), matching by filename stem.
+"""
+
+from __future__ import annotations
+
+from tracebloc_ingestor.validators.file_pairing_validator import FilePairingValidator
+
+
+def _setup(tmp_path, images, sidecars, sidecar_dir="annotations"):
+    (tmp_path / "images").mkdir()
+    (tmp_path / sidecar_dir).mkdir()
+    for n in images:
+        (tmp_path / "images" / n).write_text("x")
+    for n in sidecars:
+        (tmp_path / sidecar_dir / n).write_text("x")
+
+
+def test_pairing_all_matched(clean_env, tmp_path):
+    _setup(tmp_path, ["a.jpg", "b.jpg"], ["a.xml", "b.xml"])
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    assert FilePairingValidator().validate(None).is_valid
+
+
+def test_pairing_image_without_sidecar(clean_env, tmp_path):
+    _setup(tmp_path, ["a.jpg", "b.jpg"], ["a.xml"])  # b.jpg has no annotation
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator().validate(None)
+    assert not res.is_valid
+    assert "no matching annotation" in res.errors[0]
+    assert "b" in res.errors[0]
+
+
+def test_pairing_orphan_sidecar(clean_env, tmp_path):
+    _setup(tmp_path, ["a.jpg"], ["a.xml", "ghost.xml"])  # ghost.xml has no image
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator().validate(None)
+    assert not res.is_valid
+    assert any("no matching image" in e for e in res.errors)
+    assert any("ghost" in e for e in res.errors)
+
+
+def test_pairing_masks_label(clean_env, tmp_path):
+    _setup(tmp_path, ["a.jpg"], ["b.png"], sidecar_dir="masks")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator(sidecar_path="masks", sidecar_label="mask").validate(None)
+    assert not res.is_valid
+    assert any("mask" in e for e in res.errors)
+
+
+def test_pairing_skips_when_sidecar_dir_missing(clean_env, tmp_path):
+    # A missing directory is the FileTypeValidator's concern — don't double-report.
+    (tmp_path / "images").mkdir()
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    assert FilePairingValidator().validate(None).is_valid

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -14,6 +14,7 @@ from tracebloc_ingestor.validators.numeric_columns_validator import NumericColum
 from tracebloc_ingestor.validators.keypoint_annotation_validator import KeypointAnnotationValidator
 from tracebloc_ingestor.validators.keypoint_visibility_validator import KeypointVisibilityValidator
 from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
+from tracebloc_ingestor.validators.file_pairing_validator import FilePairingValidator
 from tracebloc_ingestor.utils.constants import TaskCategory, FileExtension
 
 
@@ -32,6 +33,9 @@ def map_validators(
             FileTypeValidator(allowed_extension=options["extension"], path="images"),
             FileTypeValidator(allowed_extension=".xml", path="annotations"),
             PascalVOCXMLValidator(),
+            FilePairingValidator(
+                image_path="images", sidecar_path="annotations", sidecar_label="annotation"
+            ),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
             TableNameValidator(),
             DuplicateValidator(),
@@ -125,6 +129,9 @@ def map_validators(
         return [
             FileTypeValidator(allowed_extension=options["extension"], path="images"),
             FileTypeValidator(allowed_extension=FileExtension.PNG, path="masks"),
+            FilePairingValidator(
+                image_path="images", sidecar_path="masks", sidecar_label="mask"
+            ),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
             TableNameValidator(),
             DuplicateValidator(),

--- a/tracebloc_ingestor/validators/file_pairing_validator.py
+++ b/tracebloc_ingestor/validators/file_pairing_validator.py
@@ -1,0 +1,104 @@
+"""File Pairing Validator Module.
+
+For datasets that pair every image with a sidecar file — object detection
+(image → annotation XML) and semantic segmentation (image → mask PNG) — this
+validator checks at ingestion time that each image has its sidecar and each
+sidecar has its image, matched by filename stem.
+
+Without this, a missing counterpart only surfaces mid-training as a
+``FileNotFoundError`` on the offending row, after the job has run for a while.
+Catching it up front lets the dataset author fix the whole set in one pass.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Set
+
+from .base import BaseValidator, ValidationResult
+from ..config import Config
+from ..utils.logging import setup_logging
+
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+
+class FilePairingValidator(BaseValidator):
+    """Ensure images and their sidecar files (annotations / masks) pair up 1:1.
+
+    Directories live under ``config.SRC_PATH`` (e.g. ``<src>/images`` and
+    ``<src>/annotations``). Matching is by filename stem, so ``cat.jpg`` pairs
+    with ``cat.xml`` / ``cat.png``.
+    """
+
+    def __init__(
+        self,
+        image_path: str = "images",
+        sidecar_path: str = "annotations",
+        sidecar_label: str = "annotation",
+        name: str = "File Pairing Validator",
+    ):
+        super().__init__(name)
+        self.image_path = image_path
+        self.sidecar_path = sidecar_path
+        self.sidecar_label = sidecar_label
+
+    @staticmethod
+    def _stems(directory: Path) -> Set[str]:
+        return {
+            p.stem
+            for p in directory.glob("*")
+            if p.is_file() and not p.name.startswith(".")
+        }
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            src = Path(config.SRC_PATH)
+            image_dir = src / self.image_path
+            sidecar_dir = src / self.sidecar_path
+
+            # A missing directory is the FileTypeValidator's concern (it reports
+            # "no files found"); skip here so we don't double-report.
+            if not image_dir.is_dir() or not sidecar_dir.is_dir():
+                return self._create_result(
+                    is_valid=True,
+                    metadata={"skipped": "image or sidecar directory not found"},
+                )
+
+            images = self._stems(image_dir)
+            sidecars = self._stems(sidecar_dir)
+            missing = sorted(images - sidecars)   # images with no sidecar
+            orphans = sorted(sidecars - images)   # sidecars with no image
+
+            errors = []
+            if missing:
+                shown = missing[:10]
+                errors.append(
+                    f"{len(missing)} image(s) have no matching {self.sidecar_label}: "
+                    f"{shown}{' …' if len(missing) > 10 else ''}"
+                )
+            if orphans:
+                shown = orphans[:10]
+                errors.append(
+                    f"{len(orphans)} {self.sidecar_label}(s) have no matching image: "
+                    f"{shown}{' …' if len(orphans) > 10 else ''}"
+                )
+
+            return self._create_result(
+                is_valid=len(errors) == 0,
+                errors=errors,
+                metadata={
+                    "images": len(images),
+                    "sidecars": len(sidecars),
+                    "images_without_sidecar": len(missing),
+                    "orphan_sidecars": len(orphans),
+                },
+            )
+        except Exception as e:
+            logger.error(f"File pairing validation error: {e}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Validation error: {str(e)}"],
+                metadata={"error_type": "validation_exception"},
+            )


### PR DESCRIPTION
## Summary

**Tier 1.2 of the ingestion-hardening audit — image ↔ sidecar pairing.**

Object detection (image ↔ annotation XML) and semantic segmentation (image ↔ mask PNG) had **no ingest-time check** that every image has its sidecar and every sidecar has its image. A missing counterpart only surfaced **mid-training** as a `FileNotFoundError` on the offending row — after the training job had already been running for a while — instead of failing fast at validation where the dataset author could fix the whole set in one pass.

## Fix

New `FilePairingValidator` that matches images to sidecars by **filename stem** under `config.SRC_PATH` (e.g. `<src>/images/cat.jpg` ↔ `<src>/annotations/cat.xml`), wired into the `object_detection` and `semantic_segmentation` validator sets. It reports both directions, by name:

```
2 image(s) have no matching annotation: ['img_044', 'img_091']
1 annotation(s) have no matching image: ['ghost']
```

A missing *directory* is deliberately left to `FileTypeValidator` (which already reports "no files found"), so there's no double-reporting.

## Tests (`test_file_pairing_validator.py`)

- all matched → valid
- image without sidecar → reported by name
- orphan sidecar → reported by name
- masks variant (segmentation) → correct label
- missing sidecar directory → skipped (deferred to FileTypeValidator)

Full suite green: **616 passed**.

## Scope

Keypoint detection is intentionally excluded — it has no separate sidecar *directory* (its annotation structure is validated by `KeypointAnnotationValidator`). New file + 2 `map_validators` wirings; independent of the other open hardening PRs.
