### PR TITLE
fix(validators): DATE/DATETIME/TIMESTAMP/TIME must tolerate NULLs

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -304,6 +304,28 @@ def test_date_invalid_fails():
     assert "invalid date" in result.errors[0]
 
 
+@pytest.mark.parametrize("dtype", ["DATE", "DATETIME", "TIMESTAMP", "TIME"])
+def test_date_family_with_nulls_is_valid(dtype):
+    # Regression: a date column with genuine missing values was wrongly
+    # reported as "invalid date values" (to_datetime turns NULL into NaT,
+    # then isnull() counted it) — an unclearable error. NULLs are valid.
+    df = pd.DataFrame({"d": ["2024-01-01", None, "2024-02-02"]})
+    assert DataValidator(schema={"d": dtype}).validate(df).is_valid
+
+
+def test_date_all_null_is_valid():
+    df = pd.DataFrame({"d": [None, None, None]})
+    assert DataValidator(schema={"d": "DATE"}).validate(df).is_valid
+
+
+def test_date_still_flags_real_bad_value_with_nulls_present():
+    # NULL tolerance must not mask a genuinely un-parseable date.
+    df = pd.DataFrame({"d": ["2024-01-01", None, "not-a-date"]})
+    result = DataValidator(schema={"d": "DATE"}).validate(df)
+    assert not result.is_valid
+    assert "invalid date" in result.errors[0]
+
+
 # ---------------------------------------------------------------------------
 # type parsing + auto-detect helper
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -614,7 +614,11 @@ class DataValidator(BaseValidator):
         # Try to convert to datetime
         try:
             date_series = pd.to_datetime(series, errors="coerce")
-            invalid_dates = date_series.isnull().sum()
+            # A NULL is valid for any column; only a value that was present
+            # but un-parseable is an "invalid date". Without the
+            # ``series.notna()`` mask every missing cell counts as invalid —
+            # an unclearable error (mirrors the INT/FLOAT validators).
+            invalid_dates = (date_series.isna() & series.notna()).sum()
 
             if invalid_dates > 0:
                 errors.append(


### PR DESCRIPTION
## Summary

Follow-up to #167 (merged). The deeper data-path audit found the **DATE / DATETIME / TIMESTAMP / TIME** validators carry the *identical* `NaN`-as-invalid bug #167 fixed for VARCHAR/CHAR/TEXT — it was simply never ported to the date family.

`_validate_date` does `pd.to_datetime(series, errors="coerce")` then `date_series.isnull().sum()` — so a genuine NULL becomes `NaT` and is counted as an "invalid date." Any sparse date column (e.g. a collection-date missing for some patients) fails ingest with `contains N invalid date values`, and inserting NULL can never clear it.

## Fix

Mask out nulls — count only values that were present but un-parseable, exactly like the INT/FLOAT validators (`numeric_series.isna() & series.notna()`):
```python
invalid_dates = (date_series.isna() & series.notna()).sum()
```
`datetime` / `timestamp` / `time` all delegate to `_validate_date`, so one change fixes all four.

## Verification
Reproduced the bug, then the fix, against the real validator. Added regression tests (date family with nulls, all-null, and still-flags a genuinely bad value when nulls are present) — 12 date tests pass.

With #167, this makes **every** string + date/time validator NULL-tolerant, consistent with INT/FLOAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
