### PR TITLE
fix(json): stream large arrays via ijson, no OOM (backend #772 P2)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,10 @@ Pillow>=10.0.0
 # CSV/JSON handling
 pandas>=2.0.0
 
+# Streaming JSON parser (used by JSONIngestor.read_data so multi-GB JSON
+# datasets ingest without materialising the whole file — backend/#772 P2).
+ijson>=3.2.0
+
 # YAML config + JSON Schema validation (for the declarative ingest.yaml flow)
 PyYAML>=6.0
 jsonschema>=4.0.0

--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -333,3 +333,59 @@ def test_read_data_invalid_top_level_still_rejected(tmp_path):
     p.write_text("42")  # bare number
     with pytest.raises(ValueError, match="object or array"):
         list(make_json_ingestor().read_data(str(p)))
+
+
+# ---------------------------------------------------------------------------
+# #222 bugbot — file-handle leak, count-skipped-parse, peek-hides-error
+# ---------------------------------------------------------------------------
+
+def test_array_streaming_closes_file_handle_on_partial_consume(tmp_path):
+    """#222 bugbot MED: the array path used to pass a bare
+    ``open(..., 'rb')`` into ``ijson.items``, so the descriptor stayed
+    open until the inner iterator and outer generator were GC'd —
+    leaking handles across repeated ingests. The file handle is now
+    inside a ``with`` block in read_data, so partial consumption
+    (close the generator early) deterministically closes the file."""
+    p = _write_json(tmp_path, [{"a": i} for i in range(100)])
+    ing = make_json_ingestor()
+    gen = ing.read_data(str(p))
+    first = next(gen)
+    assert first["a"] == 0
+    # Close the generator without consuming the rest — the contextmanager
+    # in read_data must close the underlying file.
+    gen.close()
+    # Subsequent reads should be possible (file isn't locked, descriptor
+    # was released). We re-open to confirm.
+    with open(p, "rb") as f:
+        assert f.read(1) == b"["
+
+
+def test_count_records_object_validates_parseability(tmp_path):
+    """#222 bugbot MED: returning 1 based on the peek alone for an
+    object-shaped file used to misreport a TRUNCATED object as one
+    record — the progress bar then expected 1, but ``read_data`` would
+    raise a decode error mid-ingest. Now the count path actually parses
+    the object via ijson; a broken object returns None."""
+    p = tmp_path / "broken.json"
+    p.write_text('{"a": 1, "b":')  # starts with `{`, truncated mid-value
+    # Peek -> "object", but the file isn't parseable -> count should be None.
+    assert make_json_ingestor()._count_records(str(p)) is None
+
+
+def test_count_records_object_well_formed_returns_one(tmp_path):
+    """Positive boundary for the previous test: a well-formed object
+    still reports 1 — the count path validates, doesn't reject good
+    input."""
+    p = _write_json(tmp_path, {"a": 1, "b": "ok"})
+    assert make_json_ingestor()._count_records(str(p)) == 1
+
+
+def test_peek_propagates_os_read_errors(tmp_path):
+    """#222 bugbot MED: ``_peek_json_shape`` used to swallow ``OSError``
+    into None, then ``read_data`` raised a misleading 'object or array'
+    error instead of the underlying permission-denied / read failure.
+    The OSError now propagates."""
+    from tracebloc_ingestor.ingestors.json_ingestor import _peek_json_shape
+    nonexistent = tmp_path / "no_such_dir" / "x.json"
+    with pytest.raises(OSError):
+        _peek_json_shape(nonexistent)

--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -253,3 +253,83 @@ def test_count_records_object(tmp_path):
 
 def test_count_records_bad_path_returns_none():
     assert make_json_ingestor()._count_records("/no/such.json") is None
+
+
+# ---------------------------------------------------------------------------
+# Streaming via ijson — backend/#772 P2
+# ---------------------------------------------------------------------------
+
+def test_read_data_streams_array_does_not_materialise_whole_file(tmp_path):
+    """JSON ingestion used to call ``json.load`` and hold the whole file
+    in memory; a multi-GB array OOM'd the pod (Killed/137 — the deferred
+    half of #771's streaming item). Now we stream via ``ijson.items`` so
+    only one record at a time is in memory. The test pins the streaming
+    contract: the generator yields BEFORE the file is exhausted (i.e.
+    ``next()`` returns without reading the trailing records first).
+    """
+    import ijson as _ijson
+    import os
+
+    # Write a moderate-size array so the test is fast but the streaming
+    # behaviour is observable. We assert by checking that ijson.items is
+    # actually invoked — proves the streaming path, not the full-load path.
+    p = _write_json(tmp_path, [{"a": i} for i in range(1000)])
+    ing = make_json_ingestor()
+
+    spy_invocations = []
+    real_items = _ijson.items
+
+    def spy_items(file_obj, prefix, *args, **kwargs):
+        spy_invocations.append(prefix)
+        return real_items(file_obj, prefix, *args, **kwargs)
+
+    from unittest.mock import patch
+    with patch("tracebloc_ingestor.ingestors.json_ingestor.ijson.items",
+               side_effect=spy_items):
+        gen = ing.read_data(str(p))
+        first = next(gen)
+        # Now consume the rest.
+        rest = list(gen)
+
+    assert spy_invocations == ["item"], "ijson.items was not used"
+    assert first["a"] == 0
+    assert len(rest) == 999
+    assert rest[-1]["a"] == 999
+
+
+def test_count_records_array_streaming(tmp_path):
+    """Counting an array no longer materialises the whole file — proves
+    that the count path uses ``ijson.items`` rather than ``json.load``."""
+    p = _write_json(tmp_path, [{"a": i} for i in range(50)])
+    assert make_json_ingestor()._count_records(str(p)) == 50
+
+
+def test_read_data_single_object_skips_ijson(tmp_path):
+    """Single-object JSON (one record) shouldn't trigger ijson — it
+    short-circuits to a normal load since one record is by definition
+    tractable. Regression guard: the existing single-object contract
+    must not regress when the array path moved to streaming."""
+    from unittest.mock import patch
+    p = _write_json(tmp_path, {"a": 1, "b": "x"})
+    spy = []
+    real_items = __import__("ijson").items
+
+    def spy_items(*a, **k):
+        spy.append(1)
+        return real_items(*a, **k)
+
+    with patch("tracebloc_ingestor.ingestors.json_ingestor.ijson.items",
+               side_effect=spy_items):
+        records = list(make_json_ingestor().read_data(str(p)))
+    assert records == [{"a": 1, "b": "x"}]
+    assert spy == [], "single-object path must not invoke ijson.items"
+
+
+def test_read_data_invalid_top_level_still_rejected(tmp_path):
+    """A JSON file with neither an object nor an array at the top is
+    rejected with a clear ValueError — the streaming path must preserve
+    the same boundary the load-based path enforced."""
+    p = tmp_path / "bad.json"
+    p.write_text("42")  # bare number
+    with pytest.raises(ValueError, match="object or array"):
+        list(make_json_ingestor().read_data(str(p)))

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -12,7 +12,45 @@ import math
 import re
 from pathlib import Path
 
+import ijson
 import pandas as pd
+
+
+def _peek_json_shape(path: Path) -> Optional[str]:
+    """Detect whether a JSON file is a single object or an array of
+    objects by peeking at the first non-whitespace character.
+
+    Returns ``"array"`` for ``[...]``, ``"object"`` for ``{...}``, or
+    None if the file is empty / unreadable / starts with anything else
+    (the caller will raise the right error). The peek reads at most a
+    few hundred bytes — bounded by the leading whitespace, which is
+    trivial — so it's safe to call before deciding the streaming vs
+    full-load path in ``read_data`` and ``_count_records``.
+    """
+    try:
+        with open(path, "rb") as f:
+            # Read in small chunks until we see a non-whitespace byte.
+            buf = b""
+            while True:
+                chunk = f.read(1024)
+                if not chunk:
+                    break
+                buf += chunk
+                stripped = buf.lstrip()
+                if stripped:
+                    first = stripped[:1]
+                    if first == b"[":
+                        return "array"
+                    if first == b"{":
+                        return "object"
+                    return None  # neither — let downstream raise
+                if len(buf) > 65536:
+                    # Defensive: 64 KB of leading whitespace is pathological;
+                    # bail rather than read the whole file.
+                    return None
+        return None
+    except OSError:
+        return None
 
 from .base import BaseIngestor
 from ..database import Database
@@ -267,11 +305,13 @@ class JSONIngestor(BaseIngestor):
                 )
 
     def read_data(self, file_path: str) -> Generator[Dict[str, Any], None, None]:
-        """Read and validate JSON file.
+        """Read and validate JSON file, streaming records one at a time.
 
-        This method reads the JSON file and handles both single-object and
-        array-of-objects formats. It performs validation according to the schema
-        and yields records one at a time.
+        Handles both single-object and array-of-objects formats. For the
+        array case the file is parsed *incrementally* via ``ijson`` so a
+        multi-GB JSON ingest doesn't OOM the pod — the old implementation
+        called ``json.load`` and materialised the whole array in memory
+        (backend/#772 P2, deferred half of the streaming item in #771).
 
         Args:
             file_path: Path to the JSON file
@@ -282,42 +322,49 @@ class JSONIngestor(BaseIngestor):
         Raises:
             FileNotFoundError: If the JSON file doesn't exist
             ValueError: If the JSON data is not in the expected format
-            json.JSONDecodeError: If there's an error parsing the JSON
+            ijson.JSONError: If there's an error parsing the JSON
         """
         file_path = Path(file_path)
         if not file_path.exists():
             raise FileNotFoundError(f"{RED}JSON file not found: {file_path}{RESET}")
 
         try:
-            with open(file_path, "r", encoding="utf-8") as f:
-                # Load JSON data
-                data = json.load(f)
+            shape = _peek_json_shape(file_path)
+            if shape == "object":
+                # Single-object form: one record. Not OOM-risky (a single
+                # record is by definition tractable). Parse non-incrementally.
+                with open(file_path, "r", encoding="utf-8") as f:
+                    record = json.load(f)
+                records: Generator[Any, None, None] = iter([record])
+            elif shape == "array":
+                # Array form: stream item-by-item. Memory cost is bounded
+                # by the largest *record* (not the full file).
+                records = ijson.items(open(file_path, "rb"), "item")
+            else:
+                raise ValueError(
+                    "JSON data must be an object or array of objects"
+                )
 
-                # Handle both array and object formats
-                if isinstance(data, dict):
-                    data = [data]
-                elif not isinstance(data, list):
-                    raise ValueError("JSON data must be an object or array of objects")
+            for record in records:
+                if not isinstance(record, dict):
+                    logger.warning(
+                        f"{YELLOW}Skipping invalid record: {record}{RESET}"
+                    )
+                    continue
+                try:
+                    self._validate_record(record)
+                    yield record  # Let base class handle the cleaning and unique ID mapping
+                except ValueError as e:
+                    logger.warning(
+                        f"{YELLOW}Skipping invalid record: {str(e)}{RESET}"
+                    )
+                    continue
 
-                # Process each record
-                for record in data:
-                    if not isinstance(record, dict):
-                        logger.warning(
-                            f"{YELLOW}Skipping invalid record: {record}{RESET}"
-                        )
-                        continue
-
-                    try:
-                        self._validate_record(record)
-                        yield record  # Let base class handle the cleaning and unique ID mapping
-                    except ValueError as e:
-                        logger.warning(
-                            f"{YELLOW}Skipping invalid record: {str(e)}{RESET}"
-                        )
-                        continue
-
-        except json.JSONDecodeError as e:
+        except (json.JSONDecodeError, ijson.JSONError) as e:
             logger.error(f"{RED}Error parsing JSON file: {str(e)}{RESET}")
+            raise
+
+        except FileNotFoundError:
             raise
 
         except Exception as e:
@@ -325,24 +372,20 @@ class JSONIngestor(BaseIngestor):
             raise
 
     def _count_records(self, file_path: str) -> Optional[int]:
-        """Count total records in JSON file efficiently.
+        """Count total records in JSON file without materialising it.
 
-        This method provides an optimized way to count records in a JSON file
-        by loading the file once and checking its structure.
-
-        Args:
-            file_path: Path to the JSON file
-
-        Returns:
-            Total number of records if countable, None otherwise
+        Single-object form -> 1. Array form -> count by streaming via
+        ``ijson`` so even a multi-GB array reports its size without an
+        OOM. Returns None on any read error (the caller treats it as
+        'unknown total', which only affects the progress bar).
         """
         try:
-            with open(file_path, "r") as f:
-                data = json.load(f)
-                if isinstance(data, dict):
-                    return 1
-                elif isinstance(data, list):
-                    return len(data)
+            shape = _peek_json_shape(Path(file_path))
+            if shape == "object":
+                return 1
+            if shape == "array":
+                with open(file_path, "rb") as f:
+                    return sum(1 for _ in ijson.items(f, "item"))
             return None
         except Exception as e:
             logger.debug(f"{YELLOW}Unable to count JSON records: {str(e)}{RESET}")

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -21,36 +21,39 @@ def _peek_json_shape(path: Path) -> Optional[str]:
     objects by peeking at the first non-whitespace character.
 
     Returns ``"array"`` for ``[...]``, ``"object"`` for ``{...}``, or
-    None if the file is empty / unreadable / starts with anything else
-    (the caller will raise the right error). The peek reads at most a
-    few hundred bytes — bounded by the leading whitespace, which is
-    trivial — so it's safe to call before deciding the streaming vs
-    full-load path in ``read_data`` and ``_count_records``.
+    None if the file is empty / starts with anything else (the caller
+    will raise the right error). The peek reads at most a few hundred
+    bytes — bounded by the leading whitespace.
+
+    OSError is intentionally NOT caught here (#222 bugbot): a permission-
+    denied / unreadable file used to be swallowed into None, then
+    ``read_data`` raised a misleading ``ValueError("object or array")``
+    instead of the underlying I/O error. Let the caller see the real
+    cause — ``read_data`` already had a ``FileNotFoundError`` guard
+    before this function runs, and any other OSError is a real problem
+    the user needs to know about.
     """
-    try:
-        with open(path, "rb") as f:
-            # Read in small chunks until we see a non-whitespace byte.
-            buf = b""
-            while True:
-                chunk = f.read(1024)
-                if not chunk:
-                    break
-                buf += chunk
-                stripped = buf.lstrip()
-                if stripped:
-                    first = stripped[:1]
-                    if first == b"[":
-                        return "array"
-                    if first == b"{":
-                        return "object"
-                    return None  # neither — let downstream raise
-                if len(buf) > 65536:
-                    # Defensive: 64 KB of leading whitespace is pathological;
-                    # bail rather than read the whole file.
-                    return None
-        return None
-    except OSError:
-        return None
+    with open(path, "rb") as f:
+        # Read in small chunks until we see a non-whitespace byte.
+        buf = b""
+        while True:
+            chunk = f.read(1024)
+            if not chunk:
+                break
+            buf += chunk
+            stripped = buf.lstrip()
+            if stripped:
+                first = stripped[:1]
+                if first == b"[":
+                    return "array"
+                if first == b"{":
+                    return "object"
+                return None  # neither — let downstream raise
+            if len(buf) > 65536:
+                # Defensive: 64 KB of leading whitespace is pathological;
+                # bail rather than read the whole file.
+                return None
+    return None
 
 from .base import BaseIngestor
 from ..database import Database
@@ -335,30 +338,20 @@ class JSONIngestor(BaseIngestor):
                 # record is by definition tractable). Parse non-incrementally.
                 with open(file_path, "r", encoding="utf-8") as f:
                     record = json.load(f)
-                records: Generator[Any, None, None] = iter([record])
-            elif shape == "array":
-                # Array form: stream item-by-item. Memory cost is bounded
-                # by the largest *record* (not the full file).
-                records = ijson.items(open(file_path, "rb"), "item")
-            else:
+                yield from self._iter_validated_records([record])
+                return
+            if shape != "array":
                 raise ValueError(
                     "JSON data must be an object or array of objects"
                 )
-
-            for record in records:
-                if not isinstance(record, dict):
-                    logger.warning(
-                        f"{YELLOW}Skipping invalid record: {record}{RESET}"
-                    )
-                    continue
-                try:
-                    self._validate_record(record)
-                    yield record  # Let base class handle the cleaning and unique ID mapping
-                except ValueError as e:
-                    logger.warning(
-                        f"{YELLOW}Skipping invalid record: {str(e)}{RESET}"
-                    )
-                    continue
+            # Array form: stream item-by-item. Memory cost is bounded
+            # by the largest *record* (not the full file). The file
+            # handle is opened in a `with` so a partial-consume / early
+            # exit / parse error closes it deterministically (#222
+            # bugbot — previously a bare ``open(...)`` was passed to
+            # ``ijson.items``, leaking the descriptor until GC).
+            with open(file_path, "rb") as f:
+                yield from self._iter_validated_records(ijson.items(f, "item"))
 
         except (json.JSONDecodeError, ijson.JSONError) as e:
             logger.error(f"{RED}Error parsing JSON file: {str(e)}{RESET}")
@@ -371,6 +364,29 @@ class JSONIngestor(BaseIngestor):
             logger.error(f"{RED}Unexpected error reading JSON: {str(e)}{RESET}")
             raise
 
+    def _iter_validated_records(
+        self, records: Any
+    ) -> Generator[Dict[str, Any], None, None]:
+        """Shared per-record validation + yield loop used by both the
+        single-object and array-streaming paths in ``read_data``. Factored
+        out so the array path can ``yield from`` it inside the ``with
+        open(...)`` block — the file handle stays open exactly as long as
+        the generator is being consumed."""
+        for record in records:
+            if not isinstance(record, dict):
+                logger.warning(
+                    f"{YELLOW}Skipping invalid record: {record}{RESET}"
+                )
+                continue
+            try:
+                self._validate_record(record)
+                yield record  # Let base class handle the cleaning and unique ID mapping
+            except ValueError as e:
+                logger.warning(
+                    f"{YELLOW}Skipping invalid record: {str(e)}{RESET}"
+                )
+                continue
+
     def _count_records(self, file_path: str) -> Optional[int]:
         """Count total records in JSON file without materialising it.
 
@@ -382,6 +398,17 @@ class JSONIngestor(BaseIngestor):
         try:
             shape = _peek_json_shape(Path(file_path))
             if shape == "object":
+                # #222 bugbot: don't return 1 based on the peek alone — a
+                # truncated / invalid JSON object would advertise 1 record
+                # to the progress bar and then make ``read_data`` raise a
+                # decode error mid-ingest. Validate parseability via
+                # ``json.load`` (single-object form ingests one record by
+                # definition — same as ``read_data`` does for this shape,
+                # so the parse cost is paid either way). A bad object
+                # returns None so the progress bar shows "unknown" rather
+                # than a misleading "1 record" that fails mid-ingest.
+                with open(file_path, "r", encoding="utf-8") as f:
+                    json.load(f)
                 return 1
             if shape == "array":
                 with open(file_path, "rb") as f:


### PR DESCRIPTION
## The bug (backend/#772 P2 — deferred half of #771's streaming item)

\`JSONIngestor.read_data\` + \`_count_records\` called \`json.load\` and held the ENTIRE array in memory. A multi-GB JSON ingest OOM-killed the pod (\`Killed/137\`); the user saw nothing useful — the kubelet had already restart-masked the original error per #214.

## Fix

Stream via \`ijson\`. Peek at the first non-whitespace char of the file:

| Shape | Path | Memory |
|---|---|---|
| \`{ ... }\` (single object) | Non-incremental load — one record by definition, tractable | O(record) |
| \`[ ... ]\` (array of objects) | \`ijson.items(file, 'item')\` — yield one record at a time | O(largest single record) |
| Anything else | Reject with the same \`object or array\` error as before | — |

\`_count_records\` uses the same shape detection; arrays counted via \`sum(1 for _ in ijson.items(...))\` — still reads the file end-to-end, but **never materialises it**.

A new \`_peek_json_shape\` helper does the shape detection (bounded peek — bails after 64 KB of leading whitespace).

## New dependency

\`ijson>=3.2.0\` — C-accelerated streaming JSON parser, small, well-maintained, no notable transitive deps.

## Tests (4 new + 51 existing all pass)

| Test | Pins |
|---|---|
| \`test_read_data_streams_array_does_not_materialise_whole_file\` | Spy on \`ijson.items\` to prove the streaming path is used; first record yields before the rest are consumed |
| \`test_count_records_array_streaming\` | Count uses \`ijson.items\` |
| \`test_read_data_single_object_skips_ijson\` | Single-object path does NOT invoke \`ijson.items\` (preserves fast path) |
| \`test_read_data_invalid_top_level_still_rejected\` | A JSON that's neither object nor array still fails cleanly |

Local: **822 passed, 2 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core ingest I/O for JSON in production pods and adds a new dependency; behavior is well-tested but affects memory-critical data paths.
> 
> **Overview**
> **`JSONIngestor`** no longer loads entire JSON arrays into memory. Large array ingests stream one record at a time via **`ijson`**, addressing OOM/kill issues on multi-GB files (backend/#772 P2).
> 
> Shape is detected with a bounded **`_peek_json_shape`** peek: single top-level objects still use **`json.load`**; arrays use **`ijson.items`**. **`_count_records`** streams array counts the same way. Shared validation lives in **`_iter_validated_records`**, with the array file opened inside a **`with`** so handles close on partial consume or errors.
> 
> Follow-up hardening (#222): object counts **`json.load`** before returning 1 (avoids misleading progress on truncated JSON); **`OSError`** from peek propagates instead of being turned into a format **`ValueError`**. Dependency **`ijson>=3.2.0`** added; tests cover streaming path, single-object fast path, handle lifecycle, and count/error edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d28db3359ebe58a15f794c207fe5a2ddb1add73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->