### PR TITLE
Develop to prod

### DIFF
--- a/e2e/test_database_e2e.py
+++ b/e2e/test_database_e2e.py
@@ -1,0 +1,87 @@
+"""End-to-end DATABASE behaviour against a real MySQL.
+
+The unit suite (``tests/test_database.py``) mocks the SQLAlchemy engine, so no
+SQL is ever executed despite 100% line coverage: ``CREATE TABLE``, the
+``ON DUPLICATE KEY UPDATE`` upsert, the bulk-insert -> per-row fallback, type
+mapping and charset round-tripping are never actually run. These tests run them
+for real, closing the gap between "every line executed" and "the DB behaves".
+
+Skipped unless a MySQL is reachable (see ``conftest.py``); CI runs it with a
+MySQL service in ``.github/workflows/e2e.yml``.
+"""
+import os
+import uuid
+
+import mysql.connector
+import pytest
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.database import Database
+
+
+def _query(sql):
+    conn = mysql.connector.connect(
+        host=os.environ["MYSQL_HOST"], port=int(os.environ["MYSQL_PORT"]),
+        user=os.environ["DB_USER"], password=os.environ["DB_PASSWORD"],
+        database=os.environ["DB_NAME"],
+    )
+    cur = conn.cursor()
+    cur.execute(sql)
+    rows = cur.fetchall()
+    cur.close()
+    conn.close()
+    return rows
+
+
+@pytest.fixture
+def db():
+    return Database(Config())
+
+
+@pytest.fixture
+def table(db):
+    """A uniquely-named table, dropped on teardown."""
+    name = "e2e_db_" + uuid.uuid4().hex[:8]
+    yield name
+    _query(f"DROP TABLE IF EXISTS `{name}`")
+
+
+def _rec(data_id, **cols):
+    return {"data_id": data_id, **cols}
+
+
+def test_create_table_and_insert_roundtrip(db, table):
+    """CREATE TABLE + INSERT actually run, and values come back intact."""
+    db.create_table(table, {"feature": "FLOAT"})
+    ids, failures = db.insert_batch(table, [_rec("a", feature=1.5), _rec("b", feature=2.5)])
+    assert failures == []
+    assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2
+    vals = sorted(r[0] for r in _query(f"SELECT feature FROM `{table}`"))
+    assert vals == [1.5, 2.5]
+
+
+def test_upsert_dedupes_on_data_id(db, table):
+    """Re-ingesting the same data_id UPDATEs the row (ON DUPLICATE KEY UPDATE),
+    it does not create a duplicate — the core idempotency guarantee."""
+    db.create_table(table, {"feature": "INT"})
+    db.insert_batch(table, [_rec("dup", feature=1)])
+    db.insert_batch(table, [_rec("dup", feature=99)])
+    assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 1
+    assert _query(f"SELECT feature FROM `{table}` WHERE data_id='dup'")[0][0] == 99
+
+
+def test_partial_batch_falls_back_without_duplicating_good_rows(db, table):
+    """data_id is NOT NULL UNIQUE; a NULL row aborts the bulk INSERT, so the
+    per-row fallback must still insert the good rows exactly once (no dupes)."""
+    db.create_table(table, {"feature": "INT"})
+    batch = [_rec("ok1", feature=1), _rec(None, feature=2), _rec("ok2", feature=3)]
+    ids, failures = db.insert_batch(table, batch)
+    assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2  # ok1 + ok2, once each
+    assert len(failures) == 1                                    # the NULL-data_id row
+
+
+def test_non_ascii_data_roundtrip(db, table):
+    """Non-ASCII values (German umlauts) survive the real INSERT/SELECT."""
+    db.create_table(table, {"name": "VARCHAR(64)"})
+    db.insert_batch(table, [_rec("u", name="Größe-Meßwert")])
+    assert _query(f"SELECT name FROM `{table}` WHERE data_id='u'")[0][0] == "Größe-Meßwert"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="tracebloc_ingestor",
-    version="0.3.4",
+    version="0.3.5",
     author="Tracebloc",
     author_email="support@tracebloc.com",
     description="A flexible data ingestion library for various file formats",

--- a/tests/test_api_client_failure_modes.py
+++ b/tests/test_api_client_failure_modes.py
@@ -1,0 +1,148 @@
+"""APIClient failure-mode tests against a REAL local HTTP server.
+
+The happy-path tests (``test_api_client_methods.py``) patch ``session.post`` to
+return a ``MagicMock``, so the real adapter retry, request timeout, and JSON
+decoding never execute despite 100% line coverage. These drive the real
+``requests`` session against a programmable in-process server so those paths
+actually run — including the urllib3 ``Retry`` on the ``HTTPAdapter``, which a
+``responses``/``MagicMock`` mock bypasses entirely.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from tracebloc_ingestor.api import client as client_mod
+from tracebloc_ingestor.api.client import APIClient
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+class _Program:
+    """Controls the mock server. ``queue`` is consumed one entry per request;
+    once empty, ``default`` is used. Each entry: dict with optional
+    status / body / delay / content_type."""
+
+    def __init__(self):
+        self.queue = []
+        self.default = {"status": 200, "body": "{}"}
+        self.requests = 0
+
+
+def _handler_for(program):
+    class _Handler(BaseHTTPRequestHandler):
+        def _serve(self):
+            program.requests += 1
+            spec = program.queue.pop(0) if program.queue else program.default
+            try:
+                if spec.get("delay"):
+                    time.sleep(spec["delay"])
+                body = spec.get("body", "").encode()
+                self.send_response(spec.get("status", 200))
+                self.send_header(
+                    "Content-Type", spec.get("content_type", "application/json")
+                )
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            except (BrokenPipeError, ConnectionError, OSError):
+                pass  # client gave up (e.g. the timeout test) — nothing to write
+
+        do_GET = do_POST = _serve
+
+        def log_message(self, *_a):
+            pass
+
+    return _Handler
+
+
+@pytest.fixture
+def mock_api(monkeypatch):
+    program = _Program()
+    server = HTTPServer(("127.0.0.1", 0), _handler_for(program))
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{server.server_address[1]}"
+    # API_ENDPOINT is derived from EDGE_ENV via this map; point "prod" at us.
+    monkeypatch.setitem(Config.API_ENDPOINTS, "prod", base)
+    try:
+        yield program
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _client(**overrides):
+    defaults = dict(
+        BACKEND_TOKEN="tok", CLIENT_USERNAME=None, CLIENT_PASSWORD=None,
+        EDGE_ENV="prod", TITLE=None,
+    )
+    defaults.update(overrides)
+    client = APIClient(Config(**defaults))
+    # No real backoff sleeps in tests.
+    for adapter in client.session.adapters.values():
+        adapter.max_retries.backoff_factor = 0
+    return client
+
+
+# --- retry on transient 5xx (proves the adapter retry actually fires) -------
+
+def test_send_batch_retries_transient_5xx_then_succeeds(mock_api):
+    mock_api.queue = [{"status": 503}, {"status": 503}, {"status": 200, "body": "{}"}]
+    client = _client()
+    assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is True
+    assert mock_api.requests == 3  # 2 retries + the success
+
+
+def test_send_batch_persistent_5xx_returns_false(mock_api):
+    mock_api.default = {"status": 503, "body": "down"}
+    client = _client()
+    assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+    assert mock_api.requests > 1  # it retried before giving up
+
+
+# --- non-retryable status ---------------------------------------------------
+
+def test_send_batch_401_returns_false_without_retry(mock_api):
+    mock_api.default = {"status": 401, "body": "unauthorized"}
+    client = _client()
+    assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+    assert mock_api.requests == 1  # 401 isn't in the 5xx retry list
+
+
+# --- timeout (a hanging backend must not hang the ingest) -------------------
+
+def test_send_batch_timeout_is_handled(mock_api, monkeypatch):
+    monkeypatch.setattr(client_mod, "API_TIMEOUT", 0.5)
+    mock_api.default = {"status": 200, "body": "{}", "delay": 2.0}
+    client = _client()
+    for adapter in client.session.adapters.values():
+        adapter.max_retries.total = 0  # 1 attempt (~0.5s), no retry-on-timeout
+    assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+
+
+# --- non-JSON 200 body (regression for the JSONDecodeError fix) -------------
+
+def test_send_global_meta_non_json_200_still_succeeds(mock_api):
+    # A 200 whose body isn't JSON used to flip a successful send to False (the
+    # .json() in the log line raised). It must now warn + still report success.
+    mock_api.default = {"status": 200, "body": "OK", "content_type": "text/plain"}
+    client = _client()
+    assert client.send_global_meta_meta("tbl", {"a": "INT"}, {}) is True
+
+
+def test_create_dataset_non_json_200_raises_clear_error(mock_api):
+    mock_api.default = {"status": 200, "body": "<html>oops</html>", "content_type": "text/html"}
+    client = _client()
+    with pytest.raises(ValueError, match="non-JSON"):
+        client.create_dataset(ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION)
+
+
+def test_authenticate_non_json_200_raises_clear_error(mock_api):
+    mock_api.default = {"status": 200, "body": "not-json"}
+    with pytest.raises(ValueError, match="non-JSON"):
+        APIClient(Config(BACKEND_TOKEN=None, CLIENT_USERNAME="u",
+                         CLIENT_PASSWORD="p", EDGE_ENV="prod"))

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -106,3 +106,55 @@ def test_tabular_na_values_applied(tmp_path):
     # "NA"/"NULL" should be parsed as NaN for tabular categories.
     assert pd.isna(records[0]["b"])
     assert pd.isna(records[1]["b"])
+
+
+def test_varchar_empty_cells_yield_python_none(tmp_path):
+    """Missing cells in a VARCHAR column must yield Python None, NOT float NaN
+    or the literal string 'nan'.
+
+    Regression: before the type-coercion branch matched VARCHAR/CHAR (it only
+    matched STRING/TEXT), pandas left the column as float64 with NaN for empty
+    cells. itertuples emitted those NaN floats, dict() preserved them, and the
+    SQL binder stringified them as 'nan' on INSERT — silent data corruption
+    of every missing VARCHAR cell. #167 widened NULL-tolerance in the
+    validator (so all-null VARCHAR no longer fails validation); without this
+    write-side fix the column was happily ingested as a column of 'nan'
+    strings instead of SQL NULLs.
+
+    Surfaced by an end-to-end cluster ingestion with an all-empty VARCHAR(50)
+    column: MySQL row count = 60, all rows had analyte_y = 'nan' (length 3).
+    """
+    p = tmp_path / "d.csv"
+    # 'analyte_y' is all-empty (the original biomarker scenario from #167);
+    # 'notes' mixes a value and an empty.
+    p.write_text("a,analyte_y,notes\n1,,hello\n2,,\n3,,world\n")
+    ing = make_csv_ingestor(
+        schema={"a": "INT", "analyte_y": "VARCHAR(50)", "notes": "VARCHAR(100)"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    records = list(ing.read_data(str(p)))
+
+    assert len(records) == 3
+    # All-empty VARCHAR column: every value must be None, not NaN, not "nan".
+    for r in records:
+        assert r["analyte_y"] is None, f"expected None, got {r['analyte_y']!r}"
+    # Mixed VARCHAR column: present cells preserved; empty -> None.
+    assert records[0]["notes"] == "hello"
+    assert records[1]["notes"] is None
+    assert records[2]["notes"] == "world"
+
+
+def test_char_empty_cells_yield_python_none(tmp_path):
+    """Same regression for CHAR — pre-fix code only matched STRING/TEXT, so
+    CHAR(N) columns silently stored 'nan' for empties.
+    """
+    p = tmp_path / "d.csv"
+    p.write_text("a,code\n1,A\n2,\n")
+    ing = make_csv_ingestor(
+        schema={"a": "INT", "code": "CHAR(1)"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    records = list(ing.read_data(str(p)))
+
+    assert records[0]["code"] == "A"
+    assert records[1]["code"] is None

--- a/tests/test_csv_ingestor_scale.py
+++ b/tests/test_csv_ingestor_scale.py
@@ -1,0 +1,67 @@
+"""Scale / chunked-read correctness for CSVIngestor.read_data.
+
+read_data streams the CSV in chunks (``chunk_size``, default 1000). Every other
+test uses < 1000 rows -> a single chunk -> the multi-chunk path was never
+exercised, which hid a bug: header-strip + type conversion (``_validate_csv``)
+ran only on the FIRST chunk, so rows beyond chunk_size were yielded un-converted
+(e.g. a DATE column as raw strings) with un-stripped keys. These feed a CSV
+LARGER than chunk_size and assert every row across all chunks is correct.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+def _ingestor(schema, chunk_size):
+    return CSVIngestor(
+        database=MagicMock(), api_client=MagicMock(), table_name="t",
+        schema=schema, category=TaskCategory.TABULAR_CLASSIFICATION,
+        label_column="label", csv_options={"chunk_size": chunk_size},
+    )
+
+
+def _write(tmp_path, header, rows):
+    p = tmp_path / "data.csv"
+    p.write_text(header + "\n" + "\n".join(rows) + "\n")
+    return str(p)
+
+
+def test_all_rows_yielded_in_order_across_chunks(tmp_path):
+    path = _write(tmp_path, "x,label", [f"{i},lab{i}" for i in range(1, 251)])
+    ing = _ingestor({"x": "INT", "label": "str"}, chunk_size=50)  # 250 rows -> 5 chunks
+    recs = list(ing.read_data(path))
+    assert len(recs) == 250                                   # no drops/dupes at boundaries
+    assert [int(r["x"]) for r in recs] == list(range(1, 251))  # in order
+
+
+def test_date_column_converted_in_every_chunk(tmp_path):
+    # The bug: rows past chunk 1 came back as raw 'str'. They must all convert.
+    path = _write(tmp_path, "ts,label", [f"2024-01-{i:02d},lab{i}" for i in range(1, 11)])
+    ing = _ingestor({"ts": "DATE", "label": "str"}, chunk_size=3)  # 10 rows -> 4 chunks
+    recs = list(ing.read_data(path))
+    assert len(recs) == 10
+    assert all(isinstance(r["ts"], pd.Timestamp) for r in recs)
+
+
+def test_header_whitespace_stripped_in_every_chunk(tmp_path):
+    # Leading-space header; keys must be stripped for ALL chunks, not just the first.
+    path = _write(tmp_path, " x ,label", [f"{i},lab{i}" for i in range(1, 11)])
+    ing = _ingestor({"x": "INT", "label": "str"}, chunk_size=3)
+    recs = list(ing.read_data(path))
+    assert len(recs) == 10
+    assert all("x" in r and " x " not in r for r in recs)
+
+
+def test_single_chunk_behaviour_unchanged(tmp_path):
+    # The common < chunk_size case still converts (regression guard).
+    path = _write(tmp_path, "ts,label", ["2024-01-01,a", "2024-01-02,b"])
+    ing = _ingestor({"ts": "DATE", "label": "str"}, chunk_size=1000)
+    recs = list(ing.read_data(path))
+    assert len(recs) == 2
+    assert all(isinstance(r["ts"], pd.Timestamp) for r in recs)

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -304,6 +304,28 @@ def test_date_invalid_fails():
     assert "invalid date" in result.errors[0]
 
 
+@pytest.mark.parametrize("dtype", ["DATE", "DATETIME", "TIMESTAMP", "TIME"])
+def test_date_family_with_nulls_is_valid(dtype):
+    # Regression: a date column with genuine missing values was wrongly
+    # reported as "invalid date values" (to_datetime turns NULL into NaT,
+    # then isnull() counted it) — an unclearable error. NULLs are valid.
+    df = pd.DataFrame({"d": ["2024-01-01", None, "2024-02-02"]})
+    assert DataValidator(schema={"d": dtype}).validate(df).is_valid
+
+
+def test_date_all_null_is_valid():
+    df = pd.DataFrame({"d": [None, None, None]})
+    assert DataValidator(schema={"d": "DATE"}).validate(df).is_valid
+
+
+def test_date_still_flags_real_bad_value_with_nulls_present():
+    # NULL tolerance must not mask a genuinely un-parseable date.
+    df = pd.DataFrame({"d": ["2024-01-01", None, "not-a-date"]})
+    result = DataValidator(schema={"d": "DATE"}).validate(df)
+    assert not result.is_valid
+    assert "invalid date" in result.errors[0]
+
+
 # ---------------------------------------------------------------------------
 # type parsing + auto-detect helper
 # ---------------------------------------------------------------------------

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -193,6 +193,40 @@ def test_varchar_too_long_fails():
     assert "exceeding max length" in result.errors[0]
 
 
+def test_varchar_with_nulls_is_valid():
+    # Regression: a VARCHAR column with genuine missing values was wrongly
+    # reported as containing "non-string" values (NaN != NaN), an error the
+    # user could never clear by editing data. NULLs are valid for any column.
+    df = pd.DataFrame({"s": ["abc", None, "de"]})
+    assert DataValidator(schema={"s": "VARCHAR(255)"}).validate(df).is_valid
+
+
+def test_varchar_all_null_is_valid():
+    # An entirely-empty column (e.g. an unmeasured biomarker / analyte in a
+    # sparse panel) is a column of NULLs — valid, not N "non-string values".
+    df = pd.DataFrame({"s": [None, None, None]})
+    assert DataValidator(schema={"s": "VARCHAR(255)"}).validate(df).is_valid
+
+
+def test_char_with_nulls_is_valid():
+    df = pd.DataFrame({"s": ["ab", None, "cd"]})
+    assert DataValidator(schema={"s": "CHAR(2)"}).validate(df).is_valid
+
+
+def test_text_with_nulls_is_valid():
+    df = pd.DataFrame({"s": ["any length text", None]})
+    assert DataValidator(schema={"s": "TEXT"}).validate(df).is_valid
+
+
+def test_varchar_still_flags_real_non_strings():
+    # NULL tolerance must NOT mask a genuine type error: a real numeric value
+    # in a VARCHAR column is still non-string and must be reported.
+    df = pd.DataFrame({"s": ["abc", 5, "de"]})
+    result = DataValidator(schema={"s": "VARCHAR(255)"}).validate(df)
+    assert not result.is_valid
+    assert "non-string" in result.errors[0]
+
+
 def test_char_wrong_length_fails():
     df = pd.DataFrame({"s": ["ab", "cde"]})
     result = DataValidator(schema={"s": "CHAR(2)"}).validate(df)

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -37,6 +37,48 @@ def test_loads_from_csv(make_csv):
     assert result.is_valid
 
 
+def test_loads_from_json(tmp_path):
+    """JSON top-level array of records must validate, mirroring the file shape
+    JSONIngestor.read_data consumes.
+
+    Regression: DataValidator._load_data only recognised .csv. Any .json input
+    returned None (logged "Unsupported file type"), the caller raised
+    "No data found to validate", and JSON ingestion failed end-to-end on the
+    very first validator — the recent per-record null-tolerance fix (#170)
+    lived behind an unreachable gate.
+
+    Surfaced by an end-to-end cluster ingestion: a 20-record JSON file with
+    explicit schema {id INT, age INT, score FLOAT, active BOOL, label
+    VARCHAR(20)} failed with "Data Validator Validator failed: No data found
+    to validate" before any record was read.
+    """
+    p = tmp_path / "d.json"
+    p.write_text(
+        '[{"id": 1, "age": 30, "score": 0.5, "active": true, "label": "A"},'
+        ' {"id": 2, "age": null, "score": 0.6, "active": false, "label": "B"}]'
+    )
+    result = DataValidator(
+        schema={
+            "id": "INT",
+            "age": "INT",
+            "score": "FLOAT",
+            "active": "BOOL",
+            "label": "VARCHAR(20)",
+        }
+    ).validate(str(p))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+
+
+def test_loads_from_json_genuine_type_error_still_caught(tmp_path):
+    """JSON support must not weaken type validation — a non-numeric in an INT
+    column must still fail. Pairs with the positive test to pin the boundary.
+    """
+    p = tmp_path / "bad.json"
+    p.write_text('[{"age": "not-an-int"}]')
+    result = DataValidator(schema={"age": "INT"}).validate(str(p))
+    assert not result.is_valid
+
+
 def test_unknown_type_fails():
     df = pd.DataFrame({"a": [1]})
     result = DataValidator(schema={"a": "WEIRDTYPE"}).validate(df)

--- a/tests/test_file_pairing_validator.py
+++ b/tests/test_file_pairing_validator.py
@@ -1,0 +1,57 @@
+"""Tests for FilePairingValidator — image <-> sidecar (annotation/mask) pairing.
+
+The validator reads directories under ``config.SRC_PATH`` (``<src>/images`` and
+``<src>/annotations`` or ``<src>/masks``), matching by filename stem.
+"""
+
+from __future__ import annotations
+
+from tracebloc_ingestor.validators.file_pairing_validator import FilePairingValidator
+
+
+def _setup(tmp_path, images, sidecars, sidecar_dir="annotations"):
+    (tmp_path / "images").mkdir()
+    (tmp_path / sidecar_dir).mkdir()
+    for n in images:
+        (tmp_path / "images" / n).write_text("x")
+    for n in sidecars:
+        (tmp_path / sidecar_dir / n).write_text("x")
+
+
+def test_pairing_all_matched(clean_env, tmp_path):
+    _setup(tmp_path, ["a.jpg", "b.jpg"], ["a.xml", "b.xml"])
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    assert FilePairingValidator().validate(None).is_valid
+
+
+def test_pairing_image_without_sidecar(clean_env, tmp_path):
+    _setup(tmp_path, ["a.jpg", "b.jpg"], ["a.xml"])  # b.jpg has no annotation
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator().validate(None)
+    assert not res.is_valid
+    assert "no matching annotation" in res.errors[0]
+    assert "b" in res.errors[0]
+
+
+def test_pairing_orphan_sidecar(clean_env, tmp_path):
+    _setup(tmp_path, ["a.jpg"], ["a.xml", "ghost.xml"])  # ghost.xml has no image
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator().validate(None)
+    assert not res.is_valid
+    assert any("no matching image" in e for e in res.errors)
+    assert any("ghost" in e for e in res.errors)
+
+
+def test_pairing_masks_label(clean_env, tmp_path):
+    _setup(tmp_path, ["a.jpg"], ["b.png"], sidecar_dir="masks")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator(sidecar_path="masks", sidecar_label="mask").validate(None)
+    assert not res.is_valid
+    assert any("mask" in e for e in res.errors)
+
+
+def test_pairing_skips_when_sidecar_dir_missing(clean_env, tmp_path):
+    # A missing directory is the FileTypeValidator's concern — don't double-report.
+    (tmp_path / "images").mkdir()
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    assert FilePairingValidator().validate(None).is_valid

--- a/tests/test_file_transfer_failure_modes.py
+++ b/tests/test_file_transfer_failure_modes.py
@@ -1,0 +1,141 @@
+"""file_transfer failure-mode tests: the retry, permission, and atomicity paths.
+
+The happy-path + missing-source tests live in ``test_file_transfer_transfers.py``
+and ``test_file_transfer_summary.py``. Those copy files that succeed on the first
+try, so the tenacity retry on ``_copy_file_with_retry`` (RETRY_MAX_ATTEMPTS, retry
+on OSError) never fires, the permission-denied path never runs, and the "atomic
+skip leaves no orphan" guarantee is only asserted as ``rec is None``. These cover
+exactly those gaps.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import tenacity
+
+from tracebloc_ingestor import file_transfer
+from tracebloc_ingestor.utils.constants import TaskCategory, RETRY_MAX_ATTEMPTS
+
+
+@pytest.fixture
+def dirs(tmp_path, monkeypatch):
+    """Point file_transfer's module-level Config at tmp src + storage dirs.
+    SRC_PATH is env-backed; DEST_PATH derives from STORAGE_PATH / TABLE_NAME."""
+    src = tmp_path / "src"
+    storage = tmp_path / "storage"
+    src.mkdir()
+    storage.mkdir()
+    monkeypatch.setenv("SRC_PATH", str(src))
+    monkeypatch.setenv("TABLE_NAME", "tbl")
+    monkeypatch.setattr(file_transfer.config, "STORAGE_PATH", str(storage))
+    return src, storage / "tbl"
+
+
+@pytest.fixture
+def no_retry_wait(monkeypatch):
+    """Neutralise the exponential backoff so retry tests run instantly."""
+    monkeypatch.setattr(
+        file_transfer._copy_file_with_retry.retry, "wait", tenacity.wait_none()
+    )
+
+
+def _seed(src, subdir, name, content=b"data"):
+    d = src / subdir
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_bytes(content)
+    return d / name
+
+
+def _raise_oserror(*_a, **_k):
+    raise OSError("disk error")
+
+
+# --- retry behaviour (tenacity on _copy_file_with_retry) --------------------
+
+def test_copy_retries_transient_error_then_succeeds(dirs, no_retry_wait, monkeypatch):
+    src, dest = dirs
+    s = _seed(src, "images", "a.jpg", b"payload")
+    dest.mkdir(parents=True, exist_ok=True)
+    target = dest / "a.jpg"
+
+    real_copy = file_transfer.shutil.copy
+    calls = {"n": 0}
+
+    def flaky(src_, dst_):
+        calls["n"] += 1
+        if calls["n"] < RETRY_MAX_ATTEMPTS:  # fail until the final attempt
+            raise OSError("transient")
+        return real_copy(src_, dst_)
+
+    monkeypatch.setattr(file_transfer.shutil, "copy", flaky)
+    file_transfer._copy_file_with_retry(str(s), str(target))
+    assert calls["n"] == RETRY_MAX_ATTEMPTS
+    assert target.read_bytes() == b"payload"
+
+
+def test_copy_reraises_after_exhausting_retries(dirs, no_retry_wait, monkeypatch):
+    src, dest = dirs
+    s = _seed(src, "images", "a.jpg")
+    dest.mkdir(parents=True, exist_ok=True)
+    calls = {"n": 0}
+
+    def always_fail(*_a):
+        calls["n"] += 1
+        raise OSError("persistent")
+
+    monkeypatch.setattr(file_transfer.shutil, "copy", always_fail)
+    with pytest.raises(OSError):  # reraise=True once the attempt cap is hit
+        file_transfer._copy_file_with_retry(str(s), str(dest / "a.jpg"))
+    assert calls["n"] == RETRY_MAX_ATTEMPTS
+
+
+def test_image_transfer_wraps_persistent_copy_error(dirs, no_retry_wait, monkeypatch):
+    src, _ = dirs
+    _seed(src, "images", "cat.jpg")
+    monkeypatch.setattr(file_transfer.shutil, "copy", _raise_oserror)
+    with pytest.raises(ValueError, match="Error processing"):
+        file_transfer.image_transfer({"filename": "cat"}, {"extension": ".jpg"})
+
+
+# --- a real filesystem permission error (not a mock) ------------------------
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root bypasses filesystem permission checks",
+)
+def test_image_transfer_unwritable_dest_raises(dirs, no_retry_wait):
+    src, dest = dirs
+    _seed(src, "images", "cat.jpg")
+    dest.mkdir(parents=True, exist_ok=True)
+    os.chmod(dest, 0o500)  # r-x: not writable
+    try:
+        with pytest.raises(ValueError):
+            file_transfer.image_transfer({"filename": "cat"}, {"extension": ".jpg"})
+    finally:
+        os.chmod(dest, 0o700)  # restore so pytest can clean up tmp_path
+
+
+# --- atomic skip leaves no orphan (the #99 data-integrity invariant) --------
+
+def test_object_detection_missing_annotation_leaves_no_orphan(dirs):
+    src, dest = dirs
+    _seed(src, "images", "x.jpg")  # image present, annotation absent
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.OBJECT_DETECTION, {"filename": "x"}, {"extension": ".jpg"}
+    )
+    assert rec is None
+    # the image must NOT have been copied before the missing annotation was caught
+    assert not dest.exists() or not any(dest.iterdir())
+
+
+def test_segmentation_missing_mask_leaves_no_orphan(dirs):
+    src, dest = dirs
+    _seed(src, "images", "x.jpg")  # image present, mask file absent
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        {"filename": "x", "mask_id": "m"}, {"extension": ".jpg"},
+    )
+    assert rec is None
+    assert not dest.exists() or not any(dest.iterdir())

--- a/tests/test_i18n_adversarial_csv.py
+++ b/tests/test_i18n_adversarial_csv.py
@@ -1,0 +1,392 @@
+"""Adversarial / i18n ingest fixtures for the CSVIngestor (#739).
+
+These tests pin the engine's behaviour on the data shapes a European
+clinical / lab customer actually exports: German-Excel CSV conventions
+(``;`` delimiter + decimal comma), biomarker-style column names that
+contain ``|`` and ``;``, non-UTF-8 encodings, CRLF line endings, BOMs,
+and assorted NA / ragged-row edge cases.
+
+The engine (``data-ingestors``) is the canonical schema source the CLI's
+embedded ``ingest.v1.json`` and the chart both track via the drift gate,
+so coverage here protects all three.
+
+Contract for every case (per the issue): assert **clean ingest with the
+right typing / row-count**, OR a **clear, actionable error** — never a
+silent mangle. Where the current engine silently drops / renames data
+(ragged rows under ``on_bad_lines="warn"``; pandas' duplicate-header
+mangling), the test asserts that *documented* behaviour explicitly so the
+contract is visible and any future change is caught, rather than weakening
+the assertion.
+
+The headline case is the ``|``/``;`` biomarker header reaching the MySQL
+column-name path: it is asserted twice — once that ``Database.create_table``
+carries the exact name onto the SQLAlchemy ``Table``, and once that the
+emitted ``CREATE TABLE`` DDL backtick-quotes it for the MySQL dialect.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from sqlalchemy import MetaData
+from sqlalchemy.dialects import mysql
+from sqlalchemy.schema import CreateTable
+
+from tracebloc_ingestor import database as db_mod
+from tracebloc_ingestor.database import Database
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+# A generic protein-ID-shaped header (UniProt-style accessions + gene
+# symbol). The shape — accession;isoform|accession|GENE — is exactly what
+# collides with delimiter sniffing and SQL identifier legality. It is
+# synthetic test data, not attributable to anyone.
+BIOMARKER_HEADER = "P08253;P08253-2|P08253|MMP2"
+
+
+def _make_ingestor(schema, *, category=TaskCategory.TABULAR_CLASSIFICATION, **overrides):
+    """Build a CSVIngestor with mock DB/API, mirroring tests/test_csv_*.py.
+
+    ``BaseIngestor.__init__`` runs end-to-end (including the mocked
+    ``database.create_table``); only the I/O boundary is faked.
+    """
+    kwargs = dict(
+        database=MagicMock(),
+        api_client=MagicMock(),
+        table_name="t",
+        schema=schema,
+        category=category,
+    )
+    kwargs.update(overrides)
+    return CSVIngestor(**kwargs)
+
+
+def _real_db():
+    """A ``Database`` with the engine/metadata wired but no live MySQL.
+
+    Mirrors the pattern in tests/test_database.py: bypass ``__init__`` so we
+    never open a connection, then stub ``create_all`` and ``inspect`` per
+    call site so ``create_table`` builds the SQLAlchemy ``Table`` without DB
+    I/O.
+    """
+    db = Database.__new__(Database)
+    db.metadata = MetaData()
+    db.tables = {}
+    db.engine = MagicMock(name="engine")
+    db.metadata.create_all = MagicMock()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# German-Excel: ';' delimiter + decimal-comma numerics
+# ---------------------------------------------------------------------------
+
+def test_german_excel_semicolon_and_decimal_comma(tmp_path):
+    """German Excel default export: ``;`` field separator and ``,`` decimal
+    separator. With sep/decimal passed through csv_options the numerics
+    must parse as real floats/ints, not strings."""
+    p = tmp_path / "de.csv"
+    p.write_text(
+        "age;height;label\n42;1,75;a\n30;1,80;b\n",
+        encoding="utf-8",
+    )
+    ing = _make_ingestor(
+        {"age": "INT", "height": "FLOAT", "label": "VARCHAR(10)"},
+        csv_options={"sep": ";", "decimal": ","},
+    )
+    records = list(ing.read_data(str(p)))
+
+    assert len(records) == 2
+    assert records[0]["age"] == 42
+    assert records[0]["height"] == pytest.approx(1.75)  # FLOAT downcasts to float32
+    assert records[1]["height"] == pytest.approx(1.80)
+    assert records[0]["label"] == "a"
+
+
+def test_german_decimal_comma_without_option_does_not_silently_float(tmp_path):
+    """Defensive: if the caller forgets ``decimal=","`` on German data, the
+    decimal-comma cell is NOT silently coerced to a bogus float — the FLOAT
+    cast over a string like ``"1,75"`` fails loudly with a clear error
+    instead of mangling the value (e.g. to 175 or NaN)."""
+    p = tmp_path / "de_no_opt.csv"
+    p.write_text("height\n1,75\n", encoding="utf-8")  # comma read as field sep
+    ing = _make_ingestor({"height": "FLOAT"})
+
+    # With the default comma delimiter, "1,75" splits into two columns; the
+    # declared 'height' column then holds "1" and the second value lands in
+    # an undeclared column. The point: no value is silently turned into a
+    # wrong float. Assert the declared column did not absorb "1,75" as 1.75.
+    records = list(ing.read_data(str(p)))
+    assert records[0]["height"] != pytest.approx(1.75)
+
+
+# ---------------------------------------------------------------------------
+# Headline: '|' and ';' in a header -> MySQL column-name path
+# ---------------------------------------------------------------------------
+
+def test_biomarker_header_survives_read_data(tmp_path):
+    """A biomarker column name containing ``|`` and ``;`` must reach the
+    record dict intact. A non-colliding delimiter (tab) is required because
+    the name itself contains ``;``."""
+    p = tmp_path / "bio.csv"
+    p.write_text(
+        f"sample_id\t{BIOMARKER_HEADER}\nS1\t1.2\nS2\t3.4\n",
+        encoding="utf-8",
+    )
+    ing = _make_ingestor(
+        {"sample_id": "VARCHAR(20)", BIOMARKER_HEADER: "FLOAT"},
+        category=TaskCategory.TABULAR_REGRESSION,
+        csv_options={"sep": "\t"},
+    )
+    records = list(ing.read_data(str(p)))
+
+    assert len(records) == 2
+    assert BIOMARKER_HEADER in records[0]
+    assert records[0][BIOMARKER_HEADER] == pytest.approx(1.2, rel=1e-6)
+    assert records[1][BIOMARKER_HEADER] == pytest.approx(3.4, rel=1e-6)
+
+
+def test_biomarker_header_reaches_create_table_unmangled():
+    """The headline path: a ``|``/``;`` column name flows through
+    ``Database.create_table`` onto the SQLAlchemy ``Table`` with its name
+    preserved exactly (no silent sanitisation / truncation)."""
+    db = _real_db()
+    inspector = MagicMock()
+    inspector.get_table_names.return_value = []
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        table = db.create_table(
+            "bio_tbl", {"sample_id": "VARCHAR(20)", BIOMARKER_HEADER: "FLOAT"}
+        )
+
+    # Column is reachable by its exact key and its .name is byte-identical.
+    assert BIOMARKER_HEADER in table.c
+    assert table.c[BIOMARKER_HEADER].name == BIOMARKER_HEADER
+    db.metadata.create_all.assert_called_once()
+
+
+def test_biomarker_header_is_backtick_quoted_in_mysql_ddl():
+    """End-to-end MySQL column-name assertion: the emitted ``CREATE TABLE``
+    DDL must backtick-quote the special-char identifier so MySQL accepts it
+    verbatim. Compiled against the MySQL dialect offline — no live DB."""
+    db = _real_db()
+    inspector = MagicMock()
+    inspector.get_table_names.return_value = []
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        table = db.create_table(
+            "bio_tbl", {"sample_id": "VARCHAR(20)", BIOMARKER_HEADER: "FLOAT"}
+        )
+
+    ddl = str(CreateTable(table).compile(dialect=mysql.dialect()))
+    # MySQL quotes identifiers with backticks; the full special-char name
+    # must appear backtick-wrapped exactly once.
+    assert f"`{BIOMARKER_HEADER}`" in ddl
+    # And the raw, unquoted form must NOT appear as a bare token (it would
+    # be a syntax error in MySQL).
+    assert f" {BIOMARKER_HEADER} " not in ddl
+
+
+def test_biomarker_header_collision_with_reserved_is_rejected():
+    """If a special-char schema also collides with a reserved tracebloc
+    column, the existing guard still fires with a clear error rather than a
+    cryptic DuplicateColumnError — the special-char column doesn't bypass
+    the reserved-name check."""
+    db = Database.__new__(Database)
+    with pytest.raises(ValueError, match="reserved"):
+        db.create_table("bio_tbl", {"id": "INT", BIOMARKER_HEADER: "FLOAT"})
+
+
+# ---------------------------------------------------------------------------
+# Line endings / byte-order marks / encodings
+# ---------------------------------------------------------------------------
+
+def test_crlf_line_endings(tmp_path):
+    """Windows CRLF line endings must not leak ``\\r`` into the last cell of
+    each row, and the row count must be correct."""
+    p = tmp_path / "crlf.csv"
+    p.write_bytes(b"a,b\r\n1,x\r\n2,y\r\n")
+    ing = _make_ingestor({"a": "INT", "b": "VARCHAR(5)"})
+    records = list(ing.read_data(str(p)))
+
+    assert len(records) == 2
+    assert records[-1]["b"] == "y"  # not "y\r"
+
+
+def test_utf8_bom_is_transparently_stripped(tmp_path):
+    """A UTF-8 BOM at the start of the file must not become part of the
+    first column's name. pandas' parser strips a leading BOM transparently
+    even under the engine's default ``encoding="utf-8"``."""
+    p = tmp_path / "bom.csv"
+    p.write_bytes("﻿".encode("utf-8") + b"age,label\n1,x\n")
+    ing = _make_ingestor({"age": "INT", "label": "VARCHAR(5)"})
+    records = list(ing.read_data(str(p)))
+
+    assert list(records[0].keys()) == ["age", "label"]  # not "﻿age"
+    assert records[0]["age"] == 1
+
+
+def test_utf8_bom_with_utf8_sig_encoding(tmp_path):
+    """Explicit ``encoding="utf-8-sig"`` is also accepted and yields the
+    same clean header — callers exporting a BOM can opt in safely."""
+    p = tmp_path / "bom_sig.csv"
+    p.write_bytes("﻿".encode("utf-8") + b"age,label\n7,y\n")
+    ing = _make_ingestor(
+        {"age": "INT", "label": "VARCHAR(5)"},
+        csv_options={"encoding": "utf-8-sig"},
+    )
+    records = list(ing.read_data(str(p)))
+
+    assert list(records[0].keys()) == ["age", "label"]
+    assert records[0]["age"] == 7
+
+
+def test_latin1_read_as_utf8_raises_clear_error(tmp_path):
+    """A latin-1 / ISO-8859-1 file read with the default UTF-8 encoding must
+    fail loudly with a UnicodeDecodeError — an actionable error, never a
+    mojibake'd silent mangle."""
+    p = tmp_path / "l1.csv"
+    p.write_bytes("Koerpergroesse,label\n175,a\n".replace("oe", "ö").encode("latin-1"))
+    ing = _make_ingestor({"Körpergröße": "INT", "label": "VARCHAR(5)"})
+
+    with pytest.raises(UnicodeDecodeError):
+        list(ing.read_data(str(p)))
+
+
+def test_latin1_with_correct_encoding_parses(tmp_path):
+    """The same latin-1 file parses cleanly — including the accented column
+    name — when ``encoding="latin-1"`` is supplied via csv_options."""
+    col = "Körpergröße"  # Körpergröße
+    p = tmp_path / "l1ok.csv"
+    p.write_bytes(f"{col},label\n175,a\n".encode("latin-1"))
+    ing = _make_ingestor(
+        {col: "INT", "label": "VARCHAR(5)"},
+        csv_options={"encoding": "latin-1"},
+    )
+    records = list(ing.read_data(str(p)))
+
+    assert records[0][col] == 175
+    assert records[0]["label"] == "a"
+
+
+def test_utf16_read_as_utf8_raises_clear_error(tmp_path):
+    """A UTF-16 file read as UTF-8 must raise a clear UnicodeDecodeError
+    rather than silently producing garbage."""
+    p = tmp_path / "u16.csv"
+    p.write_bytes("age,label\n5,x\n".encode("utf-16"))
+    ing = _make_ingestor({"age": "INT", "label": "VARCHAR(5)"})
+
+    with pytest.raises(UnicodeDecodeError):
+        list(ing.read_data(str(p)))
+
+
+def test_utf16_with_correct_encoding_parses(tmp_path):
+    """UTF-16 parses cleanly when ``encoding="utf-16"`` is supplied."""
+    p = tmp_path / "u16ok.csv"
+    p.write_bytes("age,label\n5,x\n".encode("utf-16"))
+    ing = _make_ingestor(
+        {"age": "INT", "label": "VARCHAR(5)"},
+        csv_options={"encoding": "utf-16"},
+    )
+    records = list(ing.read_data(str(p)))
+
+    assert len(records) == 1
+    assert records[0] == {"age": 5, "label": "x"}
+
+
+# ---------------------------------------------------------------------------
+# NA tokens
+# ---------------------------------------------------------------------------
+
+def test_default_tabular_na_tokens(tmp_path):
+    """The tabular-family default widens NA to ``["", "NA", "NULL", "None"]``.
+    Pin exactly which tokens are treated as NA under that default: empty and
+    ``NA`` become NaN; ``NaN`` / ``n/a`` / ``-`` are stored verbatim (they
+    are NOT in the default set, and keep_default_na is off). This documents
+    the boundary so a future widening is a conscious change."""
+    p = tmp_path / "na.csv"
+    p.write_text("a,b\n1,NA\n2,NaN\n3,n/a\n4,-\n5,\n", encoding="utf-8")
+    ing = _make_ingestor({"a": "INT", "b": "VARCHAR(10)"})
+    records = list(ing.read_data(str(p)))
+
+    b = [r["b"] for r in records]
+    assert pd.isna(b[0])      # "NA"  -> NaN
+    assert b[1] == "NaN"      # not in default set -> literal
+    assert b[2] == "n/a"      # not in default set -> literal
+    assert b[3] == "-"        # not in default set -> literal
+    assert pd.isna(b[4])      # ""    -> NaN
+
+
+def test_mixed_na_tokens_via_explicit_override(tmp_path):
+    """When the caller supplies the full token set via csv_options, every
+    mixed NA token (empty, NA, NaN, n/a, -) parses as NaN — the supported
+    path for clinical exports that use those sentinels."""
+    p = tmp_path / "na2.csv"
+    p.write_text("a,b\n1,NA\n2,NaN\n3,n/a\n4,-\n5,\n", encoding="utf-8")
+    ing = _make_ingestor(
+        {"a": "INT", "b": "VARCHAR(10)"},
+        csv_options={"na_values": ["", "NA", "NaN", "n/a", "-"]},
+    )
+    records = list(ing.read_data(str(p)))
+
+    assert all(pd.isna(r["b"]) for r in records)
+
+
+# ---------------------------------------------------------------------------
+# Structural edge cases: single-column, ragged rows, duplicate headers
+# ---------------------------------------------------------------------------
+
+def test_single_column_label_only_file(tmp_path):
+    """A label-only / single-column file ingests cleanly with the right row
+    count and values."""
+    p = tmp_path / "one.csv"
+    p.write_text("label\ncat\ndog\ncat\n", encoding="utf-8")
+    ing = _make_ingestor({"label": "VARCHAR(10)"})
+    records = list(ing.read_data(str(p)))
+
+    assert len(records) == 3
+    assert [r["label"] for r in records] == ["cat", "dog", "cat"]
+    assert list(records[0].keys()) == ["label"]
+
+
+def test_ragged_trailing_semicolon_row_is_dropped_with_warning(tmp_path):
+    """A ragged row (extra trailing ``;`` -> one field too many) is dropped
+    under the engine's ``on_bad_lines="warn"`` policy, emitting a
+    ParserWarning. This is data loss, but NOT silent — assert both the
+    warning and the resulting row count so the behaviour is explicit and a
+    regression to silent ``skip``/``error`` is caught."""
+    p = tmp_path / "rag.csv"
+    # Row 2 has a trailing ';' -> 4 fields where 3 are expected.
+    p.write_text("a;b;c\n1;2;3\n4;5;6;\n7;8;9\n", encoding="utf-8")
+    ing = _make_ingestor(
+        {"a": "INT", "b": "INT", "c": "INT"},
+        csv_options={"sep": ";"},
+    )
+
+    with pytest.warns(pd.errors.ParserWarning):
+        records = list(ing.read_data(str(p)))
+
+    # 3 data rows in, the ragged one dropped -> 2 out.
+    assert len(records) == 2
+    assert records[0] == {"a": 1, "b": 2, "c": 3}
+    assert records[1] == {"a": 7, "b": 8, "c": 9}
+
+
+def test_duplicate_header_names_are_pandas_mangled(tmp_path):
+    """Duplicate header names are silently de-duplicated by pandas (second
+    ``age`` -> ``age.1``). The engine does not reject this, so the second
+    column leaks through under a renamed key. Assert the documented mangling
+    explicitly: the declared ``age`` keeps the first column's value and the
+    duplicate surfaces as ``age.1`` — making the gap visible rather than
+    letting it pass unexamined."""
+    p = tmp_path / "dup.csv"
+    p.write_text("age,age,label\n10,20,x\n", encoding="utf-8")
+    ing = _make_ingestor({"age": "INT", "label": "VARCHAR(5)"})
+    records = list(ing.read_data(str(p)))
+
+    rec = records[0]
+    assert rec["age"] == 10          # first 'age' column
+    assert "age.1" in rec            # pandas-mangled duplicate leaks through
+    assert rec["age.1"] == 20
+    assert rec["label"] == "x"

--- a/tests/test_i18n_adversarial_csv.py
+++ b/tests/test_i18n_adversarial_csv.py
@@ -300,21 +300,24 @@ def test_utf16_with_correct_encoding_parses(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_default_tabular_na_tokens(tmp_path):
-    """The tabular-family default widens NA to ``["", "NA", "NULL", "None"]``.
-    Pin exactly which tokens are treated as NA under that default: empty and
-    ``NA`` become NaN; ``NaN`` / ``n/a`` / ``-`` are stored verbatim (they
-    are NOT in the default set, and keep_default_na is off). This documents
-    the boundary so a future widening is a conscious change."""
+    """Tabular-family CSVs use ``keep_default_na=True`` plus the explicit
+    ``_TABULAR_NA_VALUES`` widening (``["", "NA", "NULL", "None"]``), so the
+    effective NA set is the union of pandas' built-in tokens (which include
+    ``NaN`` / ``n/a`` / ``null`` / ``NA`` / ``NULL`` / ``None`` / ``""``) and
+    the widening. Tokens NOT in either set — e.g. ``-`` — are stored verbatim.
+    This documents the actual boundary so a future narrowing is a conscious
+    change. See csv_ingestor.py::read_data for the rationale (validators read
+    with pandas defaults, so the ingestor must match)."""
     p = tmp_path / "na.csv"
     p.write_text("a,b\n1,NA\n2,NaN\n3,n/a\n4,-\n5,\n", encoding="utf-8")
     ing = _make_ingestor({"a": "INT", "b": "VARCHAR(10)"})
     records = list(ing.read_data(str(p)))
 
     b = [r["b"] for r in records]
-    assert pd.isna(b[0])      # "NA"  -> NaN
-    assert b[1] == "NaN"      # not in default set -> literal
-    assert b[2] == "n/a"      # not in default set -> literal
-    assert b[3] == "-"        # not in default set -> literal
+    assert pd.isna(b[0])      # "NA"  -> NaN (in widening)
+    assert pd.isna(b[1])      # "NaN" -> NaN (in pandas defaults)
+    assert pd.isna(b[2])      # "n/a" -> NaN (in pandas defaults)
+    assert b[3] == "-"        # "-"   -> literal (in neither set)
     assert pd.isna(b[4])      # ""    -> NaN
 
 

--- a/tests/test_image_validator_flow.py
+++ b/tests/test_image_validator_flow.py
@@ -122,3 +122,23 @@ def test_validate_image_resolutions_unprocessable(tmp_path):
     res = ImageResolutionValidator(expected_resolution=(10, 10))._validate_image_resolutions([bad])
     assert not res.is_valid
     assert any("could not be processed" in e for e in res.errors)
+    # the per-file reason is now surfaced, not just the bare path
+    assert any("not a valid image" in e for e in res.errors)
+
+
+# --- _diagnose_image_error: distinct, actionable reasons --------------------
+
+def test_diagnose_empty_file(tmp_path):
+    p = tmp_path / "empty.jpg"
+    p.write_bytes(b"")
+    assert "empty file" in ImageResolutionValidator._diagnose_image_error(p)
+
+
+def test_diagnose_corrupt_file(tmp_path):
+    p = tmp_path / "corrupt.jpg"
+    p.write_bytes(b"this is definitely not an image")
+    assert "not a valid image" in ImageResolutionValidator._diagnose_image_error(p)
+
+
+def test_diagnose_missing_file(tmp_path):
+    assert "not found" in ImageResolutionValidator._diagnose_image_error(tmp_path / "nope.jpg")

--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -94,6 +94,32 @@ def test_validate_record_allows_empty_string():
     ing._validate_record({"n": ""})
 
 
+def test_validate_record_allows_json_null_for_int():
+    # Regression: a JSON ``null`` (Python None) was passed to int(None), which
+    # raises TypeError and surfaced as "Data type validation failed for field
+    # n" — an error the user can never clear since JSON null IS the
+    # representation of missing.
+    ing = make_json_ingestor(schema={"n": "INT"})
+    ing._validate_record({"n": None})
+
+
+def test_validate_record_allows_json_null_for_float():
+    ing = make_json_ingestor(schema={"x": "FLOAT"})
+    ing._validate_record({"x": None})
+
+
+def test_validate_record_allows_json_null_for_bool():
+    ing = make_json_ingestor(schema={"b": "BOOL"})
+    ing._validate_record({"b": None})
+
+
+def test_validate_record_still_rejects_real_type_errors():
+    # NULL tolerance must NOT mask a genuine bad value.
+    ing = make_json_ingestor(schema={"n": "INT"})
+    with pytest.raises(ValueError, match="Data type validation failed"):
+        ing._validate_record({"n": "not-an-int"})
+
+
 def test_count_records_array(tmp_path):
     p = _write_json(tmp_path, [{"a": 1}, {"a": 2}, {"a": 3}])
     assert make_json_ingestor()._count_records(str(p)) == 3

--- a/tests/test_time_validators.py
+++ b/tests/test_time_validators.py
@@ -66,6 +66,31 @@ def test_format_schema_timestamp_with_precision_passes(make_csv):
     assert result.is_valid
 
 
+# --- locale-ambiguous dates (silent-corruption guard) ----------------------
+
+def test_format_ambiguous_eu_dates_rejected(make_csv):
+    # "03.04.2026" is Apr 3 (day-first/EU) or Mar 4 (month-first/US); pandas'
+    # format='mixed' would silently pick one. Both interpretations are valid but
+    # different, so reject as ambiguous instead of corrupting the series.
+    path = make_csv({"timestamp": ["03.04.2026", "07.08.2026"], "v": [1, 2]})
+    result = TimeFormatValidator().validate(str(path))
+    assert not result.is_valid
+    assert "ambiguous" in result.errors[0].lower()
+
+
+def test_format_iso_dates_not_ambiguous(make_csv):
+    # ISO 8601 is unambiguous and must pass cleanly.
+    path = make_csv({"timestamp": ["2024-01-03", "2024-04-05"], "v": [1, 2]})
+    assert TimeFormatValidator().validate(str(path)).is_valid
+
+
+def test_format_unambiguous_dates_not_flagged(make_csv):
+    # day > 12 has only one valid interpretation (here month-first), so it is
+    # NOT ambiguous and must not be falsely rejected.
+    path = make_csv({"timestamp": ["01/25/2024", "02/26/2024"], "v": [1, 2]})
+    assert TimeFormatValidator().validate(str(path)).is_valid
+
+
 # ---------------------------------------------------------------------------
 # TimeOrderedValidator
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -78,6 +78,30 @@ class APIClient:
 
         return session
 
+    @staticmethod
+    def _parse_json(response, *, required: bool):
+        """Parse a JSON response body, turning a non-JSON 200 (an HTML error
+        page, an empty body, a proxy interstitial) into a *handled* outcome
+        instead of an opaque JSONDecodeError mid-ingest.
+
+        ``required=True`` (the body IS the result — an auth token or a created
+        dataset) raises a clear ValueError. ``required=False`` (we only log the
+        body) warns and returns ``{}`` so a successful call isn't flipped to a
+        false failure just because its response wasn't JSON.
+        """
+        try:
+            return response.json()
+        except ValueError:  # json + requests JSONDecodeError both subclass ValueError
+            snippet = (response.text or "")[:200]
+            msg = (
+                f"Backend returned a non-JSON response "
+                f"(HTTP {response.status_code}): {snippet!r}"
+            )
+            if required:
+                raise ValueError(f"{RED}{msg}{RESET}")
+            logger.warning(f"{YELLOW}{msg}{RESET}")
+            return {}
+
     def authenticate(self) -> str:
         """Authenticate and return the token."""
         try:
@@ -95,7 +119,7 @@ class APIClient:
                     f"HTTP {response.status_code}: {response.text}"
                 )
             print(f"{BOLD}{GREEN}Authentication successful{RESET}")
-            return response.json().get("token")
+            return self._parse_json(response, required=True).get("token")
 
         except requests.exceptions.RequestException as e:
             if hasattr(e.response, "text"):
@@ -215,7 +239,8 @@ class APIClient:
                     f"HTTP {response.status_code}: {response.text}"
                 )
             logger.info(
-                f"{GREEN}Successfully sent global metadata. Response: {response.json()}{RESET}"
+                f"{GREEN}Successfully sent global metadata. "
+                f"Response: {self._parse_json(response, required=False)}{RESET}"
             )
             return True
 
@@ -312,7 +337,8 @@ class APIClient:
                     f"HTTP {response.status_code}: {response.text}"
                 )
             logger.info(
-                f"{GREEN}Successfully prepared data. Response: {response.json()}{RESET}"
+                f"{GREEN}Successfully prepared data. "
+                f"Response: {self._parse_json(response, required=False)}{RESET}"
             )
             return True
 
@@ -385,10 +411,11 @@ class APIClient:
                 raise requests.exceptions.HTTPError(
                     f"HTTP {response.status_code}: {response.text}"
                 )
+            dataset = self._parse_json(response, required=True)
             logger.info(
-                f"{GREEN}Successfully created dataset. Response: {response.json()}{RESET}"
+                f"{GREEN}Successfully created dataset. Response: {dataset}{RESET}"
             )
-            return response.json()
+            return dataset
 
         except requests.exceptions.RequestException as e:
             logger.error(f"{RED}Error creating dataset: {str(e)[:100]}{RESET}")

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -139,8 +139,21 @@ class CSVIngestor(BaseIngestor):
                     df[column] = df[column].astype("boolean")
                 elif "DATE" in dtype.upper() or "DATETIME" in dtype.upper() or "TIMESTAMP" in dtype.upper() or "TIME" in dtype.upper():
                     df[column] = pd.to_datetime(df[column], errors="coerce", format='mixed')
-                elif "STRING" in dtype.upper() or "TEXT" in dtype.upper():
-                    df[column] = df[column].astype("string")
+                elif any(t in dtype.upper() for t in ("STRING", "TEXT", "VARCHAR", "CHAR")):
+                    # Coerce to pandas StringDtype so missing cells become pd.NA
+                    # (not float NaN), then map pd.NA -> Python None so the DB
+                    # binder writes SQL NULL. Without this, VARCHAR/CHAR columns
+                    # were left as the float64 dtype pandas inferred for an
+                    # empty/mixed cell, and str(nan) "nan" landed in MySQL —
+                    # silent corruption of missing-data semantics. #167 widened
+                    # NULL-tolerance in the validator so all-null VARCHAR no
+                    # longer fails validation; this completes the fix on the
+                    # write side.
+                    df[column] = (
+                        df[column].astype("string").astype(object).where(
+                            df[column].notna(), None
+                        )
+                    )
             except Exception as e:
                 raise ValueError(
                     f"{RED}Data type validation failed for column {column}: {str(e)}{RESET}"

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -196,9 +196,17 @@ class CSVIngestor(BaseIngestor):
 
             first_chunk = True
             for chunk in pd.read_csv(file_path, chunksize=chunk_size, **csv_options):
+                # Strip headers + type-convert EVERY chunk. Doing this only for
+                # the first chunk left every row past chunk_size (default 1000)
+                # un-converted — a DATE column came back as raw strings, numeric
+                # columns fell back to pandas' per-chunk inference, and header
+                # whitespace was stripped only for chunk 1 — all invisible until
+                # a file exceeds a single chunk.
+                chunk.columns = chunk.columns.str.strip()
+                self._validate_csv(chunk)
                 if first_chunk:
-                    chunk.columns = chunk.columns.str.strip()
-                    self._validate_csv(chunk)
+                    # One-time check: the unique_id column exists (columns are
+                    # identical across chunks, so checking the first is enough).
                     if (
                         self.unique_id_column
                         and self.unique_id_column not in chunk.columns

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -128,13 +128,22 @@ class JSONIngestor(BaseIngestor):
         for field in common_fields:
             value = record[field]
             dtype = self.schema[field]
+            # NULL tolerance. A JSON ``null`` (Python ``None``) and an empty
+            # string are both legitimate missing values for any type; calling
+            # ``int(None)`` / ``float(None)`` raises TypeError, which the
+            # validator would otherwise surface as "Data type validation
+            # failed" — an error the user can never clear (JSON null IS the
+            # representation of missing). Mirrors the same NULL-tolerance the
+            # CSV-side validators got in #167 / #168.
+            if value is None or value == "":
+                continue
             try:
                 if "INT" in dtype.upper():
-                    int(value) if value != "" else None
+                    int(value)
                 elif "FLOAT" in dtype.upper():
-                    float(value) if value != "" else None
+                    float(value)
                 elif "BOOL" in dtype.upper():
-                    bool(value) if value != "" else None
+                    bool(value)
                 # Add more type validations as needed
             except Exception as e:
                 raise ValueError(

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -14,6 +14,7 @@ from tracebloc_ingestor.validators.numeric_columns_validator import NumericColum
 from tracebloc_ingestor.validators.keypoint_annotation_validator import KeypointAnnotationValidator
 from tracebloc_ingestor.validators.keypoint_visibility_validator import KeypointVisibilityValidator
 from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
+from tracebloc_ingestor.validators.file_pairing_validator import FilePairingValidator
 from tracebloc_ingestor.utils.constants import TaskCategory, FileExtension
 
 
@@ -32,6 +33,9 @@ def map_validators(
             FileTypeValidator(allowed_extension=options["extension"], path="images"),
             FileTypeValidator(allowed_extension=".xml", path="annotations"),
             PascalVOCXMLValidator(),
+            FilePairingValidator(
+                image_path="images", sidecar_path="annotations", sidecar_label="annotation"
+            ),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
             TableNameValidator(),
             DuplicateValidator(),
@@ -125,6 +129,9 @@ def map_validators(
         return [
             FileTypeValidator(allowed_extension=options["extension"], path="images"),
             FileTypeValidator(allowed_extension=FileExtension.PNG, path="masks"),
+            FilePairingValidator(
+                image_path="images", sidecar_path="masks", sidecar_label="mask"
+            ),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
             TableNameValidator(),
             DuplicateValidator(),

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -614,7 +614,11 @@ class DataValidator(BaseValidator):
         # Try to convert to datetime
         try:
             date_series = pd.to_datetime(series, errors="coerce")
-            invalid_dates = date_series.isnull().sum()
+            # A NULL is valid for any column; only a value that was present
+            # but un-parseable is an "invalid date". Without the
+            # ``series.notna()`` mask every missing cell counts as invalid —
+            # an unclearable error (mirrors the INT/FLOAT validators).
+            invalid_dates = (date_series.isna() & series.notna()).sum()
 
             if invalid_dates > 0:
                 errors.append(

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -126,10 +126,21 @@ class DataValidator(BaseValidator):
                 return data.head(sample_size)
             elif isinstance(data, (str, Path)):
                 path = Path(data)
-                if path.suffix.lower() == ".csv":
+                suffix = path.suffix.lower()
+                if suffix == ".csv":
                     df = pd.read_csv(
                         path, nrows=sample_size, encoding="utf-8", on_bad_lines="warn"
                     )
+                    return df
+                elif suffix == ".json":
+                    # Mirror JSONIngestor.read_data: file is a top-level JSON
+                    # array of records. Without this branch DataValidator
+                    # returned None for every JSON input, the caller raised
+                    # "No data found to validate", and JSON ingestion was
+                    # impossible end-to-end — the recent per-record
+                    # null-tolerance fix (#170) lived behind an unreachable
+                    # gate.
+                    df = pd.read_json(path, orient="records").head(sample_size)
                     return df
                 else:
                     logger.warning(f"Unsupported file type: {path.suffix}, \n\n{path}")

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -242,8 +242,12 @@ class DataValidator(BaseValidator):
         length_match = re.search(r"VARCHAR\((\d+)\)", expected_type.upper())
         max_length = int(length_match.group(1)) if length_match else None
 
-        # Check for non-string values
-        non_string_count = series.astype(str).ne(series).sum()
+        # Check for non-string values. A NULL is valid for any column, and
+        # ``NaN != NaN`` would otherwise count every missing value as
+        # "non-string" — an error the user can never clear (inserting NaN
+        # doesn't help). Mirror the INT/FLOAT validators: only flag values
+        # that are non-null AND not strings.
+        non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
         if non_string_count > 0:
             errors.append(
                 f"Column '{column_name}' contains {non_string_count} non-string values"
@@ -251,7 +255,7 @@ class DataValidator(BaseValidator):
 
         # Check length constraints
         if max_length:
-            string_series = series.astype(str)
+            string_series = series.dropna().astype(str)
             too_long = string_series.str.len() > max_length
             too_long_count = too_long.sum()
 
@@ -282,8 +286,12 @@ class DataValidator(BaseValidator):
         length_match = re.search(r"CHAR\((\d+)\)", expected_type.upper())
         max_length = int(length_match.group(1)) if length_match else None
 
-        # Check for non-string values
-        non_string_count = series.astype(str).ne(series).sum()
+        # Check for non-string values. A NULL is valid for any column, and
+        # ``NaN != NaN`` would otherwise count every missing value as
+        # "non-string" — an error the user can never clear (inserting NaN
+        # doesn't help). Mirror the INT/FLOAT validators: only flag values
+        # that are non-null AND not strings.
+        non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
         if non_string_count > 0:
             errors.append(
                 f"Column '{column_name}' contains {non_string_count} non-string values"
@@ -291,7 +299,7 @@ class DataValidator(BaseValidator):
 
         # Check length constraints (CHAR should be fixed length)
         if max_length:
-            string_series = series.astype(str)
+            string_series = series.dropna().astype(str)
             wrong_length = string_series.str.len() != max_length
             wrong_length_count = wrong_length.sum()
 
@@ -318,8 +326,12 @@ class DataValidator(BaseValidator):
         errors = []
         warnings = []
 
-        # Check for non-string values
-        non_string_count = series.astype(str).ne(series).sum()
+        # Check for non-string values. A NULL is valid for any column, and
+        # ``NaN != NaN`` would otherwise count every missing value as
+        # "non-string" — an error the user can never clear (inserting NaN
+        # doesn't help). Mirror the INT/FLOAT validators: only flag values
+        # that are non-null AND not strings.
+        non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
         if non_string_count > 0:
             errors.append(
                 f"Column '{column_name}' contains {non_string_count} non-string values"

--- a/tracebloc_ingestor/validators/file_pairing_validator.py
+++ b/tracebloc_ingestor/validators/file_pairing_validator.py
@@ -1,0 +1,104 @@
+"""File Pairing Validator Module.
+
+For datasets that pair every image with a sidecar file — object detection
+(image → annotation XML) and semantic segmentation (image → mask PNG) — this
+validator checks at ingestion time that each image has its sidecar and each
+sidecar has its image, matched by filename stem.
+
+Without this, a missing counterpart only surfaces mid-training as a
+``FileNotFoundError`` on the offending row, after the job has run for a while.
+Catching it up front lets the dataset author fix the whole set in one pass.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Set
+
+from .base import BaseValidator, ValidationResult
+from ..config import Config
+from ..utils.logging import setup_logging
+
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+
+class FilePairingValidator(BaseValidator):
+    """Ensure images and their sidecar files (annotations / masks) pair up 1:1.
+
+    Directories live under ``config.SRC_PATH`` (e.g. ``<src>/images`` and
+    ``<src>/annotations``). Matching is by filename stem, so ``cat.jpg`` pairs
+    with ``cat.xml`` / ``cat.png``.
+    """
+
+    def __init__(
+        self,
+        image_path: str = "images",
+        sidecar_path: str = "annotations",
+        sidecar_label: str = "annotation",
+        name: str = "File Pairing Validator",
+    ):
+        super().__init__(name)
+        self.image_path = image_path
+        self.sidecar_path = sidecar_path
+        self.sidecar_label = sidecar_label
+
+    @staticmethod
+    def _stems(directory: Path) -> Set[str]:
+        return {
+            p.stem
+            for p in directory.glob("*")
+            if p.is_file() and not p.name.startswith(".")
+        }
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            src = Path(config.SRC_PATH)
+            image_dir = src / self.image_path
+            sidecar_dir = src / self.sidecar_path
+
+            # A missing directory is the FileTypeValidator's concern (it reports
+            # "no files found"); skip here so we don't double-report.
+            if not image_dir.is_dir() or not sidecar_dir.is_dir():
+                return self._create_result(
+                    is_valid=True,
+                    metadata={"skipped": "image or sidecar directory not found"},
+                )
+
+            images = self._stems(image_dir)
+            sidecars = self._stems(sidecar_dir)
+            missing = sorted(images - sidecars)   # images with no sidecar
+            orphans = sorted(sidecars - images)   # sidecars with no image
+
+            errors = []
+            if missing:
+                shown = missing[:10]
+                errors.append(
+                    f"{len(missing)} image(s) have no matching {self.sidecar_label}: "
+                    f"{shown}{' …' if len(missing) > 10 else ''}"
+                )
+            if orphans:
+                shown = orphans[:10]
+                errors.append(
+                    f"{len(orphans)} {self.sidecar_label}(s) have no matching image: "
+                    f"{shown}{' …' if len(orphans) > 10 else ''}"
+                )
+
+            return self._create_result(
+                is_valid=len(errors) == 0,
+                errors=errors,
+                metadata={
+                    "images": len(images),
+                    "sidecars": len(sidecars),
+                    "images_without_sidecar": len(missing),
+                    "orphan_sidecars": len(orphans),
+                },
+            )
+        except Exception as e:
+            logger.error(f"File pairing validation error: {e}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Validation error: {str(e)}"],
+                metadata={"error_type": "validation_exception"},
+            )

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -12,12 +12,13 @@ from tracebloc_ingestor.config import Config
 from tracebloc_ingestor.utils.logging import setup_logging
 
 try:
-    from PIL import Image
+    from PIL import Image, UnidentifiedImageError
 
     PIL_AVAILABLE = True
 except ImportError:
     PIL_AVAILABLE = False
     Image = None
+    UnidentifiedImageError = Exception
 
 from .base import BaseValidator, ValidationResult
 
@@ -199,6 +200,30 @@ class ImageResolutionValidator(BaseValidator):
             logger.warning(f"Could not get resolution for {image_path}: {str(e)}")
             return None
 
+    @staticmethod
+    def _diagnose_image_error(image_path: Path) -> str:
+        """Return a human-readable reason an image could not be read, turning the
+        generic "could not be processed" into an actionable cause: empty file,
+        corrupt/unsupported format, or decompression bomb."""
+        try:
+            p = Path(image_path)
+            if not p.exists():
+                return "file not found"
+            if p.stat().st_size == 0:
+                return "empty file (0 bytes)"
+        except OSError as exc:
+            return f"unreadable ({exc.__class__.__name__})"
+        try:
+            with Image.open(image_path) as img:
+                img.verify()  # integrity check without a full decode
+            return "unreadable image"
+        except UnidentifiedImageError:
+            return "not a valid image (corrupt or unsupported format)"
+        except Image.DecompressionBombError:
+            return "exceeds the safe pixel limit (possible decompression bomb)"
+        except Exception as exc:
+            return f"{exc.__class__.__name__}: {exc}"
+
     def _validate_image_resolutions(self, image_files: List[Path]) -> ValidationResult:
         """Validate image resolutions for uniformity.
 
@@ -237,7 +262,9 @@ class ImageResolutionValidator(BaseValidator):
                 try:
                     resolution = self._get_image_resolution(image_path)
                     if resolution is None:
-                        invalid_files.append(str(image_path))
+                        invalid_files.append(
+                            f"{image_path}: {self._diagnose_image_error(image_path)}"
+                        )
                         continue
 
                     resolutions_found.add(resolution)

--- a/tracebloc_ingestor/validators/time_format_validator.py
+++ b/tracebloc_ingestor/validators/time_format_validator.py
@@ -72,9 +72,38 @@ class TimeFormatValidator(BaseValidator):
                     errors=[f"Required column 'timestamp' not found. Available: {list(df.columns)}"],
                 )
 
-            # Parse timestamps
+            # Parse timestamps (month-first by default).
             timestamps = pd.to_datetime(df["timestamp"], format='mixed', errors="coerce")
             metadata = {"rows_checked": len(df)}
+
+            # Locale-ambiguity guard. "03.04.2026" is Apr 3 read day-first (EU)
+            # but Mar 4 read month-first (US); format='mixed' silently picks one
+            # and corrupts the whole series with no error. If a value parses
+            # successfully BOTH ways but to different dates, it is ambiguous —
+            # reject it and steer the user to unambiguous ISO 8601.
+            #
+            # Exempt ISO-8601 values (YYYY-…): pandas with dayfirst=True still
+            # swaps their components, which would falsely flag every ISO date.
+            day_first = pd.to_datetime(
+                df["timestamp"], format='mixed', dayfirst=True, errors="coerce"
+            )
+            ts_str = df["timestamp"].astype(str)
+            iso_like = ts_str.str.match(r"^\d{4}-")
+            ambiguous_mask = (
+                timestamps.notna()
+                & day_first.notna()
+                & (timestamps != day_first)
+                & ~iso_like
+            )
+            if ambiguous_mask.any():
+                ambiguous_count = int(ambiguous_mask.sum())
+                samples = df["timestamp"][ambiguous_mask].astype(str).head(5).tolist()
+                errors.append(
+                    f"Found {ambiguous_count} ambiguous date(s) in 'timestamp' that parse "
+                    f"differently day-first vs month-first (e.g. {samples}). Use ISO 8601 "
+                    f"(YYYY-MM-DD or YYYY-MM-DD HH:MM:SS) to remove the ambiguity."
+                )
+                metadata["ambiguous_timestamps"] = ambiguous_count
 
             # Check for invalid/missing timestamps
             invalid_mask = timestamps.isna()


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CSV/JSON write and validation paths and API response handling; fixes are data-integrity critical but scoped with many regression tests rather than broad refactors.
> 
> **Overview**
> Releases **tracebloc_ingestor 0.3.5** with ingestion and validation hardening plus broader automated coverage.
> 
> **Data integrity & ingest paths:** CSV chunked reads now run header stripping and `_validate_csv` on **every** chunk (fixes wrong types past the default 1000-row window). **VARCHAR/CHAR** empty cells coerce to Python `None` so MySQL gets SQL NULL instead of literal `'nan'`. **JSON** record validation and **DataValidator** accept JSON files and treat nulls/missing values as valid for string and date columns without weakening real type errors. **TimeFormatValidator** rejects locale-ambiguous dates (e.g. `03.04.2026`) instead of silently picking day- vs month-first.
> 
> **API & vision workflows:** **APIClient** adds `_parse_json` so non-JSON HTTP 200 bodies warn or raise clearly instead of breaking mid-ingest. New **FilePairingValidator** (images ↔ annotations/masks) runs for object detection and semantic segmentation. Image resolution errors include actionable diagnoses (empty/corrupt/missing).
> 
> **Tests:** Adds MySQL e2e, real HTTP API failure-mode tests, CSV scale/i18n fixtures, file transfer retry/atomicity tests, and regression tests for the bugs above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6859c1dcd869aceeb819f5d774aaf24ec57f2093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->