### PR TITLE
fix(validators): VARCHAR/CHAR/TEXT must tolerate NULLs

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -193,6 +193,40 @@ def test_varchar_too_long_fails():
     assert "exceeding max length" in result.errors[0]
 
 
+def test_varchar_with_nulls_is_valid():
+    # Regression: a VARCHAR column with genuine missing values was wrongly
+    # reported as containing "non-string" values (NaN != NaN), an error the
+    # user could never clear by editing data. NULLs are valid for any column.
+    df = pd.DataFrame({"s": ["abc", None, "de"]})
+    assert DataValidator(schema={"s": "VARCHAR(255)"}).validate(df).is_valid
+
+
+def test_varchar_all_null_is_valid():
+    # An entirely-empty column (e.g. an unmeasured biomarker / analyte in a
+    # sparse panel) is a column of NULLs — valid, not N "non-string values".
+    df = pd.DataFrame({"s": [None, None, None]})
+    assert DataValidator(schema={"s": "VARCHAR(255)"}).validate(df).is_valid
+
+
+def test_char_with_nulls_is_valid():
+    df = pd.DataFrame({"s": ["ab", None, "cd"]})
+    assert DataValidator(schema={"s": "CHAR(2)"}).validate(df).is_valid
+
+
+def test_text_with_nulls_is_valid():
+    df = pd.DataFrame({"s": ["any length text", None]})
+    assert DataValidator(schema={"s": "TEXT"}).validate(df).is_valid
+
+
+def test_varchar_still_flags_real_non_strings():
+    # NULL tolerance must NOT mask a genuine type error: a real numeric value
+    # in a VARCHAR column is still non-string and must be reported.
+    df = pd.DataFrame({"s": ["abc", 5, "de"]})
+    result = DataValidator(schema={"s": "VARCHAR(255)"}).validate(df)
+    assert not result.is_valid
+    assert "non-string" in result.errors[0]
+
+
 def test_char_wrong_length_fails():
     df = pd.DataFrame({"s": ["ab", "cde"]})
     result = DataValidator(schema={"s": "CHAR(2)"}).validate(df)

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -242,8 +242,12 @@ class DataValidator(BaseValidator):
         length_match = re.search(r"VARCHAR\((\d+)\)", expected_type.upper())
         max_length = int(length_match.group(1)) if length_match else None
 
-        # Check for non-string values
-        non_string_count = series.astype(str).ne(series).sum()
+        # Check for non-string values. A NULL is valid for any column, and
+        # ``NaN != NaN`` would otherwise count every missing value as
+        # "non-string" — an error the user can never clear (inserting NaN
+        # doesn't help). Mirror the INT/FLOAT validators: only flag values
+        # that are non-null AND not strings.
+        non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
         if non_string_count > 0:
             errors.append(
                 f"Column '{column_name}' contains {non_string_count} non-string values"
@@ -251,7 +255,7 @@ class DataValidator(BaseValidator):
 
         # Check length constraints
         if max_length:
-            string_series = series.astype(str)
+            string_series = series.dropna().astype(str)
             too_long = string_series.str.len() > max_length
             too_long_count = too_long.sum()
 
@@ -282,8 +286,12 @@ class DataValidator(BaseValidator):
         length_match = re.search(r"CHAR\((\d+)\)", expected_type.upper())
         max_length = int(length_match.group(1)) if length_match else None
 
-        # Check for non-string values
-        non_string_count = series.astype(str).ne(series).sum()
+        # Check for non-string values. A NULL is valid for any column, and
+        # ``NaN != NaN`` would otherwise count every missing value as
+        # "non-string" — an error the user can never clear (inserting NaN
+        # doesn't help). Mirror the INT/FLOAT validators: only flag values
+        # that are non-null AND not strings.
+        non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
         if non_string_count > 0:
             errors.append(
                 f"Column '{column_name}' contains {non_string_count} non-string values"
@@ -291,7 +299,7 @@ class DataValidator(BaseValidator):
 
         # Check length constraints (CHAR should be fixed length)
         if max_length:
-            string_series = series.astype(str)
+            string_series = series.dropna().astype(str)
             wrong_length = string_series.str.len() != max_length
             wrong_length_count = wrong_length.sum()
 
@@ -318,8 +326,12 @@ class DataValidator(BaseValidator):
         errors = []
         warnings = []
 
-        # Check for non-string values
-        non_string_count = series.astype(str).ne(series).sum()
+        # Check for non-string values. A NULL is valid for any column, and
+        # ``NaN != NaN`` would otherwise count every missing value as
+        # "non-string" — an error the user can never clear (inserting NaN
+        # doesn't help). Mirror the INT/FLOAT validators: only flag values
+        # that are non-null AND not strings.
+        non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
         if non_string_count > 0:
             errors.append(
                 f"Column '{column_name}' contains {non_string_count} non-string values"


### PR DESCRIPTION
## Summary

The VARCHAR / CHAR / TEXT validators counted every NULL as a "non-string" value, so any text column with missing data — including a fully-empty column — failed ingest with a contradiction the user can't resolve.

## The bug

All three string validators used:
```python
non_string_count = series.astype(str).ne(series).sum()
```
`NaN != NaN` is always true, so each missing cell is counted as "non-string." A column with 207 empty cells fails with `Column 'X' contains 207 non-string values`, and there's no edit that clears it (inserting NaN doesn't help).

The **INT/FLOAT validators already guard exactly this** (`numeric_series.isna() & series.notna()` — "Genuine missing values are valid… an error the user can never clear"). The string validators were simply missed.

## Fix

Mirror the numeric validators — only flag values that are **non-null AND not strings**:
```python
non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
```
…and drop NULLs before the length checks (`series.dropna().astype(str)`), so a missing value isn't measured as the literal `"nan"`. Applies to `_validate_varchar`, `_validate_char`, and `_validate_text`.

A genuine non-string (a real number in a text column) is **still** flagged — verified by test.

## Where it came from

A sparse biomarker panel (proteomics matrix): an analyte measured in zero samples is an all-empty column. Real example column had 207 patients, all empty → `207 non-string values`. Logic check, old vs new:

| column | old count | new count |
|---|---|---|
| all-null (empty analyte) | 207 | **0** ✅ |
| strings + some nulls | n | **0** ✅ |
| genuine number in text col | 1 | **1** ✅ (still caught) |

## Tests

Added regression tests: varchar/char/text with nulls, an all-null column, and a genuine-non-string-still-fails case.

> Note: local env lacks the package's full dependency chain (sqlalchemy/tenacity/mysql-connector), so I validated the fix logic directly on pandas + `py_compile`; the full pytest suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
