### PR TITLE
Fix: fail fast on stale/mismatched existing table (unblocks re-ingest after schema change)

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -123,6 +123,59 @@ def test_create_table_existing_in_db_reflects(db):
     db.metadata.reflect.assert_called_once()
 
 
+def test_create_table_existing_matching_schema_reflects_ok(db):
+    """An existing table whose feature columns match the incoming schema is
+    reused without error — the normal re-ingest-same-dataset path. Only the
+    feature columns are compared; the standard framework columns (id, data_id,
+    …) are ignored."""
+    inspector = MagicMock()
+    inspector.get_table_names.return_value = ["panel"]
+
+    def fake_reflect(engine, only=None):
+        Table(
+            "panel", db.metadata,
+            Column("id", BigInteger, primary_key=True),
+            Column("data_id", String(255)),
+            Column("P01033_TIMP1", String(255)),
+            Column("P02452_COL1A1", String(255)),
+        )
+
+    db.metadata.reflect = MagicMock(side_effect=fake_reflect)
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        table = db.create_table(
+            "panel", {"P01033_TIMP1": "FLOAT", "P02452_COL1A1": "FLOAT"}
+        )
+    assert db.tables["panel"] is table
+
+
+def test_create_table_existing_schema_mismatch_fails_fast(db):
+    """A stale table whose feature columns don't match the incoming schema must
+    fail fast with an actionable error — instead of being silently reused and
+    then dying on every insert with SQLAlchemy's cryptic 'Unconsumed column
+    names'.
+
+    Regression (Henrik/LMU): a prior ingestion left `IBD_Biomarker` with the
+    original proteomics headers (`P02452|COL1A1`); the customer then renamed the
+    CSV headers to sanitized identifiers (`P02452_COL1A1`) to dodge an unrelated
+    SQL error. create_table reflected the stale table, ignored the new schema,
+    and all 207 records failed with 'Unconsumed column names'."""
+    inspector = MagicMock()
+    inspector.get_table_names.return_value = ["IBD_Biomarker"]
+
+    def fake_reflect(engine, only=None):
+        Table(
+            "IBD_Biomarker", db.metadata,
+            Column("id", BigInteger, primary_key=True),
+            Column("data_id", String(255)),
+            Column("P02452|COL1A1", String(255)),  # original header (stale table)
+        )
+
+    db.metadata.reflect = MagicMock(side_effect=fake_reflect)
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        with pytest.raises(ValueError, match="do not match|stale table"):
+            db.create_table("IBD_Biomarker", {"P02452_COL1A1": "FLOAT"})  # sanitized
+
+
 # ---------------------------------------------------------------------------
 # insert_batch
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -160,6 +160,45 @@ class Database:
             # Reflect existing table using MetaData
             self.metadata.reflect(self.engine, only=[table_name])
             table = self.metadata.tables[table_name]
+
+            # Fail fast if the existing table's feature columns don't match the
+            # incoming schema. Reflecting and silently reusing a mismatched table
+            # makes every record insert die downstream with SQLAlchemy's cryptic
+            # "Unconsumed column names: ..." — the record keys (built from the
+            # current schema) reference columns the reflected table doesn't have.
+            # This happens when a table is left over from an earlier ingestion:
+            # e.g. a prior run created the table and then failed before inserting,
+            # or the dataset's column names changed between pushes (a customer
+            # renaming proteomics headers like `P01033|TIMP1` -> `P01033_TIMP1`
+            # to work around an unrelated error is exactly this case). Surface an
+            # actionable error naming the drift instead.
+            _STANDARD_COLUMNS = {
+                "id", "created_at", "updated_at", "status", "label",
+                "data_intent", "data_id", "filename", "extension",
+                "annotation", "ingestor_id",
+            }
+            existing_features = {c.name for c in table.columns} - _STANDARD_COLUMNS
+            expected_features = set(schema) - _STANDARD_COLUMNS
+            if expected_features and existing_features != expected_features:
+                missing = sorted(expected_features - existing_features)
+                extra = sorted(existing_features - expected_features)
+
+                def _preview(cols):
+                    head = ", ".join(cols[:8])
+                    return f"{head}{'' if len(cols) <= 8 else f', … (+{len(cols) - 8} more)'}"
+
+                raise ValueError(
+                    f"Table '{table_name}' already exists with feature columns "
+                    f"that do not match the dataset schema. This usually means a "
+                    f"stale table from an earlier ingestion (one that failed "
+                    f"before inserting, or a dataset whose column names changed "
+                    f"between pushes). "
+                    f"In the schema but not the table: [{_preview(missing)}]. "
+                    f"In the table but not the schema: [{_preview(extra)}]. "
+                    f"Drop the existing '{table_name}' table, or ingest under a "
+                    f"new dataset name, and re-run."
+                )
+
             self.tables[table_name] = table
             return table
 


### PR DESCRIPTION
## Summary

`create_table` reflected any pre-existing table and reused it **verbatim, ignoring the incoming schema**. When the two diverge, every record insert then dies with SQLAlchemy's cryptic:

```
Unconsumed column names: P02751_1_FN1, P42702_LIFR, P02452_COL1A1, …
```

— the record keys (built from the *current* schema) reference columns the *reflected* table doesn't have.

## When it triggers

Whenever a table is left over from an earlier ingestion whose schema differs:
- a prior run created the table then failed **before** inserting, or
- a dataset's **column names changed** between pushes.

### Field case (the customer contact / a customer)

1. Run 1 used the original proteomics headers (`P02452|COL1A1`). `create_table` built `CUSTOMER_DATASET`; the insert then failed on an unrelated SQL-escaping bug (data-ingestors#184) — leaving the table behind with original-named columns and zero rows.
2. Run 2 used **sanitized** headers (`P02452_COL1A1`, the customer's workaround for that error). `create_table` saw the table existed, **reflected the stale original-named columns**, ignored the new schema — and all **207 records** failed with `Unconsumed column names`.

This is independent of #184: #184 stops run 1 from failing in the first place; this PR stops a *schema-mismatched leftover* from producing a cryptic, hard-to-diagnose failure.

## Fix

In the reflect path, compare the existing table's **feature** columns (the 11 standard framework columns — `id`, `data_id`, timestamps, `label`, … — excluded) against the incoming schema. If they diverge, raise a clear, actionable `ValueError` naming the drift:

```
Table 'CUSTOMER_DATASET' already exists with feature columns that do not match the
dataset schema. This usually means a stale table from an earlier ingestion …
In the schema but not the table: [P02452_COL1A1]. In the table but not the
schema: [P02452|COL1A1]. Drop the existing 'CUSTOMER_DATASET' table, or ingest
under a new dataset name, and re-run.
```

An empty schema skips the check, preserving the existing reflect-and-reuse path (`test_create_table_existing_in_db_reflects` still passes).

## Test plan

- `pytest tests/test_database.py` → **28 passed** (26 + 2 new):
  - `test_create_table_existing_matching_schema_reflects_ok` — matching feature columns reuse the table without error (normal re-ingest).
  - `test_create_table_existing_schema_mismatch_fails_fast` — the the customer contact mismatch (`P02452|COL1A1` table vs `P02452_COL1A1` schema) raises the actionable error.

## Operational note

To unblock the existing `CUSTOMER_DATASET` ingestion immediately (before this ships), **drop the stale table** so it is recreated from the current schema:

```sql
DROP TABLE IF EXISTS CUSTOMER_DATASET;
```

then re-run the ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
