### PR TITLE
fix(json): align per-record validation with CSV (issue #189)

### DIFF
--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -120,6 +120,72 @@ def test_validate_record_still_rejects_real_type_errors():
         ing._validate_record({"n": "not-an-int"})
 
 
+# ---------------------------------------------------------------------------
+# Issue #189: JSON validation must match CSV — bool()/int() were too lenient
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("garbage", ["maybe", "banana", 2, "yesno"])
+def test_validate_record_rejects_garbage_boolean(garbage):
+    # Regression: bool("maybe") is True, bool(2) is True, so the previous
+    # implementation silently accepted these. Match DataValidator's fixed
+    # valid-set so JSON and CSV give the same verdict.
+    ing = make_json_ingestor(schema={"flag": "BOOL"})
+    with pytest.raises(ValueError, match="Data type validation failed"):
+        ing._validate_record({"flag": garbage})
+
+
+@pytest.mark.parametrize("v", [True, False, "true", "FALSE", "yes", "n", 0, 1])
+def test_validate_record_accepts_real_booleans(v):
+    # The valid set: Python bools, the canonical strings DataValidator
+    # accepts, and 0/1.
+    ing = make_json_ingestor(schema={"flag": "BOOL"})
+    ing._validate_record({"flag": v})
+
+
+def test_validate_record_rejects_non_integer_float_for_int():
+    # Regression: int(3.5) silently truncated to 3 with no error — INT label
+    # could end up as 0/1 from a 0.4/1.6 source value, corrupting training.
+    # Reject anything that isn't integer-valued.
+    ing = make_json_ingestor(schema={"n": "INT"})
+    with pytest.raises(ValueError, match="not an integer"):
+        ing._validate_record({"n": 3.5})
+
+
+def test_validate_record_accepts_integer_valued_float_for_int():
+    # 3.0 is integer-valued and is fine (matches the CSV validator's
+    # tolerance for whole-number floats stored as INT).
+    ing = make_json_ingestor(schema={"n": "INT"})
+    ing._validate_record({"n": 3.0})
+
+
+def test_validate_record_rejects_overlong_varchar():
+    # Regression: VARCHAR length was never enforced on JSON. The CSV path
+    # rejects a too-long string; JSON must too.
+    ing = make_json_ingestor(schema={"code": "VARCHAR(3)"})
+    with pytest.raises(ValueError, match="exceeds the declared length 3"):
+        ing._validate_record({"code": "ABCDE"})
+
+
+def test_validate_record_accepts_numeric_in_varchar():
+    # Issue #188 parity: VARCHAR accepts numeric scalars (zip codes,
+    # numeric IDs declared VARCHAR). MySQL binds them as strings.
+    ing = make_json_ingestor(schema={"code": "VARCHAR(10)"})
+    ing._validate_record({"code": 12345})
+
+
+def test_validate_record_rejects_unparseable_date():
+    # Regression: DATE wasn't validated on JSON at all — a 'not-a-date'
+    # string flowed through to the DB.
+    ing = make_json_ingestor(schema={"d": "DATE"})
+    with pytest.raises(ValueError, match="not a valid DATE"):
+        ing._validate_record({"d": "not-a-date"})
+
+
+def test_validate_record_accepts_iso_date():
+    ing = make_json_ingestor(schema={"d": "DATE"})
+    ing._validate_record({"d": "2024-01-15"})
+
+
 def test_count_records_array(tmp_path):
     p = _write_json(tmp_path, [{"a": 1}, {"a": 2}, {"a": 3}])
     assert make_json_ingestor()._count_records(str(p)) == 3

--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -210,6 +210,37 @@ def test_validate_record_rejects_non_finite_for_float(v):
         ing._validate_record({"x": v})
 
 
+# ---------------------------------------------------------------------------
+# #204 bugbot (2nd round) — JSON must not be stricter than CSV either,
+# else a record passes CSV-style preflight then drops at per-record check
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("v", [True, False])
+def test_validate_record_accepts_python_bool_for_int(v):
+    # DataValidator._validate_int accepts a bool column via pd.to_numeric
+    # (True -> 1, False -> 0). Rejecting them here would let a record pass
+    # CSV preflight and then be silently dropped mid-ingest.
+    ing = make_json_ingestor(schema={"n": "INT"})
+    ing._validate_record({"n": v})
+
+
+@pytest.mark.parametrize("v", ["00", "01", "1.0", "0.0", "1e0", "0e0"])
+def test_validate_record_accepts_numeric_string_for_bool(v):
+    # DataValidator._validate_boolean accepts any string that pd.to_numeric
+    # resolves to 0 or 1. JSON per-record validation must match.
+    ing = make_json_ingestor(schema={"flag": "BOOL"})
+    ing._validate_record({"flag": v})
+
+
+def test_validate_record_still_rejects_non_bool_numeric_string():
+    # The fallback only accepts values that resolve to exactly 0 or 1; "1.5"
+    # / "2" / "0.4" must still fail (matches DataValidator).
+    ing = make_json_ingestor(schema={"flag": "BOOL"})
+    for v in ("1.5", "2", "0.4"):
+        with pytest.raises(ValueError, match="Data type validation failed"):
+            ing._validate_record({"flag": v})
+
+
 def test_count_records_array(tmp_path):
     p = _write_json(tmp_path, [{"a": 1}, {"a": 2}, {"a": 3}])
     assert make_json_ingestor()._count_records(str(p)) == 3

--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -186,6 +186,30 @@ def test_validate_record_accepts_iso_date():
     ing._validate_record({"d": "2024-01-15"})
 
 
+# ---------------------------------------------------------------------------
+# #204 bugbot — non-finite (inf / NaN) must be rejected for INT and FLOAT
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("v", [float("inf"), float("-inf"), float("nan"), "Infinity"])
+def test_validate_record_rejects_non_finite_for_int(v):
+    # float("Infinity") returns +inf without raising, and float.is_integer()
+    # is False on inf/NaN — but the contract shouldn't depend on that detail.
+    # Mirror DataValidator's _non_finite_error on the CSV path and reject
+    # explicitly with an informative message.
+    ing = make_json_ingestor(schema={"n": "INT"})
+    with pytest.raises(ValueError, match="non-finite|not an integer"):
+        ing._validate_record({"n": v})
+
+
+@pytest.mark.parametrize("v", [float("inf"), float("-inf"), float("nan"), "Infinity"])
+def test_validate_record_rejects_non_finite_for_float(v):
+    # Bare float() lets inf through silently — DataValidator already rejects
+    # this for CSV (_non_finite_error). Match here so JSON and CSV agree.
+    ing = make_json_ingestor(schema={"x": "FLOAT"})
+    with pytest.raises(ValueError, match="non-finite"):
+        ing._validate_record({"x": v})
+
+
 def test_count_records_array(tmp_path):
     p = _write_json(tmp_path, [{"a": 1}, {"a": 2}, {"a": 3}])
     assert make_json_ingestor()._count_records(str(p)) == 3

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -58,25 +58,36 @@ def _validate_value_against_dtype(value: Any, dtype_upper: str) -> None:
     elif "BOOL" in dtype_upper:
         # ``bool(value)`` is truthy for any non-empty value, so "maybe" / 2
         # / "banana" all "passed" — match DataValidator._validate_boolean's
-        # fixed vocabulary instead.
+        # vocabulary instead. That validator also accepts string forms that
+        # ``pd.to_numeric`` maps to 0 or 1 (e.g. "00", "01", "1.0", "0.0"),
+        # so we try numeric coercion as a fallback before failing — keeps
+        # JSON and CSV in lockstep on the same input (#204 bugbot).
         if isinstance(value, bool):
             return
         if isinstance(value, (int, float)) and value in (0, 1):
             return
-        if isinstance(value, str) and value.strip().lower() in _VALID_BOOL_STRINGS:
-            return
+        if isinstance(value, str):
+            s = value.strip().lower()
+            if s in _VALID_BOOL_STRINGS:
+                return
+            # Numeric-coercible strings ("00", "01", "1.0", "0.0", "1e0", …)
+            # that resolve to 0 or 1 are accepted by DataValidator; mirror that.
+            num = pd.to_numeric(s, errors="coerce")
+            if not pd.isna(num) and num in (0, 1):
+                return
         raise ValueError(
             f"value {value!r} is not a valid BOOLEAN (expected true/false, "
             f"yes/no, 1/0, or a recognised string form)"
         )
     elif "INT" in dtype_upper:
         # ``int(value)`` silently truncated 3.5 -> 3; require integer-valued
-        # input. JSON booleans (a subclass of int) would slip through as
-        # 0/1, so guard against the bool case separately.
-        if isinstance(value, bool):
-            raise ValueError(
-                f"value {value!r} is a boolean, not an integer"
-            )
+        # input. Python booleans are intentionally allowed: ``True``/``False``
+        # are subclasses of int and ``DataValidator._validate_int`` accepts a
+        # bool column via ``pd.to_numeric`` (True -> 1, False -> 0). Rejecting
+        # them here would let a record pass CSV-style preflight and then be
+        # dropped mid-ingest by this check — the silent-drop pathway #204
+        # bugbot flagged. So a bool falls through to the numeric path below
+        # (True.is_integer() is True via float coercion).
         try:
             f = float(value)
         except (TypeError, ValueError):

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -8,6 +8,7 @@ conversion capabilities.
 from typing import Dict, Any, Generator, Optional, List
 import json
 import logging
+import math
 import re
 from pathlib import Path
 
@@ -80,15 +81,36 @@ def _validate_value_against_dtype(value: Any, dtype_upper: str) -> None:
             f = float(value)
         except (TypeError, ValueError):
             raise ValueError(f"value {value!r} is not numeric")
+        # Reject non-finite (inf / -inf / NaN) before is_integer(). inf and
+        # NaN both return False from is_integer() in CPython today, so the
+        # check below already rejects them — but make the guard explicit so
+        # the contract doesn't depend on a CPython detail and so the error
+        # message names the real problem (mirrors DataValidator's
+        # ``_non_finite_error`` on the CSV path).
+        if not math.isfinite(f):
+            raise ValueError(
+                f"value {value!r} is non-finite (inf/NaN) and cannot be "
+                f"stored in an INT column"
+            )
         if not f.is_integer():
             raise ValueError(
                 f"value {value!r} is not an integer (would silently truncate)"
             )
     elif any(t in dtype_upper for t in ("FLOAT", "DOUBLE", "DECIMAL", "NUMERIC")):
         try:
-            float(value)
+            f = float(value)
         except (TypeError, ValueError):
             raise ValueError(f"value {value!r} is not numeric")
+        # Reject inf / -inf / NaN. ``float("Infinity")`` returns +inf
+        # without raising, so the bare float() above lets non-finite values
+        # through silently; DataValidator's FLOAT branch already rejects
+        # them on the CSV path (``_non_finite_error``). Match that here so
+        # JSON and CSV give the same verdict on the same record.
+        if not math.isfinite(f):
+            raise ValueError(
+                f"value {value!r} is non-finite (inf/NaN) and cannot be "
+                f"stored in a numeric column"
+            )
     elif any(t in dtype_upper for t in ("VARCHAR", "CHAR", "TEXT")):
         # MySQL binds any scalar as a string against a string column (see
         # issue #188), so accept ints/floats/bools too. The only constraint

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -8,7 +8,10 @@ conversion capabilities.
 from typing import Dict, Any, Generator, Optional, List
 import json
 import logging
+import re
 from pathlib import Path
+
+import pandas as pd
 
 from .base import BaseIngestor
 from ..database import Database
@@ -19,6 +22,89 @@ from ..utils import label_policy as label_policy_module
 logger = logging.getLogger(__name__)
 
 __all__ = ["JSONIngestor"]
+
+
+# Boolean string forms DataValidator._validate_boolean accepts. Keep this list
+# in lockstep with that validator so the JSON per-record check and the CSV
+# preflight agree.
+_VALID_BOOL_STRINGS = {
+    "true", "false", "yes", "no", "y", "n", "t", "f", "1", "0", "1.0", "0.0"
+}
+
+
+def _validate_value_against_dtype(value: Any, dtype_upper: str) -> None:
+    """Raise ValueError if ``value`` doesn't fit the declared MySQL dtype.
+
+    Mirrors ``DataValidator``'s per-type rules so JSON and CSV give the same
+    verdict on the same record (issue #189). Caller guarantees ``value`` is
+    not None / "" (handled separately as NULL).
+    """
+    # Order matters: DATETIME / TIMESTAMP must match before DATE / TIME because
+    # "DATE" and "TIME" are substrings of "DATETIME" / "TIMESTAMP".
+    if "DATETIME" in dtype_upper or "TIMESTAMP" in dtype_upper:
+        ts = pd.to_datetime(str(value), errors="coerce")
+        if pd.isna(ts):
+            raise ValueError(
+                f"value {value!r} is not a valid {dtype_upper} (expected an "
+                f"ISO 8601 date-time)"
+            )
+    elif "DATE" in dtype_upper or "TIME" in dtype_upper:
+        ts = pd.to_datetime(str(value), errors="coerce")
+        if pd.isna(ts):
+            raise ValueError(
+                f"value {value!r} is not a valid {dtype_upper}"
+            )
+    elif "BOOL" in dtype_upper:
+        # ``bool(value)`` is truthy for any non-empty value, so "maybe" / 2
+        # / "banana" all "passed" — match DataValidator._validate_boolean's
+        # fixed vocabulary instead.
+        if isinstance(value, bool):
+            return
+        if isinstance(value, (int, float)) and value in (0, 1):
+            return
+        if isinstance(value, str) and value.strip().lower() in _VALID_BOOL_STRINGS:
+            return
+        raise ValueError(
+            f"value {value!r} is not a valid BOOLEAN (expected true/false, "
+            f"yes/no, 1/0, or a recognised string form)"
+        )
+    elif "INT" in dtype_upper:
+        # ``int(value)`` silently truncated 3.5 -> 3; require integer-valued
+        # input. JSON booleans (a subclass of int) would slip through as
+        # 0/1, so guard against the bool case separately.
+        if isinstance(value, bool):
+            raise ValueError(
+                f"value {value!r} is a boolean, not an integer"
+            )
+        try:
+            f = float(value)
+        except (TypeError, ValueError):
+            raise ValueError(f"value {value!r} is not numeric")
+        if not f.is_integer():
+            raise ValueError(
+                f"value {value!r} is not an integer (would silently truncate)"
+            )
+    elif any(t in dtype_upper for t in ("FLOAT", "DOUBLE", "DECIMAL", "NUMERIC")):
+        try:
+            float(value)
+        except (TypeError, ValueError):
+            raise ValueError(f"value {value!r} is not numeric")
+    elif any(t in dtype_upper for t in ("VARCHAR", "CHAR", "TEXT")):
+        # MySQL binds any scalar as a string against a string column (see
+        # issue #188), so accept ints/floats/bools too. The only constraint
+        # is the declared length (when present) — and the only shape error
+        # is a non-scalar container.
+        if isinstance(value, (list, dict, set, tuple)):
+            raise ValueError(
+                f"value {value!r} is a non-scalar container; cannot be "
+                f"stored as a {dtype_upper.split('(')[0]}"
+            )
+        m = re.search(r"\((\d+)\)", dtype_upper)
+        if m and len(str(value)) > int(m.group(1)):
+            raise ValueError(
+                f"value {value!r} exceeds the declared length "
+                f"{m.group(1)} (got {len(str(value))} characters)"
+            )
 
 
 class JSONIngestor(BaseIngestor):
@@ -123,31 +209,28 @@ class JSONIngestor(BaseIngestor):
                 f"{RED}Specified unique_id_column '{self.unique_id_column}' not found in record{RESET}"
             )
 
-        # Basic data type validation - only for fields that exist in the record
+        # Per-record type validation. The previous implementation used
+        # ``int(value)`` / ``float(value)`` / ``bool(value)`` to "check"
+        # types — but Python's casts are far too permissive:
+        #   bool("maybe")  -> True   (any non-empty string is truthy)
+        #   bool(2)        -> True   (any non-zero int is truthy)
+        #   int(3.5)       -> 3      (silent truncation, no error)
+        # …so JSON ingestion silently accepted data the CSV path correctly
+        # rejected (issue #189). Match the vocabulary DataValidator already
+        # enforces at file load (the same one CSV uses), so the two formats
+        # give the same verdict on the same record. NULL / "" are still
+        # tolerated as missing (mirrors #170).
         common_fields = schema_fields & record_fields
         for field in common_fields:
             value = record[field]
-            dtype = self.schema[field]
-            # NULL tolerance. A JSON ``null`` (Python ``None``) and an empty
-            # string are both legitimate missing values for any type; calling
-            # ``int(None)`` / ``float(None)`` raises TypeError, which the
-            # validator would otherwise surface as "Data type validation
-            # failed" — an error the user can never clear (JSON null IS the
-            # representation of missing). Mirrors the same NULL-tolerance the
-            # CSV-side validators got in #167 / #168.
+            dtype_upper = self.schema[field].upper()
             if value is None or value == "":
                 continue
             try:
-                if "INT" in dtype.upper():
-                    int(value)
-                elif "FLOAT" in dtype.upper():
-                    float(value)
-                elif "BOOL" in dtype.upper():
-                    bool(value)
-                # Add more type validations as needed
-            except Exception as e:
+                _validate_value_against_dtype(value, dtype_upper)
+            except ValueError as e:
                 raise ValueError(
-                    f"{RED}Data type validation failed for field {field}: {str(e)}{RESET}"
+                    f"{RED}Data type validation failed for field {field}: {e}{RESET}"
                 )
 
     def read_data(self, file_path: str) -> Generator[Dict[str, Any], None, None]:


### PR DESCRIPTION
## The bug (issue #189)

\`JSONIngestor._validate_record\` used Python's lenient built-in casts as type checks:

\`\`\`python
if "INT"  in dtype.upper(): int(value)
elif "FLOAT" in dtype.upper(): float(value)
elif "BOOL"  in dtype.upper(): bool(value)
\`\`\`

But:
- \`bool(\"maybe\")\` → True (any non-empty value is truthy) — JSON accepted garbage booleans
- \`int(3.5)\` → 3 (silent truncation) — JSON accepted non-integer floats in INT fields
- VARCHAR length and DATE parseability weren't checked at all

The CSV path's \`DataValidator\` correctly rejects all of these, so the **same dataset got different verdicts by format**. Bad labels / truncated integers reached training via JSON.

Confirmed in the deployed ingestor image.

## Fix

Replace the casts with a per-type checker (\`_validate_value_against_dtype\`) that matches \`DataValidator\`'s vocabulary exactly:

| dtype | rule |
|---|---|
| BOOL | Python bool, 0/1, or the canonical string set (true/false, yes/no, y/n, t/f, 1/0, 1.0/0.0) |
| INT | \`float(value).is_integer()\` (rejects 3.5 instead of truncating); booleans excluded (bool is an int subclass) |
| FLOAT / DOUBLE / DECIMAL / NUMERIC | \`float(value)\` must succeed |
| VARCHAR / CHAR / TEXT | any scalar OK (issue #188 parity); list/dict/set/tuple flagged; declared length enforced |
| DATE / DATETIME / TIMESTAMP / TIME | \`pd.to_datetime\` must parse it |

\`DataValidator\`'s file-load check already catches all of these at preflight (since #173); the per-record path was a regression hole and a divergence risk. Now both paths agree — the same record gives the same verdict regardless of format.

NULL ('' / None) tolerance from #170 is preserved.

## Tests (10 new)

- Garbage booleans rejected: \"maybe\", \"banana\", \`2\`, \"yesno\" (parametrised)
- Real booleans accepted: True/False, \"true\"/\"FALSE\", \"yes\"/\"n\", 0/1 (parametrised)
- INT rejects 3.5 (non-integer float); accepts 3.0 (integer-valued)
- VARCHAR(3) rejects \"ABCDE\"; VARCHAR(10) accepts numeric 12345 (issue #188 parity)
- DATE rejects \"not-a-date\"; accepts \"2024-01-15\"

Local: **783 passed, 2 xfailed**.

Closes #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ingest-time validation on the training data path; stricter rules may drop more JSON records but reduce silent corruption (truncated ints, bad labels); parity work lowers risk of CSV vs JSON divergence.
> 
> **Overview**
> **JSON per-record schema validation now mirrors the CSV `DataValidator` rules** instead of relying on permissive `int()` / `float()` / `bool()` checks that could accept bad booleans, silently truncate floats for `INT`, skip `VARCHAR` length limits, and ignore unparseable dates.
> 
> `JSONIngestor._validate_record` delegates to new `_validate_value_against_dtype`, which enforces the same BOOL vocabulary (including `pd.to_numeric` 0/1 string forms), integer-valued numeric checks for `INT` (with bools allowed for CSV parity), explicit rejection of inf/NaN on numeric types, `VARCHAR` length and scalar rules, and `pd.to_datetime` for date/time types. `None` / `""` remain allowed as missing values.
> 
> Extensive regression tests in `test_json_ingestor.py` lock in parity with CSV (including non-finite values and cases where JSON must not be stricter than CSV).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38760c387595acc9e7a9407eb3cacc86ce9266e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->