### PR TITLE
fix(csv): align date cast error policy with numeric — raise, not coerce (backend #765)

### DIFF
--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -178,3 +178,52 @@ def test_char_empty_cells_yield_python_none(tmp_path):
 
     assert records[0]["code"] == "A"
     assert records[1]["code"] is None
+
+
+# ---------------------------------------------------------------------------
+# #765 item 3 — date cast policy aligned with numeric (errors="raise")
+# ---------------------------------------------------------------------------
+
+def test_date_unparseable_raises_at_cast_not_silent_null(tmp_path):
+    """Backend #765 item 3: the date branches were errors="coerce" (silent
+    NULL) while the numeric branches were errors="raise" — opposite
+    policies for the same bad-input class. Aligning on `raise`: DataValidator
+    is the gate (catches bad dates at preflight); the cast trusts what
+    passes. A token that reaches the cast un-parseable means a validator
+    gap or schema mismatch — surface it loudly instead of silently NULLing.
+    """
+    p = tmp_path / "d.csv"
+    p.write_text("d\n2024-01-01\nnot-a-date\n")
+    ing = make_csv_ingestor(schema={"d": "DATE"})
+    with pytest.raises(ValueError, match="un-parseable date"):
+        list(ing.read_data(str(p)))
+
+
+def test_datetime_unparseable_raises_at_cast(tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("ts\n2024-01-01 10:00:00\nbroken\n")
+    ing = make_csv_ingestor(schema={"ts": "DATETIME"})
+    with pytest.raises(ValueError, match="un-parseable date"):
+        list(ing.read_data(str(p)))
+
+
+def test_time_unparseable_raises_at_cast(tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("t\n10:00:00\nnoon\n")
+    ing = make_csv_ingestor(schema={"t": "TIME"})
+    with pytest.raises(ValueError, match="un-parseable date"):
+        list(ing.read_data(str(p)))
+
+
+def test_date_missing_cells_still_pass_through_as_null(tmp_path):
+    """The strict cast must NOT flag legitimate missing values: an empty
+    date cell stays as NaT/None. Only PRESENT, un-parseable values raise."""
+    p = tmp_path / "d.csv"
+    p.write_text("d,n\n2024-01-01,1\n,2\n2024-02-02,3\n")
+    ing = make_csv_ingestor(
+        schema={"d": "DATETIME", "n": "INT"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    records = list(ing.read_data(str(p)))
+    assert len(records) == 3
+    assert records[1]["d"] is None or pd.isna(records[1]["d"])

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -31,6 +31,48 @@ __all__ = ["Ingestor"]
 # explicitly via csv_options; the YAML path can't express it because
 # schema/ingest.v1.json restricts spec.csv_options to a small whitelist.
 _TABULAR_NA_VALUES = ["", "NA", "NULL", "None"]
+
+
+def _cast_datetime_strict(series: pd.Series, column: str, dtype: str) -> pd.Series:
+    """Cast a CSV column to datetime with the SAME error policy as numeric
+    columns: an un-parseable token raises (instead of silently coercing
+    to NaT).
+
+    Backend #765 item 3: date cast was ``errors="coerce"`` (silent NULL)
+    while numeric cast was ``errors="raise"`` — opposite policies for
+    the same bad-input class, adjacent lines. Pick one: both ``raise``,
+    because ``DataValidator`` is the gate (catches bad dates with a
+    clear per-column error at preflight), and the cast layer trusts
+    what passed it. A token that reaches the cast and fails to parse
+    means either a validator gap or a schema-mismatch — both surface
+    here as a clear ``ValueError`` instead of becoming a silent NULL.
+
+    Genuine missing cells (already ``NaN`` / ``NA`` in the input) stay
+    that way: ``pd.to_datetime`` with ``errors="raise"`` treats pre-
+    existing NaN as missing (returns ``NaT``), it only raises on a
+    *present* value that fails to parse.
+    """
+    try:
+        return pd.to_datetime(series, errors="raise", format="mixed")
+    except Exception as exc:
+        # Surface the offender per the project convention: name the
+        # column, dtype, and a sample of the bad tokens.
+        offenders = (
+            series[
+                pd.to_datetime(series, errors="coerce", format="mixed").isna()
+                & series.notna()
+            ]
+            .astype(str)
+            .head(5)
+            .tolist()
+        )
+        raise ValueError(
+            f"Column '{column}' (dtype {dtype}) has un-parseable date "
+            f"value(s). Sample: {offenders}. The cast layer raises on "
+            f"un-parseable dates (matching the numeric branch); fix the "
+            f"value(s) or declare the column as VARCHAR if the content "
+            f"isn't actually a date. (Underlying parser error: {exc})"
+        ) from exc
 _TABULAR_FAMILY_CATEGORIES = frozenset({
     TaskCategory.TABULAR_CLASSIFICATION,
     TaskCategory.TABULAR_REGRESSION,
@@ -169,16 +211,16 @@ class CSVIngestor(BaseIngestor):
                     # Full date+time. Checked before DATE/TIME because the
                     # substrings "DATE" and "TIME" both appear in "DATETIME"
                     # (and "TIME" in "TIMESTAMP").
-                    df[column] = pd.to_datetime(df[column], errors="coerce", format="mixed")
+                    df[column] = _cast_datetime_strict(df[column], column, dtype)
                 elif "DATE" in dtype.upper():
                     # DATE only — emit a plain date so the value doesn't gain a
                     # spurious time ('2026-01-02' was becoming '2026-01-02 00:00:00').
-                    df[column] = pd.to_datetime(df[column], errors="coerce", format="mixed").dt.date
+                    df[column] = _cast_datetime_strict(df[column], column, dtype).dt.date
                 elif "TIME" in dtype.upper():
                     # TIME only — emit a plain time so the value doesn't gain a
                     # spurious (today's) date ('14:30:00' was becoming
                     # '2026-06-08 14:30:00', which MySQL TIME then truncates).
-                    df[column] = pd.to_datetime(df[column], errors="coerce", format="mixed").dt.time
+                    df[column] = _cast_datetime_strict(df[column], column, dtype).dt.time
                 elif any(t in dtype.upper() for t in ("STRING", "TEXT", "VARCHAR", "CHAR")):
                     # Coerce to pandas StringDtype so missing cells become pd.NA
                     # (not float NaN), then map pd.NA -> Python None so the DB


### PR DESCRIPTION
## The gap (backend #765 item 3)

\`_validate_csv\` had **opposite error policies** for adjacent branches:

\`\`\`python
df[column] = pd.to_numeric(df[column])                                # errors=\"raise\"
df[column] = pd.to_datetime(df[column], errors=\"coerce\", format=\"mixed\")  # silent NULL
\`\`\`

Same bad-input class (a token that won't parse), opposite reactions: numeric stops the ingest, date silently NULLs the cell.

## Fix

Align on \`raise\` (the numeric direction). Rationale:

- \`DataValidator\` is the **gate** — its full-column scan (since #186) already catches bad dates at preflight with a clear per-column error message + sample values.
- The cast layer **trusts** what passed the gate. A token that reaches the cast un-parseable means either a validator gap or a schema mismatch — both are bugs we want surfaced, not silently masked into a NULL on the way to MySQL.

A new \`_cast_datetime_strict\` helper backs all three date branches (DATE / DATETIME-TIMESTAMP / TIME) so the policy + error message shape match \`_raise_on_overflow\` on the numeric side.

## Compatibility

Legitimate missing cells (already \`NaN\`/\`NA\` in the input) continue to pass through as \`NaT\`/\`None\` — \`pd.to_datetime(errors=\"raise\")\` only raises on a *present* value that fails to parse, not on pre-existing missing.

The change is observable only when:
- A column not in DataValidator's schema carries a bad date (edge case)
- Or DataValidator's date check has a gap (which we'd want to know about)

In both cases, the new \`raise\` is the better signal.

## Tests

- DATE / DATETIME / TIME unparseable tokens each raise with a \`un-parseable date\` message
- Missing cells (empty in input) still pass through as NaT/None — the legitimate-missing case is not flagged

Local: **822 passed**.

Closes backend/#765 item 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ingest now fails where bad date tokens previously became silent SQL NULLs; behavior change is intentional but may surface validator gaps or mis-typed columns that used to slip through.
> 
> **Overview**
> **CSV date casting now fails loudly on bad tokens**, matching numeric columns: `DATE`, `DATETIME`/`TIMESTAMP`, and `TIME` no longer use `pd.to_datetime(..., errors="coerce")`, which silently turned unparseable values into NULL in MySQL.
> 
> A new `_cast_datetime_strict` helper uses `errors="raise"` and raises a `ValueError` with column name, dtype, and sample offenders (same shape as the numeric overflow guard). Empty/missing cells still become `NaT`/`None`; only present values that fail to parse trigger failure.
> 
> Tests cover unparseable tokens for all three temporal types and confirm missing date cells still pass through as null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0ea56474b53f1c576a91151905994785009e0fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->