### PR TITLE
fix(bugbot-190): DECIMAL scale, preflight rules, whitespace-header dtype pin

### DIFF
--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -50,6 +50,20 @@ def test_read_data_strips_column_whitespace(tmp_path):
     assert "a" in records[0] and "b" in records[0]
 
 
+def test_read_data_preserves_leading_zeros_with_whitespace_header(tmp_path):
+    # Regression (#190 bugbot): the dtype=str pin keyed by clean schema column
+    # names is applied by pandas against the RAW header literals — before
+    # `chunk.columns.str.strip()`. A header " code " missed the pin, pandas
+    # inferred int from "007" -> 7, and the leading zeros were silently lost.
+    # The fix probes the raw header and pins both the spaced and clean spellings.
+    p = tmp_path / "d.csv"
+    p.write_text(" code ,n\n007,1\n042,2\n")
+    ing = make_csv_ingestor(schema={"code": "VARCHAR(10)", "n": "INT"})
+    records = list(ing.read_data(str(p)))
+    assert records[0]["code"] == "007", f"leading zeros lost; got {records[0]['code']!r}"
+    assert records[1]["code"] == "042"
+
+
 def test_read_data_schema_column_missing_raises(make_csv):
     path = make_csv({"a": [1]})
     ing = make_csv_ingestor(schema={"a": "INT", "missing": "INT"})

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -37,6 +37,30 @@ def test_loads_from_csv(make_csv):
     assert result.is_valid
 
 
+def test_streaming_validator_rejects_duplicate_headers(tmp_path):
+    # Regression (#190 bugbot): the streaming CSV validator used to accept
+    # duplicate headers (pandas silently disambiguates "a, a" to "a, a.1"),
+    # while CSVIngestor.read_data rejects them outright — so a file passed
+    # validation and then exploded at ingest with a structural error the
+    # preflight step never surfaced. Align: reject up front.
+    p = tmp_path / "dups.csv"
+    p.write_text("a,a\n1,2\n3,4\n")
+    result = DataValidator(schema={"a": "INT"}).validate(str(p))
+    assert not result.is_valid
+    assert "Duplicate column" in result.errors[0]
+
+
+def test_streaming_validator_rejects_ragged_rows(tmp_path):
+    # Regression (#190 bugbot): the streaming validator used on_bad_lines=
+    # "warn" — a ragged row was silently dropped, validation reported success,
+    # then CSVIngestor.read_data (on_bad_lines="error") failed at ingest. Now
+    # both fail at the same point.
+    p = tmp_path / "ragged.csv"
+    p.write_text("a,b\n1,2\n3,4,5\n6,7\n")
+    result = DataValidator(schema={"a": "INT", "b": "INT"}).validate(str(p))
+    assert not result.is_valid
+
+
 def test_loads_from_json(tmp_path):
     """JSON top-level array of records must validate, mirroring the file shape
     JSONIngestor.read_data consumes.

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -86,6 +86,24 @@ def test_get_sqlalchemy_type_unsupported_raises(db):
         db._get_sqlalchemy_type("GEOMETRY")
 
 
+def test_get_sqlalchemy_type_decimal_precision_scale(db):
+    # Regression (#190 bugbot): DECIMAL(10,2) used to fail int("10,2") and
+    # fall back to a bare Numeric() — declared precision and scale silently
+    # dropped, MySQL then used its default and clipped values.
+    result = db._get_sqlalchemy_type("DECIMAL(10,2)")
+    assert isinstance(result, db_mod.Numeric)
+    assert result.precision == 10
+    assert result.scale == 2
+
+
+def test_get_sqlalchemy_type_numeric_precision_scale(db):
+    # NUMERIC is an alias for DECIMAL; same precision/scale handling.
+    result = db._get_sqlalchemy_type("NUMERIC(8, 3)")
+    assert isinstance(result, db_mod.Numeric)
+    assert result.precision == 8
+    assert result.scale == 3
+
+
 # ---------------------------------------------------------------------------
 # create_table
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -95,14 +95,24 @@ class Database:
         
         if base_type in type_mapping:
             alchemy_type = type_mapping[base_type]
-            # Extract length for VARCHAR types
-            length = None
+            # Extract parenthesised arguments. Two shapes:
+            #   - VARCHAR(255) / CHAR(10)      -> single int length
+            #   - DECIMAL(10, 2) / NUMERIC(p,s) -> precision, scale (both honoured;
+            #     previously int("10,2") raised ValueError and we silently fell
+            #     back to a bare Numeric, dropping the declared scale and writing
+            #     the column at MySQL's default — losing precision on the values
+            #     it then bound).
             if "(" in mysql_type_upper:
                 try:
-                    length = int(mysql_type_upper.split("(")[1].split(")")[0])
+                    inside = mysql_type_upper.split("(", 1)[1].rsplit(")", 1)[0]
+                    parts = [int(p.strip()) for p in inside.split(",") if p.strip()]
                 except (ValueError, IndexError):
-                    pass
-            return alchemy_type(length) if length else alchemy_type
+                    parts = []
+                if len(parts) == 2 and base_type in ("DECIMAL", "NUMERIC"):
+                    return alchemy_type(parts[0], parts[1])
+                if len(parts) == 1:
+                    return alchemy_type(parts[0])
+            return alchemy_type
 
         raise ValueError(f"Unsupported MySQL type: {mysql_type}")
 

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -245,12 +245,45 @@ class CSVIngestor(BaseIngestor):
             # by pandas, so this is safe when the schema lists more columns than
             # the CSV carries.
             _STRING_TYPES = ("VARCHAR", "CHAR", "TEXT", "STRING")
-            string_dtype = {
-                col: str
+            _string_schema_cols = {
+                col
                 for col, t in self.schema.items()
                 if isinstance(t, str)
                 and t.upper().split("(")[0].strip() in _STRING_TYPES
             }
+            # Pandas applies `dtype` keyed by the RAW header literal — before
+            # `chunk.columns.str.strip()` runs. If a header carries surrounding
+            # whitespace (" code "), keying the dtype dict by the clean schema
+            # name ("code") misses, pandas infers numeric, and "007" lands as
+            # 7 — the leading zeros silently lost on the very read this pin was
+            # meant to prevent. Read the raw header up front (same csv module
+            # path we use for duplicate detection) and pin every raw spelling
+            # whose stripped form matches a string-family schema column.
+            _string_raw_headers = set()
+            try:
+                _sep_probe = self.csv_options.get(
+                    "sep", self.csv_options.get("delimiter", ",")
+                )
+                with open(
+                    file_path,
+                    "r",
+                    encoding=self.csv_options.get("encoding", "utf-8"),
+                    newline="",
+                ) as _fh:
+                    _raw = next(_csv.reader(_fh, delimiter=_sep_probe), [])
+                for _h in _raw:
+                    if str(_h).strip() in _string_schema_cols:
+                        _string_raw_headers.add(_h)
+            except (OSError, UnicodeDecodeError, _csv.Error, TypeError, StopIteration):
+                # Probe failed; fall back to keying by the schema name only —
+                # files without leading/trailing whitespace headers (the
+                # common case) still get pinned.
+                _string_raw_headers = set(_string_schema_cols)
+            else:
+                # Always include the bare schema name too, so a file without
+                # the whitespace variant still gets pinned cleanly.
+                _string_raw_headers |= _string_schema_cols
+            string_dtype = {h: str for h in _string_raw_headers}
 
             # Enhanced default options for pandas
             default_options = {

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -5,6 +5,7 @@ It validates that data types in CSV files match the data types specified
 in the schema and provides clear errors when mismatches are found.
 """
 
+import csv as _csv
 import logging
 import re
 from pathlib import Path
@@ -143,9 +144,37 @@ class DataValidator(BaseValidator):
         past the first problem. A clean file scans to the end and reports the
         total rows checked.
         """
+        # Preflight read rules MUST match CSVIngestor.read_data — otherwise a
+        # file can pass validation and then explode at ingest time on a
+        # structural error the validator never surfaced. Two mismatches were
+        # silent until #190's bugbot caught them:
+        #   1. on_bad_lines="error" (CSVIngestor.read_data #76711e6) so a
+        #      ragged row is rejected here too, not silently warned-and-dropped.
+        #   2. Reject duplicate headers up front so they fail in validation,
+        #      not later in the ingestor — same error CSVIngestor raises.
+        try:
+            with open(path, "r", encoding="utf-8", newline="") as _fh:
+                _raw_header = next(_csv.reader(_fh), [])
+            _stripped = [str(h).strip() for h in _raw_header]
+            _dups = sorted({h for h in _stripped if _stripped.count(h) > 1})
+            if _dups:
+                return self._create_result(
+                    is_valid=False,
+                    errors=[
+                        f"Duplicate column name(s) in the CSV header: {_dups}. "
+                        f"Each column must be unique — otherwise the second is "
+                        f"silently renamed '<name>.1' by the parser and the "
+                        f"schema maps onto the wrong column."
+                    ],
+                    metadata={"rows_checked": 0},
+                )
+        except (OSError, UnicodeDecodeError, _csv.Error, TypeError, StopIteration):
+            # Header probe failed; let pd.read_csv surface the real error below.
+            pass
+
         try:
             reader = pd.read_csv(
-                path, chunksize=chunk_size, encoding="utf-8", on_bad_lines="warn"
+                path, chunksize=chunk_size, encoding="utf-8", on_bad_lines="error"
             )
         except pd.errors.EmptyDataError:
             return self._create_result(


### PR DESCRIPTION
## Summary

Addresses the three medium-severity Cursor Bugbot findings on PR #190 (develop → prod sync for 0.3.7). All three are real, user-reachable bugs.

## Findings & fixes

### 1. `tracebloc_ingestor/database.py:82` — DECIMAL(p,s) precision/scale dropped

`_get_sqlalchemy_type` parsed a single int inside parens (the `VARCHAR(n)` shape). For `DECIMAL(10,2)` / `NUMERIC(p,s)` the cast `int("10,2")` raised, the helper silently fell back to a bare `Numeric()`, and MySQL then used its default precision/scale — so a declared `DECIMAL(10,2)` accepted/clipped values inconsistently with the schema the user authored.

**Fix:** parse the comma-separated args; pass `(precision, scale)` to `Numeric`; keep single-arg behaviour for `String(length)`.

### 2. `tracebloc_ingestor/validators/data_validator.py:148` — preflight rules diverged from the real read

The streaming CSV validator used `on_bad_lines="warn"` and didn't reject duplicate headers, while `CSVIngestor.read_data` uses `on_bad_lines="error"` and rejects duplicates outright (#76711e6 in #186). A file with a ragged row or duplicate header passed validation, then died at read time with a structural error preflight never surfaced.

**Fix:** mirror both guards in the streaming path so validation fails at the same point ingestion would.

### 3. `tracebloc_ingestor/ingestors/csv_ingestor.py:308` — string dtype pin skipped on whitespace headers

`pd.read_csv` applies `dtype` keyed by the **raw** header literal — before `chunk.columns.str.strip()` runs. The pin was keyed by the clean schema name (`"code"`), so a header literal `" code "` missed, pandas inferred numeric, `"007"` landed as `7` — exactly the silent leading-zero corruption the pin was meant to prevent.

**Fix:** probe the raw header, pin both the spaced and clean spellings.

## Tests

Three regression tests, one per finding:

- `test_get_sqlalchemy_type_decimal_precision_scale` / `_numeric_…` — `DECIMAL(10,2)` and `NUMERIC(8,3)` honor precision/scale on the returned SQLAlchemy `Numeric`.
- `test_streaming_validator_rejects_duplicate_headers` + `_ragged_rows` — validation fails at preflight, matching the ingestor's rules.
- `test_read_data_preserves_leading_zeros_with_whitespace_header` — `" code "` header keeps `"007"` as the string `"007"`.

Full local suite: **765 passed, 2 xfailed.**

## Versioning

Develop is at 0.3.7. PR #190 (the prod sync) hasn't shipped yet — these fixes should land on develop before the sync goes out so 0.3.7 ships clean. No re-bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches schema-to-MySQL mapping and CSV validation/ingest parity; fixes silent data corruption but changes when some malformed CSVs fail (earlier, at validation).
> 
> **Overview**
> Fixes three **#190 Bugbot** regressions so validation, CSV reads, and DDL match user-authored schemas.
> 
> **`Database._get_sqlalchemy_type`** now parses `DECIMAL(10,2)` / `NUMERIC(p,s)` as precision + scale instead of failing on `int("10,2")` and emitting an unqualified `Numeric()`.
> 
> **Streaming `DataValidator`** preflight matches **`CSVIngestor.read_data`**: duplicate headers are rejected before pandas renames them, and **`on_bad_lines="error"`** replaces warn-and-drop so ragged rows fail at validation instead of after a green preflight.
> 
> **`CSVIngestor`** probes the raw header and keys **`dtype=str`** on both literal headers (e.g. `" code "`) and stripped schema names so zero-padded string codes like `"007"` are not inferred as integers before column strip.
> 
> Regression tests cover all three paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a6fb999b9a282af8a78e39ff6365eae22f11ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->