### PR TITLE
fix(samples): align defaults with shipped onboarding samples (#198, #199)

### DIFF
--- a/examples/yaml/image_classification.yaml
+++ b/examples/yaml/image_classification.yaml
@@ -1,7 +1,10 @@
 # The dominant case: 8 lines, no `spec` block needed.
 # `category: image_classification` implies:
 #   - data_format: image
-#   - default file_options: target_size [512, 512], extension .jpg
+#   - default file_options: target_size [256, 256], extension .jpeg
+#     (matches the bundled onboarding sample under
+#     `templates/image_classification/data/images/`; override `spec.file_options`
+#     for any other dataset shape)
 #   - default validators: [FileTypeValidator(images), ImageResolutionValidator,
 #                         TableNameValidator, DuplicateValidator]
 #   - required CSV columns: `filename` (image filename, with or without

--- a/examples/yaml/keypoint_detection.yaml
+++ b/examples/yaml/keypoint_detection.yaml
@@ -13,5 +13,7 @@ category: keypoint_detection
 csv: /data/shared/pose/labels.csv
 images: /data/shared/pose/images/
 label: image_label
-target_size: [256, 256]      # height, width — must match your pose model's input
+target_size: [448, 448]      # height, width — must match your pose model's input
+                             # (the shipped sample under templates/keypoint_detection/data/images/
+                             # is 448×448; substitute your pose model's input here)
 number_of_keypoints: 9        # e.g. 17 for COCO pose, 9 for the upper-body sample

--- a/examples/yaml/object_detection.yaml
+++ b/examples/yaml/object_detection.yaml
@@ -1,6 +1,11 @@
 # Object detection: image + Pascal VOC XML annotations.
 # `category: object_detection` implies validators include PascalVOCXMLValidator
 # and a separate FileTypeValidator(.xml) for the annotations directory.
+# Default file_options: target_size [1920, 1080] (matches the bundled VisDrone
+# aerial sample under `templates/object_detection/data/images/`, kept at native
+# resolution because aggressive downscaling obliterates the tiny-object content
+# the sample exists to demonstrate). Override `spec.file_options.target_size`
+# below for any other dataset shape (e.g. 448×448 tiles).
 apiVersion: tracebloc.io/v1
 kind: IngestConfig
 table: visdrone_train

--- a/templates/image_classification/README.md
+++ b/templates/image_classification/README.md
@@ -80,8 +80,8 @@ python image_classification.py
 ## Configuration
 
 The script uses the following configuration:
-- **Target Size**: (512, 512) - Images will be resized to this dimension (height = width)
-- **Extension**: JPG - Expected image file extension (jpeg, jpg, and png are also accepted)
+- **Target Size**: (256, 256) - Images will be resized to this dimension (height = width)
+- **Extension**: JPEG - Expected image file extension
 - **Chunk Size**: 1000 - Number of records to process in each batch
 - **Category**: IMAGE_CLASSIFICATION
 - **Data Format**: IMAGE

--- a/templates/image_classification/image_classification.py
+++ b/templates/image_classification/image_classification.py
@@ -23,8 +23,10 @@ logger = logging.getLogger(__name__)
 
 # Image specific options including CSV options
 image_options = {
-    "target_size": (512, 512),  # image size. Height = Width
-    "extension": FileExtension.JPG,  # allowed extension for images: jpeg, jpg, png
+    # Matches the bundled onboarding sample under data/images/ (#198).
+    # Override per dataset when running against your own data.
+    "target_size": (256, 256),  # image size. Height = Width
+    "extension": FileExtension.JPEG,
 }
 
 # CSV specific options

--- a/templates/object_detection/README.md
+++ b/templates/object_detection/README.md
@@ -122,8 +122,8 @@ python object_detection.py
 ## Configuration
 
 The script uses the following configuration:
-- **Target Size**: (256, 256) - Images will be resized to this dimension
-- **Extension**: PNG - Expected image file extension
+- **Target Size**: (1920, 1080) - Images will be resized to this dimension (height = width)
+- **Extension**: JPG - Expected image file extension (jpeg, jpg are also accepted)
 - **Chunk Size**: 100 - Number of records to process in each batch
 - **Category**: OBJECT_DETECTION
 - **Data Format**: IMAGE

--- a/templates/object_detection/object_detection.py
+++ b/templates/object_detection/object_detection.py
@@ -28,7 +28,11 @@ logger = logging.getLogger(__name__)
 
 # Object detection specific options including CSV options
 object_detection_options = {
-    "target_size": (448, 448),  # image size. Height = Width
+    # Matches the bundled VisDrone aerial sample under data/images/ (#199),
+    # kept at native resolution because aggressive downscaling obliterates
+    # the tiny-object content the sample exists to demonstrate. Override per
+    # dataset when running against tiled / pre-resized data.
+    "target_size": (1920, 1080),
     "extension": FileExtension.JPG,  # allowed extension for images: jpeg, jpg, png
 }
 

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -182,9 +182,10 @@ def test_csv_kwargs_match_resolved_config(clean_env, mock_runtime, monkeypatch):
     assert kwargs["data_format"] == "image"
     assert kwargs["label_column"] == "image_label"
     assert kwargs["unique_id_column"] is None  # UUID generation, the default
-    # File / CSV options carry the conventional defaults.
-    assert kwargs["file_options"]["target_size"] == [512, 512]
-    assert kwargs["file_options"]["extension"] == ".jpg"
+    # File / CSV options carry the conventional defaults — now aligned with
+    # the bundled image_classification onboarding sample (256×256 .jpeg, #198).
+    assert kwargs["file_options"]["target_size"] == [256, 256]
+    assert kwargs["file_options"]["extension"] == ".jpeg"
     assert kwargs["csv_options"]["chunk_size"] == 1000
 
 

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -117,30 +117,42 @@ def test_semantic_segmentation_sidecars_set():
 # Default options
 # ---------------------------------------------------------------------------
 
-def test_image_classification_gets_512x512_default():
+def test_image_classification_default_matches_shipped_sample():
+    """Default file_options for image_classification round-trip through the
+    bundled onboarding sample (256×256 .jpeg) with zero overrides — issue
+    #198. Previously the default was 512×512 .jpg and the framework's own
+    sample failed validation out-of-box."""
     r = resolve(_load("image_classification.yaml"))
     assert r.file_options == DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[
         TaskCategory.IMAGE_CLASSIFICATION
     ]
+    assert r.file_options["target_size"] == [256, 256]
+    assert r.file_options["extension"] == ".jpeg"
 
 
-def test_object_detection_gets_448x448_default():
-    """Object detection's template historically uses 448×448, not 512×512."""
+def test_object_detection_default_matches_shipped_sample():
+    """Default file_options for object_detection match the bundled VisDrone
+    aerial sample (1920×1080) — issue #199. Previously the default was
+    448×448 and the framework's own sample failed validation out-of-box."""
     r = resolve(_load("object_detection.yaml"))
     assert r.file_options == DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[
         TaskCategory.OBJECT_DETECTION
     ]
-    assert r.file_options["target_size"] == [448, 448]
+    assert r.file_options["target_size"] == [1920, 1080]
 
 
 def test_keypoint_detection_bridges_top_level_fields():
     """Keypoint detection has no convention defaults for target_size or
     number_of_keypoints — both are dataset-specific. The example YAML
     supplies them top-level; resolve() must bridge them into file_options
-    so validators see them at the same key the template path uses."""
+    so validators see them at the same key the template path uses.
+
+    The yaml's target_size was updated to [448, 448] (#199) to match the
+    bundled sample under templates/keypoint_detection/data/images/, which
+    is 448×448 — copy-paste against the framework's own sample now works."""
     r = resolve(_load("keypoint_detection.yaml"))
     assert r.file_options["extension"] == ".jpg"
-    assert r.file_options["target_size"] == [256, 256]
+    assert r.file_options["target_size"] == [448, 448]
     assert r.file_options["number_of_keypoints"] == 9
 
 

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -82,7 +82,9 @@ def _yaml(**fields) -> Dict[str, Any]:
 
 CASES = [
     # -----------------------------------------------------------------------
-    # image_classification — template uses 512×512, intent=TEST, label_column="label"
+    # image_classification — template + convention default now align with the
+    # bundled onboarding sample (256×256 .jpeg, #198). intent=TEST,
+    # label_column="label" unchanged.
     # -----------------------------------------------------------------------
     pytest.param(
         _yaml(
@@ -101,13 +103,16 @@ CASES = [
             "label_policy": PASSTHROUGH,
             "unique_id_column": None,
             "annotation_column": None,
-            "file_options": {"target_size": [512, 512], "extension": FileExtension.JPG},
+            "file_options": {"target_size": [256, 256], "extension": FileExtension.JPEG},
         },
         id="image_classification",
     ),
 
     # -----------------------------------------------------------------------
-    # object_detection — template uses 448×448, label_column="image_label"
+    # object_detection — template + convention default now align with the
+    # bundled VisDrone aerial sample (1920×1080, #199). The sample is kept at
+    # native resolution because aggressive downscaling obliterates the
+    # tiny-object content the sample exists to demonstrate.
     # -----------------------------------------------------------------------
     pytest.param(
         _yaml(
@@ -127,7 +132,7 @@ CASES = [
             "label_policy": PASSTHROUGH,
             "unique_id_column": None,
             "annotation_column": None,
-            "file_options": {"target_size": [448, 448], "extension": FileExtension.JPG},
+            "file_options": {"target_size": [1920, 1080], "extension": FileExtension.JPG},
         },
         id="object_detection",
     ),

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -96,9 +96,14 @@ DEFAULT_CSV_OPTIONS: Dict[str, Any] = {
 # customer-tuned values. Refining these defaults after first customer
 # migrations is explicitly out-of-scope for #44 per the ticket.
 DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY: Dict[str, Dict[str, Any]] = {
-    TaskCategory.IMAGE_CLASSIFICATION:    {"target_size": [512, 512], "extension": ".jpg"},
+    # IMAGE_CLASSIFICATION + OBJECT_DETECTION defaults now match the bundled
+    # onboarding samples under `templates/*/data/images/` (#198, #199) so the
+    # framework's own samples round-trip through the documented happy-path
+    # config with zero overrides. Production users with differently-sized data
+    # should set `spec.file_options` in their YAML.
+    TaskCategory.IMAGE_CLASSIFICATION:    {"target_size": [256, 256], "extension": ".jpeg"},
     TaskCategory.SEMANTIC_SEGMENTATION:   {"target_size": [512, 512], "extension": ".jpg"},
-    TaskCategory.OBJECT_DETECTION:        {"target_size": [448, 448], "extension": ".jpg"},
+    TaskCategory.OBJECT_DETECTION:        {"target_size": [1920, 1080], "extension": ".jpg"},
     # keypoint_detection: no target_size default — the customer's pose model
     # dictates input resolution, so the schema requires it top-level.
     TaskCategory.KEYPOINT_DETECTION:      {"extension": ".jpg"},


### PR DESCRIPTION
## The bug (issues #198 and #199)

The framework's own shipped sample data didn't match the documented happy-path defaults, so the canonical example yamls failed against the bundled fixtures out-of-box.

| Category | Shipped sample | Old default | Out-of-box result |
|---|---|---|---|
| image_classification (#198) | .jpeg 256×256 | .jpg 512×512 | `File Type Validator failed: invalid extensions [.jpeg]` + `(256, 256) (expected: [512, 512])` |
| object_detection (#199) | 1920×1080 (VisDrone aerial) | 448×448 | `(1920, 1080) (expected: [448, 448])` |
| keypoint_detection (#199) | 448×448 | example yaml says [256, 256] | `(448, 448) (expected: [256, 256])` |

The framework was rejecting its own samples.

## Strategy

Update defaults to match the shipped data. The bundled VisDrone OD sample has real test value at native resolution (aggressive downscaling obliterates the tiny-object content the sample exists to demonstrate), and the IC sample is what users see on first run. Production users with differently-sized data override `spec.file_options` as usual.

## Touched in lockstep (no drift)

| File | Change |
|---|---|
| `tracebloc_ingestor/cli/conventions.py` | IC: 512×512 .jpg → **256×256 .jpeg** · OD: 448×448 → **1920×1080** |
| `templates/image_classification/image_classification.py` | target_size + extension updated |
| `templates/object_detection/object_detection.py` | target_size updated |
| `examples/yaml/keypoint_detection.yaml` | target_size [256, 256] → **[448, 448]** + comment refreshed |
| `examples/yaml/image_classification.yaml`, `object_detection.yaml` | header comments updated; **no spec block needed** (8-line invariant preserved for IC) |
| `templates/image_classification/README.md`, `object_detection/README.md` | "Target Size" / "Extension" rows reflect new values (OD's was stale at (256, 256) PNG — fixed alongside) |
| Tests aligned: `test_conventions`, `test_template_equivalence`, `test_cli_run`, `test_schema_validation` | Each spot that pinned the old number now pins the new one + comment |

## Net effect

`helm install` with the canonical example yaml pointed at the bundled sample now passes File Type + Image Resolution validation **out-of-box** for all three categories. No more "framework rejects its own sample".

The 8-line `image_classification.yaml` invariant is preserved — because the convention default itself moved, no override block was needed.

Local: **809 passed, 2 xfailed**.

Closes #198. Closes #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default resize/extension expectations change for two categories; production configs that relied on old implicit defaults may need `spec.file_options`, but overrides still win.
> 
> **Overview**
> **Convention defaults and onboarding templates** now match the bundled sample images so declarative YAML and the Python templates validate those fixtures without `spec.file_options` overrides.
> 
> `DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY` in `conventions.py` moves **image_classification** from 512×512 `.jpg` to **256×256 `.jpeg`**, and **object_detection** from 448×448 to **1920×1080** (VisDrone-native resolution). The **image_classification** and **object_detection** template scripts and READMEs mirror those values; example YAML headers document the new implied defaults. **Keypoint** has no new convention default—`examples/yaml/keypoint_detection.yaml` **`target_size`** changes from `[256, 256]` to **`[448, 448]`** to match the shipped 448×448 sample.
> 
> Tests (`test_conventions`, `test_cli_run`, `test_template_equivalence`) pin the updated defaults and expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4994a90c821d397cb3778c915912166d22d98a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->