### PR TITLE
chore(release): bump version to 0.3.6

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -20,7 +20,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
## Summary

Bumps `__version__` `0.3.5` → `0.3.6` in `tracebloc_ingestor/__init__.py` — the single source of truth (#178). `setup.py` derives via `_read_version()` so no other file is touched.

## What's in 0.3.6 (since 0.3.5)

- **#176** — End-to-end NULL preservation: JSON `null` / JSON `""` / CSV empty cells now round-trip from source → validator → ingestor → MySQL as **SQL NULL**, not `""` or literal `"nan"` / `"NaT"` / `"<NA>"`. Closed the bugbot finding in `process_record` (treat `""` as null since `pd.isna("")` is False).
- **#178** — Single-sourced the package version: `__init__.py` is now the only place the literal lives; `setup.py` regex-parses it. Anti-drift contract guarded by `tests/test_version_single_source.py` (static-analysis, 3.12-safe — no `setuptools` subprocess).

## Verification

```
__version__                           = 0.3.6      ✓
python -m pytest tests/test_version_single_source.py  → 2 passed
```

## Acceptance

- [x] `__version__` bumped in `tracebloc_ingestor/__init__.py` (only file edited)
- [x] `setup.py` derives — no separate bump needed
- [x] `tests/test_version_single_source.py` green
- [ ] Companion `develop → master` sync PR will follow once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line SemVer bump in the established single-source version file; no runtime or packaging logic changes in the diff.
> 
> **Overview**
> **Release version bump** from `0.3.5` to `0.3.6` by updating the `__version__` literal in `tracebloc_ingestor/__init__.py` — the only file changed in this PR.
> 
> Packaging still reads that value through `setup.py`’s `_read_version()`, so no separate `setup.py` edit is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 540b68fb5c1729da93cff6b1a7891e009128319f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->