### PR TITLE
fix(file_pairing): honor _mask suffix for semantic_segmentation (#196)

### DIFF
--- a/tests/test_file_pairing_validator.py
+++ b/tests/test_file_pairing_validator.py
@@ -55,3 +55,88 @@ def test_pairing_skips_when_sidecar_dir_missing(clean_env, tmp_path):
     (tmp_path / "images").mkdir()
     clean_env.setenv("SRC_PATH", str(tmp_path))
     assert FilePairingValidator().validate(None).is_valid
+
+
+# ---------------------------------------------------------------------------
+# #196 — semantic_segmentation _mask suffix convention
+# ---------------------------------------------------------------------------
+
+def test_pairing_mask_suffix_all_matched(clean_env, tmp_path):
+    # Documented + shipped convention: image_001.jpg <-> image_001_mask.png.
+    # Plain stem comparison treated them as unrelated, so the shipped
+    # template sample failed pairing out-of-box (#196).
+    _setup(
+        tmp_path,
+        ["image_001.jpg", "image_002.jpg", "image_003.jpg"],
+        ["image_001_mask.png", "image_002_mask.png", "image_003_mask.png"],
+        sidecar_dir="masks",
+    )
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator(
+        sidecar_path="masks", sidecar_label="mask", sidecar_suffix="_mask"
+    ).validate(None)
+    assert res.is_valid, f"errors={res.errors}"
+
+
+def test_pairing_mask_suffix_image_without_mask(clean_env, tmp_path):
+    # image_002 has no corresponding _mask file → flagged as missing.
+    _setup(
+        tmp_path,
+        ["image_001.jpg", "image_002.jpg"],
+        ["image_001_mask.png"],
+        sidecar_dir="masks",
+    )
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator(
+        sidecar_path="masks", sidecar_label="mask", sidecar_suffix="_mask"
+    ).validate(None)
+    assert not res.is_valid
+    assert "no matching mask" in res.errors[0]
+    assert "image_002" in res.errors[0]
+
+
+def test_pairing_mask_suffix_orphan_mask(clean_env, tmp_path):
+    # ghost_mask.png has no corresponding image → flagged as orphan
+    # (compared by stripped stem, "ghost", not in images).
+    _setup(
+        tmp_path,
+        ["image_001.jpg"],
+        ["image_001_mask.png", "ghost_mask.png"],
+        sidecar_dir="masks",
+    )
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator(
+        sidecar_path="masks", sidecar_label="mask", sidecar_suffix="_mask"
+    ).validate(None)
+    assert not res.is_valid
+    assert any("no matching image" in e for e in res.errors)
+    assert any("ghost" in e for e in res.errors)
+
+
+def test_pairing_mask_suffix_flags_non_conforming_filename(clean_env, tmp_path):
+    # A mask that doesn't follow the `_mask` convention at all (e.g. someone
+    # dropped a plain `image_001.png` into the masks/ folder) is reported
+    # as an orphan rather than silently accepted — naming the convention
+    # consistently matters because the training-time mask-loader will look
+    # for the suffix.
+    _setup(
+        tmp_path,
+        ["image_001.jpg"],
+        ["image_001.png"],  # missing the _mask suffix
+        sidecar_dir="masks",
+    )
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator(
+        sidecar_path="masks", sidecar_label="mask", sidecar_suffix="_mask"
+    ).validate(None)
+    assert not res.is_valid
+    assert any("image_001" in e and "no matching image" in e for e in res.errors)
+
+
+def test_pairing_no_suffix_object_detection_unchanged(clean_env, tmp_path):
+    # Object detection's plain-stem pairing must NOT regress: a.jpg pairs
+    # with a.xml, no suffix involved.
+    _setup(tmp_path, ["a.jpg", "b.jpg"], ["a.xml", "b.xml"])
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    # default sidecar_suffix="" preserves the old behaviour.
+    assert FilePairingValidator().validate(None).is_valid

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -130,7 +130,15 @@ def map_validators(
             FileTypeValidator(allowed_extension=options["extension"], path="images"),
             FileTypeValidator(allowed_extension=FileExtension.PNG, path="masks"),
             FilePairingValidator(
-                image_path="images", sidecar_path="masks", sidecar_label="mask"
+                image_path="images",
+                sidecar_path="masks",
+                sidecar_label="mask",
+                # Documented + shipped convention for semantic_segmentation
+                # masks is `<filename>_mask.png` (#196). Strip the suffix
+                # before matching so image_001.jpg pairs with
+                # image_001_mask.png. object_detection's pairing above is
+                # plain stem (no suffix) — the default.
+                sidecar_suffix="_mask",
             ),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
             TableNameValidator(),

--- a/tracebloc_ingestor/validators/file_pairing_validator.py
+++ b/tracebloc_ingestor/validators/file_pairing_validator.py
@@ -3,7 +3,7 @@
 For datasets that pair every image with a sidecar file — object detection
 (image → annotation XML) and semantic segmentation (image → mask PNG) — this
 validator checks at ingestion time that each image has its sidecar and each
-sidecar has its image, matched by filename stem.
+sidecar has its image.
 
 Without this, a missing counterpart only surfaces mid-training as a
 ``FileNotFoundError`` on the offending row, after the job has run for a while.
@@ -28,8 +28,19 @@ class FilePairingValidator(BaseValidator):
     """Ensure images and their sidecar files (annotations / masks) pair up 1:1.
 
     Directories live under ``config.SRC_PATH`` (e.g. ``<src>/images`` and
-    ``<src>/annotations``). Matching is by filename stem, so ``cat.jpg`` pairs
-    with ``cat.xml`` / ``cat.png``.
+    ``<src>/annotations``). Pairing is by filename stem with an optional
+    ``sidecar_suffix`` appended on the sidecar side:
+
+    - **object_detection**: ``sidecar_suffix=""`` (default) — plain stem
+      match, so ``cat.jpg`` pairs with ``cat.xml``.
+    - **semantic_segmentation**: ``sidecar_suffix="_mask"`` — the shipped
+      template + documented convention is ``<filename>_mask.png``, so
+      ``image_001.jpg`` pairs with ``image_001_mask.png`` (issue #196).
+
+    Without the suffix support, the semantic_segmentation shipped sample
+    failed pairing — every image was reported "no matching mask" and every
+    mask "no matching image", because plain-stem comparison treated
+    ``image_001`` and ``image_001_mask`` as unrelated.
     """
 
     def __init__(
@@ -37,12 +48,14 @@ class FilePairingValidator(BaseValidator):
         image_path: str = "images",
         sidecar_path: str = "annotations",
         sidecar_label: str = "annotation",
+        sidecar_suffix: str = "",
         name: str = "File Pairing Validator",
     ):
         super().__init__(name)
         self.image_path = image_path
         self.sidecar_path = sidecar_path
         self.sidecar_label = sidecar_label
+        self.sidecar_suffix = sidecar_suffix
 
     @staticmethod
     def _stems(directory: Path) -> Set[str]:
@@ -66,10 +79,34 @@ class FilePairingValidator(BaseValidator):
                     metadata={"skipped": "image or sidecar directory not found"},
                 )
 
-            images = self._stems(image_dir)
-            sidecars = self._stems(sidecar_dir)
-            missing = sorted(images - sidecars)   # images with no sidecar
-            orphans = sorted(sidecars - images)   # sidecars with no image
+            image_stems = self._stems(image_dir)
+            sidecar_stems = self._stems(sidecar_dir)
+
+            # When a suffix is configured (e.g. semantic_segmentation's
+            # ``_mask``), strip it from sidecar stems before comparison so
+            # ``image_001_mask`` matches the image ``image_001``. Sidecars
+            # that don't carry the suffix are kept as-is so they still show
+            # up as orphans (a useful signal, not a silent miss).
+            if self.sidecar_suffix:
+                # Build: paired set after suffix-strip, plus the orphans
+                # (sidecars not following the convention).
+                stripped = set()
+                non_conforming = set()
+                for s in sidecar_stems:
+                    if s.endswith(self.sidecar_suffix):
+                        stripped.add(s[: -len(self.sidecar_suffix)])
+                    else:
+                        non_conforming.add(s)
+                sidecars_for_compare = stripped
+                # Non-conforming sidecars are orphans (named neither to match
+                # an image nor to follow the convention).
+                extra_orphans = sorted(non_conforming)
+            else:
+                sidecars_for_compare = sidecar_stems
+                extra_orphans = []
+
+            missing = sorted(image_stems - sidecars_for_compare)
+            orphans = sorted((sidecars_for_compare - image_stems)) + extra_orphans
 
             errors = []
             if missing:
@@ -89,8 +126,9 @@ class FilePairingValidator(BaseValidator):
                 is_valid=len(errors) == 0,
                 errors=errors,
                 metadata={
-                    "images": len(images),
-                    "sidecars": len(sidecars),
+                    "images": len(image_stems),
+                    "sidecars": len(sidecar_stems),
+                    "sidecar_suffix": self.sidecar_suffix,
                     "images_without_sidecar": len(missing),
                     "orphan_sidecars": len(orphans),
                 },


### PR DESCRIPTION
## The bug (issue #196)

\`FilePairingValidator\` paired images and sidecars by raw filename stem (\`cat.jpg\` ↔ \`cat.xml/png\`), but the documented + shipped convention for semantic_segmentation masks is \`<filename>_mask.png\` — so \`image_001.jpg\` is supposed to pair with \`image_001_mask.png\`.

Plain-stem comparison treated those as unrelated, and the shipped template sample failed its own pairing validator out-of-box:

\`\`\`
File Pairing Validator Validator failed:
3 image(s) have no matching mask: ['image_001', 'image_002', 'image_003']
3 mask(s) have no matching image: ['image_001_mask', 'image_002_mask', 'image_003_mask']
\`\`\`

## Fix

Add an optional \`sidecar_suffix\` parameter to \`FilePairingValidator\`. When set (default \`\"\"\`), the suffix is stripped from sidecar stems before comparison, so the \`_mask\` convention pairs correctly:

| image | sidecar | suffix=\"\" | suffix=\"_mask\" |
|---|---|---|---|
| image_001 | image_001_mask | unrelated ✗ | matched ✓ |
| image_002 | image_002 | matched | matched (degenerate case) |

Sidecars that don't end with the suffix are reported as orphans rather than silently dropped — the training-time mask loader will look for the suffix, so naming consistency matters.

\`object_detection\`'s plain-stem pairing is **unchanged** (default empty suffix).

Wired into \`validators_mapping.py\` at the semantic_segmentation site only.

## Verification

Ran the validator against the shipped \`semantic_segmentation\` template sample:

\`\`\`
shipped semseg sample: True
  metadata: {'images': 3, 'sidecars': 3, 'sidecar_suffix': '_mask',
             'images_without_sidecar': 0, 'orphan_sidecars': 0}
\`\`\`

## Tests

5 new cases:
- all-matched with \`_mask\` suffix
- image without a matching \`_mask\` → flagged
- orphan \`*_mask.png\` (no image) → flagged
- non-conforming sidecar (just \`image_001.png\`, no \`_mask\`) → flagged as orphan
- regression guard: object_detection's plain-stem pairing unchanged

Local: **815 passed, 2 xfailed**.

Closes #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Ingest-time validation logic only; object detection pairing unchanged via default empty suffix, with targeted tests.
> 
> **Overview**
> Fixes **semantic segmentation** ingest pairing so `image_001.jpg` matches `image_001_mask.png` instead of failing on plain stem comparison (#196).
> 
> `FilePairingValidator` gains optional **`sidecar_suffix`**: when set, the suffix is stripped from mask stems before matching; masks that do not use the suffix are treated as **orphans** rather than silently ignored. **Object detection** keeps default empty suffix (plain stem). **`validators_mapping.py`** passes `sidecar_suffix="_mask"` only for semantic segmentation.
> 
> Five tests cover matched `_mask` pairs, missing masks, orphan masks, non-conforming mask filenames, and a regression check for object detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faad41b477ae9dd83c9f7d2923492587b33c4212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->