### PR TITLE
fix(csv): type-convert + strip headers on every chunk (multi-chunk correctness)

### DIFF
--- a/tests/test_csv_ingestor_scale.py
+++ b/tests/test_csv_ingestor_scale.py
@@ -1,0 +1,67 @@
+"""Scale / chunked-read correctness for CSVIngestor.read_data.
+
+read_data streams the CSV in chunks (``chunk_size``, default 1000). Every other
+test uses < 1000 rows -> a single chunk -> the multi-chunk path was never
+exercised, which hid a bug: header-strip + type conversion (``_validate_csv``)
+ran only on the FIRST chunk, so rows beyond chunk_size were yielded un-converted
+(e.g. a DATE column as raw strings) with un-stripped keys. These feed a CSV
+LARGER than chunk_size and assert every row across all chunks is correct.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+def _ingestor(schema, chunk_size):
+    return CSVIngestor(
+        database=MagicMock(), api_client=MagicMock(), table_name="t",
+        schema=schema, category=TaskCategory.TABULAR_CLASSIFICATION,
+        label_column="label", csv_options={"chunk_size": chunk_size},
+    )
+
+
+def _write(tmp_path, header, rows):
+    p = tmp_path / "data.csv"
+    p.write_text(header + "\n" + "\n".join(rows) + "\n")
+    return str(p)
+
+
+def test_all_rows_yielded_in_order_across_chunks(tmp_path):
+    path = _write(tmp_path, "x,label", [f"{i},lab{i}" for i in range(1, 251)])
+    ing = _ingestor({"x": "INT", "label": "str"}, chunk_size=50)  # 250 rows -> 5 chunks
+    recs = list(ing.read_data(path))
+    assert len(recs) == 250                                   # no drops/dupes at boundaries
+    assert [int(r["x"]) for r in recs] == list(range(1, 251))  # in order
+
+
+def test_date_column_converted_in_every_chunk(tmp_path):
+    # The bug: rows past chunk 1 came back as raw 'str'. They must all convert.
+    path = _write(tmp_path, "ts,label", [f"2024-01-{i:02d},lab{i}" for i in range(1, 11)])
+    ing = _ingestor({"ts": "DATE", "label": "str"}, chunk_size=3)  # 10 rows -> 4 chunks
+    recs = list(ing.read_data(path))
+    assert len(recs) == 10
+    assert all(isinstance(r["ts"], pd.Timestamp) for r in recs)
+
+
+def test_header_whitespace_stripped_in_every_chunk(tmp_path):
+    # Leading-space header; keys must be stripped for ALL chunks, not just the first.
+    path = _write(tmp_path, " x ,label", [f"{i},lab{i}" for i in range(1, 11)])
+    ing = _ingestor({"x": "INT", "label": "str"}, chunk_size=3)
+    recs = list(ing.read_data(path))
+    assert len(recs) == 10
+    assert all("x" in r and " x " not in r for r in recs)
+
+
+def test_single_chunk_behaviour_unchanged(tmp_path):
+    # The common < chunk_size case still converts (regression guard).
+    path = _write(tmp_path, "ts,label", ["2024-01-01,a", "2024-01-02,b"])
+    ing = _ingestor({"ts": "DATE", "label": "str"}, chunk_size=1000)
+    recs = list(ing.read_data(path))
+    assert len(recs) == 2
+    assert all(isinstance(r["ts"], pd.Timestamp) for r in recs)

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -196,9 +196,17 @@ class CSVIngestor(BaseIngestor):
 
             first_chunk = True
             for chunk in pd.read_csv(file_path, chunksize=chunk_size, **csv_options):
+                # Strip headers + type-convert EVERY chunk. Doing this only for
+                # the first chunk left every row past chunk_size (default 1000)
+                # un-converted — a DATE column came back as raw strings, numeric
+                # columns fell back to pandas' per-chunk inference, and header
+                # whitespace was stripped only for chunk 1 — all invisible until
+                # a file exceeds a single chunk.
+                chunk.columns = chunk.columns.str.strip()
+                self._validate_csv(chunk)
                 if first_chunk:
-                    chunk.columns = chunk.columns.str.strip()
-                    self._validate_csv(chunk)
+                    # One-time check: the unique_id column exists (columns are
+                    # identical across chunks, so checking the first is enough).
                     if (
                         self.unique_id_column
                         and self.unique_id_column not in chunk.columns


### PR DESCRIPTION
## Summary

**Item 5 of the test-hardening program — and the scale lens caught a real silent-corruption bug.**

`csv_ingestor.read_data` streams the CSV in chunks (`chunk_size`, default **1000**) but ran the header-strip + `_validate_csv` type conversion **only inside `if first_chunk:`** (`csv_ingestor.py:199-209`). So for any CSV **larger than `chunk_size`**, every row past the first chunk was yielded **un-converted**:

- a `DATE` column came back as **raw strings**
- numeric/bool columns fell back to pandas' *per-chunk* inference (can differ chunk-to-chunk)
- header whitespace was stripped only for chunk 1 → rows 2+ got un-stripped record keys

Invisible until now because **every test used < 1000 rows** (a single chunk). Confirmed empirically — a 5-row file at `chunk_size=2` with a `DATE` column yields:

```
ts types per row: ['Timestamp', 'Timestamp', 'str', 'str', 'str']
```

## Fix

Move `chunk.columns.str.strip()` + `self._validate_csv(chunk)` **out** of the first-chunk guard so they run for **every** chunk. Keep only the one-time `unique_id_column` existence check first-chunk-only (columns are identical across chunks, so re-checking is wasteful; `_validate_csv` re-validates the same columns per chunk — cheap, no new errors).

## Tests (`tests/test_csv_ingestor_scale.py`, new)

| test | proves |
|---|---|
| 250 rows @ chunk 50 | all rows yielded **in order**, no drops/dupes at chunk boundaries |
| DATE @ chunk 3 | converted to `Timestamp` in **every** chunk (the regression) |
| ` x ` header @ chunk 3 | whitespace stripped for **all** chunks, not just the first |
| single chunk | unchanged (< `chunk_size` regression guard) |

## Verification
- Local (`/tmp/di-venv`): full suite **627 passed**; `csv_ingestor.py` **99%**; total **99%** (gate 95%).
- CI: `tests.yml` (3.11 + 3.12) + `e2e.yml`.

## Related
The **batch-sizing** question this surfaced (`chunk_size`=1000 read vs `BATCH_SIZE`=4000 DB insert, and whether either should be tuned per data type) is tracked as a separate benchmark spike in `backend` — to be done *after* this correctness fix lands.
