### PR TITLE
fix(base): Python bool must not be stringified in process_record

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -177,6 +177,33 @@ def test_process_record_preserves_real_values():
     assert rec["b"] == "42"
 
 
+def test_process_record_bool_not_stringified():
+    """Python True / False must NOT be stringified — they must reach the DB
+    binder as native bool so mysql-connector writes TINYINT 1/0.
+
+    Regression: the cleaning dict applied `str(v).strip()` to every
+    non-null value, turning True / False into the four-character strings
+    "True" / "False". MySQL rejects those against a BOOL column with
+    `Incorrect integer value: 'True' for column 'active' at row 1` —
+    16/20 rows of an end-to-end JSON ingest against v0.3.5-rc3 failed for
+    exactly this reason (the 4 rows with explicit `null` succeeded
+    because they round-tripped to SQL NULL per #176; the rest had
+    true/false). The bug was hidden until rc3 because earlier rc's
+    rejected JSON before any record reached the INSERT (#173 read path,
+    #176 validator widening).
+
+    Pass bools through unchanged; non-bool, non-null values still get
+    str()-and-strip semantics so existing INT/FLOAT/VARCHAR contracts
+    are unchanged.
+    """
+    ing = make_ingestor(schema={"a": "BOOL", "b": "BOOL", "n": "INT"}, category=None)
+    rec = ing.process_record({"a": True, "b": False, "n": 42, "filename": "f"})
+    assert rec["a"] is True, f"expected True, got {rec['a']!r}"
+    assert rec["b"] is False, f"expected False, got {rec['b']!r}"
+    # Non-bool unchanged from the prior contract.
+    assert rec["n"] == "42"
+
+
 def test_process_record_treats_empty_string_as_null():
     """Literal "" must become Python None (SQL NULL), matching the
     `value is None or value == ""` convention JSONIngestor._validate_record

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -301,8 +301,18 @@ class BaseIngestor(ABC):
             # JSONIngestor._validate_record (#170): `value is None or
             # value == ""`. pd.isna returns False for ordinary
             # strings/numbers/bools so existing values aren't touched.
+            # Python bool must NOT be stringified — mysql-connector-python
+            # writes True/False directly as TINYINT 1/0, but `str(True)` is
+            # the four-character string "True", which MySQL rejects against
+            # a BOOL column with `Incorrect integer value: 'True' for column
+            # 'active' at row 1`. Pass bools through; stringify everything
+            # else as before (the rest of the pipeline expects strings).
             cleaned_record = {
-                k.strip(): (None if pd.isna(v) or v == "" else str(v).strip())
+                k.strip(): (
+                    None if pd.isna(v) or v == ""
+                    else v if isinstance(v, bool)
+                    else str(v).strip()
+                )
                 for k, v in record.items()
                 if k in self.schema and k not in columns_to_exclude
             }


### PR DESCRIPTION
## Summary

Real end-to-end JSON ingestion against **v0.3.5-rc3** (which ships #170, #172, #173, #176) failed 16/20 records on a BOOL column:

\`\`\`
mysql.connector.errors.DatabaseError: 1366 (HY000):
  Incorrect integer value: 'True' for column 'active' at row 1
\`\`\`

[base.py:305](tracebloc_ingestor/ingestors/base.py#L305)'s cleaning dict applies \`str(v).strip()\` to every non-null value — turning Python \`True\` / \`False\` into the four-character strings \`\"True\"\` / \`\"False\"\`. MySQL TINYINT(1) (BOOL alias) rejects those string forms; it accepts native bool / 0 / 1.

## Why this only surfaces now

Earlier rcs rejected JSON **before** any record reached the INSERT:
- rc1: \`DataValidator._load_data\` returned None for .json (\"Unsupported file type\")
- rc2: validator flagged JSON \`\"\"\` as \"non-numeric\"
- rc3: validator path opens, write path opens — BOOL stringification suddenly visible

In rc3 specifically, the **4 rows that succeeded** all had \`active: null\`. #176's None path short-circuited the bool branch, so they round-tripped to SQL NULL correctly. The 16 failed rows had explicit \`true\` / \`false\` — those hit \`str(v).strip()\`.

## Fix

Pass \`bool\` through the cleaning expression unchanged; preserve \`str(v).strip()\` for every other non-null type so existing INT/FLOAT/VARCHAR contracts are unchanged. The \`isinstance(v, bool)\` check sits **before** any numeric fallback because \`bool\` is a subclass of \`int\` in Python — without the explicit branch a bool would fall straight into \`str()\`.

\`\`\`python
None if pd.isna(v) or v == \"\"
else v if isinstance(v, bool)
else str(v).strip()
\`\`\`

## Test plan

- [ ] New \`test_process_record_bool_not_stringified\`: True / False stay native bool (not \`\"True\"\` / \`\"False\"\`); INT 42 still becomes \`\"42\"\` (no contract change for non-bool).
- [ ] CI green.
- [ ] Re-run cluster ingestion against rc4: scenario A JSON lands all 20 rows; \`active\` column populates with TINYINT 0/1/NULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to record cleaning for bool fields only; other types keep existing stringify behavior and a regression test covers the contract.
> 
> **Overview**
> Fixes JSON ingestion failures on **BOOL** columns where `process_record` was turning Python `true`/`false` into the strings `"True"`/`"False"`, which MySQL rejects for TINYINT/BOOL (`Incorrect integer value: 'True'`).
> 
> In `BaseIngestor.process_record`, the schema cleaning step now **leaves native `bool` values unchanged** so mysql-connector can bind them as 0/1. **Null/empty handling and `str(v).strip()` for other types are unchanged** (e.g. INT `42` still becomes `"42"`). The `isinstance(v, bool)` branch is ordered before generic stringification because `bool` subclasses `int` in Python.
> 
> Adds **`test_process_record_bool_not_stringified`** to lock in native `True`/`False` and guard against regressions on non-bool columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a44d49336da346fad92999d1e723f4c4a4689c5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->