### PR TITLE
fix(api): refresh auth token on 401 and retry once (backend #772 P2)

### DIFF
--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -208,3 +208,79 @@ def test_create_dataset_local_mode():
         result = client.create_dataset(ingestor_id="ing", category="x")
     assert result["id"] == "mock_dataset_id"
     post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 401 auto-refresh (backend/#772 P2)
+# ---------------------------------------------------------------------------
+
+def test_authed_request_refreshes_token_on_401():
+    """A 401 on an authenticated call triggers ONE refresh + retry. The
+    refresh path rotates the token to a fresh value; the second call
+    succeeds with the new token. The terminal create_dataset / metadata
+    callback used to fail outright on multi-hour runs when the token
+    aged out — now it transparently re-mints."""
+    client = _client(BACKEND_TOKEN="old_token")
+    assert client.token == "old_token"
+    calls = []
+
+    def fake_post(url, headers=None, **kwargs):
+        calls.append(headers["Authorization"])
+        if len(calls) == 1:
+            return _resp(401, text='{"detail":"Invalid token."}')
+        return _resp(200, {"id": 7})
+
+    # Stub _refresh_token to simulate a successful rotation.
+    def fake_refresh():
+        client.token = "new_token"
+        return True
+
+    with patch.object(client.session, "post", side_effect=fake_post), \
+         patch.object(client, "_refresh_token", side_effect=fake_refresh):
+        client.create_dataset(ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION)
+
+    assert len(calls) == 2, "expected one 401 + one retry"
+    assert calls[0] == "TOKEN old_token"
+    assert calls[1] == "TOKEN new_token"
+
+
+def test_authed_request_gives_up_after_one_retry(monkeypatch):
+    """If refresh doesn't change anything (no rotation, or re-auth itself
+    fails), the second attempt is NOT made — the original 401 is surfaced
+    so the caller's existing error path runs unchanged."""
+    monkeypatch.setenv("BACKEND_TOKEN", "stuck_token")
+    client = _client()
+    # No env update -> refresh returns False.
+    calls = []
+
+    def fake_post(url, headers=None, **kwargs):
+        calls.append(1)
+        return _resp(401, text='{"detail":"Invalid token."}')
+
+    with patch.object(client.session, "post", side_effect=fake_post):
+        with pytest.raises(requests.exceptions.RequestException):
+            client.create_dataset(
+                ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
+            )
+
+    # One attempt only — refresh saw no change so no retry.
+    assert len(calls) == 1
+
+
+def test_authed_request_passes_through_non_401_unchanged():
+    """Non-401 statuses (200, 4xx other than 401, 5xx) take the no-retry
+    path. Refresh logic must NOT engage on success or on a non-auth
+    failure — the per-call error handling already covers those."""
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(200, {"id": 1})) as post:
+        client.create_dataset(ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION)
+    # Exactly one call — no refresh, no retry on the happy path.
+    assert post.call_count == 1
+
+
+def test_refresh_token_noop_in_local_mode():
+    """Local mode uses a mock token and no auth network calls — refresh
+    is a no-op so test runs / dev loops don't hit the env-read path."""
+    client = _client(EDGE_ENV="local")
+    assert client._refresh_token() is False
+    assert client.token == "mock_token"

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -1,4 +1,5 @@
-from typing import List, Tuple, Dict, Any
+from typing import List, Tuple, Dict, Any, Optional
+import os
 import requests, json
 import logging
 from requests.adapters import HTTPAdapter
@@ -129,6 +130,90 @@ class APIClient:
             else:
                 raise ValueError(f"{RED}Error response: {e}{RESET}")
 
+    def _refresh_token(self) -> bool:
+        """Re-mint or re-read the auth token (#772 P2 — token captured
+        once, expires on multi-hour runs).
+
+        Three resolution paths matching ``__init__``:
+          - local mode: keep the mock token (no real auth in the loop)
+          - BACKEND_TOKEN: re-read ``os.environ`` in case jobs-manager /
+            secret-rotator wrote a fresh value into the env. (Re-reading
+            ``self.config.BACKEND_TOKEN`` first picks up Config layer
+            overrides; the env fallback covers rotation.)
+          - CLIENT_ID/PASSWORD (deprecated): re-call ``authenticate()``
+            to mint a new short-lived token.
+
+        Returns True iff the token actually changed; False signals
+        "tried to refresh but got the same value, nothing more we can
+        do" — caller should treat the next 401 as terminal.
+        """
+        if self.config.EDGE_ENV == "local":
+            return False
+        old = self.token
+        if self.config.BACKEND_TOKEN:
+            # Re-resolve via Config (which reads the env each time) so a
+            # rotated BACKEND_TOKEN is picked up between attempts.
+            new = self.config.BACKEND_TOKEN or os.environ.get("BACKEND_TOKEN")
+            if new and new != old:
+                self.token = new
+                logger.info(
+                    f"{GREEN}Re-read rotated BACKEND_TOKEN after 401.{RESET}"
+                )
+                return True
+            return False
+        # CLIENT_ID/PASSWORD path: mint a new token.
+        try:
+            self.token = self.authenticate()
+            return self.token != old
+        except Exception as exc:
+            logger.error(
+                f"{RED}Failed to re-authenticate after 401: {exc}{RESET}"
+            )
+            return False
+
+    def _authed_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        extra_headers: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """Issue an authenticated HTTP request with a single 401-refresh
+        retry (#772 P2).
+
+        Auth tokens captured at ``__init__`` used to expire silently on
+        multi-hour runs — the terminal ``create_dataset`` then failed
+        4xx, the ingest exited non-zero, and the rows were left
+        committed-but-unregistered. Now: on a 401, attempt one token
+        refresh and retry the request once. If the second attempt still
+        401s, the caller's existing error path runs as before.
+
+        Caller passes whatever ``session.request`` kwargs are needed
+        (json, data, params, timeout, …). The Authorization header is
+        injected here and overrides anything in ``extra_headers``.
+        """
+        headers = dict(extra_headers or {})
+        headers["Authorization"] = f"TOKEN {self.token}"
+        # Dispatch by method name (not session.request) so existing tests
+        # that monkeypatch ``session.post`` / ``session.get`` directly
+        # continue to work without rewrites.
+        send = getattr(self.session, method.lower())
+        response = send(url, headers=headers, **kwargs)
+        if response.status_code != 401:
+            return response
+        logger.warning(
+            f"{YELLOW}Backend returned 401 for {method} {url} — attempting "
+            f"token refresh and one retry.{RESET}"
+        )
+        if not self._refresh_token():
+            # Refresh did nothing; the second attempt would 401 again.
+            # Surface the original 401 so the caller's existing error
+            # path runs (it already logs the response body).
+            return response
+        headers["Authorization"] = f"TOKEN {self.token}"
+        return send(url, headers=headers, **kwargs)
+
     def send_batch(
         self,
         records: List[Tuple[int, Dict[str, Any]]],
@@ -166,15 +251,11 @@ class APIClient:
 
             logger.info(f"Data to send: {payload}")
 
-            headers = {
-                "Authorization": f"TOKEN {self.token}",
-                "Content-Type": "application/json",
-            }
-
-            response = self.session.post(
+            response = self._authed_request(
+                "POST",
                 f"{self.config.API_ENDPOINT}/global_meta/{table_name}/",
                 data=payload,
-                headers=headers,
+                extra_headers={"Content-Type": "application/json"},
                 timeout=API_TIMEOUT,
             )
 
@@ -221,15 +302,11 @@ class APIClient:
 
             logger.info(f"Global metadata to send: {(payload)}")
 
-            headers = {
-                "Authorization": f"TOKEN {self.token}",
-                "Content-Type": "application/json",
-            }
-
-            response = self.session.post(
+            response = self._authed_request(
+                "POST",
                 f"{self.config.API_ENDPOINT}/global_meta/global_metadata/",
                 data=payload,
-                headers=headers,
+                extra_headers={"Content-Type": "application/json"},
                 timeout=API_TIMEOUT,
             )
 
@@ -271,12 +348,11 @@ class APIClient:
 
         try:
             url = f"{self.config.API_ENDPOINT}/global_meta/generate-edge-labels-meta/?table_name={table_name}&injestor_id={ingestor_id}&data_intent={intent}"
-            headers = {"Authorization": f"TOKEN {self.token}"}
 
             logger.info(
                 f"Sending request to generate edge label metadata for dataset type: {table_name}"
             )
-            response = self.session.get(url, headers=headers, timeout=API_TIMEOUT)
+            response = self._authed_request("GET", url, timeout=API_TIMEOUT)
 
             # Check status after retries are exhausted
             if response.status_code >= 400:
@@ -324,12 +400,11 @@ class APIClient:
 
         try:
             url = f"{self.config.API_ENDPOINT}/global_meta/prepare/?category={category}&injestor_id={ingestor_id}&data_format={data_format}&data_intent={intent}"
-            headers = {"Authorization": f"TOKEN {self.token}"}
 
             logger.info(
                 f"Sending prepare request for category: {category}, injester_id: {ingestor_id}, data_format: {data_format} , data_intent: {intent}"
             )
-            response = self.session.get(url, headers=headers, timeout=API_TIMEOUT)
+            response = self._authed_request("GET", url, timeout=API_TIMEOUT)
 
             # Check status after retries are exhausted
             if response.status_code >= 400:
@@ -394,15 +469,11 @@ class APIClient:
 
             logger.info(f"{GREEN}Creating dataset with payload: {payload}{RESET}")
 
-            headers = {
-                "Authorization": f"TOKEN {self.token}",
-                "Content-Type": "application/json",
-            }
-
-            response = self.session.post(
+            response = self._authed_request(
+                "POST",
                 f"{self.config.API_ENDPOINT}/dataset/",
                 data=payload,
-                headers=headers,
+                extra_headers={"Content-Type": "application/json"},
                 timeout=API_TIMEOUT,
             )
 


### PR DESCRIPTION
## The bug (backend/#772 P2)

\`APIClient.__init__\` captures the auth token once and never revisits it. On a multi-hour ingest (proteomics + image-heavy datasets), the token ages out: the terminal \`create_dataset\` / metadata callback 401s, the ingest exits non-zero, and rows are left **committed-but-unregistered** — exactly the orphan state #772 P0 flags as the worst failure mode.

## Fix

Two-method refresh layer:

| Method | Role |
|---|---|
| \`_refresh_token()\` | local-mode no-op; BACKEND_TOKEN re-reads Config (which re-reads env) to pick up rotations; CLIENT_ID/PASSWORD re-calls \`authenticate()\` |
| \`_authed_request(method, url, ...)\` | Adds Authorization header. On 401, calls \`_refresh_token()\`; if the token changed, retries the request **once**. If refresh didn't rotate or the retry still 401s, returns the original response so the caller's error path runs unchanged. |

Converted all 5 authenticated call sites:
- \`send_batch\` / \`send_global_meta_meta\` / \`send_generate_edge_label_meta\` / \`prepare_dataset\` / \`create_dataset\`
- \`authenticate()\` itself is unchanged — it IS the auth path

## Tests

| | Pins |
|---|---|
| \`test_authed_request_refreshes_token_on_401\` | 401 + rotated token → second attempt with new value succeeds |
| \`test_authed_request_gives_up_after_one_retry\` | refresh didn't rotate → no retry, original 401 surfaces |
| \`test_authed_request_passes_through_non_401_unchanged\` | happy path makes exactly one call |
| \`test_refresh_token_noop_in_local_mode\` | local mode bypasses env-read |

Local: **822 passed, 2 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth and every authenticated ingest API call; behavior is bounded to a single 401 retry but failures here affect dataset registration after long runs.
> 
> **Overview**
> Adds **401 handling** to `APIClient` so long ingests can recover when the backend token expires instead of failing the terminal `create_dataset` / metadata steps.
> 
> **`_refresh_token()`** re-resolves credentials: no-op in local mode; re-reads `BACKEND_TOKEN` from Config/env after rotation; otherwise re-calls `authenticate()` for the deprecated username/password path. It returns whether the token actually changed.
> 
> **`_authed_request()`** wraps authenticated GET/POST: injects `Authorization`, and on **401** runs one refresh and **one retry**; if refresh does nothing, the original 401 is returned so existing error handling is unchanged. All five authenticated API methods (`send_batch`, global metadata, edge labels, `prepare_dataset`, `create_dataset`) now go through this helper instead of calling `session` directly.
> 
> New tests cover successful refresh+retry, no retry when refresh fails, non-401 passthrough, and local-mode refresh no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c3855d584977882deeefb479f96ffb45b9d4c3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->