### PR TITLE
fix(json): JSON null must tolerate as missing, not fail type validation

### DIFF
--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -94,6 +94,32 @@ def test_validate_record_allows_empty_string():
     ing._validate_record({"n": ""})
 
 
+def test_validate_record_allows_json_null_for_int():
+    # Regression: a JSON ``null`` (Python None) was passed to int(None), which
+    # raises TypeError and surfaced as "Data type validation failed for field
+    # n" — an error the user can never clear since JSON null IS the
+    # representation of missing.
+    ing = make_json_ingestor(schema={"n": "INT"})
+    ing._validate_record({"n": None})
+
+
+def test_validate_record_allows_json_null_for_float():
+    ing = make_json_ingestor(schema={"x": "FLOAT"})
+    ing._validate_record({"x": None})
+
+
+def test_validate_record_allows_json_null_for_bool():
+    ing = make_json_ingestor(schema={"b": "BOOL"})
+    ing._validate_record({"b": None})
+
+
+def test_validate_record_still_rejects_real_type_errors():
+    # NULL tolerance must NOT mask a genuine bad value.
+    ing = make_json_ingestor(schema={"n": "INT"})
+    with pytest.raises(ValueError, match="Data type validation failed"):
+        ing._validate_record({"n": "not-an-int"})
+
+
 def test_count_records_array(tmp_path):
     p = _write_json(tmp_path, [{"a": 1}, {"a": 2}, {"a": 3}])
     assert make_json_ingestor()._count_records(str(p)) == 3

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -128,13 +128,22 @@ class JSONIngestor(BaseIngestor):
         for field in common_fields:
             value = record[field]
             dtype = self.schema[field]
+            # NULL tolerance. A JSON ``null`` (Python ``None``) and an empty
+            # string are both legitimate missing values for any type; calling
+            # ``int(None)`` / ``float(None)`` raises TypeError, which the
+            # validator would otherwise surface as "Data type validation
+            # failed" — an error the user can never clear (JSON null IS the
+            # representation of missing). Mirrors the same NULL-tolerance the
+            # CSV-side validators got in #167 / #168.
+            if value is None or value == "":
+                continue
             try:
                 if "INT" in dtype.upper():
-                    int(value) if value != "" else None
+                    int(value)
                 elif "FLOAT" in dtype.upper():
-                    float(value) if value != "" else None
+                    float(value)
                 elif "BOOL" in dtype.upper():
-                    bool(value) if value != "" else None
+                    bool(value)
                 # Add more type validations as needed
             except Exception as e:
                 raise ValueError(


### PR DESCRIPTION
## Summary

A direct sibling of #167 (VARCHAR/CHAR/TEXT) and #168 (DATE/DATETIME/TIMESTAMP/TIME) — same shape, different code path. `JSONIngestor._validate_record` rejected genuine missing data the user could never clear.

## The bug

`_validate_record` only treated the empty string `""` as missing:

```python
if "INT" in dtype.upper():
    int(value) if value != "" else None
elif "FLOAT" in dtype.upper():
    float(value) if value != "" else None
elif "BOOL" in dtype.upper():
    bool(value) if value != "" else None
```

A JSON record with `"age": null` deserialises to Python `None`. `int(None)` raises `TypeError`, which the validator surfaces as `"Data type validation failed for field age"`. JSON `null` **is** the representation of missing, so this is an unclearable error.

## Fix

Treat both `None` and `""` as legitimate missing values for any type — mirrors the NULL-tolerance pattern from #167 / #168:

```python
if value is None or value == "":
    continue
```

A genuine type error (e.g. `"age": "not-an-int"`) still raises — verified by a new regression test.

## Tests (`tests/test_json_ingestor.py`)

- JSON `null` tolerated for INT / FLOAT / BOOL (3 new tests)
- Existing empty-string-tolerated test still passes
- Genuine bad value still rejected

Full suite local: **660 passed**.

## Out of scope (separate concern)

The body of `_validate_record` uses dead expressions — `int(value) if value != \"\" else None` computes a value and discards it (no assignment). The "validation" only catches the case where the cast *would* raise. `bool(\"false\")` doesn't raise, so the BOOL branch silently accepts any non-empty string. That's a separable design question (should JSON records be mutated with converted types, like `_validate_csv` does for CSVs?) and not addressed here.

Independent of the other open hardening PRs; touches `json_ingestor.py` + its test file only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation change in the JSON ingestor with regression tests; no auth, security, or data-pipeline architecture changes.
> 
> **Overview**
> **JSON ingest validation** now treats JSON `null` (`None`) and empty strings as missing for INT/FLOAT/BOOL fields, skipping casts instead of failing with “Data type validation failed” (e.g. `int(None)`). This aligns JSON behavior with the NULL-tolerance added for CSV validators in #167/#168.
> 
> Type checks for real bad values are unchanged. New tests cover `null` for INT/FLOAT/BOOL and confirm invalid strings still raise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 765e0b071b7c8705a2e60b4da168429489cd2047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->