### PR TITLE
fix: fail loud when backend dataset registration fails (no silent half-ingest)

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -298,6 +298,29 @@ def test_ingest_happy_path():
     ing.api_client.create_dataset.assert_called_once()
 
 
+@pytest.mark.parametrize("failing_step", [
+    "send_generate_edge_label_meta",
+    "send_global_meta_meta",
+    "prepare_dataset",
+])
+def test_ingest_fails_loud_when_backend_registration_step_fails(failing_step):
+    # REGRESSION GUARD: a False return from ANY backend registration step leaves
+    # the dataset half-created — rows are committed to MySQL but the dataset is
+    # not registered. The old nested-if cascade silently skipped the remaining
+    # steps (including create_dataset) and the run STILL returned cleanly (exit
+    # 0), so the user saw a "success" over an unregistered dataset. Each step
+    # must now RAISE so the run exits non-zero and the failure is visible.
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=None)
+    getattr(ing.api_client, failing_step).return_value = False
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError, match="NOT registered"):
+            ing.ingest("src", batch_size=10)
+    # The chain must stop — create_dataset is never reached on a failed step.
+    ing.api_client.create_dataset.assert_not_called()
+
+
 def test_ingest_skips_records_that_fail_processing():
     # invalid intent -> process_record returns None -> counted as skipped
     records = [{"a": "1", "filename": "f1"}]

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -20,7 +20,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.6"
+__version__ = "0.3.7"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -145,7 +145,16 @@ def main(argv: List[str] | None = None) -> int:  # pragma: no cover - thin shell
     ingestor = _build_ingestor(database, api_client, resolved)
 
     with ingestor:
-        failed = ingestor.ingest(resolved.source_path, batch_size=config.BATCH_SIZE)
+        try:
+            failed = ingestor.ingest(resolved.source_path, batch_size=config.BATCH_SIZE)
+        except Exception as exc:
+            # A hard failure during ingestion — validation, DB write, or backend
+            # dataset registration. base.py has already logged the detail; turn
+            # the exception into a clean, single-line non-zero exit rather than a
+            # raw traceback, so the CLI's live log stream shows an actionable
+            # reason and marks the Job failed.
+            print(f"\nIngestion failed: {exc}", file=sys.stderr)
+            return 1
         if failed:
             logger.warning(
                 "%d record(s) failed during ingestion; see logs for details.",

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -581,35 +581,56 @@ class BaseIngestor(ABC):
                 session.commit()
                 pbar.close()
 
-                # Send edge label metadata
-                if self.api_client.send_generate_edge_label_meta(
+                # Register the dataset with the backend. Every step here is
+                # REQUIRED: the rows are already committed to MySQL above, so if
+                # any step fails the dataset is half-created — rows present but
+                # not registered. The previous code nested these as
+                # `if A: if B: if C: create()`, so a False return at ANY step
+                # silently skipped the rest (including create_dataset AND the
+                # summary) and the run STILL exited 0 — leaving committed rows
+                # with no registered dataset and no error the user could see.
+                # Fail loudly instead: raise so the process exits non-zero and
+                # the failure surfaces (the CLI streams these logs live and marks
+                # the Job failed). The api_client has already logged the
+                # underlying HTTP detail before returning False.
+                if not self.api_client.send_generate_edge_label_meta(
                     self.table_name, self.ingestor_id, self.intent
                 ):
+                    raise RuntimeError(
+                        "Backend rejected edge-label metadata; the dataset was "
+                        "NOT registered (its rows are already in the database). "
+                        "See the logged API error above."
+                    )
 
-                    # schema dict
-                    schema_dict = self.database.get_table_schema(self.table_name)
-                    add_info = self.file_options
-                    # Send global metadata
-                    if self.api_client.send_global_meta_meta(
-                        self.table_name, schema_dict, add_info
-                    ):
+                schema_dict = self.database.get_table_schema(self.table_name)
+                if not self.api_client.send_global_meta_meta(
+                    self.table_name, schema_dict, self.file_options
+                ):
+                    raise RuntimeError(
+                        "Backend rejected the dataset schema/metadata; the "
+                        "dataset was NOT registered (its rows are already in the "
+                        "database). See the logged API error above."
+                    )
 
-                        # Prepare dataset
-                        if self.api_client.prepare_dataset(
-                            self.category,
-                            self.ingestor_id,
-                            self.data_format,
-                            self.intent,
-                        ):
+                if not self.api_client.prepare_dataset(
+                    self.category,
+                    self.ingestor_id,
+                    self.data_format,
+                    self.intent,
+                ):
+                    raise RuntimeError(
+                        "Backend failed to prepare the dataset; it was NOT "
+                        "registered (its rows are already in the database). See "
+                        "the logged API error above."
+                    )
 
-                            self.api_client.create_dataset(
-                                category=self.category, ingestor_id=self.ingestor_id
-                            )
+                self.api_client.create_dataset(
+                    category=self.category, ingestor_id=self.ingestor_id
+                )
 
-                            # Create and log summary
-                            summary = IngestionSummary(**stats)
-
-                            self._log_summary(summary)
+                # Create and log summary — only after successful registration.
+                summary = IngestionSummary(**stats)
+                self._log_summary(summary)
 
             except Exception as e:
                 session.rollback()


### PR DESCRIPTION
## Summary

The quick-win half of backend#772 (P0: "metadata callback swallows failure").

After all rows are committed to MySQL, `ingest()` registers the dataset with the backend:

```
send_generate_edge_label_meta → send_global_meta_meta → prepare_dataset → create_dataset
```

These were nested as `if A: if B: if C: create()`, so a `False` return at **any** step silently skipped the rest — including `create_dataset` **and** the summary — and the run **still exited 0**. The rows were in the database but the dataset was never registered, no summary printed, and the process reported success. **A failed backend registration was invisible to the user.**

## Fix

- **`base.py`**: each registration step is now required — a `False` return raises a clear `RuntimeError` (e.g. *"Backend rejected the dataset schema/metadata; the dataset was NOT registered (its rows are already in the database). See the logged API error above."*). The process then exits non-zero, and since the CLI streams the ingester's logs live and watches the Job, the user **sees the failure** instead of a phantom success.
- **`cli/run.py`**: wraps the `ingest()` call so any ingestion exception becomes a clean single-line stderr message + non-zero exit, not a raw traceback.

## Why this matters

`dataset push` already streams the ingester pod logs to the user's terminal and exits 9 on Job failure — but only if the ingester actually *fails*. This was the one path where a real failure looked like success. Now it doesn't.

## Test plan

- New parametrized regression (`test_ingest_fails_loud_when_backend_registration_step_fails`) over all three gates: each `False` now raises `RuntimeError` and `create_dataset` is never reached.
- Full suite: **698 passed**, no regressions.

## Scope

This closes the *silent-exit* P0 in #772. The remaining #772 items — a **durable backend ingestion status** (so non-live viewers also see failures), atomicity, and retry idempotency — are separate follow-ups; the durable-status round-trip is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
