### PR TITLE
test(e2e): real-DB behaviour — upsert, bulk→row fallback, charset round-trip

### DIFF
--- a/e2e/test_database_e2e.py
+++ b/e2e/test_database_e2e.py
@@ -1,0 +1,87 @@
+"""End-to-end DATABASE behaviour against a real MySQL.
+
+The unit suite (``tests/test_database.py``) mocks the SQLAlchemy engine, so no
+SQL is ever executed despite 100% line coverage: ``CREATE TABLE``, the
+``ON DUPLICATE KEY UPDATE`` upsert, the bulk-insert -> per-row fallback, type
+mapping and charset round-tripping are never actually run. These tests run them
+for real, closing the gap between "every line executed" and "the DB behaves".
+
+Skipped unless a MySQL is reachable (see ``conftest.py``); CI runs it with a
+MySQL service in ``.github/workflows/e2e.yml``.
+"""
+import os
+import uuid
+
+import mysql.connector
+import pytest
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.database import Database
+
+
+def _query(sql):
+    conn = mysql.connector.connect(
+        host=os.environ["MYSQL_HOST"], port=int(os.environ["MYSQL_PORT"]),
+        user=os.environ["DB_USER"], password=os.environ["DB_PASSWORD"],
+        database=os.environ["DB_NAME"],
+    )
+    cur = conn.cursor()
+    cur.execute(sql)
+    rows = cur.fetchall()
+    cur.close()
+    conn.close()
+    return rows
+
+
+@pytest.fixture
+def db():
+    return Database(Config())
+
+
+@pytest.fixture
+def table(db):
+    """A uniquely-named table, dropped on teardown."""
+    name = "e2e_db_" + uuid.uuid4().hex[:8]
+    yield name
+    _query(f"DROP TABLE IF EXISTS `{name}`")
+
+
+def _rec(data_id, **cols):
+    return {"data_id": data_id, **cols}
+
+
+def test_create_table_and_insert_roundtrip(db, table):
+    """CREATE TABLE + INSERT actually run, and values come back intact."""
+    db.create_table(table, {"feature": "FLOAT"})
+    ids, failures = db.insert_batch(table, [_rec("a", feature=1.5), _rec("b", feature=2.5)])
+    assert failures == []
+    assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2
+    vals = sorted(r[0] for r in _query(f"SELECT feature FROM `{table}`"))
+    assert vals == [1.5, 2.5]
+
+
+def test_upsert_dedupes_on_data_id(db, table):
+    """Re-ingesting the same data_id UPDATEs the row (ON DUPLICATE KEY UPDATE),
+    it does not create a duplicate — the core idempotency guarantee."""
+    db.create_table(table, {"feature": "INT"})
+    db.insert_batch(table, [_rec("dup", feature=1)])
+    db.insert_batch(table, [_rec("dup", feature=99)])
+    assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 1
+    assert _query(f"SELECT feature FROM `{table}` WHERE data_id='dup'")[0][0] == 99
+
+
+def test_partial_batch_falls_back_without_duplicating_good_rows(db, table):
+    """data_id is NOT NULL UNIQUE; a NULL row aborts the bulk INSERT, so the
+    per-row fallback must still insert the good rows exactly once (no dupes)."""
+    db.create_table(table, {"feature": "INT"})
+    batch = [_rec("ok1", feature=1), _rec(None, feature=2), _rec("ok2", feature=3)]
+    ids, failures = db.insert_batch(table, batch)
+    assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2  # ok1 + ok2, once each
+    assert len(failures) == 1                                    # the NULL-data_id row
+
+
+def test_non_ascii_data_roundtrip(db, table):
+    """Non-ASCII values (German umlauts) survive the real INSERT/SELECT."""
+    db.create_table(table, {"name": "VARCHAR(64)"})
+    db.insert_batch(table, [_rec("u", name="Größe-Meßwert")])
+    assert _query(f"SELECT name FROM `{table}` WHERE data_id='u'")[0][0] == "Größe-Meßwert"


### PR DESCRIPTION
## Summary

Part of a deep test-suite audit (below). The suite is mature — **99% line coverage, gated at 95%** (`tests.yml`) — but the unit tests **mock the SQLAlchemy engine** (`tests/test_database.py`), so despite `database.py` showing **100% line coverage, no SQL is ever executed**. The existing real-MySQL e2e (`e2e.yml`) only proves *every bundled template ingests* (happy path). So the **stateful real-DB semantics were tested nowhere.**

This adds `e2e/test_database_e2e.py`, running the real `Database` against the e2e MySQL service:

| Test | What it proves (that mocks can't) |
|---|---|
| `test_create_table_and_insert_roundtrip` | `CREATE TABLE` + `INSERT` actually run; values come back intact (type mapping is real) |
| `test_upsert_dedupes_on_data_id` | `ON DUPLICATE KEY UPDATE` updates the row instead of duplicating it — the **idempotency guarantee** re-ingestion relies on |
| `test_partial_batch_falls_back_without_duplicating_good_rows` | a `NULL`-`data_id` row aborts the bulk insert → the per-row fallback (`database.py:257-277`) re-inserts the good rows **exactly once** (guards against the fallback double-inserting — invisible to mocks) |
| `test_non_ascii_data_roundtrip` | umlaut data survives a real `INSERT`/`SELECT` (charset/collation) |

Follows the existing e2e conventions (real `Database` for the operation under test, `mysql.connector` for verification, unique table per test dropped on teardown). **Auto-skips without a MySQL**, so the default unit run is unaffected — verified locally (`no tests ran`, unit suite still 611 passed). CI (`e2e.yml`, MySQL 8.0 service) executes it.

## Why this matters

100% line coverage on `database.py` was masking that the *behaviour* — upsert, transactional fallback, charset — had never run. This is the highest-value realism gap from the audit, and it reuses the e2e infra that already exists.

## Audit follow-ups (separate, prioritized)

- **API client failure modes** (`api/client.py`): tenacity retry/backoff, timeouts, malformed/empty JSON, 401 mid-ingest — currently only happy-path `MagicMock`. Best done with the `responses` library at the unit level.
- **`file_transfer.py` failure modes**: missing source, permission-denied, partial transfer.
- **Messy-data e2e matrix**: once the hardening guards (#155/#156/#157) merge, run encoding / locale-date / long-column-name / sentinel datasets through the full pipeline into real MySQL to prove the *guards* fire end-to-end (not just in mocked unit tests).
- **Scale**: a large-CSV (100k-row) ingest to exercise chunking/memory and `max_allowed_packet`.
