### PR TITLE
fix(base): concurrent-ingest table-name lock (backend #772 P2)

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -439,3 +439,100 @@ def test_check_csv_encoding_skips_non_csv_sources(tmp_path):
     BaseIngestor._check_csv_encoding(str(tmp_path))                   # a directory
     BaseIngestor._check_csv_encoding(None)                            # not a path
     BaseIngestor._check_csv_encoding(str(tmp_path / "missing.csv"))   # nonexistent
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-ingest table lock — backend/#772 P2
+# ---------------------------------------------------------------------------
+
+def test_acquire_table_lock_creates_lock_file(tmp_path):
+    """Lock file is created at STORAGE_PATH/.tracebloc-ingest-<table>.lock
+    with metadata (ingestor_id, pid, hostname, started_at) so a holder
+    can be identified on conflict."""
+    import json
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(table_name="dataset_a", category=None)
+        lock_path = ing._acquire_table_lock()
+        assert lock_path is not None
+        assert lock_path.endswith(".tracebloc-ingest-dataset_a.lock")
+        meta = json.loads(open(lock_path).read())
+        assert meta["table_name"] == "dataset_a"
+        assert meta["ingestor_id"] == ing.ingestor_id
+        ing._release_table_lock(lock_path)
+        assert not __import__("os").path.exists(lock_path)
+
+
+def test_acquire_table_lock_rejects_concurrent_ingest(tmp_path):
+    """A second ingest targeting the same table while a lock is held
+    fails fast with a message naming the holder. Without this guard,
+    two ingests would race create_table / interleave upserts (#772 P2)."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing_a = make_ingestor(table_name="dataset_a", category=None)
+        path_a = ing_a._acquire_table_lock()
+        try:
+            ing_b = make_ingestor(table_name="dataset_a", category=None)
+            with pytest.raises(RuntimeError, match="already running"):
+                ing_b._acquire_table_lock()
+        finally:
+            ing_a._release_table_lock(path_a)
+
+
+def test_acquire_table_lock_different_tables_dont_conflict(tmp_path):
+    """The lock is keyed by table_name — two different datasets can
+    ingest concurrently without blocking each other."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing_a = make_ingestor(table_name="dataset_a", category=None)
+        ing_b = make_ingestor(table_name="dataset_b", category=None)
+        path_a = ing_a._acquire_table_lock()
+        path_b = ing_b._acquire_table_lock()
+        assert path_a != path_b
+        ing_a._release_table_lock(path_a)
+        ing_b._release_table_lock(path_b)
+
+
+def test_acquire_table_lock_reclaims_stale_lock(tmp_path):
+    """A crashed ingest's lock auto-expires after the stale-cutoff so a
+    customer isn't blocked indefinitely. We simulate by writing a lock
+    file with an old timestamp."""
+    import json
+    from datetime import datetime, timedelta
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(table_name="dataset_stale", category=None)
+        lock_path = ing._table_lock_path()
+        old = (datetime.utcnow() - timedelta(days=2)).isoformat() + "Z"
+        with open(lock_path, "w") as f:
+            json.dump(
+                {"ingestor_id": "crashed-ingest", "started_at": old}, f
+            )
+        # Stale lock detected -> removed -> reacquired with the new holder.
+        path = ing._acquire_table_lock()
+        assert path == lock_path
+        meta = json.loads(open(lock_path).read())
+        assert meta["ingestor_id"] == ing.ingestor_id
+        ing._release_table_lock(lock_path)
+
+
+def test_acquire_table_lock_noop_when_storage_path_missing(tmp_path):
+    """No STORAGE_PATH (e.g. unit tests, local dev) -> the lock is
+    skipped. Returns None, _release_table_lock(None) is a no-op."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    missing = str(tmp_path / "never_exists")
+    with patch.object(CfgCls, "STORAGE_PATH", missing):
+        ing = make_ingestor(table_name="dataset_a", category=None)
+        assert ing._acquire_table_lock() is None
+        ing._release_table_lock(None)  # must not raise
+
+
+def test_release_table_lock_idempotent(tmp_path):
+    """Double-release (e.g. exception path + finally path both call it)
+    must not raise."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(table_name="dataset_a", category=None)
+        path = ing._acquire_table_lock()
+        ing._release_table_lock(path)
+        ing._release_table_lock(path)  # idempotent, no raise

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -536,3 +536,79 @@ def test_release_table_lock_idempotent(tmp_path):
         path = ing._acquire_table_lock()
         ing._release_table_lock(path)
         ing._release_table_lock(path)  # idempotent, no raise
+
+
+# ---------------------------------------------------------------------------
+# #221 bugbot — lock release on every exit + mtime fallback
+# ---------------------------------------------------------------------------
+
+def test_lock_released_when_validate_data_raises(tmp_path):
+    """#221 bugbot HIGH: the original code only released the lock on
+    validation errors / inner Session except. An exception escaping the
+    pre-Session region (e.g. an unexpected error during validate_data
+    that wasn't caught by the surrounding except) used to leak the lock
+    until the stale-cutoff. try/finally now releases on every exit."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(records=[], category=None)
+        with patch.object(ing, "validate_data", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError):
+                ing.ingest("src")
+        lock_path = ing._table_lock_path()
+        assert lock_path is not None
+        import os as _os
+        assert not _os.path.exists(lock_path), (
+            f"lock leaked at {lock_path} after validate_data raised"
+        )
+
+
+def test_lock_released_when_count_records_raises(tmp_path):
+    """#221 bugbot HIGH-severity scenario: a failure in
+    ``self._count_records`` (between validation and the Session block)
+    used to escape without releasing the lock — neither the validation
+    except nor the Session except covered it. try/finally fixes it."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(records=[], category=None)
+        with patch.object(ing, "validate_data", return_value=True), \
+             patch.object(ing, "_count_records", side_effect=RuntimeError("ouch")):
+            with pytest.raises(RuntimeError):
+                ing.ingest("src")
+        import os as _os
+        assert not _os.path.exists(ing._table_lock_path()), "lock leaked"
+
+
+def test_acquire_table_lock_recovers_from_corrupt_lock_via_mtime(tmp_path):
+    """#221 bugbot MED: when the lock metadata is unparseable (empty
+    file, invalid JSON, missing started_at), staleness used to skip the
+    cleanup — age stayed None and the lock blocked indefinitely. The
+    file's mtime now serves as a fallback age signal."""
+    import os as _os
+    import json
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(table_name="dataset_corrupt", category=None)
+        lock_path = ing._table_lock_path()
+        with open(lock_path, "w"):
+            pass  # empty file -> JSON parse fails
+        old = _os.path.getmtime(lock_path) - (13 * 3600)  # 13h ago
+        _os.utime(lock_path, (old, old))
+        path = ing._acquire_table_lock()
+        assert path == lock_path
+        meta = json.loads(open(lock_path).read())
+        assert meta["ingestor_id"] == ing.ingestor_id
+        ing._release_table_lock(lock_path)
+
+
+def test_acquire_table_lock_corrupt_but_fresh_blocks(tmp_path):
+    """A corrupt lock that's RECENT (not stale by mtime) still blocks
+    the second ingest — we don't auto-clear; the user has to remove it
+    manually. Boundary test against the mtime fallback."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(table_name="dataset_corrupt", category=None)
+        lock_path = ing._table_lock_path()
+        with open(lock_path, "w"):
+            pass  # empty, JSON parse fails, mtime is now (fresh)
+        with pytest.raises(RuntimeError, match="already running"):
+            ing._acquire_table_lock()

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -471,7 +471,21 @@ class BaseIngestor(ABC):
                 )
                 age = (_datetime.utcnow() - started).total_seconds()
             except Exception:
-                pass
+                # Lock metadata is corrupt (truncated file, malformed
+                # JSON, missing/un-parseable started_at). Fall back to
+                # the file's mtime as the age signal (#221 bugbot: a
+                # corrupt lock used to never auto-expire because age
+                # stayed None). Use time.time() rather than
+                # _datetime.utcnow().timestamp() — the latter is
+                # timezone-broken (naive datetime treated as local) so
+                # the cutoff would shift by the local UTC offset on
+                # non-UTC systems.
+                import time as _time
+                try:
+                    mtime = os.path.getmtime(lock_path)
+                    age = _time.time() - mtime
+                except OSError:
+                    pass
             if age is not None and age > self._TABLE_LOCK_STALE_SECONDS:
                 logger.warning(
                     f"{YELLOW}Stale lock at {lock_path} (age={age:.0f}s, "
@@ -623,20 +637,31 @@ class BaseIngestor(ABC):
         # partially-populated table and fail mid-run, with the original
         # ingestor unaware. Acquire an exclusive file-lock keyed by the
         # table name; on conflict, fail fast naming the holder. The lock
-        # is released by ``_release_table_lock`` in the finally further
-        # down (wrapping the validation + main ingest body).
+        # is released in the finally below — that wraps the ENTIRE
+        # post-acquire body so every exit path (#221 bugbot) releases,
+        # including ones the inner ``except Exception`` doesn't catch
+        # (Session() construction failure, _count_records exceptions,
+        # KeyboardInterrupt, etc.).
         _lock_path = self._acquire_table_lock()
+        try:
+            return self._ingest_with_lock(source, batch_size)
+        finally:
+            self._release_table_lock(_lock_path)
 
+    def _ingest_with_lock(
+        self, source: Any, batch_size: int = 50
+    ) -> List[Dict[str, Any]]:
+        """Inner ingest body invoked once the table lock is held. Split
+        out from ``ingest`` so the lock-release lives in a finally that
+        covers every exit path (#221 bugbot — HIGH)."""
         # Validate data before ingestion
         logger.info(f"{CYAN}Starting data validation before ingestion...{RESET}")
         try:
             self.validate_data(f"{source}")
             logger.info(f"{GREEN}Data validation completed successfully{RESET}")
         except ValueError as e:
-            self._release_table_lock(_lock_path)
             raise e
         except Exception as e:
-            self._release_table_lock(_lock_path)
             raise e
 
         batch = []
@@ -817,14 +842,8 @@ class BaseIngestor(ABC):
             except Exception as e:
                 session.rollback()
                 logger.error(f"Error during ingestion: {str(e)}")
-                # Release the table lock on the failure path too, otherwise
-                # a crashed ingest leaves a stale lock blocking re-runs
-                # until the stale-lock timeout kicks in.
-                self._release_table_lock(_lock_path)
                 raise e
 
-        # Release the table lock on clean exit (#772 P2).
-        self._release_table_lock(_lock_path)
         return failed_records
 
     def __enter__(self):

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, Generator, List, Optional, NamedTuple
 from sqlalchemy.orm import Session
 from sqlalchemy.engine import Engine
 import logging
+import os
 import pandas as pd
 from tqdm import tqdm
 import uuid
@@ -401,6 +402,132 @@ class BaseIngestor(ABC):
                 f"'CSV UTF-8 (Comma delimited)'), then re-ingest.{RESET}"
             ) from exc
 
+    # Stale-lock cutoff (seconds). A crashed ingest leaves the lock file
+    # behind; if the lock is older than this we log + remove + reacquire
+    # so a customer isn't blocked indefinitely waiting for the writer
+    # whose pod has long since been garbage-collected. 12h covers any
+    # reasonable ingest (including multi-GB proteomics).
+    _TABLE_LOCK_STALE_SECONDS = 12 * 3600
+
+    def _table_lock_path(self) -> Optional[str]:
+        """Where the lock file lives — at the top of STORAGE_PATH (the
+        parent of every per-table DEST_PATH), so it's durable across pod
+        restarts on the cluster PVC. Returns None when STORAGE_PATH is
+        unset or not a directory (test configs / local runs without a
+        staging dir) — caller treats that as "no lock available, skip".
+        """
+        # Late import: keep this module free of a Config singleton at
+        # import time so unit tests can monkeypatch the env per test.
+        from ..config import Config
+        storage = Config().STORAGE_PATH
+        if not storage or not os.path.isdir(storage):
+            return None
+        return os.path.join(storage, f".tracebloc-ingest-{self.table_name}.lock")
+
+    def _acquire_table_lock(self) -> Optional[str]:
+        """Acquire an exclusive lock for ``self.table_name`` (#772 P2).
+
+        Two ingests targeting the same table used to race
+        ``create_table`` / interleave upserts. Atomic ``O_EXCL`` create
+        either succeeds (lock acquired) or fails with ``FileExistsError``
+        (another ingest is in flight). On conflict, read the existing
+        lock's metadata and surface it in the error so ops can find the
+        other run; if the lock is older than the stale-cutoff, remove
+        and reacquire.
+
+        Returns the lock path (or None if no STORAGE_PATH is configured)
+        so ``_release_table_lock`` can remove the right file.
+        """
+        import json as _json
+        import socket as _socket
+        from datetime import datetime as _datetime
+
+        lock_path = self._table_lock_path()
+        if lock_path is None:
+            return None
+
+        lock_info = {
+            "ingestor_id": self.ingestor_id,
+            "table_name": self.table_name,
+            "pid": os.getpid(),
+            "hostname": _socket.gethostname(),
+            "started_at": _datetime.utcnow().isoformat() + "Z",
+        }
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            # Read the existing lock so the error names the holder. Also
+            # check staleness and self-recover if so.
+            existing_info: Dict[str, Any] = {}
+            try:
+                with open(lock_path, "r") as f:
+                    existing_info = _json.load(f)
+            except Exception:
+                pass
+            age = None
+            try:
+                started = _datetime.fromisoformat(
+                    existing_info.get("started_at", "").rstrip("Z")
+                )
+                age = (_datetime.utcnow() - started).total_seconds()
+            except Exception:
+                pass
+            if age is not None and age > self._TABLE_LOCK_STALE_SECONDS:
+                logger.warning(
+                    f"{YELLOW}Stale lock at {lock_path} (age={age:.0f}s, "
+                    f"holder={existing_info!r}) — removing and reacquiring. "
+                    f"The holder's pod likely crashed before its finally "
+                    f"could run.{RESET}"
+                )
+                try:
+                    os.remove(lock_path)
+                except FileNotFoundError:
+                    pass
+                return self._acquire_table_lock()
+            raise RuntimeError(
+                f"{RED}Another ingest is already running for table "
+                f"'{self.table_name}' (lock at {lock_path}). "
+                f"Holder: {existing_info!r}. Wait for it to finish, or — "
+                f"if its pod crashed — remove the lock file manually. "
+                f"(The lock auto-clears after "
+                f"{self._TABLE_LOCK_STALE_SECONDS}s.){RESET}"
+            )
+        try:
+            with os.fdopen(fd, "w") as f:
+                _json.dump(lock_info, f)
+        except Exception:
+            # Couldn't write the metadata — drop the lock so we don't
+            # block ourselves on a malformed file.
+            try:
+                os.remove(lock_path)
+            except FileNotFoundError:
+                pass
+            raise
+        logger.info(
+            f"Acquired table lock for '{self.table_name}' at {lock_path}"
+        )
+        return lock_path
+
+    def _release_table_lock(self, lock_path: Optional[str]) -> None:
+        """Remove the lock file. No-op when ``_acquire_table_lock``
+        returned None (no STORAGE_PATH configured). Idempotent — a
+        double-release (e.g. exception path + finally path both call
+        it) silently swallows ``FileNotFoundError``.
+        """
+        if not lock_path:
+            return
+        try:
+            os.remove(lock_path)
+            logger.info(f"Released table lock for '{self.table_name}'")
+        except FileNotFoundError:
+            pass
+        except Exception as exc:
+            logger.warning(
+                f"Failed to remove table lock {lock_path}: {exc}. "
+                f"It will auto-clear after "
+                f"{self._TABLE_LOCK_STALE_SECONDS}s."
+            )
+
     def validate_data(self, source: Any) -> bool:
         """Validate data before ingestion using configured validators.
 
@@ -490,14 +617,26 @@ class BaseIngestor(ABC):
         Returns:
             List of failed records
         """
+        # Concurrent-ingest guard (backend/#772 P2). Two ingests targeting
+        # the same `table_name` used to race ``create_table`` and
+        # interleave upserts; the second submission would see a
+        # partially-populated table and fail mid-run, with the original
+        # ingestor unaware. Acquire an exclusive file-lock keyed by the
+        # table name; on conflict, fail fast naming the holder. The lock
+        # is released by ``_release_table_lock`` in the finally further
+        # down (wrapping the validation + main ingest body).
+        _lock_path = self._acquire_table_lock()
+
         # Validate data before ingestion
         logger.info(f"{CYAN}Starting data validation before ingestion...{RESET}")
         try:
             self.validate_data(f"{source}")
             logger.info(f"{GREEN}Data validation completed successfully{RESET}")
         except ValueError as e:
+            self._release_table_lock(_lock_path)
             raise e
         except Exception as e:
+            self._release_table_lock(_lock_path)
             raise e
 
         batch = []
@@ -678,8 +817,14 @@ class BaseIngestor(ABC):
             except Exception as e:
                 session.rollback()
                 logger.error(f"Error during ingestion: {str(e)}")
+                # Release the table lock on the failure path too, otherwise
+                # a crashed ingest leaves a stale lock blocking re-runs
+                # until the stale-lock timeout kicks in.
+                self._release_table_lock(_lock_path)
                 raise e
 
+        # Release the table lock on clean exit (#772 P2).
+        self._release_table_lock(_lock_path)
         return failed_records
 
     def __enter__(self):


### PR DESCRIPTION
## The bug (backend/#772 P2)

Two ingests targeting the same \`table_name\` used to race \`create_table\` / interleave upserts. The second submission saw a partially-populated table and either failed mid-run (rows half-committed, dataset half-registered) or — worse — succeeded and silently mixed two datasets' rows under one \`ingestor_id\`.

## Fix

Exclusive file lock keyed by \`table_name\`, durable on the cluster PVC:

| Helper | Role |
|---|---|
| \`_table_lock_path()\` | \`STORAGE_PATH/.tracebloc-ingest-<table>.lock\`. Returns None when STORAGE_PATH isn't a real directory (unit tests / local dev) → guard is opt-in by deployment shape |
| \`_acquire_table_lock()\` | Atomic \`O_EXCL\` create. On conflict, reads existing lock's metadata (ingestor_id, hostname, started_at) and fails with a clear error naming the holder. Self-recovers from a stale lock (>12h old) — a crashed pod's lock auto-clears |
| \`_release_table_lock()\` | Idempotent — safe to call from both the exception path and the finally path |

Wired into \`BaseIngestor.ingest()\`: lock acquired before validation, released on every exit path (validation error / mid-run exception / clean exit).

## Tests

| Test | Pins |
|---|---|
| \`test_acquire_table_lock_creates_lock_file\` | metadata written with ingestor_id |
| \`test_acquire_table_lock_rejects_concurrent_ingest\` | 2nd ingest raises 'already running' naming holder |
| \`test_acquire_table_lock_different_tables_dont_conflict\` | keyed by name, not global |
| \`test_acquire_table_lock_reclaims_stale_lock\` | >12h-old lock is removed + reacquired |
| \`test_acquire_table_lock_noop_when_storage_path_missing\` | opt-in by deployment shape |
| \`test_release_table_lock_idempotent\` | safe double-release |

Local: **824 passed, 2 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `ingest()` entry path and shared PVC lock files; mis-handled locks could block or allow overlapping ingests, but behavior is gated on deployment `STORAGE_PATH` and covered by broad tests.
> 
> **Overview**
> Adds a **per-table exclusive file lock** on `STORAGE_PATH` so two ingests with the same `table_name` cannot race `create_table` / upserts (#772 P2). `ingest()` now acquires the lock first and delegates to `_ingest_with_lock`, with **`try/finally`** so the lock is released on every exit path (#221), not only on validation/Session errors.
> 
> Lock helpers use atomic `O_EXCL` create, write holder metadata (ingestor_id, hostname, `started_at`), fail fast with a clear “already running” error, and **auto-reclaim locks older than 12h**. When lock JSON is bad, **file mtime** is used for staleness; fresh corrupt locks still block.
> 
> Locking is **skipped** when `STORAGE_PATH` is missing or not a directory (local/tests). Tests cover concurrency, per-table isolation, stale/corrupt locks, no-op paths, idempotent release, and lock cleanup when `validate_data` or `_count_records` raises.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88359d4dbd5b98046c8f64eb4d63915f06918030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->