### PR TITLE
Develop to prod (v0.3.6)

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -20,7 +20,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
## Summary

Ships **v0.3.6** to prod. The bug fixes themselves (#176 null-preservation, #178 single-sourced version, #179 bool-not-stringified) already landed on master via the previous sync #177; this PR carries only the **`__version__` 0.3.5 → 0.3.6** bump (#180), which is what triggers the PyPI + image release.

## What ships in 0.3.6

- **#176 / bugbot fix** — JSON `null` / JSON `""` / CSV empty cells round-trip end-to-end as **SQL NULL** (was landing as `""` or literal `"nan"`/`"NaT"`/`"<NA>"`).
- **#178** — `__version__` single-sourced in `tracebloc_ingestor/__init__.py`; `setup.py` derives via `_read_version()`. Anti-drift guard test (`tests/test_version_single_source.py`) is now 3.12-safe (static analysis, no setuptools subprocess).
- **#179** — `process_record` no longer stringifies Python `bool` (so `True`/`False` reach MySQL as `1`/`0`, not `"True"`/`"False"`).

## Verification

- Local suite: **green** at HEAD of develop.
- `python -c "import tracebloc_ingestor; print(tracebloc_ingestor.__version__)"` → `0.3.6`.

## Release follow-up (post-merge)

- [ ] Tag `v0.3.6` on master once merged
- [ ] Confirm `Publish Master Package` workflow uploads to PyPI
- [ ] Confirm `release-image` workflow ships the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line version constant change with no behavioral code in the diff; release risk is limited to tagging and CI publish steps.
> 
> **Overview**
> Bumps the package release to **v0.3.6** by changing the single source of truth `__version__` in `tracebloc_ingestor/__init__.py` from `0.3.5` to `0.3.6`. `setup.py` already reads that literal via `_read_version()`, so PyPI/sdist metadata and `import tracebloc_ingestor` stay aligned without a second edit.
> 
> This PR does not change ingestor logic in the diff; it is the version tag that triggers the prod release pipeline for fixes already on the branch (NULL round-trip, bool handling, version single-sourcing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa127c735806a1c56a9d02cd9456a5f28138046b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->