### PR TITLE
fix(validators): DataValidator must read JSON, not skip it

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -37,6 +37,48 @@ def test_loads_from_csv(make_csv):
     assert result.is_valid
 
 
+def test_loads_from_json(tmp_path):
+    """JSON top-level array of records must validate, mirroring the file shape
+    JSONIngestor.read_data consumes.
+
+    Regression: DataValidator._load_data only recognised .csv. Any .json input
+    returned None (logged "Unsupported file type"), the caller raised
+    "No data found to validate", and JSON ingestion failed end-to-end on the
+    very first validator — the recent per-record null-tolerance fix (#170)
+    lived behind an unreachable gate.
+
+    Surfaced by an end-to-end cluster ingestion: a 20-record JSON file with
+    explicit schema {id INT, age INT, score FLOAT, active BOOL, label
+    VARCHAR(20)} failed with "Data Validator Validator failed: No data found
+    to validate" before any record was read.
+    """
+    p = tmp_path / "d.json"
+    p.write_text(
+        '[{"id": 1, "age": 30, "score": 0.5, "active": true, "label": "A"},'
+        ' {"id": 2, "age": null, "score": 0.6, "active": false, "label": "B"}]'
+    )
+    result = DataValidator(
+        schema={
+            "id": "INT",
+            "age": "INT",
+            "score": "FLOAT",
+            "active": "BOOL",
+            "label": "VARCHAR(20)",
+        }
+    ).validate(str(p))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+
+
+def test_loads_from_json_genuine_type_error_still_caught(tmp_path):
+    """JSON support must not weaken type validation — a non-numeric in an INT
+    column must still fail. Pairs with the positive test to pin the boundary.
+    """
+    p = tmp_path / "bad.json"
+    p.write_text('[{"age": "not-an-int"}]')
+    result = DataValidator(schema={"age": "INT"}).validate(str(p))
+    assert not result.is_valid
+
+
 def test_unknown_type_fails():
     df = pd.DataFrame({"a": [1]})
     result = DataValidator(schema={"a": "WEIRDTYPE"}).validate(df)

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -126,10 +126,21 @@ class DataValidator(BaseValidator):
                 return data.head(sample_size)
             elif isinstance(data, (str, Path)):
                 path = Path(data)
-                if path.suffix.lower() == ".csv":
+                suffix = path.suffix.lower()
+                if suffix == ".csv":
                     df = pd.read_csv(
                         path, nrows=sample_size, encoding="utf-8", on_bad_lines="warn"
                     )
+                    return df
+                elif suffix == ".json":
+                    # Mirror JSONIngestor.read_data: file is a top-level JSON
+                    # array of records. Without this branch DataValidator
+                    # returned None for every JSON input, the caller raised
+                    # "No data found to validate", and JSON ingestion was
+                    # impossible end-to-end — the recent per-record
+                    # null-tolerance fix (#170) lived behind an unreachable
+                    # gate.
+                    df = pd.read_json(path, orient="records").head(sample_size)
                     return df
                 else:
                     logger.warning(f"Unsupported file type: {path.suffix}, \n\n{path}")


### PR DESCRIPTION
## Summary

Surfaced by **real end-to-end cluster ingestion** against v0.3.5-rc1: a 20-record JSON file with an explicit \`{id INT, age INT, score FLOAT, active BOOL, label VARCHAR(20)}\` schema failed before any data landed in MySQL.

\`\`\`
WARNING  data_validator.py:135 | Unsupported file type: .json, /data/shared/test-json-nulls/data.json
ERROR    json_ingestor.py:263  | JSON ingestion failed: Data Validator Validator failed: No data found to validate
\`\`\`

Result on cluster: \`SELECT COUNT(*) FROM e2etest_json_nulls\` → **0** (table created, every record skipped at the validator).

## Root cause

\`DataValidator._load_data\` only branched on \`.csv\`:

\`\`\`python
if path.suffix.lower() == \".csv\":
    df = pd.read_csv(path, ...)
    return df
else:
    logger.warning(f\"Unsupported file type: {path.suffix}, \\n\\n{path}\")
    return None
\`\`\`

So every \`.json\` path returned None → caller raised \"No data found to validate\". The recent per-record null-tolerance fix (#170) lives in \`JSONIngestor._validate_record\`, which is downstream of \`DataValidator\` — that fix's gate was unreachable on real end-to-end JSON.

## Fix

Add a \`.json\` branch using \`pd.read_json(orient=\"records\")\` to mirror the top-level-array shape \`JSONIngestor.read_data\` consumes. \`read_json\` doesn't support \`nrows\`, so the sample_size limit is applied via \`.head()\` after the read.

## Test plan

- [ ] New regression tests:
  - JSON with a null cell validates against a typed schema (the recent #170 path is now reachable)
  - JSON with a real type error (\`\"age\": \"not-an-int\"\`) **still** fails — pins the boundary so this fix doesn't weaken validation
- [ ] CI green
- [ ] Re-run end-to-end JSON ingestion on cluster → 20 rows in MySQL with NULLs preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to file loading in the validator with regression tests; no auth or persistence logic touched.
> 
> **Overview**
> **Fixes JSON ingestion failing at `DataValidator`** because `_load_data` only handled `.csv`, so every `.json` path returned `None` and validation aborted with "No data found to validate" before downstream JSON ingest logic (including #170 null handling) could run.
> 
> Adds a `.json` branch that loads a top-level array of records via `pd.read_json(..., orient="records")`, then applies `sample_size` with `.head()` (same shape as `JSONIngestor.read_data`).
> 
> **Tests:** regression for typed JSON with nulls passing validation, plus a case ensuring real type errors (e.g. non-numeric `INT`) still fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b7ed1edf13323c2adefac7e6ef752e0a43c8841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->