### PR TITLE
fix: clear-error guard for empty/unset SRC_PATH (backend #772 P2)

### DIFF
--- a/tests/test_coverage_gaps2.py
+++ b/tests/test_coverage_gaps2.py
@@ -103,9 +103,12 @@ def test_ingest_image_category_batches_in_loop():
     records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
     ing = make_ingestor(records=records, category=TaskCategory.IMAGE_CLASSIFICATION)
     ing.database.insert_batch.return_value = ([1], [])
+    # Bypass the file-bearing-category SRC_PATH preflight (#772 P2) — this
+    # test is about batching, not the env-var guard which has its own tests.
     with patch.object(base_mod, "Session") as Sess, \
          patch.object(base_mod, "map_file_transfer", side_effect=lambda c, r, o: r), \
-         patch.object(base_mod, "map_validators", return_value=[]):
+         patch.object(base_mod, "map_validators", return_value=[]), \
+         patch.object(base_mod.BaseIngestor, "_check_src_path", return_value=None):
         Sess.return_value.__enter__.return_value = MagicMock()
         failed = ing.ingest("src", batch_size=1)
     assert failed == []

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -439,3 +439,69 @@ def test_check_csv_encoding_skips_non_csv_sources(tmp_path):
     BaseIngestor._check_csv_encoding(str(tmp_path))                   # a directory
     BaseIngestor._check_csv_encoding(None)                            # not a path
     BaseIngestor._check_csv_encoding(str(tmp_path / "missing.csv"))   # nonexistent
+
+
+# ---------------------------------------------------------------------------
+# SRC_PATH pre-flight (validate_data) — #772 P2
+# ---------------------------------------------------------------------------
+
+def test_check_src_path_empty_raises(clean_env):
+    # SRC_PATH unset / blank -> N copies of "Source image not found" with no
+    # actionable cause. Fail fast with the real reason.
+    clean_env.setenv("SRC_PATH", "")
+    with pytest.raises(RuntimeError, match="SRC_PATH is empty"):
+        BaseIngestor._check_src_path()
+
+
+def test_check_src_path_unset_raises(clean_env):
+    # SRC_PATH not in env at all -> same outcome.
+    clean_env.delenv("SRC_PATH", raising=False)
+    with pytest.raises(RuntimeError, match="SRC_PATH is empty"):
+        BaseIngestor._check_src_path()
+
+
+def test_check_src_path_relative_raises(clean_env):
+    # A relative SRC_PATH silently joins to a relative path at file-lookup
+    # time; the validator surfaces the misconfiguration before that point.
+    clean_env.setenv("SRC_PATH", "data/shared")  # not absolute
+    with pytest.raises(RuntimeError, match="not an absolute path"):
+        BaseIngestor._check_src_path()
+
+
+def test_check_src_path_nonexistent_raises(clean_env, tmp_path):
+    missing = tmp_path / "never_staged"
+    clean_env.setenv("SRC_PATH", str(missing))
+    with pytest.raises(RuntimeError, match="does not exist"):
+        BaseIngestor._check_src_path()
+
+
+def test_check_src_path_accepts_real_directory(clean_env, tmp_path):
+    # A properly-staged absolute directory passes — no raise.
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    BaseIngestor._check_src_path()  # must not raise
+
+
+def test_check_src_path_only_runs_for_file_bearing_categories():
+    """The guard is gated on category — tabular / time-series have no
+    sidecar dirs under SRC_PATH, so the preflight isn't applied (their
+    CSV path is checked separately). This keeps tabular-only ingests
+    working even when SRC_PATH isn't set."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+    from tracebloc_ingestor.ingestors.base import _SRC_PATH_REQUIRED_CATEGORIES
+    for cat in (
+        TaskCategory.TABULAR_CLASSIFICATION,
+        TaskCategory.TABULAR_REGRESSION,
+        TaskCategory.TIME_SERIES_FORECASTING,
+        TaskCategory.TIME_TO_EVENT_PREDICTION,
+    ):
+        assert cat not in _SRC_PATH_REQUIRED_CATEGORIES
+    # Image / text / segmentation / MLM all need a staged SRC_PATH.
+    for cat in (
+        TaskCategory.IMAGE_CLASSIFICATION,
+        TaskCategory.OBJECT_DETECTION,
+        TaskCategory.KEYPOINT_DETECTION,
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        TaskCategory.TEXT_CLASSIFICATION,
+        TaskCategory.MASKED_LANGUAGE_MODELING,
+    ):
+        assert cat in _SRC_PATH_REQUIRED_CATEGORIES

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, Generator, List, Optional, NamedTuple
 from sqlalchemy.orm import Session
 from sqlalchemy.engine import Engine
 import logging
+import os
 import pandas as pd
 from tqdm import tqdm
 import uuid
@@ -42,6 +43,24 @@ _TABULAR_FAMILY_CATEGORIES = frozenset({
     TaskCategory.TABULAR_REGRESSION,
     TaskCategory.TIME_SERIES_FORECASTING,
     TaskCategory.TIME_TO_EVENT_PREDICTION,
+})
+
+# File-bearing categories resolve every per-row sidecar against
+# ``config.SRC_PATH``. If that path is empty/unset/missing, every file
+# lookup silently falls through to a relative path (``"" + "images/x.jpg"``
+# -> ``"images/x.jpg"``), file_transfer skips every record, and the user
+# sees N copies of "Source image not found: images/x.jpg" — blaming the
+# data when the real cause is "SRC_PATH was never staged on the PVC".
+# Tabular / time-series have no sidecar dirs under SRC_PATH, so they're
+# excluded from the guard (the CSV path itself is checked elsewhere).
+_SRC_PATH_REQUIRED_CATEGORIES = frozenset({
+    TaskCategory.IMAGE_CLASSIFICATION,
+    TaskCategory.OBJECT_DETECTION,
+    TaskCategory.KEYPOINT_DETECTION,
+    TaskCategory.SEMANTIC_SEGMENTATION,
+    TaskCategory.INSTANCE_SEGMENTATION,
+    TaskCategory.TEXT_CLASSIFICATION,
+    TaskCategory.MASKED_LANGUAGE_MODELING,
 })
 
 
@@ -378,6 +397,50 @@ class BaseIngestor(ABC):
             return None
 
     @staticmethod
+    def _check_src_path() -> None:
+        """Fail fast with a clear message when ``config.SRC_PATH`` isn't set
+        or doesn't exist (#772 P2).
+
+        Every file-bearing category resolves its per-row sidecars against
+        ``config.SRC_PATH`` (file_transfer.py:105 etc.). If the env var
+        / ConfigMap key is empty, ``os.path.join("", "images", "x.jpg")``
+        returns the relative path ``"images/x.jpg"`` — every file lookup
+        fails and the user sees N copies of
+        ``Source image not found: images/x.jpg`` blaming the data, when
+        the real cause is "SRC_PATH was never set / the PVC wasn't
+        staged before the Job ran". One clear error at preflight beats
+        one cryptic error per row.
+        """
+        # Late import: keep this module free of a Config singleton at
+        # import time so unit tests can monkeypatch the env per test.
+        from ..config import Config
+        src = Config().SRC_PATH
+        if not src or not str(src).strip():
+            raise RuntimeError(
+                f"{RED}SRC_PATH is empty. Set it to the cluster-PVC path where "
+                f"your data is staged (e.g. /data/shared/<dataset>/). The "
+                f"chart's data-staging recipe (kubectl cp or init-container "
+                f"sync) must run before the ingest Job — see "
+                f"tracebloc/client/ingestor/README.md.{RESET}"
+            )
+        if not os.path.isabs(src):
+            raise RuntimeError(
+                f"{RED}SRC_PATH={src!r} is not an absolute path. The ingestor "
+                f"resolves every sidecar file against it via os.path.join, "
+                f"and a relative SRC_PATH silently falls through to the "
+                f"working directory — every file lookup then fails with a "
+                f"misleading 'Source image not found'. Use an absolute path "
+                f"(e.g. /data/shared/<dataset>/).{RESET}"
+            )
+        if not os.path.isdir(src):
+            raise RuntimeError(
+                f"{RED}SRC_PATH={src!r} does not exist or is not a directory. "
+                f"Did the data-staging step (kubectl cp / init-container sync) "
+                f"run before the ingest Job? Verify with "
+                f"`kubectl exec <pod> -- ls {src}`.{RESET}"
+            )
+
+    @staticmethod
     def _check_csv_encoding(source: Any) -> None:
         """Fail fast with a clear message if a CSV source is not valid UTF-8.
 
@@ -413,6 +476,14 @@ class BaseIngestor(ABC):
         Raises:
             ValueError: If validation fails
         """
+        # Pre-flight: SRC_PATH must be a real absolute directory or every
+        # file_transfer falls through and surfaces as N copies of
+        # "Source image not found: images/x.jpg" — blames the data when
+        # the real cause is "SRC_PATH was never staged / set" (#772 P2).
+        # File-bearing categories only (tabular has nothing under SRC_PATH).
+        if self.category in _SRC_PATH_REQUIRED_CATEGORIES:
+            self._check_src_path()
+
         # Pre-flight: a non-UTF-8 CSV otherwise surfaces as a misleading
         # "No data found" (validators read UTF-8 and swallow decode errors).
         # Catch it once here with a clear, actionable message.


### PR DESCRIPTION
## The bug (backend/#772 P2)

If \`config.SRC_PATH\` is empty/unset/missing, every file-bearing category's \`file_transfer\` silently joins to a **relative** path:

\`\`\`python
os.path.join(\"\", \"images\", \"x.jpg\")  # -> \"images/x.jpg\"
\`\`\`

Every per-row file lookup fails, and the user sees N copies of:

\`\`\`
Source image not found: images/x.jpg — skipping record
\`\`\`

…blaming the data when the real cause is \"SRC_PATH was never set / the PVC wasn't staged before the Job ran\". One cryptic error per row instead of one actionable error at startup.

## Fix

\`_check_src_path\` preflight in \`BaseIngestor.validate_data\`, gated on file-bearing categories via a new \`_SRC_PATH_REQUIRED_CATEGORIES\` frozenset (tabular / time-series excluded — they have no sidecar dirs under SRC_PATH; their CSV path is checked separately).

Three explicit error paths:

| Condition | Message |
|---|---|
| empty / unset | `SRC_PATH is empty. Set it to the cluster-PVC path…` |
| relative path | `SRC_PATH=X is not an absolute path…` |
| missing dir | `SRC_PATH=X does not exist or is not a directory…` |

Each message names the chart's data-staging recipe (kubectl cp / init-container sync) and gives the \`kubectl\` command to verify staging.

## Tests

6 new cases on the static helper + 1 category-gating assertion:
- empty / unset / relative / nonexistent → each raises with a specific message
- absolute real directory → passes (positive)
- \`_SRC_PATH_REQUIRED_CATEGORIES\` excludes tabular / time-series and includes all file-bearing categories
- Existing batching test now patches the guard so its assertion still runs

Local: **824 passed, 2 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only guard with category gating; improves operator errors without changing successful ingest paths when SRC_PATH is correctly staged.
> 
> **Overview**
> Adds a **SRC_PATH preflight** in `BaseIngestor.validate_data` so file-bearing ingest jobs fail once at validation with a clear `RuntimeError` instead of repeating per-row “Source image not found” when `config.SRC_PATH` is empty, relative, or not a real directory (#772 P2).
> 
> The check runs only for categories in new `_SRC_PATH_REQUIRED_CATEGORIES` (image, text, segmentation, MLM, etc.); tabular and time-series categories are excluded because they do not resolve sidecars under SRC_PATH. `_check_src_path` validates non-empty value, absolute path, and existing directory, with messages that point operators at PVC staging and verification.
> 
> **Tests:** six unit tests on the static helper, assertions on category membership in the frozenset, and the image batching test patches `_check_src_path` so it still exercises batching in isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c48ffcbe98277494c40f9951370146bb8cb3bc15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->