### PR TITLE
fix(validator): VARCHAR/CHAR/TEXT accept numeric scalars (issue #188)

### DIFF
--- a/tests/test_coverage_gaps3.py
+++ b/tests/test_coverage_gaps3.py
@@ -12,26 +12,31 @@ import pytest
 from tracebloc_ingestor.validators.data_validator import DataValidator
 
 
-# ---- data_validator non-string type checks -------------------------------
+# ---- data_validator non-scalar type checks --------------------------------
+# Issue #188: numeric scalars (1, 2.5, True) in a VARCHAR/CHAR/TEXT column are
+# now VALID — MySQL binds any scalar as a string against a string column, and
+# blocking them rejected legitimate zip codes / numeric IDs / 0-1 labels. The
+# only remaining shape error is a non-scalar container (list/dict/set/tuple);
+# pin that as the new contract.
 
-def test_varchar_non_string_values_flagged():
-    df = pd.DataFrame({"s": [1, 2]})  # ints under VARCHAR -> non-string
+def test_varchar_non_scalar_container_flagged():
+    df = pd.DataFrame({"s": [[1, 2], {"k": 1}]})  # lists/dicts: real shape errors
     res = DataValidator(schema={"s": "VARCHAR(10)"}).validate(df)
     assert not res.is_valid
-    assert any("non-string" in e for e in res.errors)
+    assert any("non-scalar" in e for e in res.errors)
 
 
-def test_char_non_string_values_flagged():
-    df = pd.DataFrame({"s": [1, 2]})
+def test_char_non_scalar_container_flagged():
+    df = pd.DataFrame({"s": [["a"], ["b"]]})
     res = DataValidator(schema={"s": "CHAR(1)"}).validate(df)
     assert not res.is_valid
 
 
-def test_text_non_string_values_flagged():
-    df = pd.DataFrame({"s": [1, 2]})
+def test_text_non_scalar_container_flagged():
+    df = pd.DataFrame({"s": [{"k": "v"}, [1, 2, 3]]})
     res = DataValidator(schema={"s": "TEXT"}).validate(df)
     assert not res.is_valid
-    assert any("non-string" in e for e in res.errors)
+    assert any("non-scalar" in e for e in res.errors)
 
 
 def test_data_validator_load_data_exception(make_csv):

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -312,13 +312,71 @@ def test_text_with_nulls_is_valid():
     assert DataValidator(schema={"s": "TEXT"}).validate(df).is_valid
 
 
-def test_varchar_still_flags_real_non_strings():
-    # NULL tolerance must NOT mask a genuine type error: a real numeric value
-    # in a VARCHAR column is still non-string and must be reported.
-    df = pd.DataFrame({"s": ["abc", 5, "de"]})
+def test_varchar_accepts_numeric_scalars(make_csv):
+    # Issue #188: pd.read_csv infers numeric-looking columns as int64/float64,
+    # so an all-numeric VARCHAR column (zip / category code, 0/1 label
+    # declared VARCHAR) was rejected with "Column 'code' contains N
+    # non-string values" — an error the user could never clear because
+    # MySQL would happily bind the int as a string. Any scalar (int, float,
+    # bool) must pass the validator; MySQL handles the conversion at bind.
+    df = pd.DataFrame({"code": [100, 200, 300], "label": [0, 1, 0]})
+    result = DataValidator(
+        schema={"code": "VARCHAR(10)", "label": "VARCHAR(8)"}
+    ).validate(df)
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+
+
+def test_varchar_rejects_non_scalar_containers():
+    # The only real shape error left at this layer: a list/dict/set/tuple
+    # has no sensible single-string form, so flag it as non-scalar. This is
+    # what replaces the (over-broad) astype(str)!=value check the fix drops.
+    df = pd.DataFrame({"s": ["abc", [1, 2, 3], "de"]})
     result = DataValidator(schema={"s": "VARCHAR(255)"}).validate(df)
     assert not result.is_valid
-    assert "non-string" in result.errors[0]
+    assert "non-scalar" in result.errors[0]
+
+
+def test_varchar_length_still_enforced_on_numeric():
+    # Length check applies to the stringified form, so a numeric value whose
+    # decimal representation exceeds max_length is still rejected.
+    df = pd.DataFrame({"s": [12345]})
+    result = DataValidator(schema={"s": "VARCHAR(3)"}).validate(df)
+    assert not result.is_valid
+    assert "exceeding max length" in result.errors[0]
+
+
+def test_issue_188_full_repro_csv(make_csv):
+    # End-to-end repro from issue #188:
+    #   schema {id: INT, feat: FLOAT, code: VARCHAR(10), label: VARCHAR(8)}
+    #   id,feat,code,label
+    #   1,1.2,100,A
+    #   2,3.4,200,B
+    # Before the fix: is_valid=False, two "Column 'code' contains 2
+    # non-string values" + "Column 'label' …" errors. After the fix:
+    # passes (pandas reads `code` as int64, but VARCHAR accepts any scalar).
+    path = make_csv(
+        {"id": [1, 2], "feat": [1.2, 3.4], "code": [100, 200], "label": ["A", "B"]}
+    )
+    result = DataValidator(
+        schema={
+            "id": "INT", "feat": "FLOAT",
+            "code": "VARCHAR(10)", "label": "VARCHAR(8)",
+        }
+    ).validate(str(path))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+
+
+@pytest.mark.parametrize("dtype", ["VARCHAR(10)", "CHAR(3)", "TEXT"])
+def test_issue_188_numeric_scalars_pass_string_family(dtype):
+    # All three string-family validators share the same astype(str)!=value
+    # over-rejection; the fix is applied uniformly.
+    df = pd.DataFrame({"s": ["abc", 100, 200]})  # ints mixed in (CHAR case
+                                                 # is special — see below)
+    if "CHAR(" in dtype:
+        # CHAR enforces fixed length, so use values that all stringify to 3.
+        df = pd.DataFrame({"s": ["abc", 100, 200]})
+    result = DataValidator(schema={"s": dtype}).validate(df)
+    assert result.is_valid, f"{dtype}: errors={result.errors}"
 
 
 def test_char_wrong_length_fails():

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -366,15 +366,24 @@ class DataValidator(BaseValidator):
         length_match = re.search(r"VARCHAR\((\d+)\)", expected_type.upper())
         max_length = int(length_match.group(1)) if length_match else None
 
-        # Check for non-string values. A NULL is valid for any column, and
-        # ``NaN != NaN`` would otherwise count every missing value as
-        # "non-string" — an error the user can never clear (inserting NaN
-        # doesn't help). Mirror the INT/FLOAT validators: only flag values
-        # that are non-null AND not strings.
-        non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
-        if non_string_count > 0:
+        # Issue #188: do NOT compare ``astype(str)`` to the original typed
+        # value. pd.read_csv infers numeric-looking columns as int64/float64,
+        # so for value 100 the check ``"100" != 100`` is True and the column
+        # was falsely rejected as "non-string" — blocking legitimate zip
+        # codes, numeric IDs kept as text, and 0/1 labels declared VARCHAR.
+        # MySQL binds any scalar as a string against a VARCHAR column, so the
+        # only real constraints to enforce here are presence/null tolerance
+        # (handled by other layers) and length. Flag genuinely non-scalar
+        # values (list/dict/set/tuple) — those have no sensible string form
+        # and indicate a real shape error — but let every scalar pass.
+        non_scalar_mask = series.apply(
+            lambda v: isinstance(v, (list, dict, set, tuple))
+        )
+        non_scalar_count = int(non_scalar_mask.sum())
+        if non_scalar_count > 0:
             errors.append(
-                f"Column '{column_name}' contains {non_string_count} non-string values"
+                f"Column '{column_name}' contains {non_scalar_count} non-scalar value(s) "
+                f"(list/dict/set/tuple) that cannot be stored as a string"
             )
 
         # Check length constraints
@@ -410,15 +419,18 @@ class DataValidator(BaseValidator):
         length_match = re.search(r"CHAR\((\d+)\)", expected_type.upper())
         max_length = int(length_match.group(1)) if length_match else None
 
-        # Check for non-string values. A NULL is valid for any column, and
-        # ``NaN != NaN`` would otherwise count every missing value as
-        # "non-string" — an error the user can never clear (inserting NaN
-        # doesn't help). Mirror the INT/FLOAT validators: only flag values
-        # that are non-null AND not strings.
-        non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
-        if non_string_count > 0:
+        # Issue #188: see _validate_varchar — same astype(str)!=value
+        # over-rejection bug. CHAR columns with numeric values (e.g. a
+        # 2-character state code "10") were blocked. Same fix: flag only
+        # genuinely non-scalar values, let any scalar through.
+        non_scalar_mask = series.apply(
+            lambda v: isinstance(v, (list, dict, set, tuple))
+        )
+        non_scalar_count = int(non_scalar_mask.sum())
+        if non_scalar_count > 0:
             errors.append(
-                f"Column '{column_name}' contains {non_string_count} non-string values"
+                f"Column '{column_name}' contains {non_scalar_count} non-scalar value(s) "
+                f"(list/dict/set/tuple) that cannot be stored as a string"
             )
 
         # Check length constraints (CHAR should be fixed length)
@@ -450,15 +462,18 @@ class DataValidator(BaseValidator):
         errors = []
         warnings = []
 
-        # Check for non-string values. A NULL is valid for any column, and
-        # ``NaN != NaN`` would otherwise count every missing value as
-        # "non-string" — an error the user can never clear (inserting NaN
-        # doesn't help). Mirror the INT/FLOAT validators: only flag values
-        # that are non-null AND not strings.
-        non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
-        if non_string_count > 0:
+        # Issue #188: see _validate_varchar — same astype(str)!=value bug.
+        # TEXT columns with numeric values (notes that happen to be all
+        # digits, integer IDs kept as text) were blocked. Same fix:
+        # flag only genuinely non-scalar values; any scalar passes.
+        non_scalar_mask = series.apply(
+            lambda v: isinstance(v, (list, dict, set, tuple))
+        )
+        non_scalar_count = int(non_scalar_mask.sum())
+        if non_scalar_count > 0:
             errors.append(
-                f"Column '{column_name}' contains {non_string_count} non-string values"
+                f"Column '{column_name}' contains {non_scalar_count} non-scalar value(s) "
+                f"(list/dict/set/tuple) that cannot be stored as a string"
             )
 
         return {"is_valid": len(errors) == 0, "errors": errors, "warnings": warnings}


### PR DESCRIPTION
## The bug (issue #188)

`DataValidator._validate_varchar` / `_char` / `_text` used `series.astype(str).ne(series)` to detect non-string values:

```python
non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
```

`pd.read_csv` infers numeric-looking columns as `int64`/`float64`, so for value `100` the check is `"100" != 100` → True → "non-string". The recent `series.notna()` guard fixed NULL handling but not numeric-typed values: any VARCHAR column pandas doesn't read as `object` dtype was rejected.

**Blast radius:** zip / category codes, numeric IDs declared VARCHAR, 0/1 labels declared VARCHAR — all blocked with `Column 'X' contains N non-string values`, an error the user cannot clear (MySQL would happily bind the integer as a string, but the dataset never reaches the binder).

Confirmed end-to-end against the deployed image `ghcr.io/tracebloc/ingestor@dfdaa7e6` and via the qa-fixtures matrix (cases C02, C18).

## Fix

Drop the `astype(str)!=value` comparison. Any scalar (int, float, bool, str) is representable as a string for MySQL binding and is accepted. The length constraint still runs against `series.dropna().astype(str)`, so a too-long numeric value (`12345` in `VARCHAR(3)`) is still rejected. The only remaining shape error at this layer is a non-scalar container (`list`/`dict`/`set`/`tuple`) — flag those as `non-scalar` (clearer message; doesn't lie about ints).

Applied uniformly to all three string-family validators.

## Tests

- `test_issue_188_full_repro_csv` — exact schema from the issue passes
- `test_varchar_accepts_numeric_scalars` — zip codes / 0-1 labels pass
- `test_issue_188_numeric_scalars_pass_string_family` (parametrised VARCHAR/CHAR/TEXT)
- `test_varchar_rejects_non_scalar_containers` — lists/dicts still flagged
- `test_varchar_length_still_enforced_on_numeric` — `12345` in VARCHAR(3) still rejected
- Updated 3 stale tests in `test_coverage_gaps3.py` that pinned the wrong (over-rejecting) contract

Local: **771 passed, 2 xfailed**.

## Scope

Companion issue #189 (JSON-side weaknesses: `bool()`/`int()` accept bad values; no VARCHAR/DATE/length checks) is its own PR — that's the symmetric fix on the other ingest path.

Closes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-flight validation rules on the ingest path for all string-family columns; behavior is intentionally looser for numeric scalars but length checks remain, with no auth or data-store logic touched.
> 
> **Overview**
> Fixes **issue #188** by changing how `DataValidator` treats **VARCHAR**, **CHAR**, and **TEXT** columns: it no longer rejects values where `astype(str) != value` (which falsely flagged pandas `int64`/`float64` cells like zip codes and numeric IDs).
> 
> **Scalars** (int, float, bool, str) are now accepted for MySQL string binding; **length rules** still run on the stringified form (e.g. `12345` in `VARCHAR(3)` still fails). The only new type-shape errors are **non-scalar containers** (`list`/`dict`/`set`/`tuple`), reported as `non-scalar` instead of `non-string`.
> 
> Tests add issue #188 repros and update coverage tests to match the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d5a6688c1037e74b184e7eda52240dc6f37c75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->