### PR TITLE
fix(validator): accept NUMERIC schema (alias for DECIMAL)

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -177,8 +177,12 @@ def test_bigint_delegates_to_int():
 # FLOAT / DOUBLE / DECIMAL
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("dtype", ["FLOAT", "DOUBLE", "DECIMAL(10,2)"])
+@pytest.mark.parametrize("dtype", ["FLOAT", "DOUBLE", "DECIMAL(10,2)", "NUMERIC(8,3)", "NUMERIC"])
 def test_float_family_valid(dtype):
+    # NUMERIC is a MySQL alias for DECIMAL; #190 bugbot caught that the DDL
+    # and ingestor type-cast layers accepted NUMERIC but the validator's
+    # type_validators dict didn't, so a schema using NUMERIC failed preflight
+    # with "Unknown data type" even though ingest would proceed.
     df = pd.DataFrame({"x": [1.5, 2.25]})
     assert DataValidator(schema={"x": dtype}).validate(df).is_valid
 

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -59,6 +59,13 @@ class DataValidator(BaseValidator):
             "FLOAT": self._validate_float,
             "DOUBLE": self._validate_double,
             "DECIMAL": self._validate_decimal,
+            # NUMERIC is a MySQL alias for DECIMAL and is accepted by both
+            # Database._get_sqlalchemy_type (DDL) and CSVIngestor._validate_csv
+            # (type cast). Without this entry the preflight DataValidator
+            # rejects a NUMERIC(p,s) schema with "Unknown data type" even
+            # though ingestion would happily proceed — the two layers must
+            # accept the same vocabulary, not diverge.
+            "NUMERIC": self._validate_decimal,
             "BOOLEAN": self._validate_boolean,
             "BOOL": self._validate_boolean,
             "DATE": self._validate_date,


### PR DESCRIPTION
## Bugbot finding (#190)

> **NUMERIC schema fails validation** — Medium severity
> \`DataValidator.type_validators\` has no NUMERIC entry, while \`Database._get_sqlalchemy_type\` (DDL) and \`CSVIngestor._validate_csv\` (cast) both accept NUMERIC(p,s). Schemas using NUMERIC fail preflight with \"Unknown data type\" even though ingestion would proceed.

## Fix

Map \`NUMERIC\` → \`_validate_decimal\` (same validator — NUMERIC is just a MySQL alias for DECIMAL). The three layers (validator / DDL / cast) now agree on the type vocabulary.

## Test

Parametrised \`test_float_family_valid\` to include \`NUMERIC(8,3)\` and bare \`NUMERIC\`.

Local: 768 passed, 2 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dictionary entry reusing existing decimal validation; behavior change only for schemas that previously failed preflight incorrectly.
> 
> **Overview**
> **Preflight validation now accepts `NUMERIC` in schemas**, matching DDL and CSV casting where `NUMERIC` was already treated as a DECIMAL alias.
> 
> `DataValidator.type_validators` maps **`NUMERIC`** to **`_validate_decimal`**, so forms like `NUMERIC(8,3)` and bare `NUMERIC` no longer fail preflight with **"Unknown data type"** while ingestion would still succeed.
> 
> Tests extend **`test_float_family_valid`** to cover **`NUMERIC(8,3)`** and **`NUMERIC`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf02954c83795a7885463a0d5771660b3856d85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->