### PR TITLE
fix: count batch API-send failures as failed records, exit non-zero

### DIFF
--- a/templates/image_classification/image_classification.py
+++ b/templates/image_classification/image_classification.py
@@ -6,6 +6,7 @@ supporting both binary data and file-based processing.
 """
 
 import logging
+import sys
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
 from tracebloc_ingestor.utils.logging import setup_logging
@@ -75,6 +76,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/keypoint_detection/keypoint_detection.py
+++ b/templates/keypoint_detection/keypoint_detection.py
@@ -6,6 +6,7 @@ It processes image files along with JSON-based keypoint coordinate annotations.
 """
 
 import logging
+import sys
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
 from tracebloc_ingestor.utils.logging import setup_logging
@@ -97,6 +98,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/masked_language_modeling/masked_language_modeling.py
+++ b/templates/masked_language_modeling/masked_language_modeling.py
@@ -11,6 +11,7 @@ on-the-fly during training.
 """
 
 import logging
+import sys
 import os
 from typing import Dict, Any
 
@@ -77,6 +78,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/object_detection/object_detection.py
+++ b/templates/object_detection/object_detection.py
@@ -6,6 +6,7 @@ corresponding XML annotation files from the VisDrone dataset format.
 """
 
 import logging
+import sys
 import shutil
 import xml.etree.ElementTree as ET
 from typing import Dict, Any
@@ -82,6 +83,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/semantic_segmentation/semantic_segmentation.py
+++ b/templates/semantic_segmentation/semantic_segmentation.py
@@ -6,6 +6,7 @@ both the image files and their corresponding mask annotation files.
 """
 
 import logging
+import sys
 from typing import Dict, Any
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
@@ -82,6 +83,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/tabular_classification/tabular_classification.py
+++ b/templates/tabular_classification/tabular_classification.py
@@ -6,6 +6,7 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
+import sys
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
 from tracebloc_ingestor.utils.logging import setup_logging
@@ -73,6 +74,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/tabular_regression/tabular_regression.py
+++ b/templates/tabular_regression/tabular_regression.py
@@ -6,6 +6,7 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
+import sys
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
 from tracebloc_ingestor.utils.logging import setup_logging
@@ -73,6 +74,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/text_classification/text_classification.py
+++ b/templates/text_classification/text_classification.py
@@ -6,6 +6,7 @@ corresponding labels from a CSV file, similar to object detection format.
 """
 
 import logging
+import sys
 import os
 from typing import Dict, Any
 
@@ -72,6 +73,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/time_series_forecasting/time_series_forecasting.py
+++ b/templates/time_series_forecasting/time_series_forecasting.py
@@ -6,6 +6,7 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
+import sys
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
 from tracebloc_ingestor.utils.logging import setup_logging
@@ -78,6 +79,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/time_to_event_prediction/time_to_event_prediction.py
+++ b/templates/time_to_event_prediction/time_to_event_prediction.py
@@ -6,6 +6,7 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
+import sys
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
 from tracebloc_ingestor.utils.logging import setup_logging
@@ -85,6 +86,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/token_classification/token_classification.py
+++ b/templates/token_classification/token_classification.py
@@ -12,6 +12,7 @@ Example row:
 """
 
 import logging
+import sys
 import os
 from typing import Dict, Any
 
@@ -78,6 +79,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/tests/test_batch_send_failure_accounting.py
+++ b/tests/test_batch_send_failure_accounting.py
@@ -239,6 +239,35 @@ def test_ingest_partial_db_failure_not_double_counted():
     assert summary.failed_records == 1
 
 
+def test_ingest_mid_batch_db_failure_plus_api_failure_tags_right_records():
+    # Bugbot regression guard: insert_batch's per-record fallback appends
+    # successes in scan order, so after a MID-batch DB failure the inserted
+    # records are NOT the first len(ids) entries. The api_send_failed tag
+    # must land on the records that actually inserted (here: #0 and #2),
+    # not on a batch[:len(ids)] prefix that would include the DB-failed #1
+    # and omit #2.
+    records = [{"a": str(i), "filename": f"f{i}"} for i in range(3)]
+    ing = make_ingestor(records=records, category=None)
+    ing.api_client.send_batch.return_value = False
+
+    def fake_insert(table_name, batch):
+        # Middle record fails; failure carries a COPY of the record (the
+        # real insert_batch builds processed_record = {**record, ...}).
+        failed_copy = {**batch[1], "updated_at": "now"}
+        return [10, 12], [{"record": failed_copy, "error": "dup key"}]
+
+    ing.database.insert_batch.side_effect = fake_insert
+
+    failed, summary = _run_ingest(ing)
+
+    api_failed = [f for f in failed if f["error"] == "api_send_failed"]
+    assert {f["record"]["a"] for f in api_failed} == {"0", "2"}
+    assert [f["error"] for f in failed if f["error"] != "api_send_failed"] == ["dup key"]
+    assert summary.inserted_records == 2
+    assert summary.api_sent_records == 0
+    assert summary.failed_records == 1
+
+
 # ---------------------------------------------------------------------------
 # 3. templates exit non-zero when ingest() returns failed records
 # ---------------------------------------------------------------------------

--- a/tests/test_batch_send_failure_accounting.py
+++ b/tests/test_batch_send_failure_accounting.py
@@ -1,0 +1,265 @@
+"""Batch API-send failures must surface, not vanish.
+
+Regression guards for a real silent-failure incident: every batch POST to
+``/global_meta/<table>/`` was rejected with HTTP 400, yet the run finished
+with "All records processed successfully", a summary claiming a 100% success
+rate, and exit code 0. Files were copied and MySQL rows inserted, but the
+backend had zero records — the next platform call failed with "No data found
+for table name".
+
+Three swallow points, three guard groups below:
+
+1. ``APIClient.send_batch`` logged ``str(e)[:100]`` — the manually-raised
+   HTTPError carried no ``.response``, and 100 chars truncated the message
+   right after "HTTP 400: ", hiding the DRF field error.
+2. ``BaseIngestor`` only skipped the ``api_sent_records`` increment when
+   ``api_success`` was False; the records never reached ``failed_records``,
+   so ``ingest()`` returned ``[]`` and callers exited 0. Exceptions from
+   ``_process_batch`` were likewise logged and dropped from every counter.
+3. The template scripts never exited non-zero on failed records.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.api.client import APIClient
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor, IngestionSummary
+
+
+# ---------------------------------------------------------------------------
+# helpers (mirror test_api_client_methods.py / test_ingestor_base.py)
+# ---------------------------------------------------------------------------
+
+def _client(**overrides):
+    defaults = dict(BACKEND_TOKEN="tok", CLIENT_USERNAME=None,
+                    CLIENT_PASSWORD=None, EDGE_ENV="prod", TITLE=None)
+    defaults.update(overrides)
+    return APIClient(Config(**defaults))
+
+
+def _resp(status=200, json_body=None, text=""):
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = json_body if json_body is not None else {}
+    r.text = text
+    return r
+
+
+class FakeIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source: Any) -> Generator[Dict[str, Any], None, None]:
+        yield from self._records
+
+
+def make_ingestor(records=None, **overrides):
+    db = MagicMock(name="Database")
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
+    db.get_table_schema.return_value = {"a": "INT"}
+    api = MagicMock(name="APIClient")
+    api.send_batch.return_value = True
+    api.send_generate_edge_label_meta.return_value = True
+    api.send_global_meta_meta.return_value = True
+    api.prepare_dataset.return_value = True
+    api.create_dataset.return_value = {"id": 1}
+
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=None,
+    )
+    kwargs.update(overrides)
+    return FakeIngestor(records or [], **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 1. send_batch logs the actual backend error, not a 100-char stub
+# ---------------------------------------------------------------------------
+
+# A realistic DRF batch-rejection body: well past the old 100-char cutoff
+# (str(e) started with "HTTP 400: ", leaving ~90 chars of body).
+_DRF_400_BODY = (
+    '[{"data_id": ["This field may not be blank."], '
+    '"label": ["Object with label=tok_cls_O does not exist. '
+    'Padding padding padding padding padding to push the field error '
+    'well past the first hundred characters of the message."]}]'
+)
+
+
+def test_send_batch_400_logs_status_and_full_field_error(caplog):
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(400, text=_DRF_400_BODY)):
+        with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
+            assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "Error sending batch to API" in joined
+    assert "HTTP 400" in joined
+    # The tail of the DRF body — beyond the old [:100] truncation — must be
+    # visible so the operator can see WHY the backend rejected the batch.
+    assert "well past the first hundred characters" in joined
+
+
+def test_send_batch_400_body_capped_at_2000_chars(caplog):
+    client = _client()
+    huge = "x" * 5000
+    with patch.object(client.session, "post", return_value=_resp(400, text=huge)):
+        with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
+            client.send_batch([(1, {"data_id": "a"})], "tbl", "ing")
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "x" * 2000 in joined
+    assert "x" * 2001 not in joined
+
+
+def test_send_batch_connection_error_still_logged(caplog):
+    client = _client()
+    with patch.object(
+        client.session, "post",
+        side_effect=requests.exceptions.ConnectionError("conn refused"),
+    ):
+        with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
+            assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "Error sending batch to API" in joined
+    assert "conn refused" in joined
+
+
+# ---------------------------------------------------------------------------
+# 2. ingest() surfaces API-send failures: returned, counted, summarized
+# ---------------------------------------------------------------------------
+
+def _run_ingest(ing, batch_size=10):
+    """Run ingest with Session patched out; capture the logged summary."""
+    captured = {}
+    real_log = BaseIngestor._log_summary
+
+    def spy(self, summary):
+        captured["summary"] = summary
+        return real_log(self, summary)
+
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(BaseIngestor, "_log_summary", spy):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=batch_size)
+    return failed, captured.get("summary")
+
+
+def test_ingest_api_send_failure_returns_failed_records():
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=None)
+    ing.api_client.send_batch.return_value = False  # every batch POST rejected
+
+    failed, summary = _run_ingest(ing)
+
+    # Every inserted-but-unsent record comes back as a failed record, so
+    # cli.run.main returns 1 and the template scripts sys.exit(1).
+    assert len(failed) == 2
+    assert all(f["error"] == "api_send_failed" for f in failed)
+
+    # The summary must not claim the records shipped.
+    assert summary.inserted_records == 2
+    assert summary.api_sent_records == 0
+    assert summary.has_failures is True
+
+
+def test_ingest_api_send_failure_on_final_partial_batch():
+    # 3 records with batch_size=2 exercises BOTH flush sites (in-loop and
+    # final partial batch).
+    records = [{"a": str(i), "filename": f"f{i}"} for i in range(3)]
+    ing = make_ingestor(records=records, category=None)
+    ing.api_client.send_batch.return_value = False
+    # insert_batch must echo the actual batch size, not the fixture's [1, 2]
+    ing.database.insert_batch.side_effect = lambda t, b: (list(range(len(b))), [])
+
+    failed, summary = _run_ingest(ing, batch_size=2)
+
+    assert len(failed) == 3
+    assert summary.inserted_records == 3
+    assert summary.api_sent_records == 0
+
+
+def test_ingest_api_success_keeps_failed_records_empty():
+    # Control: a clean run is unchanged by the new accounting.
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=None)
+
+    failed, summary = _run_ingest(ing)
+
+    assert failed == []
+    assert summary.api_sent_records == summary.inserted_records == 2
+    assert summary.has_failures is False
+
+
+def test_ingest_batch_exception_counts_whole_batch_as_failed():
+    # An exception escaping _process_batch (e.g. a DB connection drop mid
+    # insert) used to be logged and dropped from every counter.
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=None)
+    ing.database.insert_batch.side_effect = RuntimeError("db gone")
+
+    failed, summary = _run_ingest(ing)
+
+    assert len(failed) == 2
+    assert all("db gone" in f["error"] for f in failed)
+    assert summary.failed_records == 2
+    assert summary.inserted_records == 0
+    assert summary.has_failures is True
+
+
+def test_ingest_partial_db_failure_not_double_counted():
+    # 1 of 2 rows inserts; the API send for the inserted row succeeds. Only
+    # the DB failure is returned — the inserted+sent row is not.
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=None)
+    db_failure = {"record": {"a": "2"}, "error": "dup key"}
+    ing.database.insert_batch.return_value = ([1], [db_failure])
+
+    failed, summary = _run_ingest(ing)
+
+    assert failed == [db_failure]
+    assert summary.inserted_records == 1
+    assert summary.api_sent_records == 1
+    assert summary.failed_records == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. templates exit non-zero when ingest() returns failed records
+# ---------------------------------------------------------------------------
+
+_TEMPLATES = sorted(Path(__file__).parent.parent.glob("templates/*/*.py"))
+
+
+@pytest.mark.parametrize("template", _TEMPLATES, ids=lambda p: p.parent.name)
+def test_template_exits_nonzero_on_failed_records(template):
+    """Each template's failed-records branch must end in sys.exit(1) —
+    BEFORE the else that logs "All records processed successfully" — so a
+    run with failures can't leave the K8s Job marked Succeeded."""
+    src = template.read_text(encoding="utf-8")
+    assert re.search(r"^import sys$", src, re.M), f"{template} missing 'import sys'"
+    m = re.search(
+        r"if failed_records:(?P<branch>.*?)\n\s*else:\s*\n\s*"
+        r"logger\.info\(\"All records processed successfully\"\)",
+        src,
+        re.S,
+    )
+    assert m, f"{template}: failed_records/else block not found"
+    assert "sys.exit(1)" in m.group("branch"), (
+        f"{template}: failed_records branch does not sys.exit(1)"
+    )

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -259,18 +259,28 @@ class APIClient:
                 timeout=API_TIMEOUT,
             )
 
-            # Check status after retries are exhausted
+            # Check status after retries are exhausted. Attach the response
+            # so the handler below can log the status and body — a bare
+            # HTTPError has e.response = None, which used to route a DRF 400
+            # into the str(e)[:100] branch, truncating the message right
+            # after "HTTP 400: " and hiding the field error that explains
+            # why every batch was rejected.
             if response.status_code >= 400:
                 raise requests.exceptions.HTTPError(
-                    f"HTTP {response.status_code}: {response.text}"
+                    f"HTTP {response.status_code}: {response.text}",
+                    response=response,
                 )
             return True
 
         except requests.exceptions.RequestException as e:
-            if hasattr(e.response, "text"):
-                logger.error(f"{RED}Error response: {e.response.text}{RESET}")
+            if e.response is not None:
+                body = (e.response.text or "")[:2000]
+                logger.error(
+                    f"{RED}Error sending batch to API: "
+                    f"HTTP {e.response.status_code}: {body}{RESET}"
+                )
             else:
-                logger.error(f"{RED}Error sending batch to API: {str(e)[:100]}{RESET}")
+                logger.error(f"{RED}Error sending batch to API: {str(e)[:500]}{RESET}")
             return False
 
     def send_global_meta_meta(

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -826,19 +826,9 @@ class BaseIngestor(ABC):
 
                             if len(batch) >= batch_size:
                                 try:
-                                    inserted_ids, api_success, db_failures = (
-                                        self._process_batch(batch, session)
+                                    self._flush_batch(
+                                        batch, session, stats, failed_records
                                     )
-                                    # Only count records that were successfully inserted
-                                    if inserted_ids:
-                                        stats["inserted_records"] += len(inserted_ids)
-                                    if api_success:
-                                        stats["api_sent_records"] += len(inserted_ids)
-                                    if db_failures:
-                                        stats["failed_records"] += len(db_failures)
-                                        failed_records.extend(db_failures)
-                                except Exception as e:
-                                    logger.error(f"Batch processing failed: {str(e)}")
                                 finally:
                                     pbar.update(len(batch))
                                     batch = []
@@ -854,20 +844,9 @@ class BaseIngestor(ABC):
                 # Process remaining records
                 if batch:
                     try:
-                        inserted_ids, api_success, db_failures = self._process_batch(
-                            batch, session
-                        )
-                        # Only count records that were successfully inserted
-                        if inserted_ids:
-                            stats["inserted_records"] += len(inserted_ids)
-                        if api_success:
-                            stats["api_sent_records"] += len(inserted_ids)
-                        if db_failures:
-                            stats["failed_records"] += len(db_failures)
-                            failed_records.extend(db_failures)
+                        self._flush_batch(batch, session, stats, failed_records)
+                    finally:
                         pbar.update(len(batch))
-                    except Exception as e:
-                        logger.error(f"Final batch processing failed: {str(e)}")
 
                 session.commit()
                 pbar.close()
@@ -949,6 +928,65 @@ class BaseIngestor(ABC):
         """Cleanup when used as context manager"""
         pass
 
+    def _flush_batch(
+        self,
+        batch: List[Dict[str, Any]],
+        session: Session,
+        stats: Dict[str, int],
+        failed_records: List[Dict[str, Any]],
+    ) -> None:
+        """Process one batch and fold its outcome into ``stats`` /
+        ``failed_records``. Shared by the in-loop and final-batch flush
+        sites in ``_ingest_with_lock``.
+
+        Failure accounting is the point of this helper. A run where every
+        batch POST was rejected with HTTP 400 used to finish with
+        "All records processed successfully" and exit 0 — the rows were
+        in MySQL but the backend had zero records, and the next platform
+        call failed with "No data found for table name". Two swallow
+        points caused that:
+
+        - ``api_success=False`` only skipped the ``api_sent_records``
+          increment; the records never reached ``failed_records``, so
+          ``ingest()`` returned ``[]`` and the caller exited 0. Now each
+          inserted-but-unsent record is returned as a failed record with
+          ``error="api_send_failed"`` (the rows stay committed — they're
+          in MySQL but invisible to the platform until re-sent).
+        - an exception from ``_process_batch`` was logged and dropped,
+          leaving the whole batch out of every counter. Now the batch is
+          counted and returned as failed.
+
+        The summary needs no extra field: "Failed to Send to API" is
+        derived from ``inserted_records - api_sent_records``, and
+        ``IngestionSummary.has_failures`` already trips on that gap.
+        """
+        try:
+            inserted_ids, api_success, db_failures = self._process_batch(
+                batch, session
+            )
+            # Only count records that were successfully inserted
+            if inserted_ids:
+                stats["inserted_records"] += len(inserted_ids)
+                if api_success:
+                    stats["api_sent_records"] += len(inserted_ids)
+                else:
+                    # zip(ids, batch) in _process_batch pairs the inserted
+                    # ids with the first len(ids) records of the batch —
+                    # those are the records whose API send failed.
+                    failed_records.extend(
+                        {"record": record, "error": "api_send_failed"}
+                        for record in batch[: len(inserted_ids)]
+                    )
+            if db_failures:
+                stats["failed_records"] += len(db_failures)
+                failed_records.extend(db_failures)
+        except Exception as e:
+            logger.error(f"Batch processing failed: {str(e)}")
+            stats["failed_records"] += len(batch)
+            failed_records.extend(
+                {"record": record, "error": str(e)} for record in batch
+            )
+
     def _process_batch(
         self, batch: List[Dict[str, Any]], session: Session
     ) -> List[int]:
@@ -996,8 +1034,14 @@ class BaseIngestor(ABC):
 
         except Exception as e:
             logger.error(f"{RED}Error processing batch: {str(e)}{RESET}")
-            if hasattr(e.response, "text"):
-                logger.error(f"{RED}Error response: {e.response.text}{RESET}")
+            # Guard the attribute chain: a non-HTTP exception (e.g. a DB
+            # error) has no .response at all, and the old
+            # hasattr(e.response, "text") raised AttributeError INSIDE the
+            # handler — replacing the real error with "'RuntimeError'
+            # object has no attribute 'response'".
+            response = getattr(e, "response", None)
+            if response is not None and hasattr(response, "text"):
+                logger.error(f"{RED}Error response: {response.text}{RESET}")
             raise
 
     def _log_summary(self, summary: IngestionSummary):

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -977,12 +977,21 @@ class BaseIngestor(ABC):
                 if api_success:
                     stats["api_sent_records"] += len(inserted_ids)
                 else:
-                    # zip(ids, batch) in _process_batch pairs the inserted
-                    # ids with the first len(ids) records of the batch —
-                    # those are the records whose API send failed.
+                    # The inserted-but-unsent records are the batch minus
+                    # the DB failures. Don't assume they're the first
+                    # len(ids) entries: insert_batch's per-record fallback
+                    # appends successes in scan order, so a mid-batch DB
+                    # failure shifts which records were inserted. Failure
+                    # entries carry a *copy* of the record (processed_record
+                    # adds updated_at), so match by data_id — set on every
+                    # processed record by _map_unique_id — not by identity.
+                    db_failed_data_ids = {
+                        f.get("record", {}).get("data_id") for f in db_failures
+                    }
                     failed_records.extend(
                         {"record": record, "error": "api_send_failed"}
-                        for record in batch[: len(inserted_ids)]
+                        for record in batch
+                        if record.get("data_id") not in db_failed_data_ids
                     )
             if db_failures:
                 stats["failed_records"] += len(db_failures)


### PR DESCRIPTION
## Problem

A real ingest run (12,150-record MLM dataset) had **every** batch POST to `/global_meta/<table>/` rejected with HTTP 400 — yet the run finished with "All records processed successfully", an INGESTION SUMMARY claiming 100% success, and **exit code 0**. Files were copied and MySQL rows inserted, but the backend had zero records; the subsequent edge-label-metadata call failed with "No data found for table name".

## Swallow points fixed

1. **`ingestors/base.py`** — `api_success=False` from `_process_batch` only skipped the `api_sent_records` increment. The records never reached `failed_records`, so `ingest()` returned `[]` and the caller exited 0. Exceptions escaping `_process_batch` were likewise logged and dropped from every counter.
   - The duplicated batch-accounting at both flush sites (in-loop + final partial batch) is extracted into a single `_flush_batch()` helper.
   - Inserted-but-unsent records are now returned from `ingest()` as failed records with `error="api_send_failed"` (the rows stay committed — they're in MySQL but invisible to the platform until re-sent). The summary's "Failed to Send to API" line and `has_failures` already derive from `inserted_records - api_sent_records`, so no new summary field is needed.
   - A batch-level exception now counts the whole batch as failed instead of vanishing.
   - Bonus fix: `_process_batch`'s handler did `hasattr(e.response, "text")`, which raises `AttributeError` *inside the handler* for non-HTTP exceptions — masking the real error with `'RuntimeError' object has no attribute 'response'`.

2. **`api/client.py` `send_batch`** — the manually-raised `HTTPError` carried no `.response`, so a DRF 400 fell into the `str(e)[:100]` branch and was truncated right after `"HTTP 400: "` — the field error explaining *why* every batch was rejected never reached the logs. The response is now attached to the raised error and the handler logs `HTTP <status>: <body>` with the body capped at 2,000 chars instead of 100.

3. **`templates/*`** — all 10 template scripts logged failed records but never exited non-zero, so the K8s Job was marked `Succeeded` even on total failure. Each now `sys.exit(1)` when `ingest()` returns failed records (`SystemExit` deliberately bypasses the templates' `except Exception` re-log). The `tracebloc-ingest` CLI path already returned 1 on failed records (`cli/run.py`).

## Tests

`tests/test_batch_send_failure_accounting.py` (18 tests):
- `send_batch` 400 logs status + full DRF field error (beyond the old 100-char cutoff), body capped at 2,000 chars, connection errors still logged.
- `ingest()` returns `api_send_failed` records and the summary shows `api_sent_records == 0` / `has_failures` when every POST fails; both flush sites covered via a 3-record/batch-size-2 run; clean-run control; batch-exception accounting; partial DB-failure not double-counted.
- Structural check that every template's `failed_records` branch ends in `sys.exit(1)`.

Full suite: **881 passed, 1 xfailed**, coverage 97.31% (gate: 95%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core ingest failure propagation and exit behavior for all template-based K8s jobs; committed MySQL rows can remain when API send fails (now reported, not hidden).
> 
> **Overview**
> Fixes **silent success** when batch API posts fail: rows land in MySQL but the platform sees nothing, while jobs still exit 0.
> 
> **`BaseIngestor`** centralizes batch handling in **`_flush_batch`**. When **`send_batch`** returns false, each inserted row is added to **`failed_records`** with **`api_send_failed`** (matched by **`data_id`**, not batch order, so mid-batch DB failures aren’t mis-tagged). Batch-level exceptions now count the whole batch as failed instead of being logged and ignored.
> 
> **`APIClient.send_batch`** attaches **`response`** to raised **`HTTPError`** and logs **`HTTP <status>: <body>`** (body capped at 2k chars) instead of truncating **`str(e)[:100]`**. **`_process_batch`** error logging no longer breaks on non-HTTP exceptions via **`hasattr(e.response, ...)`**.
> 
> All **10 task templates** call **`sys.exit(1)`** when **`ingest()`** returns failures so K8s jobs don’t show **Succeeded**.
> 
> Adds **`tests/test_batch_send_failure_accounting.py`** for logging, ingest accounting, and template **`sys.exit(1)`** structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6f716b32806dc6b7d8e3e1bc0fe0705422dcb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->