### PR TITLE
fix(213): self-supervised categories must not set label / skip edge-label call

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -384,6 +384,50 @@ def test_ingest_fails_loud_when_backend_registration_step_fails(failing_step):
     ing.api_client.create_dataset.assert_not_called()
 
 
+def test_ingest_skips_edge_label_call_for_self_supervised_categories():
+    """Issue #213: self-supervised categories (MLM, …) have no `label` column,
+    so the backend's edge-label endpoint returns a misleading HTTP 400
+    ('No data found') even though the table has rows. Gate the call so it
+    only runs for label-carrying categories. The remaining registration
+    steps (send_global_meta_meta, prepare_dataset, create_dataset) still run."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(
+        records=records,
+        category=TaskCategory.MASKED_LANGUAGE_MODELING,
+        label_column=None,
+    )
+    # Patch validate_data + map_file_transfer to skip real-filesystem checks;
+    # the gate we're testing lives at the registration block AFTER ingest.
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(ing, "validate_data", return_value=True), \
+         patch.object(base_mod, "map_file_transfer", side_effect=lambda c, r, o: r):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    ing.api_client.send_generate_edge_label_meta.assert_not_called()
+    ing.api_client.send_global_meta_meta.assert_called_once()
+    ing.api_client.prepare_dataset.assert_called_once()
+    ing.api_client.create_dataset.assert_called_once()
+
+
+def test_ingest_still_calls_edge_label_for_label_carrying_categories():
+    """Regression guard for the gate above: a non-self-supervised category
+    still calls the edge-label endpoint."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(
+        records=records,
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(ing, "validate_data", return_value=True), \
+         patch.object(base_mod, "map_file_transfer", side_effect=lambda c, r, o: r):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    ing.api_client.send_generate_edge_label_meta.assert_called_once()
+
+
 def test_ingest_skips_records_that_fail_processing():
     # invalid intent -> process_record returns None -> counted as skipped
     records = [{"a": "1", "filename": "f1"}]

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -218,6 +218,27 @@ def test_tabular_without_schema_rejected(validator):
         validator.validate(config)
 
 
+def test_masked_language_modeling_with_label_rejected(validator):
+    """Issue #213: self-supervised categories (MLM, …) MUST NOT carry a
+    `label:` field. The CSV has no label column, and the framework registers
+    no edge-label metadata for them — setting `label:` anyway used to ingest
+    rows successfully then crash at backend registration with a misleading
+    HTTP 400 ('No data found'). Reject at submission so the user sees the
+    real cause."""
+    config = _load_example("masked_language_modeling.yaml")
+    config["label"] = "some_column"
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_masked_language_modeling_without_label_accepted(validator):
+    """The shipped MLM example yaml omits `label:` by design. Confirm it
+    still validates cleanly (the new constraint is strictly additive)."""
+    config = _load_example("masked_language_modeling.yaml")
+    assert "label" not in config, "test premise: the example yaml has no label"
+    validator.validate(config)  # must not raise
+
+
 # Regression-class tasks must specify label.policy explicitly; the shorthand
 # string form must be rejected for these categories.
 @pytest.mark.parametrize(

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -44,6 +44,19 @@ _TABULAR_FAMILY_CATEGORIES = frozenset({
     TaskCategory.TIME_TO_EVENT_PREDICTION,
 })
 
+# Self-supervised categories have no `label` column — the CSV manifest just
+# points at sidecar files and the model creates its own targets at training
+# time (e.g. masked_language_modeling masks tokens on-the-fly). The backend
+# correspondingly stores no edge-label metadata for these datasets, so the
+# `send_generate_edge_label_meta` call is a no-op at best and a misleading
+# HTTP 400 ("No data found for table X") at worst — see issue #213.
+# The schema (schema/ingest.v1.json) now rejects `label:` on these categories
+# at submission time; this set + the gate below are the defensive in-ingestor
+# half (script-driven runs that bypass the schema still skip the wasted call).
+_SELF_SUPERVISED_CATEGORIES = frozenset({
+    TaskCategory.MASKED_LANGUAGE_MODELING,
+})
+
 
 class IngestionSummary(NamedTuple):
     """Data class to hold ingestion summary statistics.
@@ -636,14 +649,26 @@ class BaseIngestor(ABC):
                 # the failure surfaces (the CLI streams these logs live and marks
                 # the Job failed). The api_client has already logged the
                 # underlying HTTP detail before returning False.
-                if not self.api_client.send_generate_edge_label_meta(
-                    self.table_name, self.ingestor_id, self.intent
-                ):
-                    raise RuntimeError(
-                        "Backend rejected edge-label metadata; the dataset was "
-                        "NOT registered (its rows are already in the database). "
-                        "See the logged API error above."
-                    )
+                # Skip the edge-label backend call for self-supervised
+                # categories (#213). They have no `label` column on the rows;
+                # the backend's edge-label endpoint then returns a misleading
+                # HTTP 400 ("No data found for table X" — wrong, the table HAS
+                # rows, it just has no edge labels). Combined with PR #187's
+                # fail-loud behaviour, the user saw a registration crash that
+                # had nothing to do with the actual misconfiguration. The
+                # schema now rejects `label:` on these categories at
+                # submission, but this gate is the defensive in-ingestor half
+                # so script-driven / older-schema runs don't trip the same
+                # trap.
+                if self.category not in _SELF_SUPERVISED_CATEGORIES:
+                    if not self.api_client.send_generate_edge_label_meta(
+                        self.table_name, self.ingestor_id, self.intent
+                    ):
+                        raise RuntimeError(
+                            "Backend rejected edge-label metadata; the dataset was "
+                            "NOT registered (its rows are already in the database). "
+                            "See the logged API error above."
+                        )
 
                 schema_dict = self.database.get_table_schema(self.table_name)
                 if not self.api_client.send_global_meta_meta(

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -397,6 +397,20 @@
         "required": ["category"]
       },
       "then": { "required": ["label"] }
+    },
+    {
+      "description": "Self-supervised categories MUST NOT set `label`. The shipped CSV has no label column, and the framework registers no edge-label metadata for them. Setting `label` anyway used to ingest rows successfully, then crash at backend registration with a misleading HTTP 400 'No data found' (issue #213). Reject at submission instead.",
+      "if": {
+        "properties": {
+          "category": {
+            "enum": [
+              "masked_language_modeling"
+            ]
+          }
+        },
+        "required": ["category"]
+      },
+      "then": { "not": { "required": ["label"] } }
     }
   ]
 }


### PR DESCRIPTION
## The bug (issue #213)

For self-supervised categories (currently \`masked_language_modeling\`), the canonical example yaml omits \`label:\` by design — the CSV has no label column, and the model creates its own targets at training time. But the schema didn't **forbid** \`label:\` for those categories, so a user who copy-pastes another category's yaml gets:

1. Rows ingest into MySQL ✓
2. \`send_generate_edge_label_meta\` runs → backend returns HTTP 400 \`No data found for table X\` (misleading — the table HAS rows; the real problem is \"no rows with edge labels\")
3. PR #187's fail-loud raises and the user sees a registration crash that has nothing to do with their actual misconfiguration

Combined with the #214 restart-masking, this used to be very hard to diagnose.

## Fix — both layers

### Schema (`ingest.v1.json`)
Add a `not.required: [\"label\"]` rule for `masked_language_modeling`:

\`\`\`json
{
  \"description\": \"Self-supervised categories MUST NOT set `label`.\",
  \"if\": { \"properties\": { \"category\": { \"enum\": [\"masked_language_modeling\"] } } },
  \"then\": { \"not\": { \"required\": [\"label\"] } }
}
\`\`\`

User sees a clear validation error at submission, before any rows commit.

### Ingestor (`base.py`)
New `_SELF_SUPERVISED_CATEGORIES` frozenset alongside `_TABULAR_FAMILY_CATEGORIES`. Gate the `send_generate_edge_label_meta` call so it only runs for label-carrying categories. The remaining registration steps (`send_global_meta_meta` / `prepare_dataset` / `create_dataset`) still run unchanged.

Defensive half: script-driven ingests or older-schema submissions that bypass YAML validation **still** can't trip the trap.

## Tests

| | What it pins |
|---|---|
| `test_masked_language_modeling_with_label_rejected` | Schema rejects `label:` on MLM at submission |
| `test_masked_language_modeling_without_label_accepted` | Shipped example yaml still validates (additive change) |
| `test_ingest_skips_edge_label_call_for_self_supervised_categories` | Ingest gate: MLM skips the call, other registration steps still fire |
| `test_ingest_still_calls_edge_label_for_label_carrying_categories` | Regression guard: image_classification still calls the endpoint |

Local: **822 passed, 2 xfailed**.

## Related

- #187 — fail-loud at registration (the right principle; this PR makes it land on the right error)
- #214 — restart-masking that compounded the confusion (separate Helm-chart fix)

Closes #213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted validation and registration gating for one category; other ingest paths and fail-loud behavior for supervised categories are unchanged.
> 
> **Overview**
> Fixes **#213**: self-supervised ingest (e.g. `masked_language_modeling`) no longer misleads users with a backend registration failure when configs wrongly include `label:` or when edge-label metadata does not apply.
> 
> **Schema (`ingest.v1.json`)** adds a rule that **`masked_language_modeling` must not include `label`**, so YAML validation fails at submit time with a clear error instead of committing rows and failing later.
> 
> **Ingestor (`base.py`)** introduces `_SELF_SUPERVISED_CATEGORIES` and **skips `send_generate_edge_label_meta`** for those categories during dataset registration; global meta, prepare, and create still run unchanged.
> 
> **Tests** lock schema rejection/acceptance for MLM configs and assert the edge-label API is skipped for MLM but still called for label-carrying categories like image classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15f9a293fb9441e9d187afa4b45b6b5d6bfdb051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->