### PR TITLE
docs: target_size is [width, height], not [height, width] (#202)

### DIFF
--- a/examples/yaml/keypoint_detection.yaml
+++ b/examples/yaml/keypoint_detection.yaml
@@ -13,7 +13,9 @@ category: keypoint_detection
 csv: /data/shared/pose/labels.csv
 images: /data/shared/pose/images/
 label: image_label
-target_size: [448, 448]      # height, width — must match your pose model's input
-                             # (the shipped sample under templates/keypoint_detection/data/images/
-                             # is 448×448; substitute your pose model's input here)
+target_size: [448, 448]      # width, height — must match your pose model's input.
+                             # Convention is width-first to match PIL.Image.size +
+                             # ImageResolutionValidator. The shipped sample under
+                             # templates/keypoint_detection/data/images/ is 448×448
+                             # (square, so order doesn't matter for this sample).
 number_of_keypoints: 9        # e.g. 17 for COCO pose, 9 for the upper-body sample

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -20,7 +20,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.7"
+__version__ = "0.3.8"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -143,7 +143,7 @@
       "items": { "type": "integer", "minimum": 1 },
       "minItems": 2,
       "maxItems": 2,
-      "description": "[height, width] to resize images to. Required for keypoint_detection (no default — depends on the customer's pose model). Other image categories use category defaults if unset."
+      "description": "[width, height] to resize images to. Required for keypoint_detection (no default — depends on the customer's pose model). Other image categories use category defaults if unset. The order matches PIL.Image.size and what ImageResolutionValidator expects."
     },
 
     "number_of_keypoints": {
@@ -198,7 +198,7 @@
               "items": { "type": "integer", "minimum": 1 },
               "minItems": 2,
               "maxItems": 2,
-              "description": "[height, width]. Image categories only. Default [512, 512]."
+              "description": "[width, height]. Image categories only. Default [512, 512]. The order matches PIL.Image.size and what ImageResolutionValidator expects."
             },
             "extension": {
               "type": "string",


### PR DESCRIPTION
## The bug (issue #202)

The ingest schema described \`spec.file_options.target_size\` as \`[height, width]\`:

\`\`\`
[height, width] to resize images to. Image categories only.
\`\`\`

But \`ImageResolutionValidator\` consumes it as \`(width, height)\` and compares against \`PIL.Image.size\` (also \`(width, height)\`). For the square defaults (512×512, 448×448, 256×256) the mis-documentation was invisible — both orderings match. It only bit on the shipped non-square sample (1920×1080 OD):

| YAML value | Schema docs say | Validator wants | Result |
|---|---|---|---|
| \`[1080, 1920]\` | ✓ matches \`[height, width]\` | ✗ got (1920, 1080), expected (1080, 1920) | **fails** |
| \`[1920, 1080]\` | ✗ matches "wrong" order | ✓ matches PIL/validator | passes |

So the **schema description is wrong** (or the validator + every existing default + PIL all do the wrong thing). Per the issue's recommendation: fix the docs to match the code's actual behavior.

## Fix

Updated to \`[width, height]\` in:

- \`schema/ingest.v1.json\` — both \`target_size\` description fields
- \`examples/yaml/keypoint_detection.yaml\` — inline comment

Each now explicitly mentions \`PIL.Image.size\` + \`ImageResolutionValidator\` so the next reader knows where the convention comes from.

Docs-only. No code change.

Closes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example comments only, plus a patch version bump; ingest behavior is unchanged.
> 
> **Overview**
> Corrects **ingest config documentation** so `target_size` is documented as **`[width, height]`**, matching how **`ImageResolutionValidator`** and **`PIL.Image.size`** already interpret the values (fixes #202). The old `[height, width]` wording was harmless for square sizes but misled users on non-square images (e.g. 1920×1080 object-detection samples).
> 
> Updates **`schema/ingest.v1.json`** for both top-level and `spec.file_options.target_size` descriptions, and refreshes comments in **`examples/yaml/keypoint_detection.yaml`**. Bumps package version **0.3.7 → 0.3.8** in **`tracebloc_ingestor/__init__.py`**; **no runtime or validation logic changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88ff532e5e90d3797127e995fd55402db81074f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->