### PR TITLE
Develop to prod

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ How to cut a new release of `tracebloc-ingestor` (PyPI package) and `ghcr.io/tra
 
 Each publisher runs the schema-load smoke probe (`tracebloc_ingestor.cli.run._load_schema()`) before publishing. If the bundled `schema/ingest.v1.json` ever goes missing from the artifact (the v0.3.0-rc1 bug), the workflow aborts and nothing ships.
 
-The image and the PyPI package release **independently**. A tag without a `setup.py` bump produces an image whose pip-reported version lags. A `master` merge without a tag produces a PyPI release with no image. Doing the bump *inside* the sync PR (step 2) keeps them aligned.
+The image and the PyPI package release **independently**. A tag without a version bump produces an image whose pip-reported version lags. A `master` merge without a tag produces a PyPI release with no image. Doing the bump *inside* the sync PR (step 2) keeps them aligned.
 
 ## Pre-flight
 
@@ -39,16 +39,19 @@ gh run list --repo tracebloc/data-ingestors \
   --workflow publish-dev.yml --branch develop --limit 5
 ```
 
-## 2. Bump the version in `setup.py`
+## 2. Bump the version in `tracebloc_ingestor/__init__.py`
+
+The version is **single-sourced** in `tracebloc_ingestor/__init__.py` (`__version__`); `setup.py` parses that literal at build time, so this is the only file you edit and the two can no longer drift. (They drifted once — `setup.py` 0.3.5 vs `__version__` 0.3.4, #171/#175 — because the bump touched only one file; single-sourcing is the fix.)
 
 Pick the next SemVer per [semver.org](https://semver.org/) — patch for fixes, minor for backwards-compatible features, major for breaking changes. Export it once so the rest of this doc copy-pastes cleanly:
 
 ```bash
 export VERSION=X.Y.Z   # e.g. 0.3.1
 git checkout -b release/v${VERSION} origin/develop
-# Edit setup.py: version="X.Y.Z"
-git diff setup.py     # confirm only the version string changed
-git add setup.py
+# Edit tracebloc_ingestor/__init__.py: __version__ = "X.Y.Z"   (do NOT touch setup.py)
+git diff tracebloc_ingestor/__init__.py   # confirm only the version string changed
+python setup.py --version                 # must print X.Y.Z — proves setup.py picked it up
+git add tracebloc_ingestor/__init__.py
 git commit -m "chore(release): bump version to ${VERSION}"
 git push -u origin release/v${VERSION}
 
@@ -56,6 +59,8 @@ gh pr create --base develop \
   --title "chore(release): bump version to ${VERSION}" \
   --body "Version bump ahead of v${VERSION} release. Companion sync PR will follow."
 ```
+
+On the release ticket, this collapses the old two-line acceptance item (`setup.py` **and** `__init__.py` bumped) into a single check — **`__version__` bumped in `tracebloc_ingestor/__init__.py`** (`setup.py` derives it; verified by `tests/test_version_single_source.py`).
 
 Get it reviewed and merged into `develop` like any other PR.
 
@@ -171,7 +176,7 @@ gh workflow run release-image.yml --repo tracebloc/data-ingestors \
 - **No `:latest`** is published (deliberate, see #45). Consumers pin to a major, minor, or specific patch.
 - **No CHANGELOG.md** in the repo — release notes are auto-generated from the digest. If you want a human-written summary, edit it in afterwards: `gh release edit v${VERSION} --notes-file <(...)`.
 - **PR base is always `develop`** for normal work. The `sync/develop-to-master-vX.Y.Z` PR is the only one targeting `master`.
-- **Version bump lives in the sync flow**, not as a tag-time afterthought, so the PyPI version and image-baked version don't drift.
+- **Version is single-sourced** in `tracebloc_ingestor/__init__.py`; `setup.py` parses that literal, so bump the one file and never hardcode a version back into `setup.py` (that re-introduces the 0.3.4/0.3.5 drift, #175 — guarded by `tests/test_version_single_source.py`). The bump lives in the sync flow, not as a tag-time afterthought, so the PyPI version and image-baked version stay aligned.
 - **The image entrypoint requires `MYSQL_HOST`** at runtime (see `docker-entrypoint.sh`). Smoke probes bypass it with `--entrypoint`; if you're sanity-checking by hand outside CI, you'll need the same flag.
 
 ## Troubleshooting

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 import os
+import re
 
 # read the contents of your README file
 from pathlib import Path
@@ -7,12 +8,29 @@ from pathlib import Path
 this_directory = Path(__file__).parent
 long_description = (this_directory / "Readme.md").read_text()
 
+
+def _read_version():
+    """Single-source the version from tracebloc_ingestor/__init__.py.
+
+    Parsed as text (not imported) so building the sdist never has to import the
+    package or its dependencies. Keeping the version literal in exactly one
+    place is what stops setup.py and __version__ drifting again (#175).
+    """
+    init_py = (this_directory / "tracebloc_ingestor" / "__init__.py").read_text()
+    match = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']', init_py, re.M)
+    if match is None:
+        raise RuntimeError(
+            "Unable to find __version__ in tracebloc_ingestor/__init__.py"
+        )
+    return match.group(1)
+
+
 with open("requirements.txt", "r") as f:
     requirements = f.read().splitlines()
 
 setup(
     name="tracebloc_ingestor",
-    version="0.3.5",
+    version=_read_version(),
     author="Tracebloc",
     author_email="support@tracebloc.com",
     description="A flexible data ingestion library for various file formats",

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -79,6 +79,34 @@ def test_loads_from_json_genuine_type_error_still_caught(tmp_path):
     assert not result.is_valid
 
 
+def test_loads_from_json_empty_string_is_missing(tmp_path):
+    """Empty strings in JSON INT/FLOAT cells must be treated as missing, the
+    same way `null` is — matching JSONIngestor._validate_record's convention
+    (`if value is None or value == ""`, #170).
+
+    Regression: pd.read_json (unlike pd.read_csv with keep_default_na=True)
+    preserves "" as the literal empty string. The INT validator then reported
+    `"Column 'age' contains N non-numeric value(s). Sample invalid values:
+    ['', '']"` even though those rows would have been ingested as missing —
+    so a JSON file that JSONIngestor handles fine was rejected by the
+    validator that runs before it.
+
+    Surfaced by an end-to-end cluster ingestion against v0.3.5-rc2: 20-record
+    JSON file with mixed `null` and `""` in INT/FLOAT columns failed
+    validation with the above error.
+    """
+    p = tmp_path / "d.json"
+    p.write_text(
+        '[{"id": 1, "age": 30,   "score": 0.5},'
+        ' {"id": 2, "age": null, "score": 0.6},'
+        ' {"id": 3, "age": "",   "score": ""}]'
+    )
+    result = DataValidator(
+        schema={"id": "INT", "age": "INT", "score": "FLOAT"}
+    ).validate(str(p))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+
+
 def test_unknown_type_fails():
     df = pd.DataFrame({"a": [1]})
     result = DataValidator(schema={"a": "WEIRDTYPE"}).validate(df)

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -177,6 +177,33 @@ def test_process_record_preserves_real_values():
     assert rec["b"] == "42"
 
 
+def test_process_record_bool_not_stringified():
+    """Python True / False must NOT be stringified — they must reach the DB
+    binder as native bool so mysql-connector writes TINYINT 1/0.
+
+    Regression: the cleaning dict applied `str(v).strip()` to every
+    non-null value, turning True / False into the four-character strings
+    "True" / "False". MySQL rejects those against a BOOL column with
+    `Incorrect integer value: 'True' for column 'active' at row 1` —
+    16/20 rows of an end-to-end JSON ingest against v0.3.5-rc3 failed for
+    exactly this reason (the 4 rows with explicit `null` succeeded
+    because they round-tripped to SQL NULL per #176; the rest had
+    true/false). The bug was hidden until rc3 because earlier rc's
+    rejected JSON before any record reached the INSERT (#173 read path,
+    #176 validator widening).
+
+    Pass bools through unchanged; non-bool, non-null values still get
+    str()-and-strip semantics so existing INT/FLOAT/VARCHAR contracts
+    are unchanged.
+    """
+    ing = make_ingestor(schema={"a": "BOOL", "b": "BOOL", "n": "INT"}, category=None)
+    rec = ing.process_record({"a": True, "b": False, "n": 42, "filename": "f"})
+    assert rec["a"] is True, f"expected True, got {rec['a']!r}"
+    assert rec["b"] is False, f"expected False, got {rec['b']!r}"
+    # Non-bool unchanged from the prior contract.
+    assert rec["n"] == "42"
+
+
 def test_process_record_treats_empty_string_as_null():
     """Literal "" must become Python None (SQL NULL), matching the
     `value is None or value == ""` convention JSONIngestor._validate_record

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any, Dict, Generator, List
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from tracebloc_ingestor.ingestors import base as base_mod
@@ -134,6 +135,46 @@ def test_process_record_applies_bucket_label_policy():
     rec = ing.process_record({"a": "12345", "filename": "f"})
     # bucket policy hashes the raw value -> not equal to the raw value
     assert rec["label"] != "12345"
+
+
+def test_process_record_preserves_none_for_sql_null():
+    """Null-like values (Python None, NaN, pd.NA, NaT) must round-trip as
+    Python None so the DB binder writes SQL NULL — not as the literal
+    string "nan"/"NaT"/"<NA>", and not as "".
+
+    Regression: the cleaning dict mapped `None -> ""` and applied
+    `str(v).strip()` to everything else, so pandas' NaN/NaT/pd.NA were
+    silently stringified ("nan", "NaT", "<NA>") and explicit None inputs
+    landed as empty-string. Both broke missing-data semantics in MySQL
+    — a nullable VARCHAR ended up either with the 3-char string "nan"
+    (before the upstream CSV-side fix in #172) or with "" (after #172,
+    because this dict still mapped None -> ""). Surfaced by an
+    end-to-end cluster ingestion of a 60-row CSV with an all-empty
+    VARCHAR(50) column.
+    """
+    import numpy as np
+
+    ing = make_ingestor(schema={"a": "VARCHAR(10)", "b": "INT", "c": "VARCHAR(50)"}, category=None)
+    rec = ing.process_record({
+        "a": None,            # explicit Python None
+        "b": np.nan,           # float NaN (e.g. from pd.read_csv)
+        "c": pd.NA,           # pd.NA (e.g. from pandas StringDtype)
+        "filename": "f",
+    })
+    assert rec is not None
+    assert rec["a"] is None, f"expected None, got {rec['a']!r}"
+    assert rec["b"] is None, f"expected None, got {rec['b']!r}"
+    assert rec["c"] is None, f"expected None, got {rec['c']!r}"
+
+
+def test_process_record_preserves_real_values():
+    """Non-null values continue to be stringified + stripped as before —
+    this fix must not weaken the existing contract for present values.
+    """
+    ing = make_ingestor(schema={"a": "VARCHAR(10)", "b": "INT"}, category=None)
+    rec = ing.process_record({"a": "  hello  ", "b": 42, "filename": "f"})
+    assert rec["a"] == "hello"
+    assert rec["b"] == "42"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -177,6 +177,24 @@ def test_process_record_preserves_real_values():
     assert rec["b"] == "42"
 
 
+def test_process_record_treats_empty_string_as_null():
+    """Literal "" must become Python None (SQL NULL), matching the
+    `value is None or value == ""` convention JSONIngestor._validate_record
+    uses (#170).
+
+    Regression context: JSONIngestor.read_data reads via `json.load`, not
+    `pd.read_json`, so an empty-string JSON value (`"score": ""`) reaches
+    here as the literal `""` — pd.isna("") is False, so without the `or
+    v == ""` guard the empty string would be written verbatim to MySQL.
+    The CSV path is unaffected because pandas' keep_default_na=True turns
+    "" into NaN at read time (caught by the pd.isna branch).
+    """
+    ing = make_ingestor(schema={"a": "VARCHAR(10)", "b": "INT"}, category=None)
+    rec = ing.process_record({"a": "", "b": "", "filename": "f"})
+    assert rec["a"] is None
+    assert rec["b"] is None
+
+
 # ---------------------------------------------------------------------------
 # _process_batch
 # ---------------------------------------------------------------------------

--- a/tests/test_version_single_source.py
+++ b/tests/test_version_single_source.py
@@ -1,0 +1,66 @@
+"""Guard the single-sourced package version.
+
+``tracebloc_ingestor/__init__.py`` holds the one and only version literal;
+``setup.py`` parses it at build time (``_read_version``) so the importable
+``__version__`` and the packaged/PyPI version cannot drift. They drifted once
+(``setup.py`` 0.3.5 vs ``__version__`` 0.3.4, #171/#175) precisely because the
+bump touched only one file — these tests fail loudly if that contract breaks
+again, e.g. someone re-hardcodes a literal back into ``setup.py``.
+
+Pure file checks — no DB, no network, no subprocess.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import tracebloc_ingestor
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INIT_PY = REPO_ROOT / "tracebloc_ingestor" / "__init__.py"
+SETUP_PY = REPO_ROOT / "setup.py"
+
+# The exact pattern setup.py uses to extract the version. Kept in sync on
+# purpose: this test pins the contract setup.py's _read_version() relies on.
+_VERSION_RE = re.compile(r'^__version__\s*=\s*["\']([^"\']+)["\']', re.M)
+
+
+def _parse_init_version() -> str:
+    match = _VERSION_RE.search(INIT_PY.read_text())
+    assert match is not None, "__version__ literal not found in __init__.py"
+    return match.group(1)
+
+
+def test_version_is_a_pep440_ish_literal() -> None:
+    """The runtime attribute is a non-empty, regex-parseable version string."""
+    assert isinstance(tracebloc_ingestor.__version__, str)
+    assert re.fullmatch(r"\d+\.\d+\.\d+([.\-+].+)?", tracebloc_ingestor.__version__)
+    # The literal setup.py will parse must equal the runtime attribute.
+    assert _parse_init_version() == tracebloc_ingestor.__version__
+
+
+def test_setup_py_derives_version_not_hardcoded() -> None:
+    """``setup.py`` must derive ``version=`` from ``__init__.py``, not hardcode it.
+
+    This is the real anti-drift guard: if a hardcoded ``version="x.y.z"`` ever
+    creeps back into ``setup.py`` (the exact drift #171/#175 hit), the two
+    files diverge and this fails.
+
+    Static analysis (not a subprocess) so the test does not require setuptools
+    at runtime — Python 3.12 dropped the auto-bundled setuptools, so the
+    previous ``python setup.py --version`` subprocess broke under CI's bare
+    interpreter even though the contract itself was fine.
+    """
+    source = SETUP_PY.read_text()
+    # Anything matching version="literal" / version='literal' is hardcoded.
+    hardcoded = re.search(r'version\s*=\s*["\'][^"\']+["\']', source)
+    assert hardcoded is None, (
+        f"setup.py hardcodes a version literal ({hardcoded.group(0)!r}); "
+        "it must derive from tracebloc_ingestor/__init__.py via _read_version()."
+    )
+    # And it must actually call the derivation helper (or an equivalent).
+    assert "_read_version()" in source, (
+        "setup.py no longer calls _read_version(); the single-source contract "
+        "is broken."
+    )

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -17,7 +17,10 @@ from .validators import (
     TableNameValidator,
 )
 
-__version__ = "0.3.4"
+# Single source of truth for the package version. setup.py parses this literal
+# (see _read_version in setup.py) so the two can't drift again (#175). Bump here
+# only — setup.py picks it up automatically.
+__version__ = "0.3.5"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, Generator, List, Optional, NamedTuple
 from sqlalchemy.orm import Session
 from sqlalchemy.engine import Engine
 import logging
+import pandas as pd
 from tqdm import tqdm
 import uuid
 from pathlib import Path
@@ -285,8 +286,17 @@ class BaseIngestor(ABC):
                 columns_to_exclude.add(self.annotation_column)
             if self.unique_id_column:
                 columns_to_exclude.add(self.unique_id_column)
+            # Preserve missing-data semantics: any null-like value (Python
+            # None, float NaN, pd.NA, pd.NaT) becomes Python None so the DB
+            # binder writes SQL NULL. Previously this dict mapped None -> ""
+            # which (a) inserted empty-string into nullable VARCHAR/TEXT
+            # columns instead of NULL, and (b) silently coerced pandas'
+            # NaN/NaT/pd.NA into the literal string "nan"/"NaT"/"<NA>" via
+            # str(v). pd.isna handles all four uniformly and returns False
+            # for ordinary strings/numbers/bools so existing values aren't
+            # touched.
             cleaned_record = {
-                k.strip(): ("" if v is None else str(v).strip())
+                k.strip(): (None if pd.isna(v) else str(v).strip())
                 for k, v in record.items()
                 if k in self.schema and k not in columns_to_exclude
             }

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -286,17 +286,23 @@ class BaseIngestor(ABC):
                 columns_to_exclude.add(self.annotation_column)
             if self.unique_id_column:
                 columns_to_exclude.add(self.unique_id_column)
-            # Preserve missing-data semantics: any null-like value (Python
-            # None, float NaN, pd.NA, pd.NaT) becomes Python None so the DB
-            # binder writes SQL NULL. Previously this dict mapped None -> ""
-            # which (a) inserted empty-string into nullable VARCHAR/TEXT
-            # columns instead of NULL, and (b) silently coerced pandas'
-            # NaN/NaT/pd.NA into the literal string "nan"/"NaT"/"<NA>" via
-            # str(v). pd.isna handles all four uniformly and returns False
-            # for ordinary strings/numbers/bools so existing values aren't
-            # touched.
+            # Preserve missing-data semantics: any null-like value becomes
+            # Python None so the DB binder writes SQL NULL. Treats four
+            # representations uniformly:
+            #   - Python None         (explicit absence, JSON null)
+            #   - float NaN / pd.NaT  (from pd.read_csv / pd.to_datetime)
+            #   - pd.NA               (from pandas StringDtype after #172)
+            #   - literal "" string   (JSON empty string — JSONIngestor reads
+            #                         via json.load, not pd.read_json, so ""
+            #                         survives to here; CSVs never hit this
+            #                         case because keep_default_na=True turns
+            #                         "" into NaN at read time)
+            # Mirrors the missing-data convention in
+            # JSONIngestor._validate_record (#170): `value is None or
+            # value == ""`. pd.isna returns False for ordinary
+            # strings/numbers/bools so existing values aren't touched.
             cleaned_record = {
-                k.strip(): (None if pd.isna(v) else str(v).strip())
+                k.strip(): (None if pd.isna(v) or v == "" else str(v).strip())
                 for k, v in record.items()
                 if k in self.schema and k not in columns_to_exclude
             }

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -301,8 +301,18 @@ class BaseIngestor(ABC):
             # JSONIngestor._validate_record (#170): `value is None or
             # value == ""`. pd.isna returns False for ordinary
             # strings/numbers/bools so existing values aren't touched.
+            # Python bool must NOT be stringified — mysql-connector-python
+            # writes True/False directly as TINYINT 1/0, but `str(True)` is
+            # the four-character string "True", which MySQL rejects against
+            # a BOOL column with `Incorrect integer value: 'True' for column
+            # 'active' at row 1`. Pass bools through; stringify everything
+            # else as before (the rest of the pipeline expects strings).
             cleaned_record = {
-                k.strip(): (None if pd.isna(v) or v == "" else str(v).strip())
+                k.strip(): (
+                    None if pd.isna(v) or v == ""
+                    else v if isinstance(v, bool)
+                    else str(v).strip()
+                )
                 for k, v in record.items()
                 if k in self.schema and k not in columns_to_exclude
             }

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -141,6 +141,14 @@ class DataValidator(BaseValidator):
                     # null-tolerance fix (#170) lived behind an unreachable
                     # gate.
                     df = pd.read_json(path, orient="records").head(sample_size)
+                    # pd.read_json (unlike pd.read_csv with keep_default_na=True)
+                    # preserves "" as the literal empty string. Normalise to NaN
+                    # so per-type validators below treat "" identically to JSON
+                    # null — matches the JSONIngestor._validate_record convention
+                    # `if value is None or value == ""` (#170). Without this, an
+                    # INT column with `""` is reported as "non-numeric value"
+                    # even though JSONIngestor would have read it as missing.
+                    df = df.replace("", np.nan)
                     return df
                 else:
                     logger.warning(f"Unsupported file type: {path.suffix}, \n\n{path}")


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core record cleaning and pre-ingest validation on the MySQL insert path; behavior shifts for missing values and booleans but is covered by regression tests and fixes production ingestion failures.
> 
> **Overview**
> **Release 0.3.5** promotes develop fixes and aligns packaging: **`__version__` in `tracebloc_ingestor/__init__.py` is the only version literal**; `setup.py` parses it via `_read_version()` (guarded by `tests/test_version_single_source.py`). `RELEASING.md` now documents bumping `__init__.py` only.
> 
> **Ingestion correctness** fixes missing-value and type handling that broke real JSON/CSV cluster runs:
> 
> - **`BaseIngestor.process_record`** no longer maps null-like values to `""` or stringifies them as `"nan"` / `"True"`. `None`, pandas NA/NaN/NaT, and `""` become **SQL NULL**; **bools stay native** for MySQL `BOOL`; other fields still `str().strip()`.
> - **`DataValidator`** normalizes JSON-loaded `""` to NaN before numeric checks so pre-ingest validation matches **`JSONIngestor`** (`null` and `""` as missing).
> 
> Regression tests cover JSON empty strings in validation and null/bool/`""` cleaning in `process_record`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04b484e0a7dba81acc8cd01e3e2f1241fda04584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->