### PR TITLE
fix(csv): VARCHAR/CHAR empty cells must be None, not literal "nan"

### DIFF
--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -106,3 +106,55 @@ def test_tabular_na_values_applied(tmp_path):
     # "NA"/"NULL" should be parsed as NaN for tabular categories.
     assert pd.isna(records[0]["b"])
     assert pd.isna(records[1]["b"])
+
+
+def test_varchar_empty_cells_yield_python_none(tmp_path):
+    """Missing cells in a VARCHAR column must yield Python None, NOT float NaN
+    or the literal string 'nan'.
+
+    Regression: before the type-coercion branch matched VARCHAR/CHAR (it only
+    matched STRING/TEXT), pandas left the column as float64 with NaN for empty
+    cells. itertuples emitted those NaN floats, dict() preserved them, and the
+    SQL binder stringified them as 'nan' on INSERT — silent data corruption
+    of every missing VARCHAR cell. #167 widened NULL-tolerance in the
+    validator (so all-null VARCHAR no longer fails validation); without this
+    write-side fix the column was happily ingested as a column of 'nan'
+    strings instead of SQL NULLs.
+
+    Surfaced by an end-to-end cluster ingestion with an all-empty VARCHAR(50)
+    column: MySQL row count = 60, all rows had analyte_y = 'nan' (length 3).
+    """
+    p = tmp_path / "d.csv"
+    # 'analyte_y' is all-empty (the original biomarker scenario from #167);
+    # 'notes' mixes a value and an empty.
+    p.write_text("a,analyte_y,notes\n1,,hello\n2,,\n3,,world\n")
+    ing = make_csv_ingestor(
+        schema={"a": "INT", "analyte_y": "VARCHAR(50)", "notes": "VARCHAR(100)"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    records = list(ing.read_data(str(p)))
+
+    assert len(records) == 3
+    # All-empty VARCHAR column: every value must be None, not NaN, not "nan".
+    for r in records:
+        assert r["analyte_y"] is None, f"expected None, got {r['analyte_y']!r}"
+    # Mixed VARCHAR column: present cells preserved; empty -> None.
+    assert records[0]["notes"] == "hello"
+    assert records[1]["notes"] is None
+    assert records[2]["notes"] == "world"
+
+
+def test_char_empty_cells_yield_python_none(tmp_path):
+    """Same regression for CHAR — pre-fix code only matched STRING/TEXT, so
+    CHAR(N) columns silently stored 'nan' for empties.
+    """
+    p = tmp_path / "d.csv"
+    p.write_text("a,code\n1,A\n2,\n")
+    ing = make_csv_ingestor(
+        schema={"a": "INT", "code": "CHAR(1)"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    records = list(ing.read_data(str(p)))
+
+    assert records[0]["code"] == "A"
+    assert records[1]["code"] is None

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -139,8 +139,21 @@ class CSVIngestor(BaseIngestor):
                     df[column] = df[column].astype("boolean")
                 elif "DATE" in dtype.upper() or "DATETIME" in dtype.upper() or "TIMESTAMP" in dtype.upper() or "TIME" in dtype.upper():
                     df[column] = pd.to_datetime(df[column], errors="coerce", format='mixed')
-                elif "STRING" in dtype.upper() or "TEXT" in dtype.upper():
-                    df[column] = df[column].astype("string")
+                elif any(t in dtype.upper() for t in ("STRING", "TEXT", "VARCHAR", "CHAR")):
+                    # Coerce to pandas StringDtype so missing cells become pd.NA
+                    # (not float NaN), then map pd.NA -> Python None so the DB
+                    # binder writes SQL NULL. Without this, VARCHAR/CHAR columns
+                    # were left as the float64 dtype pandas inferred for an
+                    # empty/mixed cell, and str(nan) "nan" landed in MySQL —
+                    # silent corruption of missing-data semantics. #167 widened
+                    # NULL-tolerance in the validator so all-null VARCHAR no
+                    # longer fails validation; this completes the fix on the
+                    # write side.
+                    df[column] = (
+                        df[column].astype("string").astype(object).where(
+                            df[column].notna(), None
+                        )
+                    )
             except Exception as e:
                 raise ValueError(
                     f"{RED}Data type validation failed for column {column}: {str(e)}{RESET}"


### PR DESCRIPTION
## Summary

Surfaced by **real end-to-end cluster ingestion** against v0.3.5-rc1: a 60-row CSV with an all-empty `VARCHAR(50)` column ingested without error, but every row in MySQL had the column set to the three-character string `'nan'`, not SQL NULL.

\`\`\`sql
SELECT analyte_y, LENGTH(analyte_y), COUNT(*)
FROM e2etest_varchar_nulls
GROUP BY analyte_y;
-- analyte_y | LENGTH | COUNT
-- 'nan'     | 3      | 60
\`\`\`

## Root cause

`CSVIngestor._validate_csv` only matched **STRING / TEXT** for string-dtype coercion:

\`\`\`python
elif "STRING" in dtype.upper() or "TEXT" in dtype.upper():
    df[column] = df[column].astype("string")
\`\`\`

So a column declared \`VARCHAR(50)\` or \`CHAR(N)\` was left at whatever pandas inferred — \`float64\` with NaN for any cell in pandas's tabular NA set (`""`, `NA`, `NaN`, `null`, …). \`itertuples\` emitted those NaN floats, \`dict()\` preserved them, and \`str(nan) == "nan"\` was written to MySQL on INSERT.

## Why this only became visible now

#167 widened NULL-tolerance in the **VARCHAR/CHAR/TEXT validator**, so all-null / sparse VARCHAR columns no longer fail validation. **Before #167** the validator rejected those columns with \`"N non-string values"\` — the ingest failed loudly and bad rows never reached the DB. After #167, validation passes → the un-coerced write path runs → silent corruption.

## Fix

Extend the string branch to match VARCHAR/CHAR, coerce via pandas StringDtype (which maps NaN → \`pd.NA\`), then explicitly map \`pd.NA → Python None\` so the DB binder writes SQL NULL.

## Test plan

- [ ] New regression tests cover:
  - VARCHAR(N): all-empty column → None on every record; mixed → value-or-None
  - CHAR(N): empty cell → None; non-empty preserved
- [ ] \`test_tabular_na_values_applied\` continues to pass (\`pd.isna(None) is True\`)
- [ ] CI green
- [ ] Re-run cluster ingestion → DB shows NULL, not 'nan'

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tabular CSV type coercion for all VARCHAR/CHAR columns at insert time; wrong coercion could affect any string column with missing data, but scope is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes a **write-path bug** where empty `VARCHAR`/`CHAR` cells were persisted as the literal string `'nan'` in MySQL instead of SQL NULL.
> 
> `CSVIngestor._validate_csv` now treats **STRING, TEXT, VARCHAR, and CHAR** the same: columns are coerced through pandas string dtype and missing values are normalized to **Python `None`** so the DB binder inserts NULL. Previously only STRING/TEXT were coerced, so sparse `VARCHAR(50)`/`CHAR(N)` columns stayed as float64 NaN and were stringified on INSERT.
> 
> Adds regression tests for all-empty and mixed-empty **VARCHAR** and **CHAR** columns asserting `None` (not NaN/`"nan"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2052dc82f761a6eae30c9045edad62b490727b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->