### PR TITLE
docs(readme): image_classification — single-extension-per-dataset (#201)

### DIFF
--- a/templates/image_classification/README.md
+++ b/templates/image_classification/README.md
@@ -55,7 +55,11 @@ image_classification/
 ## Data Format
 
 ### Images
-- Supported formats: PNG, JPEG, JPG
+- Each dataset uses **one** image extension across all files: `.jpg`, `.jpeg`,
+  or `.png`. Mixed extensions in a single dataset are not supported by design —
+  `FileTypeValidator` is strict and rejects any file whose extension doesn't
+  match the declared one. Set the extension via `spec.file_options.extension`
+  in your YAML (default `.jpeg` — see `cli/conventions.py`).
 - Images should be placed in the `data/images/` directory
 - Each image must have a corresponding row in the CSV file
 
@@ -81,7 +85,8 @@ python image_classification.py
 
 The script uses the following configuration:
 - **Target Size**: (256, 256) - Images will be resized to this dimension (height = width)
-- **Extension**: JPEG - Expected image file extension
+- **Extension**: `.jpeg` — strictly enforced for every image in the dataset.
+  Override via `spec.file_options.extension` (one of `.jpg` / `.jpeg` / `.png`).
 - **Chunk Size**: 1000 - Number of records to process in each batch
 - **Category**: IMAGE_CLASSIFICATION
 - **Data Format**: IMAGE


### PR DESCRIPTION
## The bug (issue #201)

\`templates/image_classification/README.md\` said:

> ### Images
> - **Supported formats: PNG, JPEG, JPG**
>
> ### Configuration
> - **Extension**: JPG - Expected image file extension (**jpeg, jpg, and png are also accepted**)

A reasonable reader interpreted "are also accepted" as "you can mix .jpg, .jpeg, and .png files in a single dataset" — but \`FileTypeValidator\` is **intentionally strict**: one extension per dataset, declared via \`spec.file_options.extension\`. Mixed-extension datasets are not supported by design.

## Fix

Reword both sections to make the contract explicit. The valid choices are \`.jpg\` / \`.jpeg\` / \`.png\` — but only one per dataset.

Docs-only. No code change.

Closes #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to README wording; no code or ingestion behavior is modified.
> 
> **Overview**
> **Clarifies the image-classification template README** so it no longer implies mixed `.jpg` / `.jpeg` / `.png` files in one dataset.
> 
> The **Images** section now states that each dataset must use a **single** extension (`.jpg`, `.jpeg`, or `.png`), that mixed extensions are unsupported by design, and that **`FileTypeValidator`** rejects mismatches. It points readers to **`spec.file_options.extension`** in YAML and the default **`.jpeg`** in **`cli/conventions.py`**.
> 
> The **Configuration** **Extension** bullet is aligned: **`.jpeg`** is strictly enforced unless overridden via **`spec.file_options.extension`**, with the same three allowed values.
> 
> Docs-only; no runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18c7ec4ac6dbc80faa4ec199d22f034f2ebc751a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->