### PR TITLE
fix(numeric_cols): tolerate nulls in time-series feature columns (#195)

### DIFF
--- a/tests/test_numeric_columns_validator.py
+++ b/tests/test_numeric_columns_validator.py
@@ -23,15 +23,39 @@ def test_all_numeric_passes(make_csv):
     assert result.metadata["columns_to_validate"] == 2
 
 
-def test_null_value_fails(make_csv):
+def test_null_value_is_valid(make_csv):
+    # Issue #195: nulls in a numeric column are legitimate missing values
+    # (stored as SQL NULL), NOT a validation error. The shipped time-series
+    # template explicitly documents lag/window features as leading-null, and
+    # the validator was rejecting its own shipped sample. Null count is
+    # still surfaced via metadata for observability.
     path = make_csv({
         "timestamp": ["2024-01-01", "2024-01-02"],
         "value": [1.0, None],
         "count": [3, 4],
     })
     result = NumericColumnsValidator(schema=SCHEMA).validate(str(path))
-    assert not result.is_valid
-    assert any("null/missing" in e for e in result.errors)
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+    assert result.metadata["value_null_count"] == 1
+
+
+def test_time_series_lag_window_leading_nulls_pass(make_csv):
+    # End-to-end repro from #195: the shipped time-series template README
+    # documents `lag_1` as blank for row 1 and `moving_avg_7` as blank
+    # until enough history accumulates. The shipped sample CSV ships with
+    # exactly those nulls, and the validator rejected its own sample.
+    path = make_csv({
+        "timestamp": ["2024-01-0%d" % i for i in range(1, 9)],
+        "value": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0],
+        "lag_1":          [None, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+        "moving_avg_7":   [None, None, None, None, None, None, 13.0, 14.0],
+    })
+    schema = {
+        "timestamp": "TIMESTAMP", "value": "FLOAT",
+        "lag_1": "FLOAT", "moving_avg_7": "FLOAT",
+    }
+    result = NumericColumnsValidator(schema=schema).validate(str(path))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
 
 
 def test_non_numeric_fails(make_csv):

--- a/tracebloc_ingestor/validators/numeric_columns_validator.py
+++ b/tracebloc_ingestor/validators/numeric_columns_validator.py
@@ -77,19 +77,23 @@ class NumericColumnsValidator(BaseValidator):
                     metadata={**metadata, "message": "No schema columns to validate (only timestamp or non-existent columns)"},
                 )
 
-            # Step 1: Check for null values in all columns (except timestamp)
+            # NOTE on null handling (issue #195): the previous step rejected
+            # ANY null in a non-timestamp column as an error. That contract is
+            # wrong for time-series forecasting — the shipped template README
+            # explicitly documents lag/window feature columns as "blank for
+            # the first row" / "blank until enough history accumulates", and
+            # the shipped sample CSV ships with exactly those nulls. So the
+            # validator was rejecting its own shipped sample, and any real
+            # lag_1 / moving_avg_N / rolling_* feature in customer data.
+            #
+            # Treat nulls as legitimate (stored as SQL NULL), mirroring the
+            # null tolerance the rest of DataValidator gained in #167/#168.
+            # The downstream model preprocessor handles leading-NaN in
+            # lag/window features by design. We still surface the count via
+            # metadata for observability, but it isn't an error.
             for column in columns_to_validate:
-                null_count = df[column].isna().sum()
-                
+                null_count = int(df[column].isna().sum())
                 if null_count > 0:
-                    null_rows = [i+1 for i in df.index[df[column].isna()][:10]]
-                    error_msg = (
-                        f"Column '{column}' contains {null_count} null/missing value(s). "
-                        f"Null values found at rows: {null_rows}"
-                    )
-                    if null_count > 10:
-                        error_msg += f" (and {null_count - 10} more)"
-                    errors.append(error_msg)
                     metadata[f"{column}_null_count"] = null_count
 
             # Step 2: Check if all columns are numeric


### PR DESCRIPTION
## The bug (issue #195)

\`NumericColumnsValidator\` (used by \`time_series_forecasting\`) unconditionally rejected ANY null in a non-timestamp column. But the shipped template's own README documents lag/window features as leading-null:

> - \`lag_1\`: Previous timestep's value (FLOAT; **blank for the first row**)
> - \`moving_avg_7\`: 7-day moving average (FLOAT; **blank until enough history accumulates**)

…and the shipped sample CSV ships with exactly those nulls (row 1 \`lag_1\`, rows 1–6 \`moving_avg_7\`).

The shipped sample **failed its own category's validation**:

\`\`\`
Numeric Columns Validator failed:
Column 'lag_1' contains 1 null/missing value(s). Null values found at rows: [1]
Column 'moving_avg_7' contains 6 null/missing value(s). Null values found at rows: [1, 2, 3, 4, 5, 6]
\`\`\`

## Fix

Drop the unconditional null-rejection step. Nulls in numeric columns are legitimate missing values (stored as SQL NULL), mirroring the null-tolerance the rest of \`DataValidator\` gained in #167/#168. The downstream model preprocessor handles leading-NaN in lag/window features by design.

The validator's numeric-coercion step (Step 2) was already null-tolerant and still correctly flags **present-but-unparseable** values (e.g. a stray string in a numeric column) — that's the real data-quality check this validator should be doing.

Null count is still surfaced via metadata for observability (e.g. \`lag_1_null_count: 1\`), it's just not an error.

## Verification

Ran the validator against the shipped \`time_series_forecasting\` template sample:

\`\`\`
shipped TSF sample: True
  null counts: {'lag_1_null_count': 1, 'moving_avg_7_null_count': 6}
  errors: []
\`\`\`

## Tests

- \`test_null_value_fails\` → \`test_null_value_is_valid\` (renamed; pins the new contract)
- \`test_time_series_lag_window_leading_nulls_pass\` (end-to-end repro of the issue's scenario)
- Existing \`test_non_numeric_fails\` still pins the present-but-unparseable case

Local: **810 passed, 2 xfailed**.

Closes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes ingest validation for time_series_forecasting data quality; wrong null tolerance could let bad data through, but non-numeric checks remain and behavior matches documented templates.
> 
> **Overview**
> **`NumericColumnsValidator`** no longer fails validation when numeric schema columns contain nulls. Missing values are treated as legitimate (aligned with **#167/#168**), while per-column null counts are still recorded in result metadata for observability.
> 
> The numeric-coercion step is unchanged and still errors on **present but unparseable** values (e.g. strings in a FLOAT column). Tests were updated to expect nulls to pass, including a time-series **lag_1** / **moving_avg_7** leading-null scenario from **#195**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63aaf1e7d2a9bb7b19a51ae61666f708f490dd3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->