### PR TITLE
chore(release): bump version to 0.3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="tracebloc_ingestor",
-    version="0.3.4",
+    version="0.3.5",
     author="Tracebloc",
     author_email="support@tracebloc.com",
     description="A flexible data ingestion library for various file formats",

--- a/tests/test_i18n_adversarial_csv.py
+++ b/tests/test_i18n_adversarial_csv.py
@@ -300,21 +300,24 @@ def test_utf16_with_correct_encoding_parses(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_default_tabular_na_tokens(tmp_path):
-    """The tabular-family default widens NA to ``["", "NA", "NULL", "None"]``.
-    Pin exactly which tokens are treated as NA under that default: empty and
-    ``NA`` become NaN; ``NaN`` / ``n/a`` / ``-`` are stored verbatim (they
-    are NOT in the default set, and keep_default_na is off). This documents
-    the boundary so a future widening is a conscious change."""
+    """Tabular-family CSVs use ``keep_default_na=True`` plus the explicit
+    ``_TABULAR_NA_VALUES`` widening (``["", "NA", "NULL", "None"]``), so the
+    effective NA set is the union of pandas' built-in tokens (which include
+    ``NaN`` / ``n/a`` / ``null`` / ``NA`` / ``NULL`` / ``None`` / ``""``) and
+    the widening. Tokens NOT in either set — e.g. ``-`` — are stored verbatim.
+    This documents the actual boundary so a future narrowing is a conscious
+    change. See csv_ingestor.py::read_data for the rationale (validators read
+    with pandas defaults, so the ingestor must match)."""
     p = tmp_path / "na.csv"
     p.write_text("a,b\n1,NA\n2,NaN\n3,n/a\n4,-\n5,\n", encoding="utf-8")
     ing = _make_ingestor({"a": "INT", "b": "VARCHAR(10)"})
     records = list(ing.read_data(str(p)))
 
     b = [r["b"] for r in records]
-    assert pd.isna(b[0])      # "NA"  -> NaN
-    assert b[1] == "NaN"      # not in default set -> literal
-    assert b[2] == "n/a"      # not in default set -> literal
-    assert b[3] == "-"        # not in default set -> literal
+    assert pd.isna(b[0])      # "NA"  -> NaN (in widening)
+    assert pd.isna(b[1])      # "NaN" -> NaN (in pandas defaults)
+    assert pd.isna(b[2])      # "n/a" -> NaN (in pandas defaults)
+    assert b[3] == "-"        # "-"   -> literal (in neither set)
     assert pd.isna(b[4])      # ""    -> NaN
 
 


### PR DESCRIPTION
## Summary
- Bumps setup.py from 0.3.4 → 0.3.5 in preparation for the `v0.3.5-rc1` tag.
- Also fixes a pre-existing test break on develop (introduced by #149) that was blocking ALL PRs off develop — `test_default_tabular_na_tokens` had assertions disagreeing with the code's intentional `keep_default_na=True` behavior. Bundled here to unblock CI; happy to split if preferred.

The rc1 will exercise four recently-merged fixes against the dev cluster:
- #166 (csv: type-convert + strip headers on every chunk)
- #167 (validators: VARCHAR/CHAR/TEXT NULL tolerance)
- #168 (validators: DATE/DATETIME/TIMESTAMP/TIME NULL tolerance)
- #170 (json: null tolerance for INT/FLOAT/BOOL)

## Test plan
- [ ] CI green
- [ ] Tag `v0.3.5-rc1` after merge → `release-image.yml` builds + publishes signed image
- [ ] dev cluster image-refresh picks up new digest on `ghcr.io/tracebloc/ingestor:0.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version bump and test/doc alignment only; no production logic changes in this diff.
> 
> **Overview**
> Prepares **v0.3.5-rc1** by bumping the package version in `setup.py` from **0.3.4** to **0.3.5** (no other packaging changes in the diff).
> 
> **`test_default_tabular_na_tokens`** is updated so the contract matches tabular CSV parsing with **`keep_default_na=True`** plus **`_TABULAR_NA_VALUES`**: docstring now describes the union of pandas defaults and the explicit widening, and expectations change so **`NaN`** and **`n/a`** cells are **NaN** (not literal strings); **`"-"`** remains a verbatim value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4cb9fe2a63e55eef9b6dbe723924208c6973423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->