### PR TITLE
docs(yaml): time_series_forecasting timestamp must be TIMESTAMP not VARCHAR (#200)

### DIFF
--- a/examples/yaml/time_series_forecasting.yaml
+++ b/examples/yaml/time_series_forecasting.yaml
@@ -8,7 +8,11 @@ intent: train
 category: time_series_forecasting
 csv: /data/shared/energy-demand/demand.csv
 schema:
-  timestamp: VARCHAR(64)
+  # `timestamp` must be the SQL TIMESTAMP type — TimeFormatValidator
+  # rejects anything else with "Timestamp column in schema must be of type
+  # 'TIMESTAMP'". The previous `VARCHAR(64)` here failed on the very
+  # first validator (#200).
+  timestamp: TIMESTAMP
   region: VARCHAR(32)
   temperature_c: FLOAT
   is_holiday: INT


### PR DESCRIPTION
## The bug (issue #200)

\`examples/yaml/time_series_forecasting.yaml:11\` declared:

\`\`\`yaml
schema:
  timestamp: VARCHAR(64)
\`\`\`

But \`TimeFormatValidator\` (validator #1 in the TSF pipeline) rejects anything other than the SQL \`TIMESTAMP\` type:

\`\`\`
Time Format Validator failed:
Timestamp column in schema must be of type 'TIMESTAMP', but found 'VARCHAR(64)'.
For time series forecasting, timestamp column must be TIMESTAMP type.
\`\`\`

The canonical example told the user to do exactly what the validator forbids.

## Fix

\`timestamp: VARCHAR(64)\` → \`timestamp: TIMESTAMP\`, plus a comment naming the validator + rule so the next reader doesn't repeat the mistake.

Closes #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an example YAML file; no runtime or production code paths affected.
> 
> **Overview**
> Fixes the canonical **time series forecasting** ingest example so it matches what **`TimeFormatValidator`** enforces: the `timestamp` schema column must be SQL **`TIMESTAMP`**, not **`VARCHAR(64)`**.
> 
> The example previously failed on the first validator in the TSF pipeline with a type mismatch error. Inline comments now document that rule and reference issue **#200** so readers do not repeat the mistake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ee70bc6615d21bf6eb75313ac65250693e8bbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->