### PR TITLE
fix: null-like values must round-trip end-to-end as SQL NULL

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -79,6 +79,34 @@ def test_loads_from_json_genuine_type_error_still_caught(tmp_path):
     assert not result.is_valid
 
 
+def test_loads_from_json_empty_string_is_missing(tmp_path):
+    """Empty strings in JSON INT/FLOAT cells must be treated as missing, the
+    same way `null` is — matching JSONIngestor._validate_record's convention
+    (`if value is None or value == ""`, #170).
+
+    Regression: pd.read_json (unlike pd.read_csv with keep_default_na=True)
+    preserves "" as the literal empty string. The INT validator then reported
+    `"Column 'age' contains N non-numeric value(s). Sample invalid values:
+    ['', '']"` even though those rows would have been ingested as missing —
+    so a JSON file that JSONIngestor handles fine was rejected by the
+    validator that runs before it.
+
+    Surfaced by an end-to-end cluster ingestion against v0.3.5-rc2: 20-record
+    JSON file with mixed `null` and `""` in INT/FLOAT columns failed
+    validation with the above error.
+    """
+    p = tmp_path / "d.json"
+    p.write_text(
+        '[{"id": 1, "age": 30,   "score": 0.5},'
+        ' {"id": 2, "age": null, "score": 0.6},'
+        ' {"id": 3, "age": "",   "score": ""}]'
+    )
+    result = DataValidator(
+        schema={"id": "INT", "age": "INT", "score": "FLOAT"}
+    ).validate(str(p))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+
+
 def test_unknown_type_fails():
     df = pd.DataFrame({"a": [1]})
     result = DataValidator(schema={"a": "WEIRDTYPE"}).validate(df)

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any, Dict, Generator, List
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from tracebloc_ingestor.ingestors import base as base_mod
@@ -134,6 +135,46 @@ def test_process_record_applies_bucket_label_policy():
     rec = ing.process_record({"a": "12345", "filename": "f"})
     # bucket policy hashes the raw value -> not equal to the raw value
     assert rec["label"] != "12345"
+
+
+def test_process_record_preserves_none_for_sql_null():
+    """Null-like values (Python None, NaN, pd.NA, NaT) must round-trip as
+    Python None so the DB binder writes SQL NULL — not as the literal
+    string "nan"/"NaT"/"<NA>", and not as "".
+
+    Regression: the cleaning dict mapped `None -> ""` and applied
+    `str(v).strip()` to everything else, so pandas' NaN/NaT/pd.NA were
+    silently stringified ("nan", "NaT", "<NA>") and explicit None inputs
+    landed as empty-string. Both broke missing-data semantics in MySQL
+    — a nullable VARCHAR ended up either with the 3-char string "nan"
+    (before the upstream CSV-side fix in #172) or with "" (after #172,
+    because this dict still mapped None -> ""). Surfaced by an
+    end-to-end cluster ingestion of a 60-row CSV with an all-empty
+    VARCHAR(50) column.
+    """
+    import numpy as np
+
+    ing = make_ingestor(schema={"a": "VARCHAR(10)", "b": "INT", "c": "VARCHAR(50)"}, category=None)
+    rec = ing.process_record({
+        "a": None,            # explicit Python None
+        "b": np.nan,           # float NaN (e.g. from pd.read_csv)
+        "c": pd.NA,           # pd.NA (e.g. from pandas StringDtype)
+        "filename": "f",
+    })
+    assert rec is not None
+    assert rec["a"] is None, f"expected None, got {rec['a']!r}"
+    assert rec["b"] is None, f"expected None, got {rec['b']!r}"
+    assert rec["c"] is None, f"expected None, got {rec['c']!r}"
+
+
+def test_process_record_preserves_real_values():
+    """Non-null values continue to be stringified + stripped as before —
+    this fix must not weaken the existing contract for present values.
+    """
+    ing = make_ingestor(schema={"a": "VARCHAR(10)", "b": "INT"}, category=None)
+    rec = ing.process_record({"a": "  hello  ", "b": 42, "filename": "f"})
+    assert rec["a"] == "hello"
+    assert rec["b"] == "42"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -177,6 +177,24 @@ def test_process_record_preserves_real_values():
     assert rec["b"] == "42"
 
 
+def test_process_record_treats_empty_string_as_null():
+    """Literal "" must become Python None (SQL NULL), matching the
+    `value is None or value == ""` convention JSONIngestor._validate_record
+    uses (#170).
+
+    Regression context: JSONIngestor.read_data reads via `json.load`, not
+    `pd.read_json`, so an empty-string JSON value (`"score": ""`) reaches
+    here as the literal `""` — pd.isna("") is False, so without the `or
+    v == ""` guard the empty string would be written verbatim to MySQL.
+    The CSV path is unaffected because pandas' keep_default_na=True turns
+    "" into NaN at read time (caught by the pd.isna branch).
+    """
+    ing = make_ingestor(schema={"a": "VARCHAR(10)", "b": "INT"}, category=None)
+    rec = ing.process_record({"a": "", "b": "", "filename": "f"})
+    assert rec["a"] is None
+    assert rec["b"] is None
+
+
 # ---------------------------------------------------------------------------
 # _process_batch
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, Generator, List, Optional, NamedTuple
 from sqlalchemy.orm import Session
 from sqlalchemy.engine import Engine
 import logging
+import pandas as pd
 from tqdm import tqdm
 import uuid
 from pathlib import Path
@@ -285,8 +286,17 @@ class BaseIngestor(ABC):
                 columns_to_exclude.add(self.annotation_column)
             if self.unique_id_column:
                 columns_to_exclude.add(self.unique_id_column)
+            # Preserve missing-data semantics: any null-like value (Python
+            # None, float NaN, pd.NA, pd.NaT) becomes Python None so the DB
+            # binder writes SQL NULL. Previously this dict mapped None -> ""
+            # which (a) inserted empty-string into nullable VARCHAR/TEXT
+            # columns instead of NULL, and (b) silently coerced pandas'
+            # NaN/NaT/pd.NA into the literal string "nan"/"NaT"/"<NA>" via
+            # str(v). pd.isna handles all four uniformly and returns False
+            # for ordinary strings/numbers/bools so existing values aren't
+            # touched.
             cleaned_record = {
-                k.strip(): ("" if v is None else str(v).strip())
+                k.strip(): (None if pd.isna(v) else str(v).strip())
                 for k, v in record.items()
                 if k in self.schema and k not in columns_to_exclude
             }

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -286,17 +286,23 @@ class BaseIngestor(ABC):
                 columns_to_exclude.add(self.annotation_column)
             if self.unique_id_column:
                 columns_to_exclude.add(self.unique_id_column)
-            # Preserve missing-data semantics: any null-like value (Python
-            # None, float NaN, pd.NA, pd.NaT) becomes Python None so the DB
-            # binder writes SQL NULL. Previously this dict mapped None -> ""
-            # which (a) inserted empty-string into nullable VARCHAR/TEXT
-            # columns instead of NULL, and (b) silently coerced pandas'
-            # NaN/NaT/pd.NA into the literal string "nan"/"NaT"/"<NA>" via
-            # str(v). pd.isna handles all four uniformly and returns False
-            # for ordinary strings/numbers/bools so existing values aren't
-            # touched.
+            # Preserve missing-data semantics: any null-like value becomes
+            # Python None so the DB binder writes SQL NULL. Treats four
+            # representations uniformly:
+            #   - Python None         (explicit absence, JSON null)
+            #   - float NaN / pd.NaT  (from pd.read_csv / pd.to_datetime)
+            #   - pd.NA               (from pandas StringDtype after #172)
+            #   - literal "" string   (JSON empty string — JSONIngestor reads
+            #                         via json.load, not pd.read_json, so ""
+            #                         survives to here; CSVs never hit this
+            #                         case because keep_default_na=True turns
+            #                         "" into NaN at read time)
+            # Mirrors the missing-data convention in
+            # JSONIngestor._validate_record (#170): `value is None or
+            # value == ""`. pd.isna returns False for ordinary
+            # strings/numbers/bools so existing values aren't touched.
             cleaned_record = {
-                k.strip(): (None if pd.isna(v) else str(v).strip())
+                k.strip(): (None if pd.isna(v) or v == "" else str(v).strip())
                 for k, v in record.items()
                 if k in self.schema and k not in columns_to_exclude
             }

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -141,6 +141,14 @@ class DataValidator(BaseValidator):
                     # null-tolerance fix (#170) lived behind an unreachable
                     # gate.
                     df = pd.read_json(path, orient="records").head(sample_size)
+                    # pd.read_json (unlike pd.read_csv with keep_default_na=True)
+                    # preserves "" as the literal empty string. Normalise to NaN
+                    # so per-type validators below treat "" identically to JSON
+                    # null — matches the JSONIngestor._validate_record convention
+                    # `if value is None or value == ""` (#170). Without this, an
+                    # INT column with `""` is reported as "non-numeric value"
+                    # even though JSONIngestor would have read it as missing.
+                    df = df.replace("", np.nan)
                     return df
                 else:
                     logger.warning(f"Unsupported file type: {path.suffix}, \n\n{path}")


### PR DESCRIPTION
## Summary

Re-ran the end-to-end ingestion scenarios against v0.3.5-rc2 (digest ships #170 + #172 + #173). Found two remaining gaps in the missing-data path that prevent the merged fixes from actually delivering SQL NULL to MySQL.

## What's left broken after the rc1 fixes

### 1. JSON `\"\"` rejected by per-type validators

`DataValidator._load_data` (.json branch from #173) uses \`pd.read_json(orient=\"records\")\`, which preserves \`\"\"\` literally — unlike \`pd.read_csv\` with \`keep_default_na=True\`. The INT/FLOAT validators tolerate NaN (via \`series.notna()\` from #167/#168) but not \`\"\"\`:

\`\`\`
Column 'age' contains 2 non-numeric value(s). Sample invalid values: ['', '']
Column 'score' contains 2 non-numeric value(s). Sample invalid values: ['', '']
\`\`\`

…even though \`JSONIngestor._validate_record\` (#170) treats both \`null\` and \`\"\"\` as missing. So a JSON file the ingestor would accept is rejected by the validator that runs before it.

### 2. \`process_record\` corrupts every null-like value

[ingestors/base.py:289](tracebloc_ingestor/ingestors/base.py#L289):

\`\`\`python
k.strip(): (\"\" if v is None else str(v).strip())
\`\`\`

- Explicit \`None\` → \`\"\"\`: a nullable VARCHAR cell that arrived as None (the correct outcome of #172's NaN coercion) was then written as the empty string, **not** SQL NULL.
- pandas \`NaN\` / \`NaT\` / \`pd.NA\` fall through \`is None\` and hit \`str(v).strip()\` — landing in MySQL as the literal three-/four-character strings \`\"nan\"\`, \`\"NaT\"\`, \`\"<NA>\"\`. Before #172 this was masked on VARCHAR (validator rejected the column); after #172, the columns pass validation and the corruption surfaces.

## Cluster verification

\`\`\`sql
-- rc2 (with #172 + #173), BEFORE this PR:
SELECT analyte_y, LENGTH(analyte_y), COUNT(*) FROM e2etest_varchar_nulls
  GROUP BY analyte_y;
-- ''   | 0 | 60     <-- empty string, not NULL
\`\`\`

The 60 rows of all-empty VARCHAR(50) landed as \`\"\"\`, not SQL NULL. Plus the JSON scenario can't even reach the write path because of #1.

## Fix

1. In \`DataValidator._load_data\`: after \`pd.read_json\`, \`df.replace(\"\", np.nan)\` so the per-type validators see JSON \`\"\"\` the same way they see CSV-empty.
2. In \`BaseIngestor.process_record\`: replace \`\"\" if v is None\` with \`None if pd.isna(v)\` — \`pd.isna\` handles None / NaN / NaT / pd.NA uniformly, ordinary strings/numbers/bools pass through unchanged.

Combined effect: missing inputs (JSON null, JSON \"\", CSV empty cell) round-trip from source → validator → ingestor → MySQL as **SQL NULL**.

## Test plan

- [ ] New regression tests:
  - JSON \"\" in INT/FLOAT validates (paired with the existing genuine-bad-value test so the boundary stays pinned)
  - explicit None / np.nan / pd.NA all land as Python None in the cleaned record
  - non-null values continue to be stringified+stripped (no contract change)
- [ ] CI green
- [ ] Re-run cluster ingestion against rc3 → MySQL shows NULL (not '', not 'nan'); JSON ingest reaches the write path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ingestion record cleaning and JSON validation gates; wrong null handling could still corrupt DB rows, but scope is narrow and well-covered by regression tests.
> 
> **Overview**
> Aligns **missing-data handling** from JSON/CSV validation through `BaseIngestor.process_record` so MySQL gets **SQL NULL** instead of `""`, `"nan"`, or failed pre-ingest validation.
> 
> **`DataValidator` (JSON load):** After `pd.read_json`, empty strings are normalized with `df.replace("", np.nan)` so INT/FLOAT checks treat JSON `""` like `null`—matching `JSONIngestor._validate_record` and fixing false “non-numeric” errors on files the ingestor would accept.
> 
> **`BaseIngestor.process_record`:** Schema field cleaning now maps null-like inputs (`None`, `pd.isna` values including NaN/NaT/`pd.NA`, and literal `""`) to **Python `None`** for the DB binder; present values still go through `str(v).strip()` unchanged.
> 
> Regression tests cover JSON `""` in numeric columns, null-like round-trip to `None`, empty string → `None`, and unchanged behavior for real values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9e89bb90e2a5af4e84fcbfd6ffd439f9e37cbda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->