### PR TITLE
Sync develop → master for v0.3.4 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="tracebloc_ingestor",
-    version="0.3.3",
+    version="0.3.4",
     author="Tracebloc",
     author_email="support@tracebloc.com",
     description="A flexible data ingestion library for various file formats",

--- a/tests/test_csv_na_values.py
+++ b/tests/test_csv_na_values.py
@@ -48,6 +48,10 @@ def test_tabular_family_uses_wider_na_values(category, tmp_path):
 
     _, kwargs = mock_read.call_args
     assert kwargs["na_values"] == ["", "NA", "NULL", "None"]
+    # keep_default_na=True for tabular so pandas' full NA set (NaN/N/A/null/...)
+    # is recognised — matching the validators' read, which closes the gate-lie
+    # where a file passes validation but crashes the ingestor's type-conversion.
+    assert kwargs["keep_default_na"] is True
 
 
 def test_non_tabular_keeps_narrow_na_values(tmp_path):
@@ -61,3 +65,25 @@ def test_non_tabular_keeps_narrow_na_values(tmp_path):
 
     _, kwargs = mock_read.call_args
     assert kwargs["na_values"] == [""]
+    assert kwargs["keep_default_na"] is False
+
+
+def test_tabular_na_token_in_numeric_column_does_not_crash(tmp_path):
+    """A 'NaN'/'N/A' cell in a numeric column used to PASS the validator but then
+    crash the ingestor's numeric type-conversion (the validator read it as NaN,
+    the ingestor kept it as text). With keep_default_na=True both agree: the cell
+    parses as NaN, read_data succeeds, and the value is missing."""
+    csv_path = tmp_path / "x.csv"
+    csv_path.write_text("x,label\n1.5,a\nNaN,b\nN/A,c\n")
+    ing = CSVIngestor(
+        database=MagicMock(),
+        api_client=MagicMock(),
+        table_name="t",
+        schema={"x": "FLOAT", "label": "str"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+        label_column="label",
+    )
+    records = list(ing.read_data(str(csv_path)))  # must not raise
+    xs = [r["x"] for r in records]
+    assert xs[0] == 1.5
+    assert pd.isna(xs[1]) and pd.isna(xs[2])

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -127,6 +128,53 @@ def test_non_numeric_error_includes_sample_values():
     assert not result.is_valid
     assert "Sample invalid values" in result.errors[0]
     assert "abc" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Non-finite (inf) + realistic messy-data scenarios
+# ---------------------------------------------------------------------------
+
+def test_float_infinity_is_rejected():
+    # inf survives pd.to_numeric (it is "numeric") but flows through the training
+    # scaler unchanged and produces a NaN loss — so the gate must reject it.
+    df = pd.DataFrame({"x": [1.0, np.inf, -np.inf]})
+    result = DataValidator(schema={"x": "FLOAT"}).validate(df)
+    assert not result.is_valid
+    assert "non-finite" in result.errors[0]
+
+
+def test_int_infinity_is_rejected():
+    df = pd.DataFrame({"n": [1.0, np.inf, 3.0]})
+    result = DataValidator(schema={"n": "INT"}).validate(df)
+    assert not result.is_valid
+    assert "non-finite" in result.errors[0]
+
+
+def test_eu_comma_decimal_rejected_with_sample():
+    # German/EU exports write "1,5" for 1.5 — non-numeric to pandas. It is
+    # correctly rejected, and the sample value shows the user what to fix.
+    df = pd.DataFrame({"x": ["1,5", "2,3"]})
+    result = DataValidator(schema={"x": "FLOAT"}).validate(df)
+    assert not result.is_valid
+    assert "1,5" in result.errors[0]
+
+
+def test_thousands_separator_rejected():
+    df = pd.DataFrame({"n": ["1,234", "5,678"]})
+    assert not DataValidator(schema={"n": "INT"}).validate(df).is_valid
+
+
+def test_units_in_numeric_rejected_with_sample():
+    df = pd.DataFrame({"x": ["95%", "3kg"]})
+    result = DataValidator(schema={"x": "FLOAT"}).validate(df)
+    assert not result.is_valid
+    assert "95%" in result.errors[0] or "3kg" in result.errors[0]
+
+
+def test_scientific_notation_is_valid():
+    # Mass-spec / proteomics intensities are commonly in scientific notation.
+    df = pd.DataFrame({"x": ["1.23E+08", "4.5e7"]})
+    assert DataValidator(schema={"x": "FLOAT"}).validate(df).is_valid
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -240,3 +240,13 @@ def test_create_table_allows_label_in_schema():
     db = Database.__new__(Database)
     db.tables = {"t": "sentinel"}  # short-circuit before any engine use
     assert db.create_table("t", {"feature_0": "FLOAT", "label": "INT"}) == "sentinel"
+
+
+def test_create_table_rejects_overlong_column_name():
+    """Column names over MySQL's 64-char identifier limit fail fast with a clear
+    error naming the offenders, instead of a raw MySQL 1059 at CREATE TABLE.
+    Like the reserved-column guard, this runs before any DB I/O."""
+    db = Database.__new__(Database)
+    long_name = "Protein_" + "X" * 70  # 78 chars, > 64
+    with pytest.raises(ValueError, match="64-character"):
+        db.create_table("t", {long_name: "FLOAT", "feature_0": "FLOAT"})

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -241,3 +241,29 @@ def test_context_manager_protocol():
     ing = make_ingestor()
     with ing as x:
         assert x is ing
+
+
+# ---------------------------------------------------------------------------
+# CSV encoding pre-flight (validate_data)
+# ---------------------------------------------------------------------------
+
+def test_check_csv_encoding_rejects_non_utf8(tmp_path):
+    # A Latin-1 export (German umlauts) used to surface as a misleading
+    # "No data found"; now it fails fast with a clear UTF-8 message.
+    bad = tmp_path / "umlaut.csv"
+    bad.write_bytes("Größe,label\n1,a\n".encode("latin-1"))
+    with pytest.raises(ValueError, match="UTF-8"):
+        BaseIngestor._check_csv_encoding(str(bad))
+
+
+def test_check_csv_encoding_accepts_utf8(tmp_path):
+    good = tmp_path / "ok.csv"
+    good.write_text("Größe,label\n1,a\n", encoding="utf-8")
+    BaseIngestor._check_csv_encoding(str(good))  # must not raise
+
+
+def test_check_csv_encoding_skips_non_csv_sources(tmp_path):
+    # Non-CSV / non-path / missing sources are left to the validators.
+    BaseIngestor._check_csv_encoding(str(tmp_path))                   # a directory
+    BaseIngestor._check_csv_encoding(None)                            # not a path
+    BaseIngestor._check_csv_encoding(str(tmp_path / "missing.csv"))   # nonexistent

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -98,6 +98,37 @@ def test_all_task_categories_covered():
     assert not missing, f"No example for categories: {missing}"
 
 
+def test_schema_category_enum_matches_engine_categories():
+    """Anti-drift: the schema's ``category`` enum must list EXACTLY the
+    categories the engine supports (``TaskCategory``).
+
+    ``cli/run.py`` validates every ingest config against this schema before the
+    engine runs, so a category the engine supports but the enum omits would be
+    rejected before ingestion ever starts. This schema is also published as the
+    ingestion contract, so any downstream service that validates submissions
+    against it would reject the same configs (HTTP 4xx) before any work begins.
+
+    This test anchors the enum to the engine's category list so the next
+    category added to ``TaskCategory`` cannot silently desync the published
+    schema. Equality (not subset) so an enum value the engine cannot handle is
+    flagged too.
+    """
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    enum_values = set(schema["properties"]["category"]["enum"])
+    engine_categories = set(TaskCategory.get_all_categories())
+
+    rejected_by_schema = engine_categories - enum_values
+    unknown_to_engine = enum_values - engine_categories
+    assert not (rejected_by_schema or unknown_to_engine), (
+        "ingest.v1.json `category` enum has drifted from the engine's "
+        "TaskCategory (jobs-manager vendors this enum as its submit gate):\n"
+        f"  supported by engine but REJECTED by schema/gate: {sorted(rejected_by_schema)}\n"
+        f"  allowed by schema/gate but UNKNOWN to engine:     {sorted(unknown_to_engine)}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Negative coverage: each rejection path the schema is supposed to enforce.
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -17,7 +17,7 @@ from .validators import (
     TableNameValidator,
 )
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -136,6 +136,20 @@ class Database:
                 f"data_id.strategy=column instead.)"
             )
 
+        # Fail fast on column names longer than MySQL's 64-char identifier limit,
+        # before CREATE TABLE turns it into a raw MySQL 1059 error. CSV headers are
+        # used verbatim as column names, so long proteomics/genomics headers (e.g. a
+        # semicolon-joined isoform list) blow the limit; name the offenders clearly.
+        _MAX_IDENTIFIER = 64
+        _too_long = sorted(c for c in schema if len(str(c)) > _MAX_IDENTIFIER)
+        if _too_long:
+            preview = "; ".join(f"'{c[:40]}…' ({len(c)} chars)" for c in _too_long[:5])
+            more = "" if len(_too_long) <= 5 else f" (and {len(_too_long) - 5} more)"
+            raise ValueError(
+                f"{len(_too_long)} column name(s) exceed the {_MAX_IDENTIFIER}-character "
+                f"database column-name limit and must be shortened: {preview}{more}"
+            )
+
         # Return existing table if already created
         if table_name in self.tables:
             return self.tables[table_name]

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -5,6 +5,7 @@ from sqlalchemy.engine import Engine
 import logging
 from tqdm import tqdm
 import uuid
+from pathlib import Path
 
 from ..database import Database
 from ..api.client import APIClient
@@ -307,6 +308,30 @@ class BaseIngestor(ABC):
             logger.error(f"Error processing record: {str(e)}")
             return None
 
+    @staticmethod
+    def _check_csv_encoding(source: Any) -> None:
+        """Fail fast with a clear message if a CSV source is not valid UTF-8.
+
+        Every validator reads CSVs as UTF-8 and swallows decode errors into a
+        misleading "No data found"; a non-UTF-8 export (e.g. a Latin-1/Windows
+        CSV with umlauts) would otherwise crash or mislead. Probe once, up front.
+        """
+        if not isinstance(source, (str, Path)):
+            return
+        path = Path(source)
+        if path.suffix.lower() != ".csv" or not path.exists():
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                while fh.read(1 << 20):  # decode in 1 MB chunks; raises on a bad byte
+                    pass
+        except UnicodeDecodeError as exc:
+            raise ValueError(
+                f"{RED}'{path.name}' is not valid UTF-8 — a non-UTF-8 byte was found at "
+                f"byte {exc.start}. Re-save the file as UTF-8 (in Excel: Save As → "
+                f"'CSV UTF-8 (Comma delimited)'), then re-ingest.{RESET}"
+            ) from exc
+
     def validate_data(self, source: Any) -> bool:
         """Validate data before ingestion using configured validators.
 
@@ -319,6 +344,10 @@ class BaseIngestor(ABC):
         Raises:
             ValueError: If validation fails
         """
+        # Pre-flight: a non-UTF-8 CSV otherwise surfaces as a misleading
+        # "No data found" (validators read UTF-8 and swallow decode errors).
+        # Catch it once here with a clear, actionable message.
+        self._check_csv_encoding(source)
 
         validators = map_validators(self.category, self.file_options)
         logger.info(f"Running {len(validators)} validator(s) on data source")

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -171,19 +171,20 @@ class CSVIngestor(BaseIngestor):
         try:
             chunk_size = self.csv_options.pop("chunk_size", 1000)
 
-            # Wider null sentinel for tabular-family categories — matches the
-            # legacy templates and prevents "NA"/"NULL"/"None" string cells
-            # from being stored verbatim instead of as NaN.
-            na_values = (
-                _TABULAR_NA_VALUES
-                if self.category in _TABULAR_FAMILY_CATEGORIES
-                else [""]
-            )
+            # NA handling. Tabular-family CSVs use pandas' full default NA set
+            # (keep_default_na=True) so every common missing sentinel — ""/NaN/
+            # "N/A"/"null"/"NA"/"NULL"/"None" — parses as NaN. Crucially this
+            # MATCHES how the validators read the file (plain pd.read_csv with
+            # defaults), so a file that passes validation can't then crash the
+            # numeric type-conversion below on an unrecognised NA token. Other
+            # categories keep the conservative empty-only behaviour.
+            is_tabular = self.category in _TABULAR_FAMILY_CATEGORIES
+            na_values = _TABULAR_NA_VALUES if is_tabular else [""]
 
             # Enhanced default options for pandas
             default_options = {
                 "dtype": None,  # Let pandas infer types initially
-                "keep_default_na": False,
+                "keep_default_na": is_tabular,
                 "na_values": na_values,
                 "encoding": "utf-8",
                 "on_bad_lines": "warn",

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, List, Dict, Optional, Union
 from datetime import datetime
 
+import numpy as np
 import pandas as pd
 
 from .base import BaseValidator, ValidationResult
@@ -326,6 +327,25 @@ class DataValidator(BaseValidator):
 
         return {"is_valid": len(errors) == 0, "errors": errors, "warnings": warnings}
 
+    @staticmethod
+    def _non_finite_error(series, numeric_series, column_name):
+        """Return an error string if a numeric column has inf/-inf values.
+
+        ``pd.to_numeric`` treats inf/-inf as valid numbers, so they slip past
+        the non-numeric check — but they are not valid finite input: they flow
+        through the training preprocessor's scaling unchanged and produce a NaN
+        loss. Reject them at the gate, showing the offending values.
+        """
+        mask = numeric_series.notna() & ~np.isfinite(numeric_series)
+        count = int(mask.sum())
+        if count == 0:
+            return None
+        sample = series[mask].head(5).tolist()
+        return (
+            f"Column '{column_name}' contains {count} non-finite value(s) "
+            f"(inf/-inf): {sample}"
+        )
+
     def _validate_int(
         self, series: pd.Series, column_name: str, expected_type: str
     ) -> Dict[str, Any]:
@@ -358,10 +378,15 @@ class DataValidator(BaseValidator):
                 f"Sample invalid values: {sample}"
             )
 
-        # Check for integer values among the parsed, non-null numbers only
-        # (a NaN would otherwise be miscounted as "non-integer" via NaN % 1).
+        non_finite = self._non_finite_error(series, numeric_series, column_name)
+        if non_finite:
+            errors.append(non_finite)
+
+        # Check for integer values among the parsed, finite, non-null numbers only
+        # (NaN/inf would otherwise be miscounted as "non-integer" via NaN % 1).
         if non_numeric_count == 0:
-            non_integer_mask = numeric_series.notna() & (numeric_series % 1 != 0)
+            finite = numeric_series.notna() & np.isfinite(numeric_series)
+            non_integer_mask = finite & (numeric_series % 1 != 0)
             non_integer_count = int(non_integer_mask.sum())
             if non_integer_count > 0:
                 errors.append(
@@ -416,6 +441,10 @@ class DataValidator(BaseValidator):
                 f"Column '{column_name}' contains {non_numeric_count} non-numeric value(s). "
                 f"Sample invalid values: {sample}"
             )
+
+        non_finite = self._non_finite_error(series, numeric_series, column_name)
+        if non_finite:
+            errors.append(non_finite)
 
         return {"is_valid": len(errors) == 0, "errors": errors, "warnings": warnings}
 


### PR DESCRIPTION
Promotes `develop` to `master` for the **v0.3.4** release. On merge, `publish-master.yml` publishes to PyPI; the `v0.3.4` tag (after merge) triggers the signed image via `release-image.yml`. Live clusters auto-roll within ~15 min of the push.

Release tracked in #160.

### Shipping
- **#151** — reject non-finite (inf/-inf) numerics (silent NaN-loss guard)
- **#155** — align tabular NA parsing with the validator + reject >64-char column names
- **#157** — clear error for non-UTF-8 CSVs
- **#146** — schema category-enum anti-drift test (test-only)
- **#161** — version bump 0.3.3 → 0.3.4

Merge as a **merge commit** (not squash) per RELEASING.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes alter pre-ingestion validation and tabular CSV parsing so some files that previously passed or failed opaquely will now fail or succeed differently; effects are intentional and well-tested but touch the ingestion gate.
> 
> **Overview**
> **v0.3.4 release** promotes `develop` to `master` (version **0.3.3 → 0.3.4**).
> 
> **Validation and ingestion hardening:** `DataValidator` now rejects **inf/-inf** in numeric columns (values that `pd.to_numeric` accepts but break downstream training). Tabular-family `CSVIngestor` reads use **`keep_default_na=True`** so missing sentinels match validator `read_csv` behavior and numeric columns no longer fail type conversion after a passing gate. **`validate_data`** runs a **UTF-8 pre-flight** on CSV paths so bad encodings fail with an actionable message instead of “No data found”. **`Database.create_table`** rejects column names **over 64 characters** before MySQL.
> 
> **Tests:** Coverage for NA/`keep_default_na`, non-finite and messy numeric cases, overlong names, UTF-8 checks, and a **schema `category` enum ↔ `TaskCategory` anti-drift** test (no runtime schema change in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44c0e6d4c936405bbbc06f86a77ebe18a1e36bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->