### PR TITLE
docs(yaml): fix text_classification example — drop wrong schema block (#197)

### DIFF
--- a/examples/yaml/text_classification.yaml
+++ b/examples/yaml/text_classification.yaml
@@ -1,6 +1,19 @@
-# Text classification: CSV + .txt sidecar files (one per row, named by text_id).
+# Text classification: CSV + .txt sidecar files (one per row).
 # `texts:` directory is convention-mapped; default extension is .txt.
-# `schema:` is required so DataValidator can typecheck the CSV columns.
+#
+# Required CSV columns: `filename` (the .txt sidecar's filename, with or
+# without extension — the default .txt is appended if missing), and the
+# label column you set below. Both columns are framework-managed (filename
+# is reserved by the DB layer), so they do NOT belong in a `schema:` block.
+#
+# `schema:` is optional for text_classification (used only if you have
+# additional feature columns to type-check). The previous example shipped
+# with `schema: { text_id: VARCHAR(255), label: VARCHAR(64) }` which (a)
+# used the wrong column name (`text_id` — actual is `filename`, see the
+# shipped sample CSV at templates/text_classification/data/) and (b) tried
+# to declare reserved framework columns in the schema. Following it
+# literally caused every record to skip at file-transfer with
+# "No filename found in record". Issue #197.
 apiVersion: tracebloc.io/v1
 kind: IngestConfig
 table: support_tickets_train
@@ -8,7 +21,4 @@ intent: train
 category: text_classification
 csv: /data/shared/support-tickets/labels.csv
 texts: /data/shared/support-tickets/texts/
-schema:
-  text_id: VARCHAR(255)
-  label: VARCHAR(64)
 label: label

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -210,7 +210,10 @@ CASES = [
             intent="train",
             csv="/data/labels.csv",
             texts="/data/texts/",
-            schema={"text_id": "VARCHAR(255)", "label": "VARCHAR(64)"},
+            # text_classification's filename + label are framework-managed
+            # (see #197); this synthetic schema only declares extra columns
+            # to exercise resolve()'s schema-bridging code path.
+            schema={"extra_feature": "VARCHAR(255)"},
             label="label",
         ),
         {


### PR DESCRIPTION
## The bug (issue #197)

\`examples/yaml/text_classification.yaml\` shipped with:

\`\`\`yaml
schema:
  text_id: VARCHAR(255)
  label: VARCHAR(64)
\`\`\`

Both wrong:

1. **\`text_id\` is not a real column.** The framework + the shipped sample CSV (\`templates/text_classification/data/labels_file_sample.csv\`) use \`filename\` as the .txt sidecar reference (consumed by \`file_transfer.py:243\`). Following the example literally caused every record to skip at file-transfer with \`"No filename found in record"\` — **5/5 records lost** on the shipped sample, despite the validator suite passing.

2. **\`filename\` and \`label\` are framework-managed**, not user feature columns. \`filename\` is in the DB layer's reserved-column list (\`database.py:131\`), so declaring it in a \`schema:\` block would also trip the reserved-column collision check.

## Fix

\`schema:\` is **optional** for text_classification (the ingest schema declares it required only for tabular + time-series categories). The example yaml was using it incorrectly — drop the block entirely, mirroring \`image_classification.yaml\`'s minimal form.

Documented the convention in the header comment with the trap (reserved-column collision) called out so the next reader doesn't repeat the mistake.

Also tidied a lingering \`text_id\` reference in \`tests/test_template_equivalence.py\` — that test exercises \`resolve()\`'s schema-bridging code path, not the example yaml contract; replaced with an \`extra_feature\` synthetic schema + a back-reference to #197.

## Verification

The shipped \`templates/text_classification/data/labels_file_sample.csv\` already uses the correct \`filename\` column; with the schema block gone, helm install with the canonical example yaml + the bundled sample now ingests **5/5 records** instead of dropping all of them.

Local: **810 passed, 2 xfailed**.

Closes #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; no ingestor or validation logic is modified.
> 
> **Overview**
> Fixes **#197** by correcting the `text_classification` YAML example so copy-paste configs actually ingest rows instead of dropping them at file transfer.
> 
> The example **removes** the misleading `schema:` block that declared `text_id` and `label`. Ingest expects the CSV sidecar column **`filename`** (not `text_id`), and **`filename` / `label` must not appear in `schema:`** because they are framework-managed reserved columns. New header comments spell out required CSV columns, when `schema:` is optional, and why the old block caused `"No filename found in record"`.
> 
> The **template-equivalence test** no longer mirrors that bad schema; it keeps a synthetic `extra_feature` column only to exercise `resolve()`’s schema-bridging path, with a note pointing at #197.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb70743207bd8abdbe77d48336f1e4abfe720906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->