### PR TITLE
chore(release): bump version to 0.3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="tracebloc_ingestor",
-    version="0.3.3",
+    version="0.3.4",
     author="Tracebloc",
     author_email="support@tracebloc.com",
     description="A flexible data ingestion library for various file formats",

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -17,7 +17,7 @@ from .validators import (
     TableNameValidator,
 )
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
Version bump ahead of the **v0.3.4** messy-data hardening release. Companion sync PR (`sync/develop-to-master-v0.3.4`) will follow.

Bumps `setup.py` + `__init__.py` 0.3.3 → 0.3.4 in lockstep. Ships #151 / #155 / #157. Release tracked in #160.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no runtime or behavioral code modifications.
> 
> **Overview**
> **Release prep:** bumps package version **0.3.3 → 0.3.4** in `setup.py` and `tracebloc_ingestor/__init__.py` so PyPI metadata and `__version__` stay aligned ahead of the v0.3.4 release (messy-data hardening; related work in linked PRs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd03bc3b2189d5d3f8f98861e1afe3c7bce46a37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->