### PR TITLE
fix(csv): surface IEEE float overflow at cast time (backend #771)

### DIFF
--- a/tests/test_adversarial_ingestion_harness.py
+++ b/tests/test_adversarial_ingestion_harness.py
@@ -487,19 +487,12 @@ def test_bigint_overflow_is_clear_error():
         _ingest({"n": "BIGINT"}, "n\n99999999999999999999\n")
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Silent-corruption gap: 1e400 overflows IEEE float and becomes +inf "
-        "in pd.to_numeric. CSVIngestor._validate_csv does not surface this — "
-        "+inf lands in the FLOAT column as if it were a legitimate value. "
-        "DataValidator already rejects inf (non-finite check) but CSVIngestor's "
-        "cast path is what _ingest() exercises here. Remove this marker when "
-        "csv_ingestor surfaces the overflow with a clear per-column error."
-    ),
-)
 def test_float_overflow_is_clear_error():
-    with pytest.raises(Exception):
+    # Closed by _raise_on_overflow in CSVIngestor._validate_csv — the
+    # cast path now mirrors DataValidator's _non_finite_error guard so
+    # 1e400 (which pd.to_numeric silently turns into +inf) is rejected
+    # at cast time with an actionable per-column error.
+    with pytest.raises(Exception, match="overflow|non-finite|inf"):
         _ingest({"x": "FLOAT"}, "x\n1e400\n")
 
 

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -178,3 +178,54 @@ def test_char_empty_cells_yield_python_none(tmp_path):
 
     assert records[0]["code"] == "A"
     assert records[1]["code"] is None
+
+
+def test_float_overflow_raises_at_cast(tmp_path):
+    """`pd.to_numeric("1e400")` returns +inf silently — without a guard
+    the overflowed value lands in MySQL as a legitimate-looking number.
+    DataValidator already rejects inf at preflight; this is the cast-path
+    defense-in-depth (backend #771 / harness #186). Surfaces the overflow
+    with a clear per-column error instead of silent corruption."""
+    p = tmp_path / "d.csv"
+    p.write_text("x\n1e400\n")
+    ing = make_csv_ingestor(schema={"x": "FLOAT"})
+    with pytest.raises(ValueError, match="overflow"):
+        list(ing.read_data(str(p)))
+
+
+def test_float_overflow_negative_also_caught(tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("x\n-1e400\n")
+    ing = make_csv_ingestor(schema={"x": "FLOAT"})
+    with pytest.raises(ValueError, match="overflow"):
+        list(ing.read_data(str(p)))
+
+
+def test_int_overflow_via_float_path_caught(tmp_path):
+    """An INT column receiving an overflowing token (e.g. a Python-int
+    literal beyond float64 range) is caught at the same guard before
+    the Int64 cast can mask it."""
+    p = tmp_path / "d.csv"
+    p.write_text("n\n1e400\n")
+    ing = make_csv_ingestor(schema={"n": "INT"})
+    with pytest.raises(ValueError, match="overflow"):
+        list(ing.read_data(str(p)))
+
+
+def test_float_missing_cells_still_pass_through_as_null(tmp_path):
+    """The overflow guard must NOT flag legitimate missing values:
+    an empty cell becomes NaN in `original` and stays NaN in `converted`
+    — the helper only flags non-finite values whose source was non-NA.
+    A naive `~np.isfinite(converted)` check would crash on this CSV."""
+    p = tmp_path / "d.csv"
+    # Two-column form so the second row's empty `x` is unambiguously a
+    # missing cell (rather than a blank line that pandas would skip).
+    p.write_text("x,n\n1.5,1\n,2\n3.0,3\n")
+    ing = make_csv_ingestor(
+        schema={"x": "FLOAT", "n": "INT"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    records = list(ing.read_data(str(p)))
+    assert records[0]["x"] == 1.5
+    assert pd.isna(records[1]["x"]), f"expected NaN, got {records[1]['x']!r}"
+    assert records[2]["x"] == 3.0

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -6,6 +6,7 @@ pandas-based reading and validation capabilities.
 
 from typing import Dict, Any, Generator, Optional, List
 import csv as _csv
+import numpy as np
 import pandas as pd
 import logging
 from pathlib import Path
@@ -18,6 +19,39 @@ from ..utils import label_policy as label_policy_module
 from ..config import Config
 
 config = Config()
+
+
+def _raise_on_overflow(
+    column: str, original: pd.Series, converted: pd.Series, dtype: str
+) -> None:
+    """Reject overflow ±inf in a numeric column at cast time.
+
+    ``pd.to_numeric("1e400")`` returns ``+inf`` silently (IEEE float
+    overflow). Without this guard the overflowed value lands in MySQL as
+    a legitimately-looking number. ``DataValidator`` already runs an inf
+    guard at the gate via ``_non_finite_error``; this is defense-in-depth
+    on the cast path so a bad token that slips through validation can't
+    corrupt the row silently.
+
+    Distinguishes overflow from legitimate missing: a genuinely empty
+    cell was ``NaN``/``NA`` in ``original`` *before* coercion, so we
+    only flag values that are non-finite in ``converted`` AND were
+    present (non-NA) in ``original``.
+    """
+    # Use np.isinf rather than ~np.isfinite to keep NaN tolerance:
+    # legitimate missing cells were NaN in `original` and stay NaN in
+    # `converted`; pd.to_numeric never produces NaN from an inf path.
+    overflowed = np.isinf(converted) | (np.isnan(converted) & original.notna())
+    if overflowed.any():
+        offenders = original[overflowed].head(5).tolist()
+        raise ValueError(
+            f"Column '{column}' (dtype {dtype}) contains "
+            f"{int(overflowed.sum())} value(s) that overflow IEEE float "
+            f"(±inf / NaN). Sample: {offenders}. ``pd.to_numeric`` "
+            f"silently converted overflow (e.g. ``1e400``) into ±inf; "
+            f"this guard surfaces it at cast time instead of letting it "
+            f"reach MySQL."
+        )
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
@@ -140,7 +174,9 @@ class CSVIngestor(BaseIngestor):
                     # Int64 keeps integers integral and stores missing as pd.NA
                     # (-> SQL NULL); default errors="raise" still surfaces a
                     # genuinely non-numeric value as a clear per-column error.
-                    df[column] = pd.to_numeric(df[column]).astype("Int64")
+                    converted = pd.to_numeric(df[column])
+                    _raise_on_overflow(column, df[column], converted, dtype)
+                    df[column] = converted.astype("Int64")
                 elif any(t in dtype.upper() for t in ("FLOAT", "DOUBLE", "DECIMAL", "NUMERIC")):
                     # float64 — NOT downcast='float' (float32), which corrupted
                     # precision: 3.14 -> '3.140000104904175'. Also covers DOUBLE/
@@ -149,7 +185,9 @@ class CSVIngestor(BaseIngestor):
                     # (the default) now rejects junk with a clear per-column
                     # error. MySQL still applies the column's own precision/scale
                     # on write.
-                    df[column] = pd.to_numeric(df[column])
+                    converted = pd.to_numeric(df[column])
+                    _raise_on_overflow(column, df[column], converted, dtype)
+                    df[column] = converted
                 elif "BOOL" in dtype.upper():
                     # Map the textual/numeric boolean forms DataValidator accepts
                     # (true/false, yes/no, t/f, y/n, 1/0) to a nullable boolean


### PR DESCRIPTION
## The gap (backend #771 follow-up)

\`pd.to_numeric(\"1e400\")\` returns \`+inf\` silently — IEEE float overflow. The overflowed value lands in MySQL as a legitimate-looking number; for INT columns the subsequent \`Int64\` cast even hides it. \`DataValidator\` already runs an inf guard at the gate via \`_non_finite_error\` (#150), so a CSV that passes preflight is fine — but a token that slips past validation (e.g. a column not in the validator's schema, or any future code path that skips DataValidator) corrupts the row silently.

This is the last unresolved gap on the data-ingestors side of backend #771 / harness #186. The companion \`test_float_overflow_is_clear_error\` xfail in the adversarial harness flagged this exact case.

## Fix

\`_raise_on_overflow\` helper, invoked from both the INT and FLOAT/DOUBLE/DECIMAL/NUMERIC branches of \`_validate_csv\`. Distinguishes overflow from legitimate missing: a genuinely empty cell was \`NaN\` in the original column **before** coercion, so the helper only flags non-finite values in the converted column whose source was non-NA. Mirrors the shape of \`DataValidator._non_finite_error\` — cast and validator agree on the contract.

\`\`\`python
overflowed = np.isinf(converted) | (np.isnan(converted) & original.notna())
\`\`\`

## Tests

- \`test_float_overflow_raises_at_cast\` — \`1e400\` rejected with \"overflow\" message
- \`test_float_overflow_negative_also_caught\` — \`-1e400\` same
- \`test_int_overflow_via_float_path_caught\` — INT column receiving an overflowing token caught before the \`Int64\` cast can mask it
- \`test_float_missing_cells_still_pass_through_as_null\` — empty cell stays as NaN, NOT flagged (boundary test against a naive \`~isfinite\` implementation)
- The adversarial harness's \`test_float_overflow_is_clear_error\` xfail is removed — it now passes as a regular regression guard

## Net status

Backend #771's remaining harness xfails go from 2 → 1. The last one (\`test_int_typed_codes_keep_zeros\`) stays by design — it pins documented INT semantics; the recommended fix for leading-zero codes is declaring them as VARCHAR.

Local: **823 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defense-in-depth on CSV numeric coercion with explicit tests; legitimate missing values are preserved by design.
> 
> **Overview**
> **CSV numeric casting now rejects IEEE overflow** instead of letting `pd.to_numeric` turn values like `1e400` into ±inf that could be written to MySQL. A new `_raise_on_overflow` helper runs on the INT and FLOAT/DOUBLE/DECIMAL/NUMERIC branches of `_validate_csv` immediately after `pd.to_numeric`, raising a per-column `ValueError` with sample offenders. It only flags inf or NaN in the converted column when the original cell was non-missing, so empty/missing cells still become SQL NULL.
> 
> Tests add cast-path coverage (positive/negative overflow, INT path, missing cells) and **drop the `xfail` on** `test_float_overflow_is_clear_error` in the adversarial harness so overflow is a normal regression guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ead2c4e1511cca3d9b8a0fbcc681b6f5be74deb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->