### PR TITLE
Develop to prod 0.3.7

### DIFF
--- a/tests/test_adversarial_ingestion_harness.py
+++ b/tests/test_adversarial_ingestion_harness.py
@@ -1,0 +1,568 @@
+"""Adversarial ingestion harness — Murphy's-law coverage for raw user data.
+
+WHY THIS FILE EXISTS
+--------------------
+Users dump *raw, un-preprocessed* data: Excel exports, instrument dumps, hand-
+built CSVs, proteomics matrices with ``UniProt|gene`` headers, clinical tables
+with ``yes/no`` booleans and European dates. Everything that can go wrong, will.
+Four customer-blocking ingestion bugs in a row on one real dataset proved the
+point. This harness throws the full zoo of raw-data pathologies at the *real*
+ingest code and pins the behaviour.
+
+THE CONTRACT EACH TEST ENFORCES
+-------------------------------
+For any input, the ingestor must do exactly one of:
+  1. INGEST IT CORRECTLY (the value that lands in the DB is faithful), or
+  2. FAIL WITH A CLEAR, ACTIONABLE ERROR naming what's wrong.
+
+It must NEVER:
+  - crash with a cryptic/non-actionable error,
+  - SILENTLY CORRUPT a value (store something subtly wrong), or
+  - SILENTLY DROP rows/columns while reporting success.
+
+HOW TO READ THE RESULTS
+-----------------------
+- A PASSING test = the pipeline already honours the contract for that input.
+- An ``xfail`` test = a KNOWN GAP: the pipeline violates the contract today.
+  The test asserts the *correct* behaviour, so it currently fails and is marked
+  expected-fail (``strict=True``). When the gap is fixed, the test starts
+  PASSING, ``strict`` turns that into a SUITE FAILURE, and whoever fixed it is
+  forced to delete the marker. That makes the iceberg of gaps an explicit,
+  self-updating checklist instead of tribal knowledge.
+
+Every ``xfail`` reason names the failure mode and (where known) the tracking
+PR/issue. Run ``pytest tests/test_adversarial_ingestion_harness.py -v`` to see
+the full checklist; ``-rxX`` also prints the xfail reasons.
+
+Layers exercised (no live MySQL — engine/DB mocked at the boundary):
+  - CSV read + type-cast:  CSVIngestor.read_data -> process_record
+  - schema validation:     DataValidator.validate
+  - DDL / identifiers:      Database.create_table (+ compiled MySQL DDL)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from sqlalchemy import BigInteger, Column, MetaData, String, Table
+from sqlalchemy.dialects import mysql
+from sqlalchemy.schema import CreateTable
+
+from tracebloc_ingestor import database as db_mod
+from tracebloc_ingestor.database import Database
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+from tracebloc_ingestor.validators.data_validator import DataValidator
+
+TAB = TaskCategory.TABULAR_CLASSIFICATION
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ingestor(schema, **opts):
+    return CSVIngestor(
+        database=MagicMock(),
+        api_client=MagicMock(),
+        table_name="t",
+        schema=schema,
+        category=opts.pop("category", TAB),
+        intent=opts.pop("intent", "train"),
+        **opts,
+    )
+
+
+def _ingest(schema, payload, *, tmp_path=None, name="d.csv", **opts):
+    """Run the real cast path end to end and return the cleaned feature dicts.
+
+    payload: str or bytes written verbatim as the CSV file (so we can inject
+             BOMs, CRLFs, latin-1 bytes, ragged rows — genuinely raw files).
+    Returns a list of dicts containing only the schema (feature) columns, with
+    the exact values process_record would hand to the SQL binder. Exceptions
+    propagate (a test asserts on them).
+    """
+    base = tmp_path if tmp_path is not None else Path(__import__("tempfile").mkdtemp())
+    p = Path(base) / name
+    p.write_bytes(payload.encode("utf-8") if isinstance(payload, str) else payload)
+    ing = _ingestor(schema, **opts)
+    raw = list(ing.read_data(str(p)))
+    cleaned = [ing.process_record(r) for r in raw]
+    return [{k: c[k] for k in schema if c and k in c} for c in cleaned]
+
+
+def _real_db():
+    """A Database with metadata + a mock engine, no live MySQL. Drives the real
+    create_table / DDL-compilation logic (the reserved/length/reflect guards run
+    before any I/O)."""
+    db = Database.__new__(Database)
+    db.metadata = MetaData()
+    db.tables = {}
+    db.engine = MagicMock(name="engine")
+    db.metadata.create_all = MagicMock()
+    return db
+
+
+def _create_table(db, name, schema, existing_columns=None):
+    """Invoke real Database.create_table with inspect() mocked. If
+    existing_columns is given, simulate a pre-existing reflected table with
+    those feature columns."""
+    insp = MagicMock()
+    insp.get_table_names.return_value = [name] if existing_columns is not None else []
+    if existing_columns is not None:
+        def fake_reflect(engine, only=None):
+            cols = [Column("id", BigInteger, primary_key=True), Column("data_id", String(255))]
+            cols += [Column(c, String(255)) for c in existing_columns]
+            Table(name, db.metadata, *cols)
+        db.metadata.reflect = MagicMock(side_effect=fake_reflect)
+    with patch.object(db_mod, "inspect", return_value=insp):
+        return db.create_table(name, schema)
+
+
+def _ddl(table) -> str:
+    return str(CreateTable(table).compile(dialect=mysql.dialect()))
+
+
+# ===========================================================================
+# Section A — Encoding & byte-level integrity
+# ===========================================================================
+
+def test_utf8_clean_round_trips():
+    rows = _ingest({"city": "VARCHAR(40)"}, "city\nMünchen\nZürich\n")
+    assert [r["city"] for r in rows] == ["München", "Zürich"]
+
+
+def test_latin1_read_as_utf8_errors_not_silently():
+    """A latin-1 file read as UTF-8 must surface an error, not silently mojibake.
+    (The friendly preflight message lives in validate_data; at the read layer a
+    decode error is acceptable — what matters is it is NOT silent.)"""
+    payload = "city\nM\xfcnchen\n".encode("latin-1")  # 0xFC is invalid UTF-8
+    with pytest.raises(Exception):
+        _ingest({"city": "VARCHAR(40)"}, payload)
+
+
+def test_utf8_bom_header_not_mangled():
+    """A UTF-8 BOM on the first header must be stripped so the first column name
+    still matches the schema — otherwise the first column silently vanishes."""
+    payload = b"\xef\xbb\xbfid,city\n1,Berlin\n"
+    rows = _ingest({"id": "INT", "city": "VARCHAR(40)"}, payload)
+    assert rows and rows[0].get("id") is not None and rows[0].get("city") == "Berlin"
+
+
+def test_crlf_line_endings_no_trailing_cr():
+    rows = _ingest({"city": "VARCHAR(40)"}, "city\r\nBerlin\r\nParis\r\n")
+    assert [r["city"] for r in rows] == ["Berlin", "Paris"]
+
+
+# ===========================================================================
+# Section B — CSV structural integrity
+# ===========================================================================
+
+def test_quoted_embedded_comma_preserved():
+    rows = _ingest({"name": "VARCHAR(40)", "n": "INT"}, 'name,n\n"Smith, John",2\n')
+    assert rows[0]["name"] == "Smith, John"
+
+
+def test_wrong_delimiter_is_not_silent():
+    """A semicolon-separated file ingested without sep=';' must NOT silently
+    succeed as one garbage column — it should error (schema columns absent)."""
+    with pytest.raises(Exception):
+        _ingest({"a": "INT", "b": "INT"}, "a;b\n1;2\n3;4\n")
+
+
+def test_semicolon_delimiter_with_option_works():
+    rows = _ingest({"a": "INT", "b": "INT"}, "a;b\n1;2\n", csv_options={"sep": ";"})
+    assert rows[0]["a"] == "1" and rows[0]["b"] == "2"
+
+
+def test_ragged_row_is_a_hard_error_not_silent_drop():
+    # REGRESSION GUARD (fixed): a ragged row (wrong field count) used to be
+    # silently dropped (on_bad_lines='warn'), shrinking the dataset with no
+    # signal and a still-green success. read_data now uses on_bad_lines='error',
+    # so a malformed row fails loudly (naming the line) instead of vanishing.
+    with pytest.raises(Exception):
+        _ingest({"a": "INT", "b": "INT"}, "a,b\n1,2\n3,4,5\n6,7\n")
+
+
+def test_duplicate_headers_rejected():
+    # REGRESSION GUARD (fixed): duplicate header names used to be silently
+    # de-duplicated by pandas (x -> x.1) and the second column dropped. read_data
+    # now rejects them with a clear error before parsing.
+    with pytest.raises(Exception):
+        _ingest({"x": "INT"}, "x,x\n1,2\n")
+
+
+def test_wide_file_column_count_guarded():
+    # REGRESSION GUARD (fixed): create_table now fails fast above ~4000 columns
+    # (MySQL's hard limit is 4096) with an actionable message, instead of a raw
+    # MySQL 1117/1118 deep inside CREATE TABLE.
+    db = _real_db()
+    schema = {"f%d" % i: "FLOAT" for i in range(5000)}
+    with pytest.raises(ValueError, match="column"):
+        _create_table(db, "wide", schema)
+
+
+# ===========================================================================
+# Section C — Type casting (the soft underbelly)
+# ===========================================================================
+
+def test_bool_true_false_not_stringified():
+    # REGRESSION GUARD (fixed): a CSV BOOL column comes back from pandas as
+    # numpy.bool_; process_record now recognises it via pd.api.types.is_bool and
+    # emits a Python bool, so MySQL writes TINYINT 1/0 instead of rejecting the
+    # string 'True'. (base.py process_record.)
+    rows = _ingest({"flag": "BOOL"}, "flag\nTrue\nFalse\n")
+    assert rows[0]["flag"] in (True, False, 1, 0)
+    assert rows[0]["flag"] != "True"
+
+
+def test_string_booleans_ingest_cleanly():
+    # REGRESSION GUARD (fixed): string booleans (yes/no/true/false/t/f/y/n/1/0)
+    # that DataValidator accepts used to crash astype('boolean') ('Need to pass
+    # bool-like values'). The BOOL branch now maps the accepted forms to a
+    # nullable boolean, so validator and ingestor agree. (csv_ingestor._validate_csv.)
+    rows = _ingest({"flag": "BOOL"}, "flag\nyes\nno\n")
+    assert rows[0]["flag"] in (True, 1) and rows[1]["flag"] in (False, 0)
+
+
+def test_int_plain_large_value_clean():
+    rows = _ingest({"n": "INT"}, "n\n1000000000\n")
+    assert rows[0]["n"] == "1000000000"
+
+
+def test_int_scientific_notation_clean():
+    # Pins behaviour: a lone scientific-notation int coerces to the integer
+    # value, NOT '1000000000.0'. Guards against a float-stringify regression.
+    rows = _ingest({"n": "INT"}, "n\n1e9\n")
+    assert rows[0]["n"] == "1000000000"
+
+
+def test_varchar_leading_zero_codes_preserved():
+    # REGRESSION GUARD (fixed): leading-zero codes used to be lost even for
+    # VARCHAR columns because pandas inferred the all-digit column as int at read
+    # (dtype=None) before the VARCHAR cast. read_data now pins string-family
+    # schema columns to dtype=str, so zip/accession/gene codes survive verbatim.
+    rows = _ingest({"code": "VARCHAR(10)"}, "code\n007\n0012\n")
+    assert [r["code"] for r in rows] == ["007", "0012"]
+
+
+@pytest.mark.xfail(strict=True, reason=(
+    "Same root cause as the VARCHAR case: a code column typed INT loses leading "
+    "zeros (007 -> '7') because pandas infers int at read. A raw dumper who types "
+    "a zip/accession/gene code as INT silently corrupts it."
+))
+def test_int_typed_codes_keep_zeros():
+    rows = _ingest({"code": "INT"}, "code\n007\n0012\n")
+    assert [r["code"] for r in rows] == ["007", "0012"]
+
+
+def test_float_precision_preserved():
+    # REGRESSION GUARD (fixed): FLOAT used to be downcast to float32, so 3.14
+    # stringified as '3.140000104904175'. The numeric branch now keeps float64.
+    rows = _ingest({"x": "FLOAT"}, "x\n3.14\n")
+    assert rows[0]["x"] in ("3.14", 3.14)
+
+
+def test_date_no_spurious_time_component():
+    # REGRESSION GUARD (fixed): a DATE used to gain '... 00:00:00'. The DATE
+    # branch now emits a plain date (.dt.date).
+    rows = _ingest({"d": "DATE"}, "d\n2026-01-02\n")
+    assert rows[0]["d"] == "2026-01-02"
+
+
+def test_time_no_spurious_date_component():
+    # REGRESSION GUARD (fixed): a TIME used to gain today's date. The TIME branch
+    # now emits a plain time (.dt.time).
+    rows = _ingest({"t": "TIME"}, "t\n14:30:00\n")
+    assert rows[0]["t"] == "14:30:00"
+
+
+def test_double_column_rejects_non_numeric():
+    # REGRESSION GUARD (fixed): DOUBLE/DECIMAL had no _validate_csv branch, so
+    # junk flowed straight to the DB. The numeric branch now covers them and
+    # raises a clear per-column error on non-numeric input.
+    with pytest.raises(Exception):
+        _ingest({"x": "DOUBLE"}, "x\nabc\n")
+
+
+def test_decimal_column_supported_and_coerced():
+    # REGRESSION GUARD (new): DECIMAL/NUMERIC are now first-class — mapped to
+    # SQLAlchemy Numeric in create_table (previously create_table rejected them
+    # with "Unsupported MySQL type") and coerced/validated like other numerics.
+    db = _real_db()
+    table = _create_table(db, "t", {"conc": "DECIMAL(10,2)"})
+    assert "conc" in {c.name for c in table.columns}
+    rows = _ingest({"conc": "DECIMAL(10,2)"}, "conc\n3.14\n")
+    assert rows[0]["conc"] in ("3.14", 3.14)
+
+
+# ===========================================================================
+# Section D — Missing-data semantics (a hardened strength — pin it)
+# ===========================================================================
+
+@pytest.mark.parametrize("token", ["", "NA", "NULL", "None"])
+def test_tabular_na_tokens_become_none(token):
+    rows = _ingest({"name": "VARCHAR(20)", "n": "INT"}, "name,n\n%s,5\n" % token)
+    assert rows[0]["name"] is None
+    assert rows[0]["n"] == "5"
+
+
+def test_missing_int_cell_becomes_none():
+    # A blank cell in an INT column round-trips to SQL NULL — a hardened strength.
+    rows = _ingest({"a": "VARCHAR(5)", "n": "INT"}, "a,n\nx,\ny,7\n")
+    assert rows[0]["n"] is None
+
+
+def test_int_column_missing_cell_does_not_float_promote():
+    # REGRESSION GUARD (fixed): a single blank cell used to promote the whole INT
+    # column to float64, so 7 round-tripped as '7.0'. The INT branch now casts to
+    # nullable Int64, so present integers stay integral and missing -> SQL NULL.
+    rows = _ingest({"a": "VARCHAR(5)", "n": "INT"}, "a,n\nx,\ny,7\n")
+    assert rows[1]["n"] == "7"
+
+
+# ===========================================================================
+# Section E — Identifiers & DDL (DB-layer guards)
+# ===========================================================================
+
+def test_special_char_header_backtick_quoted_in_ddl():
+    # Proteomics UniProt|gene headers must be backtick-quoted in CREATE TABLE.
+    db = _real_db()
+    table = _create_table(db, "panel", {"P08254|MMP3": "FLOAT", "sample_id": "VARCHAR(20)"})
+    ddl = _ddl(table)
+    assert "`P08254|MMP3`" in ddl
+
+
+def test_reserved_column_collision_clear_error():
+    db = _real_db()
+    with pytest.raises(ValueError, match="reserved"):
+        _create_table(db, "t", {"id": "INT", "feature_0": "FLOAT"})
+
+
+def test_overlong_column_name_clear_error():
+    db = _real_db()
+    long_name = "Protein_" + "X" * 70
+    with pytest.raises(ValueError, match="64-character"):
+        _create_table(db, "t", {long_name: "FLOAT", "f0": "FLOAT"})
+
+
+def test_stale_table_schema_mismatch_clear_error():
+    # Was xfail pending #185; #185 merged and the fail-fast guard now raises
+    # a clear ValueError instead of silently reflecting + dying at insert time.
+    db = _real_db()
+    with pytest.raises(ValueError, match="match the dataset schema|stale"):
+        _create_table(db, "IBD", {"P02452_COL1A1": "FLOAT"},
+                      existing_columns=["P02452|COL1A1"])
+
+
+# ===========================================================================
+# Section F — Schema validation (DataValidator)
+# ===========================================================================
+
+def test_validator_flags_non_numeric_in_int():
+    res = DataValidator(schema={"n": "INT"}).validate(pd.DataFrame({"n": ["1", "abc"]}))
+    assert not res.is_valid and "non-numeric" in res.errors[0]
+
+
+def test_validator_tolerates_nulls_in_typed_column():
+    res = DataValidator(schema={"x": "FLOAT"}).validate(pd.DataFrame({"x": [1.5, None, 2.0]}))
+    assert res.is_valid
+
+
+def test_validator_rejects_infinity():
+    res = DataValidator(schema={"x": "FLOAT"}).validate(pd.DataFrame({"x": [1.0, float("inf")]}))
+    assert not res.is_valid
+
+
+def test_validator_scans_beyond_first_1000_rows():
+    # REGRESSION GUARD (fixed): DataValidator used to sample only the first 1000
+    # rows, so a bad value past row 1000 passed validation and then corrupted or
+    # crashed the ingest. It now scans the whole column (default sample_size=None).
+    good = ["1"] * 1500
+    good[1200] = "not-an-int"  # poison well past the old 1000-row window
+    res = DataValidator(schema={"n": "INT"}).validate(pd.DataFrame({"n": good}))
+    assert not res.is_valid
+
+
+# ===========================================================================
+# Section G — extended battery: special characters & size (the long tail)
+# Each case was probed empirically against the current pipeline before being
+# pinned here. "Anything that could go wrong" — headers, values, SQL safety,
+# overflow, line endings.
+# ===========================================================================
+
+# --- Special characters in HEADERS (read/cast layer) -----------------------
+
+@pytest.mark.parametrize("header", [
+    "gene name",        # space
+    "conc (mg/L)",      # parentheses + slash
+    "feature.1",        # dot
+    "温度",             # non-latin unicode
+    "col_🔥",           # emoji
+    "select",           # SQL reserved word
+])
+def test_special_char_header_ingests(header):
+    rows = _ingest({header: "INT"}, "%s\n5\n" % header)
+    assert rows[0][header] == "5"
+
+
+# --- SQL safety of headers at the DDL layer (the injection-adjacent worry) --
+
+def test_header_with_backtick_is_escaped_in_ddl():
+    # A backtick in a header must be doubled (MySQL identifier escaping) so it
+    # cannot break out of the quoted identifier.
+    db = _real_db()
+    table = _create_table(db, "t", {"a`b": "FLOAT"})
+    assert "`a``b`" in _ddl(table)
+
+
+def test_sql_injection_header_is_neutralised_in_ddl():
+    # A crafted "injection" header is emitted as ONE backtick-quoted identifier
+    # (backtick doubled); the trailing SQL is inert inside it, never an
+    # executable statement. A CSV header therefore cannot inject SQL at CREATE
+    # TABLE. Locks SQLAlchemy's quoting against a future hand-rolled DDL path
+    # that might string-interpolate the name.
+    db = _real_db()
+    evil = "x`; DROP TABLE y; --"
+    ddl = _ddl(_create_table(db, "t", {evil: "FLOAT"}))
+    assert "`x``; DROP TABLE y; --`" in ddl
+
+
+def _capture_upsert_sql(table_name, schema, record):
+    """Drive the real insert_batch with a capturing connection; return the
+    compiled ON DUPLICATE KEY UPDATE statement (MySQL dialect)."""
+    db = _real_db()
+    _create_table(db, table_name, schema)
+    sqls = []
+    conn = MagicMock()
+
+    def _exec(stmt, *a, **k):
+        try:
+            sqls.append(str(stmt.compile(dialect=mysql.dialect())))
+        except Exception:
+            sqls.append("")
+        res = MagicMock()
+        res.fetchall.return_value = []
+        res.fetchone.return_value = None
+        return res
+
+    conn.execute.side_effect = _exec
+    db.engine.connect.return_value.__enter__.return_value = conn
+    db.insert_batch(table_name, [record])
+    return next((s for s in sqls if "DUPLICATE" in s.upper()), "")
+
+
+def test_upsert_quotes_special_char_column():
+    # Was xfail pending #184; #184 merged with text(f"VALUES(`{col}`)") so the
+    # column name is now backtick-quoted in the upsert RHS — special-character
+    # proteomics headers (P08254|MMP3) compile to valid SQL.
+    sql = _capture_upsert_sql(
+        "t", {"P08254|MMP3": "FLOAT"}, {"data_id": "x", "P08254|MMP3": 1.0}
+    )
+    assert "VALUES(`P08254|MMP3`)" in sql
+
+
+# --- Special characters in VALUES (preserved via parameterised binding) ----
+
+@pytest.mark.parametrize("value,payload", [
+    ('He said "hi"', 's\n"He said ""hi"""\n'),   # escaped embedded quotes
+    ("C:\\new",      "s\nC:\\new\n"),             # backslash (Windows path)
+    ("line1\nline2", 's\n"line1\nline2"\n'),      # embedded newline in a quoted field
+    ("a;b;c",        "s\na;b;c\n"),               # semicolons (not the delimiter)
+    ("🔥hot",        "s\n🔥hot\n"),               # emoji
+])
+def test_special_char_value_preserved(value, payload):
+    rows = _ingest({"s": "VARCHAR(40)"}, payload)
+    assert rows[0]["s"] == value
+
+
+# --- Size / overflow -------------------------------------------------------
+
+def test_bigint_overflow_is_clear_error():
+    # A value beyond Int64 range must fail clearly, not wrap or corrupt.
+    with pytest.raises(Exception):
+        _ingest({"n": "BIGINT"}, "n\n99999999999999999999\n")
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Silent-corruption gap: 1e400 overflows IEEE float and becomes +inf "
+        "in pd.to_numeric. CSVIngestor._validate_csv does not surface this — "
+        "+inf lands in the FLOAT column as if it were a legitimate value. "
+        "DataValidator already rejects inf (non-finite check) but CSVIngestor's "
+        "cast path is what _ingest() exercises here. Remove this marker when "
+        "csv_ingestor surfaces the overflow with a clear per-column error."
+    ),
+)
+def test_float_overflow_is_clear_error():
+    with pytest.raises(Exception):
+        _ingest({"x": "FLOAT"}, "x\n1e400\n")
+
+
+def test_value_exceeding_varchar_length_rejected():
+    # A cell longer than the declared VARCHAR(n) is caught by DataValidator (now
+    # a full-column scan) with an actionable "exceeding max length" error, rather
+    # than silently truncating at MySQL write time.
+    res = DataValidator(schema={"s": "VARCHAR(10)"}).validate(
+        pd.DataFrame({"s": ["x" * 5000]})
+    )
+    assert not res.is_valid and "max length" in res.errors[0]
+
+
+def test_mixed_type_column_is_clear_error():
+    # A non-numeric mixed into an INT column fails with a clear per-column error,
+    # not a silent coerce or a cryptic crash.
+    with pytest.raises(Exception):
+        _ingest({"n": "INT"}, "n\n1\n2\nabc\n4\n")
+
+
+# --- Structure: line endings -----------------------------------------------
+
+def test_cr_only_line_endings_parse():
+    # Classic-Mac CR-only line endings must parse, not collapse to a single row.
+    rows = _ingest({"a": "INT", "b": "INT"}, "a,b\r1,2\r3,4\r")
+    assert len(rows) == 2 and rows[1]["a"] == "3"
+
+
+# ===========================================================================
+# Section H — column headers (hardening)
+# ===========================================================================
+
+def test_header_whitespace_collision_rejected():
+    # Two headers differing only by whitespace (" age" and "age") both strip to
+    # "age" -> a post-strip duplicate. Must be rejected, not silently merged
+    # into one ambiguous column.
+    with pytest.raises(Exception):
+        _ingest({"age": "INT"}, "age, age\n1,2\n")
+
+
+def test_case_mismatched_header_is_clear_error():
+    # Schema "age" vs CSV "Age": a clear "schema column not present" error, not a
+    # silent skip (header matching is case-sensitive).
+    with pytest.raises(Exception):
+        _ingest({"age": "INT"}, "Age\n5\n")
+
+
+def test_empty_and_whitespace_only_headers_ignored():
+    # Empty ("a,,c") or whitespace-only header columns aren't in the schema, so
+    # they're simply not ingested — the declared columns still come through.
+    rows = _ingest({"a": "INT", "c": "INT"}, "a,,c\n1,2,3\n")
+    assert rows[0] == {"a": "1", "c": "3"}
+
+
+def test_extra_csv_column_excluded_by_schema():
+    # The schema is the contract for what gets ingested: a CSV column not in the
+    # schema is read but excluded from the record. (A typo'd schema KEY fails
+    # loudly via "schema column not present", so this exclusion can't silently
+    # swallow a column the user actually declared.)
+    ing = _ingestor({"a": "INT"})
+    p = Path(__import__("tempfile").mkdtemp()) / "d.csv"
+    p.write_bytes(b"a,extra\n1,99\n")
+    raw = list(ing.read_data(str(p)))
+    cleaned = ing.process_record(raw[0])
+    assert "extra" in raw[0] and "extra" not in cleaned
+    assert cleaned.get("a") == "1"

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -50,6 +50,20 @@ def test_read_data_strips_column_whitespace(tmp_path):
     assert "a" in records[0] and "b" in records[0]
 
 
+def test_read_data_preserves_leading_zeros_with_whitespace_header(tmp_path):
+    # Regression (#190 bugbot): the dtype=str pin keyed by clean schema column
+    # names is applied by pandas against the RAW header literals — before
+    # `chunk.columns.str.strip()`. A header " code " missed the pin, pandas
+    # inferred int from "007" -> 7, and the leading zeros were silently lost.
+    # The fix probes the raw header and pins both the spaced and clean spellings.
+    p = tmp_path / "d.csv"
+    p.write_text(" code ,n\n007,1\n042,2\n")
+    ing = make_csv_ingestor(schema={"code": "VARCHAR(10)", "n": "INT"})
+    records = list(ing.read_data(str(p)))
+    assert records[0]["code"] == "007", f"leading zeros lost; got {records[0]['code']!r}"
+    assert records[1]["code"] == "042"
+
+
 def test_read_data_schema_column_missing_raises(make_csv):
     path = make_csv({"a": [1]})
     ing = make_csv_ingestor(schema={"a": "INT", "missing": "INT"})

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -79,9 +79,15 @@ def test_validate_csv_type_coercion():
         "b": [True, False],
         "d": ["2024-01-01", "2024-02-02"],
     })
-    # Should not raise; coerces in place.
+    # Should not raise; coerces in place. A DATE column now becomes plain
+    # datetime.date objects (object dtype), NOT datetime64 — so no spurious
+    # 00:00:00 time component is appended downstream (DATE vs DATETIME split).
+    import datetime
     ing._validate_csv(df)
-    assert str(df["d"].dtype).startswith("datetime")
+    assert all(
+        isinstance(v, datetime.date) and not isinstance(v, datetime.datetime)
+        for v in df["d"]
+    )
 
 
 def test_count_records(make_csv):

--- a/tests/test_csv_ingestor_scale.py
+++ b/tests/test_csv_ingestor_scale.py
@@ -10,6 +10,8 @@ LARGER than chunk_size and assert every row across all chunks is correct.
 
 from __future__ import annotations
 
+import datetime
+
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -46,7 +48,8 @@ def test_date_column_converted_in_every_chunk(tmp_path):
     ing = _ingestor({"ts": "DATE", "label": "str"}, chunk_size=3)  # 10 rows -> 4 chunks
     recs = list(ing.read_data(path))
     assert len(recs) == 10
-    assert all(isinstance(r["ts"], pd.Timestamp) for r in recs)
+    # DATE now coerces to plain datetime.date (no spurious time), in every chunk.
+    assert all(isinstance(r["ts"], datetime.date) for r in recs)
 
 
 def test_header_whitespace_stripped_in_every_chunk(tmp_path):
@@ -64,4 +67,5 @@ def test_single_chunk_behaviour_unchanged(tmp_path):
     ing = _ingestor({"ts": "DATE", "label": "str"}, chunk_size=1000)
     recs = list(ing.read_data(path))
     assert len(recs) == 2
-    assert all(isinstance(r["ts"], pd.Timestamp) for r in recs)
+    # DATE now coerces to plain datetime.date (no spurious time), in every chunk.
+    assert all(isinstance(r["ts"], datetime.date) for r in recs)

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -418,3 +418,36 @@ def test_constraints_are_stripped_from_type():
 )
 def test_detect_column_type(series, expected):
     assert DataValidator()._detect_column_type(series) == expected
+
+
+# ---------------------------------------------------------------------------
+# Streaming / large-file validation (bounded memory, full coverage)
+# ---------------------------------------------------------------------------
+
+def test_validate_csv_streams_and_catches_late_chunk(tmp_path):
+    # A bad value PAST the first chunk must still be caught — the validator
+    # scans the whole file chunk by chunk (memory-bounded), not just a sample
+    # and not by loading the entire file. chunk_size forces multiple chunks.
+    p = tmp_path / "big.csv"
+    rows = [str(i) for i in range(50)]
+    rows[35] = "not-an-int"  # lands in the 4th chunk of 10
+    p.write_text("n\n" + "\n".join(rows) + "\n")
+    res = DataValidator(schema={"n": "INT"}).validate(str(p), chunk_size=10)
+    assert not res.is_valid and "non-numeric" in res.errors[0]
+
+
+def test_validate_csv_streaming_clean_file_is_valid(tmp_path):
+    p = tmp_path / "clean.csv"
+    p.write_text("n\n" + "\n".join(str(i) for i in range(50)) + "\n")
+    res = DataValidator(schema={"n": "INT"}).validate(str(p), chunk_size=10)
+    assert res.is_valid and res.metadata["rows_checked"] == 50
+
+
+def test_validate_strips_header_whitespace_to_match_ingestor():
+    # The ingestor strips header whitespace on every chunk (" age" -> "age");
+    # the validator must do the same so it validates the column the ingestor
+    # will actually ingest, rather than silently skipping it.
+    res = DataValidator(schema={"age": "INT"}).validate(
+        pd.DataFrame({" age": [1, "bad"]})
+    )
+    assert not res.is_valid

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -177,8 +177,12 @@ def test_bigint_delegates_to_int():
 # FLOAT / DOUBLE / DECIMAL
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("dtype", ["FLOAT", "DOUBLE", "DECIMAL(10,2)"])
+@pytest.mark.parametrize("dtype", ["FLOAT", "DOUBLE", "DECIMAL(10,2)", "NUMERIC(8,3)", "NUMERIC"])
 def test_float_family_valid(dtype):
+    # NUMERIC is a MySQL alias for DECIMAL; #190 bugbot caught that the DDL
+    # and ingestor type-cast layers accepted NUMERIC but the validator's
+    # type_validators dict didn't, so a schema using NUMERIC failed preflight
+    # with "Unknown data type" even though ingest would proceed.
     df = pd.DataFrame({"x": [1.5, 2.25]})
     assert DataValidator(schema={"x": dtype}).validate(df).is_valid
 

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -37,6 +37,30 @@ def test_loads_from_csv(make_csv):
     assert result.is_valid
 
 
+def test_streaming_validator_rejects_duplicate_headers(tmp_path):
+    # Regression (#190 bugbot): the streaming CSV validator used to accept
+    # duplicate headers (pandas silently disambiguates "a, a" to "a, a.1"),
+    # while CSVIngestor.read_data rejects them outright — so a file passed
+    # validation and then exploded at ingest with a structural error the
+    # preflight step never surfaced. Align: reject up front.
+    p = tmp_path / "dups.csv"
+    p.write_text("a,a\n1,2\n3,4\n")
+    result = DataValidator(schema={"a": "INT"}).validate(str(p))
+    assert not result.is_valid
+    assert "Duplicate column" in result.errors[0]
+
+
+def test_streaming_validator_rejects_ragged_rows(tmp_path):
+    # Regression (#190 bugbot): the streaming validator used on_bad_lines=
+    # "warn" — a ragged row was silently dropped, validation reported success,
+    # then CSVIngestor.read_data (on_bad_lines="error") failed at ingest. Now
+    # both fail at the same point.
+    p = tmp_path / "ragged.csv"
+    p.write_text("a,b\n1,2\n3,4,5\n6,7\n")
+    result = DataValidator(schema={"a": "INT", "b": "INT"}).validate(str(p))
+    assert not result.is_valid
+
+
 def test_loads_from_json(tmp_path):
     """JSON top-level array of records must validate, mirroring the file shape
     JSONIngestor.read_data consumes.

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -388,3 +388,45 @@ def test_upsert_backtick_quotes_special_char_columns_in_values_clause():
     # the INSERT list — the e2e failure that flipped the original PR red.
     assert " AS new " not in sql
     assert "new.status" not in sql
+
+
+def test_upsert_doubles_embedded_backticks_in_column_name():
+    """Identifier-escape regression (#190 bugbot, re-applied).
+
+    A column name containing a literal backtick must be escaped by doubling
+    it (` -> ``) — MySQL's identifier-escape rule, same one CREATE TABLE DDL
+    already follows. Without that, an embedded backtick closes the quoted
+    identifier early and the rest of the name leaks into the SQL as literal
+    tokens — the statement is either rejected or silently altered.
+
+    Bugbot flagged that the upsert RHS wraps in backticks but does NOT
+    double embedded ones; this test pins the fix. (The original was authored
+    in #191 but dropped by GitHub's squash-merge — re-applying.)
+    """
+    from sqlalchemy import MetaData, Table, Column, BigInteger, Float, text
+    from sqlalchemy.dialects import mysql
+    from sqlalchemy.dialects.mysql import insert
+
+    weird = "ev`il"
+    table = Table(
+        "t",
+        MetaData(),
+        Column("id", BigInteger, primary_key=True),
+        Column("data_id", mysql.VARCHAR(255)),
+        Column(weird, Float),
+    )
+    insert_stmt = insert(table)
+    update_dict = {
+        column.name: text(f"VALUES(`{column.name.replace('`', '``')}`)")
+        for column in table.columns
+        if column.name not in ["id", "created_at", "data_id"]
+    }
+    stmt = insert_stmt.values(
+        [{"data_id": "x", weird: 1.0}]
+    ).on_duplicate_key_update(**update_dict)
+    sql = str(stmt.compile(dialect=mysql.dialect()))
+
+    # Escaped form ` -> `` is present.
+    assert "VALUES(`ev``il`)" in sql
+    # Unescaped form would close the identifier early — must not appear.
+    assert "VALUES(`ev`il`)" not in sql

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -123,6 +123,59 @@ def test_create_table_existing_in_db_reflects(db):
     db.metadata.reflect.assert_called_once()
 
 
+def test_create_table_existing_matching_schema_reflects_ok(db):
+    """An existing table whose feature columns match the incoming schema is
+    reused without error — the normal re-ingest-same-dataset path. Only the
+    feature columns are compared; the standard framework columns (id, data_id,
+    …) are ignored."""
+    inspector = MagicMock()
+    inspector.get_table_names.return_value = ["panel"]
+
+    def fake_reflect(engine, only=None):
+        Table(
+            "panel", db.metadata,
+            Column("id", BigInteger, primary_key=True),
+            Column("data_id", String(255)),
+            Column("P01033_TIMP1", String(255)),
+            Column("P02452_COL1A1", String(255)),
+        )
+
+    db.metadata.reflect = MagicMock(side_effect=fake_reflect)
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        table = db.create_table(
+            "panel", {"P01033_TIMP1": "FLOAT", "P02452_COL1A1": "FLOAT"}
+        )
+    assert db.tables["panel"] is table
+
+
+def test_create_table_existing_schema_mismatch_fails_fast(db):
+    """A stale table whose feature columns don't match the incoming schema must
+    fail fast with an actionable error — instead of being silently reused and
+    then dying on every insert with SQLAlchemy's cryptic 'Unconsumed column
+    names'.
+
+    Regression (Henrik/LMU): a prior ingestion left `IBD_Biomarker` with the
+    original proteomics headers (`P02452|COL1A1`); the customer then renamed the
+    CSV headers to sanitized identifiers (`P02452_COL1A1`) to dodge an unrelated
+    SQL error. create_table reflected the stale table, ignored the new schema,
+    and all 207 records failed with 'Unconsumed column names'."""
+    inspector = MagicMock()
+    inspector.get_table_names.return_value = ["IBD_Biomarker"]
+
+    def fake_reflect(engine, only=None):
+        Table(
+            "IBD_Biomarker", db.metadata,
+            Column("id", BigInteger, primary_key=True),
+            Column("data_id", String(255)),
+            Column("P02452|COL1A1", String(255)),  # original header (stale table)
+        )
+
+    db.metadata.reflect = MagicMock(side_effect=fake_reflect)
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        with pytest.raises(ValueError, match="do not match|stale table"):
+            db.create_table("IBD_Biomarker", {"P02452_COL1A1": "FLOAT"})  # sanitized
+
+
 # ---------------------------------------------------------------------------
 # insert_batch
 # ---------------------------------------------------------------------------

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -86,6 +86,24 @@ def test_get_sqlalchemy_type_unsupported_raises(db):
         db._get_sqlalchemy_type("GEOMETRY")
 
 
+def test_get_sqlalchemy_type_decimal_precision_scale(db):
+    # Regression (#190 bugbot): DECIMAL(10,2) used to fail int("10,2") and
+    # fall back to a bare Numeric() — declared precision and scale silently
+    # dropped, MySQL then used its default and clipped values.
+    result = db._get_sqlalchemy_type("DECIMAL(10,2)")
+    assert isinstance(result, db_mod.Numeric)
+    assert result.precision == 10
+    assert result.scale == 2
+
+
+def test_get_sqlalchemy_type_numeric_precision_scale(db):
+    # NUMERIC is an alias for DECIMAL; same precision/scale handling.
+    result = db._get_sqlalchemy_type("NUMERIC(8, 3)")
+    assert isinstance(result, db_mod.Numeric)
+    assert result.precision == 8
+    assert result.scale == 3
+
+
 # ---------------------------------------------------------------------------
 # create_table
 # ---------------------------------------------------------------------------

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -250,3 +250,70 @@ def test_create_table_rejects_overlong_column_name():
     long_name = "Protein_" + "X" * 70  # 78 chars, > 64
     with pytest.raises(ValueError, match="64-character"):
         db.create_table("t", {long_name: "FLOAT", "feature_0": "FLOAT"})
+
+
+# ---------------------------------------------------------------------------
+# upsert quoting (regression): special-character column names
+# ---------------------------------------------------------------------------
+
+def test_upsert_backtick_quotes_special_char_columns_in_values_clause():
+    """ON DUPLICATE KEY UPDATE must backtick-quote the column name inside
+    VALUES(...).
+
+    Proteomics panels use "UniProt|gene" headers (e.g. `P01033|TIMP1`) and
+    isoform names (`P02751-1|FN1`). The previous construction built the update
+    clause with a raw f-string ``text(f"VALUES({column.name})")``, leaving the
+    name unquoted on the right-hand side. MySQL then parsed the `|` (and `-`)
+    as operators and raised 1064 (syntax error) — failing the entire batch.
+
+    Surfaced by Henrik's IBD_Biomarkers ingestion (LMU): all 207 records failed
+    with ``near '|TIMP1), `P02452|COL1A1` = VALUES(P02452|COL1A1)'``. Note the
+    left-hand side was already correctly quoted; only the VALUES() argument was
+    not — which is exactly what this test pins.
+
+    Compiles for the MySQL dialect (no live DB) and asserts both the fixed form
+    is present and the broken form is gone.
+    """
+    from sqlalchemy import MetaData, Table, Column, BigInteger, Float, text
+    from sqlalchemy.dialects import mysql
+    from sqlalchemy.dialects.mysql import insert
+
+    pipe_col = "P01033|TIMP1"
+    isoform_col = "P02751-1|FN1"
+    # Include a column that WILL NOT appear in the inserted record. The
+    # production code iterates every table column; the fix must keep working
+    # when an update target isn't in the INSERT list (the e2e regression that
+    # `insert_stmt.inserted[col]` introduced — MySQL 8 row-alias `new.col`
+    # requires the column to be in the INSERT list and raised 1054).
+    table = Table(
+        "IBD_Biomarkers",
+        MetaData(),
+        Column("id", BigInteger, primary_key=True),
+        Column("data_id", mysql.VARCHAR(255)),
+        Column(pipe_col, Float),
+        Column(isoform_col, Float),
+        Column("status", mysql.VARCHAR(50)),
+    )
+    insert_stmt = insert(table)
+    # Mirror the production construction exactly (database.py):
+    update_dict = {
+        column.name: text(f"VALUES(`{column.name}`)")
+        for column in table.columns
+        if column.name not in ["id", "created_at", "data_id"]
+    }
+    stmt = insert_stmt.values(
+        [{"data_id": "x", pipe_col: 1.0, isoform_col: 2.0}]
+    ).on_duplicate_key_update(**update_dict)
+    sql = str(stmt.compile(dialect=mysql.dialect()))
+
+    # Fixed: the name is backtick-quoted inside VALUES(...).
+    assert "VALUES(`P01033|TIMP1`)" in sql
+    assert "VALUES(`P02751-1|FN1`)" in sql
+    # Regression guard: the unquoted form that broke MySQL must not reappear.
+    assert "VALUES(P01033|TIMP1)" not in sql
+    assert "VALUES(P02751-1|FN1)" not in sql
+    # Second regression guard: never re-introduce the MySQL-8 row-alias form
+    # (`AS new ... new.col`) which requires every referenced column to be in
+    # the INSERT list — the e2e failure that flipped the original PR red.
+    assert " AS new " not in sql
+    assert "new.status" not in sql

--- a/tests/test_i18n_adversarial_csv.py
+++ b/tests/test_i18n_adversarial_csv.py
@@ -353,12 +353,13 @@ def test_single_column_label_only_file(tmp_path):
     assert list(records[0].keys()) == ["label"]
 
 
-def test_ragged_trailing_semicolon_row_is_dropped_with_warning(tmp_path):
-    """A ragged row (extra trailing ``;`` -> one field too many) is dropped
-    under the engine's ``on_bad_lines="warn"`` policy, emitting a
-    ParserWarning. This is data loss, but NOT silent — assert both the
-    warning and the resulting row count so the behaviour is explicit and a
-    regression to silent ``skip``/``error`` is caught."""
+def test_ragged_row_raises_not_silently_dropped(tmp_path):
+    """A ragged row (extra trailing ``;`` -> one field too many) must now FAIL
+    LOUDLY (``on_bad_lines="error"``) rather than be silently dropped. Silently
+    shrinking the dataset corrupts it under a still-green success, and a
+    malformed row almost always signals a real structural problem (wrong
+    delimiter, unquoted comma) the user must fix. Replaces the former
+    drop-with-ParserWarning behaviour."""
     p = tmp_path / "rag.csv"
     # Row 2 has a trailing ';' -> 4 fields where 3 are expected.
     p.write_text("a;b;c\n1;2;3\n4;5;6;\n7;8;9\n", encoding="utf-8")
@@ -367,29 +368,17 @@ def test_ragged_trailing_semicolon_row_is_dropped_with_warning(tmp_path):
         csv_options={"sep": ";"},
     )
 
-    with pytest.warns(pd.errors.ParserWarning):
-        records = list(ing.read_data(str(p)))
-
-    # 3 data rows in, the ragged one dropped -> 2 out.
-    assert len(records) == 2
-    assert records[0] == {"a": 1, "b": 2, "c": 3}
-    assert records[1] == {"a": 7, "b": 8, "c": 9}
+    with pytest.raises(Exception):
+        list(ing.read_data(str(p)))
 
 
-def test_duplicate_header_names_are_pandas_mangled(tmp_path):
-    """Duplicate header names are silently de-duplicated by pandas (second
-    ``age`` -> ``age.1``). The engine does not reject this, so the second
-    column leaks through under a renamed key. Assert the documented mangling
-    explicitly: the declared ``age`` keeps the first column's value and the
-    duplicate surfaces as ``age.1`` — making the gap visible rather than
-    letting it pass unexamined."""
+def test_duplicate_header_names_are_rejected(tmp_path):
+    """Duplicate header names are now rejected with a clear error BEFORE pandas
+    silently de-duplicates them (second ``age`` -> ``age.1``) and the schema
+    maps onto the wrong physical column. Replaces the former
+    documented-mangling behaviour."""
     p = tmp_path / "dup.csv"
     p.write_text("age,age,label\n10,20,x\n", encoding="utf-8")
     ing = _make_ingestor({"age": "INT", "label": "VARCHAR(5)"})
-    records = list(ing.read_data(str(p)))
-
-    rec = records[0]
-    assert rec["age"] == 10          # first 'age' column
-    assert "age.1" in rec            # pandas-mangled duplicate leaks through
-    assert rec["age.1"] == 20
-    assert rec["label"] == "x"
+    with pytest.raises(ValueError, match="[Dd]uplicate"):
+        list(ing.read_data(str(p)))

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -298,6 +298,29 @@ def test_ingest_happy_path():
     ing.api_client.create_dataset.assert_called_once()
 
 
+@pytest.mark.parametrize("failing_step", [
+    "send_generate_edge_label_meta",
+    "send_global_meta_meta",
+    "prepare_dataset",
+])
+def test_ingest_fails_loud_when_backend_registration_step_fails(failing_step):
+    # REGRESSION GUARD: a False return from ANY backend registration step leaves
+    # the dataset half-created — rows are committed to MySQL but the dataset is
+    # not registered. The old nested-if cascade silently skipped the remaining
+    # steps (including create_dataset) and the run STILL returned cleanly (exit
+    # 0), so the user saw a "success" over an unregistered dataset. Each step
+    # must now RAISE so the run exits non-zero and the failure is visible.
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=None)
+    getattr(ing.api_client, failing_step).return_value = False
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError, match="NOT registered"):
+            ing.ingest("src", batch_size=10)
+    # The chain must stop — create_dataset is never reached on a failed step.
+    ing.api_client.create_dataset.assert_not_called()
+
+
 def test_ingest_skips_records_that_fail_processing():
     # invalid intent -> process_record returns None -> counted as skipped
     records = [{"a": "1", "filename": "f1"}]

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -20,7 +20,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.6"
+__version__ = "0.3.7"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -145,7 +145,16 @@ def main(argv: List[str] | None = None) -> int:  # pragma: no cover - thin shell
     ingestor = _build_ingestor(database, api_client, resolved)
 
     with ingestor:
-        failed = ingestor.ingest(resolved.source_path, batch_size=config.BATCH_SIZE)
+        try:
+            failed = ingestor.ingest(resolved.source_path, batch_size=config.BATCH_SIZE)
+        except Exception as exc:
+            # A hard failure during ingestion — validation, DB write, or backend
+            # dataset registration. base.py has already logged the detail; turn
+            # the exception into a clean, single-line non-zero exit rather than a
+            # raw traceback, so the CLI's live log stream shows an actionable
+            # reason and marks the Job failed.
+            print(f"\nIngestion failed: {exc}", file=sys.stderr)
+            return 1
         if failed:
             logger.warning(
                 "%d record(s) failed during ingestion; see logs for details.",

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -327,9 +327,19 @@ class Database:
                 # rows). Sticking with the legacy ``VALUES(`col`)`` syntax
                 # preserves the prior behaviour (works regardless of which
                 # columns the row actually has) while fixing the quoting bug.
+                # Embedded backticks in the name are doubled (MySQL identifier
+                # escape rule, mirrors the CREATE TABLE DDL path). Without
+                # that, a header containing a literal backtick would close
+                # the quoted identifier early and either break SQL parsing or
+                # silently alter the statement. Pipe / dash / dot headers
+                # worked because they carry no backtick; this guards the
+                # residual case bugbot flagged on #190 (the fix was authored
+                # in #191 but dropped by the squash-merge — re-applying).
                 insert_stmt = insert(table)
                 update_dict = {
-                    column.name: text(f"VALUES(`{column.name}`)")
+                    column.name: text(
+                        f"VALUES(`{column.name.replace('`', '``')}`)"
+                    )
                     for column in table.columns
                     if column.name not in ["id", "created_at", "data_id"]
                 }

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -95,14 +95,24 @@ class Database:
         
         if base_type in type_mapping:
             alchemy_type = type_mapping[base_type]
-            # Extract length for VARCHAR types
-            length = None
+            # Extract parenthesised arguments. Two shapes:
+            #   - VARCHAR(255) / CHAR(10)      -> single int length
+            #   - DECIMAL(10, 2) / NUMERIC(p,s) -> precision, scale (both honoured;
+            #     previously int("10,2") raised ValueError and we silently fell
+            #     back to a bare Numeric, dropping the declared scale and writing
+            #     the column at MySQL's default — losing precision on the values
+            #     it then bound).
             if "(" in mysql_type_upper:
                 try:
-                    length = int(mysql_type_upper.split("(")[1].split(")")[0])
+                    inside = mysql_type_upper.split("(", 1)[1].rsplit(")", 1)[0]
+                    parts = [int(p.strip()) for p in inside.split(",") if p.strip()]
                 except (ValueError, IndexError):
-                    pass
-            return alchemy_type(length) if length else alchemy_type
+                    parts = []
+                if len(parts) == 2 and base_type in ("DECIMAL", "NUMERIC"):
+                    return alchemy_type(parts[0], parts[1])
+                if len(parts) == 1:
+                    return alchemy_type(parts[0])
+            return alchemy_type
 
         raise ValueError(f"Unsupported MySQL type: {mysql_type}")
 

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -160,6 +160,45 @@ class Database:
             # Reflect existing table using MetaData
             self.metadata.reflect(self.engine, only=[table_name])
             table = self.metadata.tables[table_name]
+
+            # Fail fast if the existing table's feature columns don't match the
+            # incoming schema. Reflecting and silently reusing a mismatched table
+            # makes every record insert die downstream with SQLAlchemy's cryptic
+            # "Unconsumed column names: ..." — the record keys (built from the
+            # current schema) reference columns the reflected table doesn't have.
+            # This happens when a table is left over from an earlier ingestion:
+            # e.g. a prior run created the table and then failed before inserting,
+            # or the dataset's column names changed between pushes (a customer
+            # renaming proteomics headers like `P01033|TIMP1` -> `P01033_TIMP1`
+            # to work around an unrelated error is exactly this case). Surface an
+            # actionable error naming the drift instead.
+            _STANDARD_COLUMNS = {
+                "id", "created_at", "updated_at", "status", "label",
+                "data_intent", "data_id", "filename", "extension",
+                "annotation", "ingestor_id",
+            }
+            existing_features = {c.name for c in table.columns} - _STANDARD_COLUMNS
+            expected_features = set(schema) - _STANDARD_COLUMNS
+            if expected_features and existing_features != expected_features:
+                missing = sorted(expected_features - existing_features)
+                extra = sorted(existing_features - expected_features)
+
+                def _preview(cols):
+                    head = ", ".join(cols[:8])
+                    return f"{head}{'' if len(cols) <= 8 else f', … (+{len(cols) - 8} more)'}"
+
+                raise ValueError(
+                    f"Table '{table_name}' already exists with feature columns "
+                    f"that do not match the dataset schema. This usually means a "
+                    f"stale table from an earlier ingestion (one that failed "
+                    f"before inserting, or a dataset whose column names changed "
+                    f"between pushes). "
+                    f"In the schema but not the table: [{_preview(missing)}]. "
+                    f"In the table but not the schema: [{_preview(extra)}]. "
+                    f"Drop the existing '{table_name}' table, or ingest under a "
+                    f"new dataset name, and re-run."
+                )
+
             self.tables[table_name] = table
             return table
 

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Float,
     Boolean,
     Double,
+    Numeric,
     inspect,
 
 )
@@ -77,6 +78,8 @@ class Database:
             "BIGINT": BigInteger,
             "FLOAT": Float,
             "DOUBLE": Double,
+            "DECIMAL": Numeric,
+            "NUMERIC": Numeric,
             "BOOLEAN": Boolean,
             "BOOL": Boolean,
             "DATE": Date,
@@ -148,6 +151,25 @@ class Database:
             raise ValueError(
                 f"{len(_too_long)} column name(s) exceed the {_MAX_IDENTIFIER}-character "
                 f"database column-name limit and must be shortened: {preview}{more}"
+            )
+
+        # Fail fast on too many columns before CREATE TABLE turns it into a raw
+        # MySQL 1117 ("Too many columns"). MySQL's hard limit is 4096 columns per
+        # table; the framework adds ~11 standard columns on top of the schema, so
+        # bound the user schema below that. A very wide panel (genomics /
+        # proteomics matrices with thousands of feature columns) is the realistic
+        # trigger. (MySQL also caps the row at ~65535 bytes — that limit binds
+        # first for very wide VARCHAR panels and still surfaces at CREATE TABLE as
+        # 1118; this count guard catches the common numeric-panel case with an
+        # actionable message.)
+        _MAX_FEATURE_COLUMNS = 4000
+        if len(schema) > _MAX_FEATURE_COLUMNS:
+            raise ValueError(
+                f"Schema has {len(schema)} columns, exceeding the supported "
+                f"maximum of {_MAX_FEATURE_COLUMNS} (MySQL's hard limit is 4096 "
+                f"columns per table, and the framework reserves ~11). Reduce the "
+                f"column count — e.g. narrow the feature panel, or pivot a very "
+                f"wide matrix to long form."
             )
 
         # Return existing table if already created

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -238,10 +238,27 @@ class Database:
 
                     processed_records.append(processed_record)
 
-                # Create an "INSERT ... ON DUPLICATE KEY UPDATE" statement
+                # Create an "INSERT ... ON DUPLICATE KEY UPDATE" statement.
+                # Build the VALUES(...) RHS as a backtick-quoted raw fragment.
+                #
+                # The previous f-string ``VALUES({column.name})`` left the name
+                # unquoted, so any header with a character MySQL treats as an
+                # operator — proteomics ``UniProt|gene`` columns like
+                # ``P01033|TIMP1`` or isoform names like ``P02751-1|FN1`` —
+                # produced 1064 (syntax error) and failed the whole batch.
+                #
+                # The natural SQLAlchemy alternative ``insert_stmt.inserted[
+                # column.name]`` looks right but, against MySQL 8, the dialect
+                # compiles it as the row-alias form ``AS new ... new.col`` —
+                # which *requires* every referenced column to appear in the
+                # INSERT column list and breaks any batch whose records don't
+                # supply every column on the table (e.g. created_at-only
+                # rows). Sticking with the legacy ``VALUES(`col`)`` syntax
+                # preserves the prior behaviour (works regardless of which
+                # columns the row actually has) while fixing the quoting bug.
                 insert_stmt = insert(table)
                 update_dict = {
-                    column.name: text(f"VALUES({column.name})")
+                    column.name: text(f"VALUES(`{column.name}`)")
                     for column in table.columns
                     if column.name not in ["id", "created_at", "data_id"]
                 }

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -606,35 +606,56 @@ class BaseIngestor(ABC):
                 session.commit()
                 pbar.close()
 
-                # Send edge label metadata
-                if self.api_client.send_generate_edge_label_meta(
+                # Register the dataset with the backend. Every step here is
+                # REQUIRED: the rows are already committed to MySQL above, so if
+                # any step fails the dataset is half-created — rows present but
+                # not registered. The previous code nested these as
+                # `if A: if B: if C: create()`, so a False return at ANY step
+                # silently skipped the rest (including create_dataset AND the
+                # summary) and the run STILL exited 0 — leaving committed rows
+                # with no registered dataset and no error the user could see.
+                # Fail loudly instead: raise so the process exits non-zero and
+                # the failure surfaces (the CLI streams these logs live and marks
+                # the Job failed). The api_client has already logged the
+                # underlying HTTP detail before returning False.
+                if not self.api_client.send_generate_edge_label_meta(
                     self.table_name, self.ingestor_id, self.intent
                 ):
+                    raise RuntimeError(
+                        "Backend rejected edge-label metadata; the dataset was "
+                        "NOT registered (its rows are already in the database). "
+                        "See the logged API error above."
+                    )
 
-                    # schema dict
-                    schema_dict = self.database.get_table_schema(self.table_name)
-                    add_info = self.file_options
-                    # Send global metadata
-                    if self.api_client.send_global_meta_meta(
-                        self.table_name, schema_dict, add_info
-                    ):
+                schema_dict = self.database.get_table_schema(self.table_name)
+                if not self.api_client.send_global_meta_meta(
+                    self.table_name, schema_dict, self.file_options
+                ):
+                    raise RuntimeError(
+                        "Backend rejected the dataset schema/metadata; the "
+                        "dataset was NOT registered (its rows are already in the "
+                        "database). See the logged API error above."
+                    )
 
-                        # Prepare dataset
-                        if self.api_client.prepare_dataset(
-                            self.category,
-                            self.ingestor_id,
-                            self.data_format,
-                            self.intent,
-                        ):
+                if not self.api_client.prepare_dataset(
+                    self.category,
+                    self.ingestor_id,
+                    self.data_format,
+                    self.intent,
+                ):
+                    raise RuntimeError(
+                        "Backend failed to prepare the dataset; it was NOT "
+                        "registered (its rows are already in the database). See "
+                        "the logged API error above."
+                    )
 
-                            self.api_client.create_dataset(
-                                category=self.category, ingestor_id=self.ingestor_id
-                            )
+                self.api_client.create_dataset(
+                    category=self.category, ingestor_id=self.ingestor_id
+                )
 
-                            # Create and log summary
-                            summary = IngestionSummary(**stats)
-
-                            self._log_summary(summary)
+                # Create and log summary — only after successful registration.
+                summary = IngestionSummary(**stats)
+                self._log_summary(summary)
 
             except Exception as e:
                 session.rollback()

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -251,8 +251,25 @@ class BaseIngestor(ABC):
             # regression-class categories ``"bucket"`` replaces the raw target
             # with a stable hash-bucket ID so the value never leaks to the
             # central backend (#44 / parent client#85).
+            #
+            # Coerce numpy / pandas scalar types to native Python before the
+            # policy runs. After the INT-cast switch to nullable ``Int64``,
+            # itertuples yields ``numpy.int64`` (the old ``downcast='integer'``
+            # incidentally produced plain ``int``) — and mysql-connector-python
+            # refuses to bind numpy scalars, failing the passthrough path with
+            # "Python type numpy.int64 cannot be converted" on every row of any
+            # INT label column (tabular_classification on the e2e job). The
+            # other policies (e.g. ``bucket``) stringify their output so they
+            # never hit this; the fix lives here so passthrough also yields a
+            # binder-friendly value.
+            label_val = record.get(self.label_column)
+            if hasattr(label_val, "item") and not isinstance(label_val, str):
+                try:
+                    label_val = label_val.item()
+                except (ValueError, AttributeError):
+                    pass
             cleaned_record["label"] = label_policy_module.apply(
-                record.get(self.label_column), self.label_policy
+                label_val, self.label_policy
             )
 
         if self.intent:
@@ -301,16 +318,24 @@ class BaseIngestor(ABC):
             # JSONIngestor._validate_record (#170): `value is None or
             # value == ""`. pd.isna returns False for ordinary
             # strings/numbers/bools so existing values aren't touched.
-            # Python bool must NOT be stringified — mysql-connector-python
-            # writes True/False directly as TINYINT 1/0, but `str(True)` is
-            # the four-character string "True", which MySQL rejects against
-            # a BOOL column with `Incorrect integer value: 'True' for column
-            # 'active' at row 1`. Pass bools through; stringify everything
-            # else as before (the rest of the pipeline expects strings).
+            # Booleans must NOT be stringified — mysql-connector-python writes
+            # True/False directly as TINYINT 1/0, but `str(True)` is the
+            # four-character string "True", which MySQL rejects against a BOOL
+            # column with `Incorrect integer value: 'True' for column 'active'
+            # at row 1`. This must catch BOTH Python `bool` AND `numpy.bool_`:
+            # a CSV BOOL column comes back from pandas/itertuples as numpy.bool_,
+            # and `isinstance(np.True_, bool)` is False — so the previous
+            # `isinstance(v, bool)` check missed it and every CSV boolean was
+            # stringified to "True"/"False" and rejected by MySQL. `is_bool`
+            # covers both; convert to a plain Python bool so the binder writes
+            # 1/0. Checked FIRST so a bool never reaches the `v == ""` compare
+            # (numpy scalar-vs-str comparison would warn) and pd.NA (is_bool
+            # False) falls through to the null branch. The rest of the pipeline
+            # expects strings, so everything non-bool/non-null is stringified.
             cleaned_record = {
                 k.strip(): (
-                    None if pd.isna(v) or v == ""
-                    else v if isinstance(v, bool)
+                    bool(v) if pd.api.types.is_bool(v)
+                    else None if pd.isna(v) or v == ""
                     else str(v).strip()
                 )
                 for k, v in record.items()

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -245,12 +245,45 @@ class CSVIngestor(BaseIngestor):
             # by pandas, so this is safe when the schema lists more columns than
             # the CSV carries.
             _STRING_TYPES = ("VARCHAR", "CHAR", "TEXT", "STRING")
-            string_dtype = {
-                col: str
+            _string_schema_cols = {
+                col
                 for col, t in self.schema.items()
                 if isinstance(t, str)
                 and t.upper().split("(")[0].strip() in _STRING_TYPES
             }
+            # Pandas applies `dtype` keyed by the RAW header literal — before
+            # `chunk.columns.str.strip()` runs. If a header carries surrounding
+            # whitespace (" code "), keying the dtype dict by the clean schema
+            # name ("code") misses, pandas infers numeric, and "007" lands as
+            # 7 — the leading zeros silently lost on the very read this pin was
+            # meant to prevent. Read the raw header up front (same csv module
+            # path we use for duplicate detection) and pin every raw spelling
+            # whose stripped form matches a string-family schema column.
+            _string_raw_headers = set()
+            try:
+                _sep_probe = self.csv_options.get(
+                    "sep", self.csv_options.get("delimiter", ",")
+                )
+                with open(
+                    file_path,
+                    "r",
+                    encoding=self.csv_options.get("encoding", "utf-8"),
+                    newline="",
+                ) as _fh:
+                    _raw = next(_csv.reader(_fh, delimiter=_sep_probe), [])
+                for _h in _raw:
+                    if str(_h).strip() in _string_schema_cols:
+                        _string_raw_headers.add(_h)
+            except (OSError, UnicodeDecodeError, _csv.Error, TypeError, StopIteration):
+                # Probe failed; fall back to keying by the schema name only —
+                # files without leading/trailing whitespace headers (the
+                # common case) still get pinned.
+                _string_raw_headers = set(_string_schema_cols)
+            else:
+                # Always include the bare schema name too, so a file without
+                # the whitespace variant still gets pinned cleanly.
+                _string_raw_headers |= _string_schema_cols
+            string_dtype = {h: str for h in _string_raw_headers}
 
             # Enhanced default options for pandas
             default_options = {

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -5,6 +5,7 @@ pandas-based reading and validation capabilities.
 """
 
 from typing import Dict, Any, Generator, Optional, List
+import csv as _csv
 import pandas as pd
 import logging
 from pathlib import Path
@@ -132,13 +133,52 @@ class CSVIngestor(BaseIngestor):
             dtype = self.schema[column]
             try:
                 if "INT" in dtype.upper():
-                    df[column] = pd.to_numeric(df[column], downcast="integer")
-                elif "FLOAT" in dtype.upper():
-                    df[column] = pd.to_numeric(df[column], downcast="float")
+                    # Nullable Int64, NOT to_numeric(downcast="integer"): under
+                    # the old code any missing cell forced the column to float64,
+                    # so 7 round-tripped as "7.0" — silent corruption of every
+                    # integer in any INT column that had a single blank cell.
+                    # Int64 keeps integers integral and stores missing as pd.NA
+                    # (-> SQL NULL); default errors="raise" still surfaces a
+                    # genuinely non-numeric value as a clear per-column error.
+                    df[column] = pd.to_numeric(df[column]).astype("Int64")
+                elif any(t in dtype.upper() for t in ("FLOAT", "DOUBLE", "DECIMAL", "NUMERIC")):
+                    # float64 — NOT downcast='float' (float32), which corrupted
+                    # precision: 3.14 -> '3.140000104904175'. Also covers DOUBLE/
+                    # DECIMAL/NUMERIC, which previously matched NO branch and let
+                    # non-numeric junk flow untouched to the DB; errors='raise'
+                    # (the default) now rejects junk with a clear per-column
+                    # error. MySQL still applies the column's own precision/scale
+                    # on write.
+                    df[column] = pd.to_numeric(df[column])
                 elif "BOOL" in dtype.upper():
-                    df[column] = df[column].astype("boolean")
-                elif "DATE" in dtype.upper() or "DATETIME" in dtype.upper() or "TIMESTAMP" in dtype.upper() or "TIME" in dtype.upper():
-                    df[column] = pd.to_datetime(df[column], errors="coerce", format='mixed')
+                    # Map the textual/numeric boolean forms DataValidator accepts
+                    # (true/false, yes/no, t/f, y/n, 1/0) to a nullable boolean
+                    # column. df.astype("boolean") alone raises "Need to pass
+                    # bool-like values" on those strings — a direct contradiction
+                    # with the validator, which blesses them, so a CSV with a
+                    # yes/no column passed validation then crashed the ingestor.
+                    _truthy = {"true", "t", "yes", "y", "1", "1.0"}
+                    _falsy = {"false", "f", "no", "n", "0", "0.0"}
+                    _norm = df[column].astype("string").str.strip().str.lower()
+                    df[column] = _norm.map(
+                        lambda x: True if x in _truthy
+                        else (False if x in _falsy else pd.NA),
+                        na_action="ignore",
+                    ).astype("boolean")
+                elif "DATETIME" in dtype.upper() or "TIMESTAMP" in dtype.upper():
+                    # Full date+time. Checked before DATE/TIME because the
+                    # substrings "DATE" and "TIME" both appear in "DATETIME"
+                    # (and "TIME" in "TIMESTAMP").
+                    df[column] = pd.to_datetime(df[column], errors="coerce", format="mixed")
+                elif "DATE" in dtype.upper():
+                    # DATE only — emit a plain date so the value doesn't gain a
+                    # spurious time ('2026-01-02' was becoming '2026-01-02 00:00:00').
+                    df[column] = pd.to_datetime(df[column], errors="coerce", format="mixed").dt.date
+                elif "TIME" in dtype.upper():
+                    # TIME only — emit a plain time so the value doesn't gain a
+                    # spurious (today's) date ('14:30:00' was becoming
+                    # '2026-06-08 14:30:00', which MySQL TIME then truncates).
+                    df[column] = pd.to_datetime(df[column], errors="coerce", format="mixed").dt.time
                 elif any(t in dtype.upper() for t in ("STRING", "TEXT", "VARCHAR", "CHAR")):
                     # Coerce to pandas StringDtype so missing cells become pd.NA
                     # (not float NaN), then map pd.NA -> Python None so the DB
@@ -194,18 +234,77 @@ class CSVIngestor(BaseIngestor):
             is_tabular = self.category in _TABULAR_FAMILY_CATEGORIES
             na_values = _TABULAR_NA_VALUES if is_tabular else [""]
 
+            # Pin string-family schema columns to dtype=str so pandas can't infer
+            # them numeric and silently strip meaning. An all-digit code column
+            # (zip / UniProt accession / zero-padded ID) like "007" is otherwise
+            # inferred as int64 at read time and is already 7 by the time the
+            # VARCHAR cast in _validate_csv runs -> "7", with the leading zeros
+            # gone. na_values are still applied first, so empty/NA cells become
+            # NaN (-> SQL NULL) before the str pin; only present values are kept
+            # verbatim. dtype keys for columns absent from the file are ignored
+            # by pandas, so this is safe when the schema lists more columns than
+            # the CSV carries.
+            _STRING_TYPES = ("VARCHAR", "CHAR", "TEXT", "STRING")
+            string_dtype = {
+                col: str
+                for col, t in self.schema.items()
+                if isinstance(t, str)
+                and t.upper().split("(")[0].strip() in _STRING_TYPES
+            }
+
             # Enhanced default options for pandas
             default_options = {
-                "dtype": None,  # Let pandas infer types initially
+                # Pin string-family columns to str; let pandas infer the rest
+                # (numeric/bool/date columns are coerced explicitly in
+                # _validate_csv). None when there are no string columns.
+                "dtype": string_dtype or None,
                 "keep_default_na": is_tabular,
                 "na_values": na_values,
                 "encoding": "utf-8",
-                "on_bad_lines": "warn",
+                # Fail loudly on a malformed (ragged) row instead of silently
+                # dropping it. A wrong-field-count line almost always signals a
+                # real problem (wrong delimiter, an unquoted/embedded comma), and
+                # silently shrinking the dataset corrupts it with no signal and a
+                # still-green "success". pandas' error names the offending line +
+                # field counts. (This also matches _count_records, which reads
+                # with pandas' default on_bad_lines='error'.)
+                "on_bad_lines": "error",
                 "low_memory": False,  # Prevent mixed type inference warnings
                 "engine": "c",  # Use faster C engine
             }
 
             csv_options = {**default_options, **self.csv_options}
+
+            # Reject duplicate column names before pandas silently disambiguates
+            # them (a, a -> a, a.1) and the schema mapping then targets the wrong
+            # physical column — invisible corruption. Read just the raw header row
+            # with the stdlib csv module (NOT pandas) so this is independent of
+            # the pd.read_csv path (and the same delimiter/encoding as the main
+            # read). csv.reader needs a single-char delimiter; a multi-char/regex
+            # sep or a bad encoding falls back to "no header read" (the main read
+            # then surfaces the real error).
+            _sep = csv_options.get("sep", csv_options.get("delimiter", ","))
+            _header = []
+            try:
+                with open(
+                    file_path,
+                    "r",
+                    encoding=csv_options.get("encoding", "utf-8"),
+                    newline="",
+                ) as _fh:
+                    _row = next(_csv.reader(_fh, delimiter=_sep), [])
+                _header = [str(h).strip() for h in _row]
+            except (OSError, UnicodeDecodeError, _csv.Error, TypeError):
+                _header = []
+            _dup_headers = sorted({h for h in _header if _header.count(h) > 1})
+            if _dup_headers:
+                raise ValueError(
+                    f"{RED}Duplicate column name(s) in the CSV header: "
+                    f"{_dup_headers}. Each column must be unique — otherwise the "
+                    f"second is silently renamed '<name>.1' by the parser and the "
+                    f"schema maps onto the wrong column. Rename the duplicates and "
+                    f"re-ingest.{RESET}"
+                )
 
             first_chunk = True
             for chunk in pd.read_csv(file_path, chunksize=chunk_size, **csv_options):
@@ -284,8 +383,19 @@ class CSVIngestor(BaseIngestor):
             Total number of records if countable, None otherwise
         """
         try:
-            # Use pandas to count lines efficiently
-            return pd.read_csv(file_path).shape[0]
+            # Count rows WITHOUT materialising the whole file. The old
+            # `pd.read_csv(file_path).shape[0]` loaded every column of every row
+            # into memory just to get a count — for a multi-GB dataset that's an
+            # OOM (the pod is Killed/137) before ingestion even starts. Read a
+            # single column in chunks and sum the lengths: CSV-aware (quoting /
+            # embedded newlines handled, unlike a raw line count) and bounded
+            # memory. usecols=[0] keeps each chunk to one column.
+            total = 0
+            for chunk in pd.read_csv(
+                file_path, usecols=[0], chunksize=100_000, encoding="utf-8"
+            ):
+                total += len(chunk)
+            return total
         except Exception as e:
             logger.debug(
                 f"{YELLOW}Unable to count CSV records using pandas: {str(e)}{RESET}"

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -59,6 +59,13 @@ class DataValidator(BaseValidator):
             "FLOAT": self._validate_float,
             "DOUBLE": self._validate_double,
             "DECIMAL": self._validate_decimal,
+            # NUMERIC is a MySQL alias for DECIMAL and is accepted by both
+            # Database._get_sqlalchemy_type (DDL) and CSVIngestor._validate_csv
+            # (type cast). Without this entry the preflight DataValidator
+            # rejects a NUMERIC(p,s) schema with "Unknown data type" even
+            # though ingestion would happily proceed — the two layers must
+            # accept the same vocabulary, not diverge.
+            "NUMERIC": self._validate_decimal,
             "BOOLEAN": self._validate_boolean,
             "BOOL": self._validate_boolean,
             "DATE": self._validate_date,

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -89,9 +89,30 @@ class DataValidator(BaseValidator):
                     metadata={"schema_provided": False},
                 )
 
-            sample_size = kwargs.get("sample_size", 1000)
+            # Validate the ENTIRE column, not a sample. The old default of 1000
+            # meant a bad value past row 1000 (a non-numeric in an INT column, a
+            # too-long VARCHAR) passed validation and then corrupted or crashed
+            # the ingest — validation success did not predict ingestion success.
+            # Callers can still pass an explicit sample_size to cap it.
+            sample_size = kwargs.get("sample_size", None)
 
-            # Load data
+            # Full-column scan of a CSV is done CHUNK BY CHUNK so a very large
+            # file is never materialised at once — the old full load OOM'd the
+            # pod (Killed/137) on multi-GB datasets. Each chunk is validated and
+            # we return on the FIRST failing chunk (reporting that problem
+            # without scanning further or holding the whole file). DataFrame /
+            # JSON inputs, and any explicit sample_size, keep the single-shot
+            # path below.
+            if (
+                sample_size is None
+                and isinstance(data, (str, Path))
+                and Path(data).suffix.lower() == ".csv"
+            ):
+                return self._validate_csv_streaming(
+                    Path(data), chunk_size=kwargs.get("chunk_size", 50_000)
+                )
+
+            # Load data (DataFrame, JSON, or an explicitly capped CSV sample)
             df = self._load_data(data, sample_size)
             if df is None or df.empty:
                 return self._create_result(
@@ -110,6 +131,52 @@ class DataValidator(BaseValidator):
                 errors=[f"Data type validation error: {str(e)}"],
                 metadata={"error_type": "validation_exception"},
             )
+
+    def _validate_csv_streaming(
+        self, path: Path, chunk_size: int = 50_000
+    ) -> ValidationResult:
+        """Validate a CSV's full contents chunk by chunk, with bounded memory.
+
+        Reads ``chunk_size`` rows at a time, validates each against the schema,
+        and returns on the FIRST failing chunk — so a bad value anywhere in a
+        large file is caught without materialising the whole file or scanning
+        past the first problem. A clean file scans to the end and reports the
+        total rows checked.
+        """
+        try:
+            reader = pd.read_csv(
+                path, chunksize=chunk_size, encoding="utf-8", on_bad_lines="warn"
+            )
+        except pd.errors.EmptyDataError:
+            return self._create_result(
+                is_valid=False,
+                errors=["No data found to validate"],
+                metadata={"rows_checked": 0},
+            )
+
+        rows_checked = 0
+        saw_data = False
+        for chunk in reader:
+            if chunk.empty:
+                continue
+            saw_data = True
+            rows_checked += len(chunk)
+            result = self._validate_schema(chunk)
+            if not result.is_valid:
+                if isinstance(result.metadata, dict):
+                    result.metadata["rows_checked"] = rows_checked
+                return result
+
+        if not saw_data:
+            return self._create_result(
+                is_valid=False,
+                errors=["No data found to validate"],
+                metadata={"rows_checked": 0},
+            )
+        return self._create_result(
+            is_valid=True,
+            metadata={"rows_checked": rows_checked, "schema_provided": True},
+        )
 
     def _load_data(self, data: Any, sample_size: int) -> Optional[pd.DataFrame]:
         """Load data from input source.
@@ -173,6 +240,15 @@ class DataValidator(BaseValidator):
         Returns:
             ValidationResult containing validation status and messages
         """
+        # Strip header whitespace so validation matches what the ingestor
+        # actually ingests: CSVIngestor.read_data does `chunk.columns.str.strip()`
+        # on every chunk, so a header like " age" becomes "age" and is ingested
+        # against schema key "age". Without the same strip here, the validator
+        # saw " age" (!= "age"), silently skipped the column, and a bad value in
+        # it passed pre-flight validation only to fail later at ingest. rename()
+        # returns a new frame, so the caller's DataFrame is untouched.
+        df = df.rename(columns=lambda c: str(c).strip())
+
         errors = []
         warnings = []
         metadata = {

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -5,6 +5,7 @@ It validates that data types in CSV files match the data types specified
 in the schema and provides clear errors when mismatches are found.
 """
 
+import csv as _csv
 import logging
 import re
 from pathlib import Path
@@ -143,9 +144,37 @@ class DataValidator(BaseValidator):
         past the first problem. A clean file scans to the end and reports the
         total rows checked.
         """
+        # Preflight read rules MUST match CSVIngestor.read_data — otherwise a
+        # file can pass validation and then explode at ingest time on a
+        # structural error the validator never surfaced. Two mismatches were
+        # silent until #190's bugbot caught them:
+        #   1. on_bad_lines="error" (CSVIngestor.read_data #76711e6) so a
+        #      ragged row is rejected here too, not silently warned-and-dropped.
+        #   2. Reject duplicate headers up front so they fail in validation,
+        #      not later in the ingestor — same error CSVIngestor raises.
+        try:
+            with open(path, "r", encoding="utf-8", newline="") as _fh:
+                _raw_header = next(_csv.reader(_fh), [])
+            _stripped = [str(h).strip() for h in _raw_header]
+            _dups = sorted({h for h in _stripped if _stripped.count(h) > 1})
+            if _dups:
+                return self._create_result(
+                    is_valid=False,
+                    errors=[
+                        f"Duplicate column name(s) in the CSV header: {_dups}. "
+                        f"Each column must be unique — otherwise the second is "
+                        f"silently renamed '<name>.1' by the parser and the "
+                        f"schema maps onto the wrong column."
+                    ],
+                    metadata={"rows_checked": 0},
+                )
+        except (OSError, UnicodeDecodeError, _csv.Error, TypeError, StopIteration):
+            # Header probe failed; let pd.read_csv surface the real error below.
+            pass
+
         try:
             reader = pd.read_csv(
-                path, chunksize=chunk_size, encoding="utf-8", on_bad_lines="warn"
+                path, chunksize=chunk_size, encoding="utf-8", on_bad_lines="error"
             )
         except pd.errors.EmptyDataError:
             return self._create_result(


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core ingest, MySQL DDL/upserts, and post-commit backend registration—bugs could block customer datasets or leave rows committed without registration, though changes aim to reduce silent data loss.
> 
> **Overview**
> **Release 0.3.7** hardens tabular CSV ingestion and database handling so messy real-world files either land correctly or fail with clear errors instead of silent corruption or false success.
> 
> **CSV read & cast:** Ragged rows and duplicate headers are rejected up front (`on_bad_lines="error"`, header preflight). Type coercion is tightened—nullable **Int64**, **DATE**/**TIME** without spurious datetime parts, **BOOL**/**numpy.bool_** and yes/no strings, **DECIMAL**/**NUMERIC**, **float64** precision, and **dtype=str** for string columns including headers with surrounding whitespace. Header strip + `_validate_csv` run on **every** chunk; record counting uses chunked single-column reads to avoid OOM.
> 
> **Validation:** **DataValidator** defaults to scanning full columns (optional sample), streams large CSVs in chunks with the same structural rules as the ingestor, accepts **NUMERIC**, and strips header whitespace to match ingest.
> 
> **Database:** **DECIMAL**/**NUMERIC** precision/scale are honored in DDL; fail-fast guards for ~4000+ feature columns and **stale reflected tables** whose columns don’t match the incoming schema; **ON DUPLICATE KEY UPDATE** backtick-quotes column names (including embedded backticks) for proteomics-style headers.
> 
> **Ingest lifecycle:** Failed backend registration steps after MySQL commit now **raise** (no exit-0 with unregistered datasets); the CLI maps hard failures to a single stderr line and exit **1**.
> 
> Tests add a large **adversarial ingestion harness** and expand regression coverage; known gaps remain marked **xfail** (e.g. INT leading zeros, float overflow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a486661a89e2a653cd154bb046874c9d7b2a92cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->