### PR TITLE
Develop to prod 0.3.9

### DIFF
--- a/examples/yaml/image_classification.yaml
+++ b/examples/yaml/image_classification.yaml
@@ -1,7 +1,10 @@
 # The dominant case: 8 lines, no `spec` block needed.
 # `category: image_classification` implies:
 #   - data_format: image
-#   - default file_options: target_size [512, 512], extension .jpg
+#   - default file_options: target_size [256, 256], extension .jpeg
+#     (matches the bundled onboarding sample under
+#     `templates/image_classification/data/images/`; override `spec.file_options`
+#     for any other dataset shape)
 #   - default validators: [FileTypeValidator(images), ImageResolutionValidator,
 #                         TableNameValidator, DuplicateValidator]
 #   - required CSV columns: `filename` (image filename, with or without

--- a/examples/yaml/keypoint_detection.yaml
+++ b/examples/yaml/keypoint_detection.yaml
@@ -13,7 +13,9 @@ category: keypoint_detection
 csv: /data/shared/pose/labels.csv
 images: /data/shared/pose/images/
 label: image_label
-target_size: [448, 448]      # height, width — must match your pose model's input
-                             # (the shipped sample under templates/keypoint_detection/data/images/
-                             # is 448×448; substitute your pose model's input here)
+target_size: [448, 448]      # width, height — must match your pose model's input.
+                             # Convention is width-first to match PIL.Image.size +
+                             # ImageResolutionValidator. The shipped sample under
+                             # templates/keypoint_detection/data/images/ is 448×448
+                             # (square, so order doesn't matter for this sample).
 number_of_keypoints: 9        # e.g. 17 for COCO pose, 9 for the upper-body sample

--- a/examples/yaml/keypoint_detection.yaml
+++ b/examples/yaml/keypoint_detection.yaml
@@ -13,5 +13,7 @@ category: keypoint_detection
 csv: /data/shared/pose/labels.csv
 images: /data/shared/pose/images/
 label: image_label
-target_size: [256, 256]      # height, width — must match your pose model's input
+target_size: [448, 448]      # height, width — must match your pose model's input
+                             # (the shipped sample under templates/keypoint_detection/data/images/
+                             # is 448×448; substitute your pose model's input here)
 number_of_keypoints: 9        # e.g. 17 for COCO pose, 9 for the upper-body sample

--- a/examples/yaml/object_detection.yaml
+++ b/examples/yaml/object_detection.yaml
@@ -1,6 +1,11 @@
 # Object detection: image + Pascal VOC XML annotations.
 # `category: object_detection` implies validators include PascalVOCXMLValidator
 # and a separate FileTypeValidator(.xml) for the annotations directory.
+# Default file_options: target_size [1920, 1080] (matches the bundled VisDrone
+# aerial sample under `templates/object_detection/data/images/`, kept at native
+# resolution because aggressive downscaling obliterates the tiny-object content
+# the sample exists to demonstrate). Override `spec.file_options.target_size`
+# below for any other dataset shape (e.g. 448×448 tiles).
 apiVersion: tracebloc.io/v1
 kind: IngestConfig
 table: visdrone_train

--- a/examples/yaml/text_classification.yaml
+++ b/examples/yaml/text_classification.yaml
@@ -1,6 +1,19 @@
-# Text classification: CSV + .txt sidecar files (one per row, named by text_id).
+# Text classification: CSV + .txt sidecar files (one per row).
 # `texts:` directory is convention-mapped; default extension is .txt.
-# `schema:` is required so DataValidator can typecheck the CSV columns.
+#
+# Required CSV columns: `filename` (the .txt sidecar's filename, with or
+# without extension — the default .txt is appended if missing), and the
+# label column you set below. Both columns are framework-managed (filename
+# is reserved by the DB layer), so they do NOT belong in a `schema:` block.
+#
+# `schema:` is optional for text_classification (used only if you have
+# additional feature columns to type-check). The previous example shipped
+# with `schema: { text_id: VARCHAR(255), label: VARCHAR(64) }` which (a)
+# used the wrong column name (`text_id` — actual is `filename`, see the
+# shipped sample CSV at templates/text_classification/data/) and (b) tried
+# to declare reserved framework columns in the schema. Following it
+# literally caused every record to skip at file-transfer with
+# "No filename found in record". Issue #197.
 apiVersion: tracebloc.io/v1
 kind: IngestConfig
 table: support_tickets_train
@@ -8,7 +21,4 @@ intent: train
 category: text_classification
 csv: /data/shared/support-tickets/labels.csv
 texts: /data/shared/support-tickets/texts/
-schema:
-  text_id: VARCHAR(255)
-  label: VARCHAR(64)
 label: label

--- a/examples/yaml/time_series_forecasting.yaml
+++ b/examples/yaml/time_series_forecasting.yaml
@@ -8,7 +8,11 @@ intent: train
 category: time_series_forecasting
 csv: /data/shared/energy-demand/demand.csv
 schema:
-  timestamp: VARCHAR(64)
+  # `timestamp` must be the SQL TIMESTAMP type — TimeFormatValidator
+  # rejects anything else with "Timestamp column in schema must be of type
+  # 'TIMESTAMP'". The previous `VARCHAR(64)` here failed on the very
+  # first validator (#200).
+  timestamp: TIMESTAMP
   region: VARCHAR(32)
   temperature_c: FLOAT
   is_holiday: INT

--- a/examples/yaml/token_classification.yaml
+++ b/examples/yaml/token_classification.yaml
@@ -2,6 +2,13 @@
 # Each .txt holds whitespace-tokenized words; the `label` column holds the
 # space-separated BIO tags — exactly one tag per word.
 # `texts:` is convention-mapped; default extension is .txt.
+#
+# Required CSV columns: `filename` (the .txt sidecar's filename) and the
+# label column you set below. Both are framework-managed (`filename` is
+# reserved by the DB layer), so they do NOT belong in a `schema:` block —
+# declaring them there fails ingestor init with a reserved-column
+# collision. `schema:` is optional here (only for additional feature
+# columns to type-check). Same contract as text_classification (#197).
 apiVersion: tracebloc.io/v1
 kind: IngestConfig
 table: ner_conll_train
@@ -9,7 +16,4 @@ intent: train
 category: token_classification
 csv: /data/shared/ner/labels.csv
 texts: /data/shared/ner/texts/
-schema:
-  filename: VARCHAR(255)
-  label: VARCHAR(2048)
 label: label

--- a/examples/yaml/token_classification.yaml
+++ b/examples/yaml/token_classification.yaml
@@ -1,0 +1,15 @@
+# Token classification (NER/POS): CSV + .txt sidecar files (one per row).
+# Each .txt holds whitespace-tokenized words; the `label` column holds the
+# space-separated BIO tags — exactly one tag per word.
+# `texts:` is convention-mapped; default extension is .txt.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: ner_conll_train
+intent: train
+category: token_classification
+csv: /data/shared/ner/labels.csv
+texts: /data/shared/ner/texts/
+schema:
+  filename: VARCHAR(255)
+  label: VARCHAR(2048)
+label: label

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,10 @@ Pillow>=10.0.0
 # CSV/JSON handling
 pandas>=2.0.0
 
+# Streaming JSON parser (used by JSONIngestor.read_data so multi-GB JSON
+# datasets ingest without materialising the whole file — backend/#772 P2).
+ijson>=3.2.0
+
 # YAML config + JSON Schema validation (for the declarative ingest.yaml flow)
 PyYAML>=6.0
 jsonschema>=4.0.0

--- a/templates/image_classification/README.md
+++ b/templates/image_classification/README.md
@@ -80,8 +80,8 @@ python image_classification.py
 ## Configuration
 
 The script uses the following configuration:
-- **Target Size**: (512, 512) - Images will be resized to this dimension (height = width)
-- **Extension**: JPG - Expected image file extension (jpeg, jpg, and png are also accepted)
+- **Target Size**: (256, 256) - Images will be resized to this dimension (height = width)
+- **Extension**: JPEG - Expected image file extension
 - **Chunk Size**: 1000 - Number of records to process in each batch
 - **Category**: IMAGE_CLASSIFICATION
 - **Data Format**: IMAGE

--- a/templates/image_classification/README.md
+++ b/templates/image_classification/README.md
@@ -55,7 +55,11 @@ image_classification/
 ## Data Format
 
 ### Images
-- Supported formats: PNG, JPEG, JPG
+- Each dataset uses **one** image extension across all files: `.jpg`, `.jpeg`,
+  or `.png`. Mixed extensions in a single dataset are not supported by design —
+  `FileTypeValidator` is strict and rejects any file whose extension doesn't
+  match the declared one. Set the extension via `spec.file_options.extension`
+  in your YAML (default `.jpeg` — see `cli/conventions.py`).
 - Images should be placed in the `data/images/` directory
 - Each image must have a corresponding row in the CSV file
 
@@ -81,7 +85,8 @@ python image_classification.py
 
 The script uses the following configuration:
 - **Target Size**: (256, 256) - Images will be resized to this dimension (height = width)
-- **Extension**: JPEG - Expected image file extension
+- **Extension**: `.jpeg` — strictly enforced for every image in the dataset.
+  Override via `spec.file_options.extension` (one of `.jpg` / `.jpeg` / `.png`).
 - **Chunk Size**: 1000 - Number of records to process in each batch
 - **Category**: IMAGE_CLASSIFICATION
 - **Data Format**: IMAGE

--- a/templates/image_classification/image_classification.py
+++ b/templates/image_classification/image_classification.py
@@ -23,8 +23,10 @@ logger = logging.getLogger(__name__)
 
 # Image specific options including CSV options
 image_options = {
-    "target_size": (512, 512),  # image size. Height = Width
-    "extension": FileExtension.JPG,  # allowed extension for images: jpeg, jpg, png
+    # Matches the bundled onboarding sample under data/images/ (#198).
+    # Override per dataset when running against your own data.
+    "target_size": (256, 256),  # image size. Height = Width
+    "extension": FileExtension.JPEG,
 }
 
 # CSV specific options

--- a/templates/image_classification/image_classification.py
+++ b/templates/image_classification/image_classification.py
@@ -6,6 +6,7 @@ supporting both binary data and file-based processing.
 """
 
 import logging
+import sys
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
 from tracebloc_ingestor.utils.logging import setup_logging
@@ -75,6 +76,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/keypoint_detection/keypoint_detection.py
+++ b/templates/keypoint_detection/keypoint_detection.py
@@ -6,6 +6,7 @@ It processes image files along with JSON-based keypoint coordinate annotations.
 """
 
 import logging
+import sys
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
 from tracebloc_ingestor.utils.logging import setup_logging
@@ -97,6 +98,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/masked_language_modeling/masked_language_modeling.py
+++ b/templates/masked_language_modeling/masked_language_modeling.py
@@ -11,6 +11,7 @@ on-the-fly during training.
 """
 
 import logging
+import sys
 import os
 from typing import Dict, Any
 
@@ -77,6 +78,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/object_detection/README.md
+++ b/templates/object_detection/README.md
@@ -122,8 +122,8 @@ python object_detection.py
 ## Configuration
 
 The script uses the following configuration:
-- **Target Size**: (256, 256) - Images will be resized to this dimension
-- **Extension**: PNG - Expected image file extension
+- **Target Size**: (1920, 1080) - Images will be resized to this dimension (height = width)
+- **Extension**: JPG - Expected image file extension (jpeg, jpg are also accepted)
 - **Chunk Size**: 100 - Number of records to process in each batch
 - **Category**: OBJECT_DETECTION
 - **Data Format**: IMAGE

--- a/templates/object_detection/object_detection.py
+++ b/templates/object_detection/object_detection.py
@@ -28,7 +28,11 @@ logger = logging.getLogger(__name__)
 
 # Object detection specific options including CSV options
 object_detection_options = {
-    "target_size": (448, 448),  # image size. Height = Width
+    # Matches the bundled VisDrone aerial sample under data/images/ (#199),
+    # kept at native resolution because aggressive downscaling obliterates
+    # the tiny-object content the sample exists to demonstrate. Override per
+    # dataset when running against tiled / pre-resized data.
+    "target_size": (1920, 1080),
     "extension": FileExtension.JPG,  # allowed extension for images: jpeg, jpg, png
 }
 

--- a/templates/object_detection/object_detection.py
+++ b/templates/object_detection/object_detection.py
@@ -6,6 +6,7 @@ corresponding XML annotation files from the VisDrone dataset format.
 """
 
 import logging
+import sys
 import shutil
 import xml.etree.ElementTree as ET
 from typing import Dict, Any
@@ -82,6 +83,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/semantic_segmentation/semantic_segmentation.py
+++ b/templates/semantic_segmentation/semantic_segmentation.py
@@ -6,6 +6,7 @@ both the image files and their corresponding mask annotation files.
 """
 
 import logging
+import sys
 from typing import Dict, Any
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
@@ -82,6 +83,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/tabular_classification/tabular_classification.py
+++ b/templates/tabular_classification/tabular_classification.py
@@ -6,6 +6,7 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
+import sys
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
 from tracebloc_ingestor.utils.logging import setup_logging
@@ -73,6 +74,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/tabular_regression/tabular_regression.py
+++ b/templates/tabular_regression/tabular_regression.py
@@ -6,6 +6,7 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
+import sys
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
 from tracebloc_ingestor.utils.logging import setup_logging
@@ -73,6 +74,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/text_classification/text_classification.py
+++ b/templates/text_classification/text_classification.py
@@ -6,6 +6,7 @@ corresponding labels from a CSV file, similar to object detection format.
 """
 
 import logging
+import sys
 import os
 from typing import Dict, Any
 
@@ -72,6 +73,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/time_series_forecasting/time_series_forecasting.py
+++ b/templates/time_series_forecasting/time_series_forecasting.py
@@ -6,6 +6,7 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
+import sys
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
 from tracebloc_ingestor.utils.logging import setup_logging
@@ -78,6 +79,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/time_to_event_prediction/time_to_event_prediction.py
+++ b/templates/time_to_event_prediction/time_to_event_prediction.py
@@ -6,6 +6,7 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
+import sys
 
 from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
 from tracebloc_ingestor.utils.logging import setup_logging
@@ -85,6 +86,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/templates/token_classification/README.md
+++ b/templates/token_classification/README.md
@@ -22,11 +22,10 @@ table: ner_conll_train
 intent: train
 csv: /data/shared/ner/labels.csv
 texts: /data/shared/ner/texts/
-schema:
-  filename: VARCHAR(255)
-  label: VARCHAR(2048)
 label: label
 ```
+
+> **Note:** `filename` and the label column are framework-managed (`filename` is reserved by the DB layer) and must **not** be declared in a `schema:` block — doing so fails ingestor init with a reserved-column collision. `schema:` is only for additional feature columns.
 
 **3. Install:**
 

--- a/templates/token_classification/README.md
+++ b/templates/token_classification/README.md
@@ -1,0 +1,99 @@
+# Token Classification (NER/POS) Data Ingestion Template
+
+This template demonstrates how to ingest token classification data — `.txt` files of whitespace-tokenized words plus a CSV whose `label` column holds the per-token BIO tags — into a database using the tracebloc_ingestor framework.
+
+The on-disk layout is identical to text classification; the only difference is the `label` column: instead of a single class it carries a **space-separated string of BIO/IOB2 tags, one tag per word**.
+
+## Quickstart — declarative (recommended)
+
+Ingest with ~10 lines of YAML using the official ingestor image (`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage your files on the cluster's shared PVC first — see the [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc) in the chart docs (kubectl cp pattern for small datasets, init-container sync for production).
+
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a `texts/` subdirectory holding the `.txt` files.
+
+**2. Write `ingest.yaml`:**
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: token_classification
+table: ner_conll_train
+intent: train
+csv: /data/shared/ner/labels.csv
+texts: /data/shared/ner/texts/
+schema:
+  filename: VARCHAR(255)
+  label: VARCHAR(2048)
+label: label
+```
+
+**3. Install:**
+
+```bash
+helm install my-ner-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+Canonical example: [`examples/yaml/token_classification.yaml`](../../examples/yaml/token_classification.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
+
+## Directory Structure
+
+```
+token_classification/
+├── token_classification.py     # Main ingestion script
+├── README.md                   # This file
+└── data/
+    ├── texts/                  # Source text files (whitespace-tokenized words)
+    │   ├── sample1.txt
+    │   ├── sample2.txt
+    │   └── sample3.txt
+    └── labels_file_sample.csv  # CSV mapping each file to its BIO tag sequence
+```
+
+## Data Format
+
+### Text Files
+- Supported extension: `.txt`
+- One **pre-tokenized** sentence per file: words separated by whitespace (the word boundaries define the tokens that get labeled).
+- Each text file must have a corresponding row in the CSV.
+
+### CSV Labels File
+- `filename`: Base name of the text file, without extension (e.g. `sample1`)
+- `extension`: File extension as a quoted string (e.g. `'.txt'`)
+- `label`: **Space-separated BIO/IOB2 tags, one per word** in the `.txt` (e.g. `B-PER I-PER O O B-ORG`)
+
+The number of tags **must equal** the number of whitespace-separated words in the corresponding `.txt`. The ingestor's `BIOLabelValidator` enforces this (and that every tag is `O` or `B-<TYPE>` / `I-<TYPE>`) and rejects the dataset otherwise — catching annotation drift before training instead of failing on the client.
+
+## Usage
+
+1. Place your pre-tokenized `.txt` documents in `data/texts/`
+2. Update `labels_file_sample.csv` with one row per document
+3. Configure the ingestion parameters in `token_classification.py`
+4. Run the ingestion script:
+
+```bash
+python token_classification.py
+```
+
+## Configuration
+
+- **Extension**: TXT - Expected text file extension
+- **Chunk Size**: 100
+- **Encoding**: utf-8
+- **Category**: TOKEN_CLASSIFICATION
+- **Data Format**: TEXT
+- **Intent**: TRAIN (change to `Intent.TEST` for evaluation data)
+- **Label column**: `label`
+
+## Sample Data
+
+- 3 text files (`sample1.txt` … `sample3.txt`) of pre-tokenized sentences
+- BIO tags spanning `PER`, `ORG`, `LOC`, `MISC` entity types
+- Each row's tag count matches its file's word count
+
+## Notes
+
+- The `filename` column does **not** include the extension — that's supplied separately via the `extension` column.
+- Choose the tokenizer at training time via `tokenizer_id` / `model_id` (defaults to `bert-base-uncased`); the words here define label alignment, and the model's tokenizer handles sub-word splitting.

--- a/templates/token_classification/data/labels_file_sample.csv
+++ b/templates/token_classification/data/labels_file_sample.csv
@@ -1,0 +1,4 @@
+filename,extension,label
+sample1,'.txt',B-PER I-PER O O B-ORG
+sample2,'.txt',B-LOC O O
+sample3,'.txt',B-ORG O B-MISC O

--- a/templates/token_classification/data/texts/sample1.txt
+++ b/templates/token_classification/data/texts/sample1.txt
@@ -1,0 +1,1 @@
+John Smith works at Google

--- a/templates/token_classification/data/texts/sample2.txt
+++ b/templates/token_classification/data/texts/sample2.txt
@@ -1,0 +1,1 @@
+Paris is beautiful

--- a/templates/token_classification/data/texts/sample3.txt
+++ b/templates/token_classification/data/texts/sample3.txt
@@ -1,0 +1,1 @@
+Microsoft released Windows today

--- a/templates/token_classification/token_classification.py
+++ b/templates/token_classification/token_classification.py
@@ -1,0 +1,90 @@
+"""Token Classification (NER/POS) Data Ingestion Example.
+
+This example demonstrates how to ingest token classification data — one
+``.txt`` file of whitespace-tokenized words per sample, plus a CSV whose
+``label`` column holds the space-separated BIO/IOB2 tags (exactly one tag per
+word). The on-disk layout is identical to text classification; only the label
+semantics differ (a sequence of per-token tags instead of a single class).
+
+Example row:
+    filename = "sentence_001",  label = "B-PER I-PER O O B-LOC"
+    sentence_001.txt           -> "John Smith works in Paris"
+"""
+
+import logging
+import os
+from typing import Dict, Any
+
+from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor.utils.logging import setup_logging
+from tracebloc_ingestor.utils.constants import (
+    TaskCategory,
+    Intent,
+    DataFormat,
+    FileExtension,
+)
+
+# Initialize config and configure logging
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+
+# Text specific options including CSV options
+text_options = {"extension": FileExtension.TXT}  # Allowed text file extensions
+
+# CSV specific options
+csv_options = {
+    "chunk_size": 100,  # Smaller chunk size due to text processing
+    "delimiter": ",",
+    "quotechar": '"',
+    "escapechar": "\\",
+    "on_bad_lines": "warn",
+    "encoding": "utf-8",
+}
+
+
+def main():
+    """Run the token classification ingestion example."""
+    try:
+        # Initialize components
+        database = Database(config)
+        api_client = APIClient(config)
+
+        # Create ingestor for token classification data with validators
+        ingestor = CSVIngestor(
+            database=database,
+            api_client=api_client,
+            table_name=config.TABLE_NAME,
+            data_format=DataFormat.TEXT,
+            category=TaskCategory.TOKEN_CLASSIFICATION,
+            csv_options=csv_options,
+            file_options=text_options,
+            label_column="label",
+            intent=Intent.TRAIN,  # Is the data for training or testing
+        )
+
+        # Ingest data with validation
+        logger.info("Starting token classification ingestion with data validation...")
+        with ingestor:
+            failed_records = ingestor.ingest(
+                config.LABEL_FILE, batch_size=config.BATCH_SIZE
+            )
+            if failed_records:
+                logger.warning(f"Failed to process {len(failed_records)} records")
+                for record in failed_records:
+                    logger.warning(
+                        f"Failed record: {record.get('filename', 'Unknown')}"
+                    )
+                    logger.warning(
+                        f"Error details: {record.get('error', 'Unknown error')}"
+                    )
+            else:
+                logger.info("All records processed successfully")
+
+    except Exception as e:
+        logger.error(f"Ingestion failed: {str(e)}")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/token_classification/token_classification.py
+++ b/templates/token_classification/token_classification.py
@@ -12,6 +12,7 @@ Example row:
 """
 
 import logging
+import sys
 import os
 from typing import Dict, Any
 
@@ -78,6 +79,11 @@ def main():
                     logger.warning(
                         f"Error details: {record.get('error', 'Unknown error')}"
                     )
+                # Failed records (DB insert, API send, or processing) must
+                # fail the run — exit non-zero so the K8s Job is marked
+                # failed instead of reporting silent success (SystemExit
+                # bypasses the except Exception handler below).
+                sys.exit(1)
             else:
                 logger.info("All records processed successfully")
 

--- a/tests/test_adversarial_ingestion_harness.py
+++ b/tests/test_adversarial_ingestion_harness.py
@@ -487,19 +487,12 @@ def test_bigint_overflow_is_clear_error():
         _ingest({"n": "BIGINT"}, "n\n99999999999999999999\n")
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Silent-corruption gap: 1e400 overflows IEEE float and becomes +inf "
-        "in pd.to_numeric. CSVIngestor._validate_csv does not surface this — "
-        "+inf lands in the FLOAT column as if it were a legitimate value. "
-        "DataValidator already rejects inf (non-finite check) but CSVIngestor's "
-        "cast path is what _ingest() exercises here. Remove this marker when "
-        "csv_ingestor surfaces the overflow with a clear per-column error."
-    ),
-)
 def test_float_overflow_is_clear_error():
-    with pytest.raises(Exception):
+    # Closed by _raise_on_overflow in CSVIngestor._validate_csv — the
+    # cast path now mirrors DataValidator's _non_finite_error guard so
+    # 1e400 (which pd.to_numeric silently turns into +inf) is rejected
+    # at cast time with an actionable per-column error.
+    with pytest.raises(Exception, match="overflow|non-finite|inf"):
         _ingest({"x": "FLOAT"}, "x\n1e400\n")
 
 

--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -208,3 +208,79 @@ def test_create_dataset_local_mode():
         result = client.create_dataset(ingestor_id="ing", category="x")
     assert result["id"] == "mock_dataset_id"
     post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 401 auto-refresh (backend/#772 P2)
+# ---------------------------------------------------------------------------
+
+def test_authed_request_refreshes_token_on_401():
+    """A 401 on an authenticated call triggers ONE refresh + retry. The
+    refresh path rotates the token to a fresh value; the second call
+    succeeds with the new token. The terminal create_dataset / metadata
+    callback used to fail outright on multi-hour runs when the token
+    aged out — now it transparently re-mints."""
+    client = _client(BACKEND_TOKEN="old_token")
+    assert client.token == "old_token"
+    calls = []
+
+    def fake_post(url, headers=None, **kwargs):
+        calls.append(headers["Authorization"])
+        if len(calls) == 1:
+            return _resp(401, text='{"detail":"Invalid token."}')
+        return _resp(200, {"id": 7})
+
+    # Stub _refresh_token to simulate a successful rotation.
+    def fake_refresh():
+        client.token = "new_token"
+        return True
+
+    with patch.object(client.session, "post", side_effect=fake_post), \
+         patch.object(client, "_refresh_token", side_effect=fake_refresh):
+        client.create_dataset(ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION)
+
+    assert len(calls) == 2, "expected one 401 + one retry"
+    assert calls[0] == "TOKEN old_token"
+    assert calls[1] == "TOKEN new_token"
+
+
+def test_authed_request_gives_up_after_one_retry(monkeypatch):
+    """If refresh doesn't change anything (no rotation, or re-auth itself
+    fails), the second attempt is NOT made — the original 401 is surfaced
+    so the caller's existing error path runs unchanged."""
+    monkeypatch.setenv("BACKEND_TOKEN", "stuck_token")
+    client = _client()
+    # No env update -> refresh returns False.
+    calls = []
+
+    def fake_post(url, headers=None, **kwargs):
+        calls.append(1)
+        return _resp(401, text='{"detail":"Invalid token."}')
+
+    with patch.object(client.session, "post", side_effect=fake_post):
+        with pytest.raises(requests.exceptions.RequestException):
+            client.create_dataset(
+                ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
+            )
+
+    # One attempt only — refresh saw no change so no retry.
+    assert len(calls) == 1
+
+
+def test_authed_request_passes_through_non_401_unchanged():
+    """Non-401 statuses (200, 4xx other than 401, 5xx) take the no-retry
+    path. Refresh logic must NOT engage on success or on a non-auth
+    failure — the per-call error handling already covers those."""
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(200, {"id": 1})) as post:
+        client.create_dataset(ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION)
+    # Exactly one call — no refresh, no retry on the happy path.
+    assert post.call_count == 1
+
+
+def test_refresh_token_noop_in_local_mode():
+    """Local mode uses a mock token and no auth network calls — refresh
+    is a no-op so test runs / dev loops don't hit the env-read path."""
+    client = _client(EDGE_ENV="local")
+    assert client._refresh_token() is False
+    assert client.token == "mock_token"

--- a/tests/test_batch_send_failure_accounting.py
+++ b/tests/test_batch_send_failure_accounting.py
@@ -1,0 +1,294 @@
+"""Batch API-send failures must surface, not vanish.
+
+Regression guards for a real silent-failure incident: every batch POST to
+``/global_meta/<table>/`` was rejected with HTTP 400, yet the run finished
+with "All records processed successfully", a summary claiming a 100% success
+rate, and exit code 0. Files were copied and MySQL rows inserted, but the
+backend had zero records — the next platform call failed with "No data found
+for table name".
+
+Three swallow points, three guard groups below:
+
+1. ``APIClient.send_batch`` logged ``str(e)[:100]`` — the manually-raised
+   HTTPError carried no ``.response``, and 100 chars truncated the message
+   right after "HTTP 400: ", hiding the DRF field error.
+2. ``BaseIngestor`` only skipped the ``api_sent_records`` increment when
+   ``api_success`` was False; the records never reached ``failed_records``,
+   so ``ingest()`` returned ``[]`` and callers exited 0. Exceptions from
+   ``_process_batch`` were likewise logged and dropped from every counter.
+3. The template scripts never exited non-zero on failed records.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.api.client import APIClient
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor, IngestionSummary
+
+
+# ---------------------------------------------------------------------------
+# helpers (mirror test_api_client_methods.py / test_ingestor_base.py)
+# ---------------------------------------------------------------------------
+
+def _client(**overrides):
+    defaults = dict(BACKEND_TOKEN="tok", CLIENT_USERNAME=None,
+                    CLIENT_PASSWORD=None, EDGE_ENV="prod", TITLE=None)
+    defaults.update(overrides)
+    return APIClient(Config(**defaults))
+
+
+def _resp(status=200, json_body=None, text=""):
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = json_body if json_body is not None else {}
+    r.text = text
+    return r
+
+
+class FakeIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source: Any) -> Generator[Dict[str, Any], None, None]:
+        yield from self._records
+
+
+def make_ingestor(records=None, **overrides):
+    db = MagicMock(name="Database")
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
+    db.get_table_schema.return_value = {"a": "INT"}
+    api = MagicMock(name="APIClient")
+    api.send_batch.return_value = True
+    api.send_generate_edge_label_meta.return_value = True
+    api.send_global_meta_meta.return_value = True
+    api.prepare_dataset.return_value = True
+    api.create_dataset.return_value = {"id": 1}
+
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=None,
+    )
+    kwargs.update(overrides)
+    return FakeIngestor(records or [], **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 1. send_batch logs the actual backend error, not a 100-char stub
+# ---------------------------------------------------------------------------
+
+# A realistic DRF batch-rejection body: well past the old 100-char cutoff
+# (str(e) started with "HTTP 400: ", leaving ~90 chars of body).
+_DRF_400_BODY = (
+    '[{"data_id": ["This field may not be blank."], '
+    '"label": ["Object with label=tok_cls_O does not exist. '
+    'Padding padding padding padding padding to push the field error '
+    'well past the first hundred characters of the message."]}]'
+)
+
+
+def test_send_batch_400_logs_status_and_full_field_error(caplog):
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(400, text=_DRF_400_BODY)):
+        with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
+            assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "Error sending batch to API" in joined
+    assert "HTTP 400" in joined
+    # The tail of the DRF body — beyond the old [:100] truncation — must be
+    # visible so the operator can see WHY the backend rejected the batch.
+    assert "well past the first hundred characters" in joined
+
+
+def test_send_batch_400_body_capped_at_2000_chars(caplog):
+    client = _client()
+    huge = "x" * 5000
+    with patch.object(client.session, "post", return_value=_resp(400, text=huge)):
+        with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
+            client.send_batch([(1, {"data_id": "a"})], "tbl", "ing")
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "x" * 2000 in joined
+    assert "x" * 2001 not in joined
+
+
+def test_send_batch_connection_error_still_logged(caplog):
+    client = _client()
+    with patch.object(
+        client.session, "post",
+        side_effect=requests.exceptions.ConnectionError("conn refused"),
+    ):
+        with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
+            assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "Error sending batch to API" in joined
+    assert "conn refused" in joined
+
+
+# ---------------------------------------------------------------------------
+# 2. ingest() surfaces API-send failures: returned, counted, summarized
+# ---------------------------------------------------------------------------
+
+def _run_ingest(ing, batch_size=10):
+    """Run ingest with Session patched out; capture the logged summary."""
+    captured = {}
+    real_log = BaseIngestor._log_summary
+
+    def spy(self, summary):
+        captured["summary"] = summary
+        return real_log(self, summary)
+
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(BaseIngestor, "_log_summary", spy):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=batch_size)
+    return failed, captured.get("summary")
+
+
+def test_ingest_api_send_failure_returns_failed_records():
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=None)
+    ing.api_client.send_batch.return_value = False  # every batch POST rejected
+
+    failed, summary = _run_ingest(ing)
+
+    # Every inserted-but-unsent record comes back as a failed record, so
+    # cli.run.main returns 1 and the template scripts sys.exit(1).
+    assert len(failed) == 2
+    assert all(f["error"] == "api_send_failed" for f in failed)
+
+    # The summary must not claim the records shipped.
+    assert summary.inserted_records == 2
+    assert summary.api_sent_records == 0
+    assert summary.has_failures is True
+
+
+def test_ingest_api_send_failure_on_final_partial_batch():
+    # 3 records with batch_size=2 exercises BOTH flush sites (in-loop and
+    # final partial batch).
+    records = [{"a": str(i), "filename": f"f{i}"} for i in range(3)]
+    ing = make_ingestor(records=records, category=None)
+    ing.api_client.send_batch.return_value = False
+    # insert_batch must echo the actual batch size, not the fixture's [1, 2]
+    ing.database.insert_batch.side_effect = lambda t, b: (list(range(len(b))), [])
+
+    failed, summary = _run_ingest(ing, batch_size=2)
+
+    assert len(failed) == 3
+    assert summary.inserted_records == 3
+    assert summary.api_sent_records == 0
+
+
+def test_ingest_api_success_keeps_failed_records_empty():
+    # Control: a clean run is unchanged by the new accounting.
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=None)
+
+    failed, summary = _run_ingest(ing)
+
+    assert failed == []
+    assert summary.api_sent_records == summary.inserted_records == 2
+    assert summary.has_failures is False
+
+
+def test_ingest_batch_exception_counts_whole_batch_as_failed():
+    # An exception escaping _process_batch (e.g. a DB connection drop mid
+    # insert) used to be logged and dropped from every counter.
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=None)
+    ing.database.insert_batch.side_effect = RuntimeError("db gone")
+
+    failed, summary = _run_ingest(ing)
+
+    assert len(failed) == 2
+    assert all("db gone" in f["error"] for f in failed)
+    assert summary.failed_records == 2
+    assert summary.inserted_records == 0
+    assert summary.has_failures is True
+
+
+def test_ingest_partial_db_failure_not_double_counted():
+    # 1 of 2 rows inserts; the API send for the inserted row succeeds. Only
+    # the DB failure is returned — the inserted+sent row is not.
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=None)
+    db_failure = {"record": {"a": "2"}, "error": "dup key"}
+    ing.database.insert_batch.return_value = ([1], [db_failure])
+
+    failed, summary = _run_ingest(ing)
+
+    assert failed == [db_failure]
+    assert summary.inserted_records == 1
+    assert summary.api_sent_records == 1
+    assert summary.failed_records == 1
+
+
+def test_ingest_mid_batch_db_failure_plus_api_failure_tags_right_records():
+    # Bugbot regression guard: insert_batch's per-record fallback appends
+    # successes in scan order, so after a MID-batch DB failure the inserted
+    # records are NOT the first len(ids) entries. The api_send_failed tag
+    # must land on the records that actually inserted (here: #0 and #2),
+    # not on a batch[:len(ids)] prefix that would include the DB-failed #1
+    # and omit #2.
+    records = [{"a": str(i), "filename": f"f{i}"} for i in range(3)]
+    ing = make_ingestor(records=records, category=None)
+    ing.api_client.send_batch.return_value = False
+
+    def fake_insert(table_name, batch):
+        # Middle record fails; failure carries a COPY of the record (the
+        # real insert_batch builds processed_record = {**record, ...}).
+        failed_copy = {**batch[1], "updated_at": "now"}
+        return [10, 12], [{"record": failed_copy, "error": "dup key"}]
+
+    ing.database.insert_batch.side_effect = fake_insert
+
+    failed, summary = _run_ingest(ing)
+
+    api_failed = [f for f in failed if f["error"] == "api_send_failed"]
+    assert {f["record"]["a"] for f in api_failed} == {"0", "2"}
+    assert [f["error"] for f in failed if f["error"] != "api_send_failed"] == ["dup key"]
+    assert summary.inserted_records == 2
+    assert summary.api_sent_records == 0
+    assert summary.failed_records == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. templates exit non-zero when ingest() returns failed records
+# ---------------------------------------------------------------------------
+
+_TEMPLATES = sorted(Path(__file__).parent.parent.glob("templates/*/*.py"))
+
+
+@pytest.mark.parametrize("template", _TEMPLATES, ids=lambda p: p.parent.name)
+def test_template_exits_nonzero_on_failed_records(template):
+    """Each template's failed-records branch must end in sys.exit(1) —
+    BEFORE the else that logs "All records processed successfully" — so a
+    run with failures can't leave the K8s Job marked Succeeded."""
+    src = template.read_text(encoding="utf-8")
+    assert re.search(r"^import sys$", src, re.M), f"{template} missing 'import sys'"
+    m = re.search(
+        r"if failed_records:(?P<branch>.*?)\n\s*else:\s*\n\s*"
+        r"logger\.info\(\"All records processed successfully\"\)",
+        src,
+        re.S,
+    )
+    assert m, f"{template}: failed_records/else block not found"
+    assert "sys.exit(1)" in m.group("branch"), (
+        f"{template}: failed_records branch does not sys.exit(1)"
+    )

--- a/tests/test_bio_label_validator.py
+++ b/tests/test_bio_label_validator.py
@@ -1,0 +1,146 @@
+"""Tests for BIOLabelValidator — token-classification label/word alignment."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
+
+
+@pytest.fixture
+def texts_dir(tmp_path, monkeypatch):
+    """Create a SRC_PATH/texts dir and point the validator's config at it."""
+    (tmp_path / "texts").mkdir()
+    monkeypatch.setenv("SRC_PATH", str(tmp_path))
+    return tmp_path / "texts"
+
+
+def _write(texts_dir, name, words):
+    (texts_dir / f"{name}.txt").write_text(words, encoding="utf-8")
+
+
+@pytest.fixture
+def validator():
+    return BIOLabelValidator()
+
+
+def test_valid_alignment_passes(validator, texts_dir):
+    _write(texts_dir, "s1", "John Smith works at Google")
+    _write(texts_dir, "s2", "Paris is nice")
+    df = pd.DataFrame(
+        {
+            "filename": ["s1", "s2"],
+            "label": ["B-PER I-PER O O B-ORG", "B-LOC O O"],
+        }
+    )
+    result = validator.validate(df)
+    assert result.is_valid, result.errors
+    assert result.metadata["rows_checked"] == 2
+
+
+def test_count_mismatch_fails(validator, texts_dir):
+    _write(texts_dir, "s1", "John Smith works")  # 3 words
+    df = pd.DataFrame({"filename": ["s1"], "label": ["B-PER I-PER"]})  # 2 tags
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "count mismatch" in result.errors[0]
+
+
+def test_invalid_tag_format_fails(validator, texts_dir):
+    _write(texts_dir, "s1", "John lives here")
+    df = pd.DataFrame({"filename": ["s1"], "label": ["B-PER BOGUS O"]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "invalid BIO tag" in result.errors[0]
+
+
+def test_missing_text_file_fails(validator, texts_dir):
+    df = pd.DataFrame({"filename": ["nope"], "label": ["O"]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "not found" in result.errors[0]
+
+
+def test_empty_dataframe_fails(validator):
+    result = validator.validate(pd.DataFrame())
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_missing_label_column_fails(validator, texts_dir):
+    df = pd.DataFrame({"filename": ["s1"]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "Missing required column" in result.errors[0]
+
+
+def test_missing_filename_column_fails(validator, texts_dir):
+    df = pd.DataFrame({"label": ["O"]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert "filename" in result.errors[0]
+
+
+def test_case_insensitive_columns(validator, texts_dir):
+    _write(texts_dir, "s1", "Paris")
+    df = pd.DataFrame({"Filename": ["s1"], "Label": ["B-LOC"]})
+    result = validator.validate(df)
+    assert result.is_valid, result.errors
+
+
+def test_extension_without_leading_dot_is_normalized(texts_dir):
+    _write(texts_dir, "s1", "Paris")
+    v = BIOLabelValidator(extension="txt")  # no leading dot
+    df = pd.DataFrame({"filename": ["s1"], "label": ["B-LOC"]})
+    result = v.validate(df)
+    assert result.is_valid, result.errors
+
+
+def test_custom_label_column(texts_dir):
+    _write(texts_dir, "s1", "Barack Obama")
+    v = BIOLabelValidator(label_column="ner_tags")
+    df = pd.DataFrame({"filename": ["s1"], "ner_tags": ["B-PER I-PER"]})
+    result = v.validate(df)
+    assert result.is_valid, result.errors
+
+
+def test_filename_with_extension_not_double_appended(validator, texts_dir):
+    # CSV filename already carries the extension -> must resolve sample1.txt,
+    # not sample1.txt.txt.
+    _write(texts_dir, "s1", "Paris is nice")
+    df = pd.DataFrame({"filename": ["s1.txt"], "label": ["B-LOC O O"]})
+    result = validator.validate(df)
+    assert result.is_valid, result.errors
+
+
+def test_resolution_matches_text_transfer_when_both_paths_exist(validator, texts_dir):
+    # texts/s1 (bare) and texts/s1.txt both exist with different word
+    # counts. text_transfer appends the extension for a bare CSV filename
+    # and copies s1.txt, so validation must align tags against s1.txt —
+    # never the bare file a filesystem probe would have found first.
+    (texts_dir / "s1").write_text("one two three four five", encoding="utf-8")
+    _write(texts_dir, "s1", "Paris is nice")  # writes s1.txt, 3 words
+
+    df = pd.DataFrame({"filename": ["s1"], "label": ["B-LOC O O"]})  # 3 tags
+    result = validator.validate(df)
+    assert result.is_valid, result.errors
+
+    # Tags sized to the bare file must fail — that file is never ingested.
+    df_bad = pd.DataFrame({"filename": ["s1"], "label": ["O O O O O"]})  # 5 tags
+    result_bad = validator.validate(df_bad)
+    assert not result_bad.is_valid
+    assert "count mismatch" in result_bad.errors[0]
+
+
+def test_error_reporting_is_capped(validator, texts_dir):
+    # 60 mismatched rows -> errors are capped with a suppression notice
+    n = 60
+    for i in range(n):
+        _write(texts_dir, f"s{i}", "one two")  # 2 words
+    df = pd.DataFrame(
+        {"filename": [f"s{i}" for i in range(n)], "label": ["O"] * n}  # 1 tag
+    )
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("further errors suppressed" in e for e in result.errors)

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -182,9 +182,10 @@ def test_csv_kwargs_match_resolved_config(clean_env, mock_runtime, monkeypatch):
     assert kwargs["data_format"] == "image"
     assert kwargs["label_column"] == "image_label"
     assert kwargs["unique_id_column"] is None  # UUID generation, the default
-    # File / CSV options carry the conventional defaults.
-    assert kwargs["file_options"]["target_size"] == [512, 512]
-    assert kwargs["file_options"]["extension"] == ".jpg"
+    # File / CSV options carry the conventional defaults — now aligned with
+    # the bundled image_classification onboarding sample (256×256 .jpeg, #198).
+    assert kwargs["file_options"]["target_size"] == [256, 256]
+    assert kwargs["file_options"]["extension"] == ".jpeg"
     assert kwargs["csv_options"]["chunk_size"] == 1000
 
 

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -87,6 +87,13 @@ def test_text_classification_data_format():
     assert r.texts == "/data/shared/support-tickets/texts/"
 
 
+def test_token_classification_data_format():
+    r = resolve(_load("token_classification.yaml"))
+    assert r.data_format == DataFormat.TEXT
+    assert r.file_options == DEFAULT_TEXT_FILE_OPTIONS
+    assert r.label_column == "label"
+
+
 def test_tabular_classification_data_format():
     r = resolve(_load("tabular_classification.yaml"))
     assert r.data_format == DataFormat.TABULAR

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -117,30 +117,42 @@ def test_semantic_segmentation_sidecars_set():
 # Default options
 # ---------------------------------------------------------------------------
 
-def test_image_classification_gets_512x512_default():
+def test_image_classification_default_matches_shipped_sample():
+    """Default file_options for image_classification round-trip through the
+    bundled onboarding sample (256×256 .jpeg) with zero overrides — issue
+    #198. Previously the default was 512×512 .jpg and the framework's own
+    sample failed validation out-of-box."""
     r = resolve(_load("image_classification.yaml"))
     assert r.file_options == DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[
         TaskCategory.IMAGE_CLASSIFICATION
     ]
+    assert r.file_options["target_size"] == [256, 256]
+    assert r.file_options["extension"] == ".jpeg"
 
 
-def test_object_detection_gets_448x448_default():
-    """Object detection's template historically uses 448×448, not 512×512."""
+def test_object_detection_default_matches_shipped_sample():
+    """Default file_options for object_detection match the bundled VisDrone
+    aerial sample (1920×1080) — issue #199. Previously the default was
+    448×448 and the framework's own sample failed validation out-of-box."""
     r = resolve(_load("object_detection.yaml"))
     assert r.file_options == DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[
         TaskCategory.OBJECT_DETECTION
     ]
-    assert r.file_options["target_size"] == [448, 448]
+    assert r.file_options["target_size"] == [1920, 1080]
 
 
 def test_keypoint_detection_bridges_top_level_fields():
     """Keypoint detection has no convention defaults for target_size or
     number_of_keypoints — both are dataset-specific. The example YAML
     supplies them top-level; resolve() must bridge them into file_options
-    so validators see them at the same key the template path uses."""
+    so validators see them at the same key the template path uses.
+
+    The yaml's target_size was updated to [448, 448] (#199) to match the
+    bundled sample under templates/keypoint_detection/data/images/, which
+    is 448×448 — copy-paste against the framework's own sample now works."""
     r = resolve(_load("keypoint_detection.yaml"))
     assert r.file_options["extension"] == ".jpg"
-    assert r.file_options["target_size"] == [256, 256]
+    assert r.file_options["target_size"] == [448, 448]
     assert r.file_options["number_of_keypoints"] == 9
 
 

--- a/tests/test_coverage_gaps2.py
+++ b/tests/test_coverage_gaps2.py
@@ -103,9 +103,12 @@ def test_ingest_image_category_batches_in_loop():
     records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
     ing = make_ingestor(records=records, category=TaskCategory.IMAGE_CLASSIFICATION)
     ing.database.insert_batch.return_value = ([1], [])
+    # Bypass the file-bearing-category SRC_PATH preflight (#772 P2) — this
+    # test is about batching, not the env-var guard which has its own tests.
     with patch.object(base_mod, "Session") as Sess, \
          patch.object(base_mod, "map_file_transfer", side_effect=lambda c, r, o: r), \
-         patch.object(base_mod, "map_validators", return_value=[]):
+         patch.object(base_mod, "map_validators", return_value=[]), \
+         patch.object(base_mod.BaseIngestor, "_check_src_path", return_value=None):
         Sess.return_value.__enter__.return_value = MagicMock()
         failed = ing.ingest("src", batch_size=1)
     assert failed == []

--- a/tests/test_coverage_gaps3.py
+++ b/tests/test_coverage_gaps3.py
@@ -12,26 +12,31 @@ import pytest
 from tracebloc_ingestor.validators.data_validator import DataValidator
 
 
-# ---- data_validator non-string type checks -------------------------------
+# ---- data_validator non-scalar type checks --------------------------------
+# Issue #188: numeric scalars (1, 2.5, True) in a VARCHAR/CHAR/TEXT column are
+# now VALID — MySQL binds any scalar as a string against a string column, and
+# blocking them rejected legitimate zip codes / numeric IDs / 0-1 labels. The
+# only remaining shape error is a non-scalar container (list/dict/set/tuple);
+# pin that as the new contract.
 
-def test_varchar_non_string_values_flagged():
-    df = pd.DataFrame({"s": [1, 2]})  # ints under VARCHAR -> non-string
+def test_varchar_non_scalar_container_flagged():
+    df = pd.DataFrame({"s": [[1, 2], {"k": 1}]})  # lists/dicts: real shape errors
     res = DataValidator(schema={"s": "VARCHAR(10)"}).validate(df)
     assert not res.is_valid
-    assert any("non-string" in e for e in res.errors)
+    assert any("non-scalar" in e for e in res.errors)
 
 
-def test_char_non_string_values_flagged():
-    df = pd.DataFrame({"s": [1, 2]})
+def test_char_non_scalar_container_flagged():
+    df = pd.DataFrame({"s": [["a"], ["b"]]})
     res = DataValidator(schema={"s": "CHAR(1)"}).validate(df)
     assert not res.is_valid
 
 
-def test_text_non_string_values_flagged():
-    df = pd.DataFrame({"s": [1, 2]})
+def test_text_non_scalar_container_flagged():
+    df = pd.DataFrame({"s": [{"k": "v"}, [1, 2, 3]]})
     res = DataValidator(schema={"s": "TEXT"}).validate(df)
     assert not res.is_valid
-    assert any("non-string" in e for e in res.errors)
+    assert any("non-scalar" in e for e in res.errors)
 
 
 def test_data_validator_load_data_exception(make_csv):

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -180,6 +180,10 @@ def test_char_empty_cells_yield_python_none(tmp_path):
     assert records[1]["code"] is None
 
 
+# ---------------------------------------------------------------------------
+# #771 — IEEE float overflow defense at cast (PR #215 — already on develop)
+# ---------------------------------------------------------------------------
+
 def test_float_overflow_raises_at_cast(tmp_path):
     """`pd.to_numeric("1e400")` returns +inf silently — without a guard
     the overflowed value lands in MySQL as a legitimate-looking number.
@@ -229,3 +233,52 @@ def test_float_missing_cells_still_pass_through_as_null(tmp_path):
     assert records[0]["x"] == 1.5
     assert pd.isna(records[1]["x"]), f"expected NaN, got {records[1]['x']!r}"
     assert records[2]["x"] == 3.0
+
+
+# ---------------------------------------------------------------------------
+# #765 item 3 — date cast policy aligned with numeric (errors="raise")
+# ---------------------------------------------------------------------------
+
+def test_date_unparseable_raises_at_cast_not_silent_null(tmp_path):
+    """Backend #765 item 3: the date branches were errors="coerce" (silent
+    NULL) while the numeric branches were errors="raise" — opposite
+    policies for the same bad-input class. Aligning on `raise`: DataValidator
+    is the gate (catches bad dates at preflight); the cast trusts what
+    passes. A token that reaches the cast un-parseable means a validator
+    gap or schema mismatch — surface it loudly instead of silently NULLing.
+    """
+    p = tmp_path / "d.csv"
+    p.write_text("d\n2024-01-01\nnot-a-date\n")
+    ing = make_csv_ingestor(schema={"d": "DATE"})
+    with pytest.raises(ValueError, match="un-parseable date"):
+        list(ing.read_data(str(p)))
+
+
+def test_datetime_unparseable_raises_at_cast(tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("ts\n2024-01-01 10:00:00\nbroken\n")
+    ing = make_csv_ingestor(schema={"ts": "DATETIME"})
+    with pytest.raises(ValueError, match="un-parseable date"):
+        list(ing.read_data(str(p)))
+
+
+def test_time_unparseable_raises_at_cast(tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("t\n10:00:00\nnoon\n")
+    ing = make_csv_ingestor(schema={"t": "TIME"})
+    with pytest.raises(ValueError, match="un-parseable date"):
+        list(ing.read_data(str(p)))
+
+
+def test_date_missing_cells_still_pass_through_as_null(tmp_path):
+    """The strict cast must NOT flag legitimate missing values: an empty
+    date cell stays as NaT/None. Only PRESENT, un-parseable values raise."""
+    p = tmp_path / "d.csv"
+    p.write_text("d,n\n2024-01-01,1\n,2\n2024-02-02,3\n")
+    ing = make_csv_ingestor(
+        schema={"d": "DATETIME", "n": "INT"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    records = list(ing.read_data(str(p)))
+    assert len(records) == 3
+    assert records[1]["d"] is None or pd.isna(records[1]["d"])

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -178,3 +178,54 @@ def test_char_empty_cells_yield_python_none(tmp_path):
 
     assert records[0]["code"] == "A"
     assert records[1]["code"] is None
+
+
+def test_float_overflow_raises_at_cast(tmp_path):
+    """`pd.to_numeric("1e400")` returns +inf silently — without a guard
+    the overflowed value lands in MySQL as a legitimate-looking number.
+    DataValidator already rejects inf at preflight; this is the cast-path
+    defense-in-depth (backend #771 / harness #186). Surfaces the overflow
+    with a clear per-column error instead of silent corruption."""
+    p = tmp_path / "d.csv"
+    p.write_text("x\n1e400\n")
+    ing = make_csv_ingestor(schema={"x": "FLOAT"})
+    with pytest.raises(ValueError, match="overflow"):
+        list(ing.read_data(str(p)))
+
+
+def test_float_overflow_negative_also_caught(tmp_path):
+    p = tmp_path / "d.csv"
+    p.write_text("x\n-1e400\n")
+    ing = make_csv_ingestor(schema={"x": "FLOAT"})
+    with pytest.raises(ValueError, match="overflow"):
+        list(ing.read_data(str(p)))
+
+
+def test_int_overflow_via_float_path_caught(tmp_path):
+    """An INT column receiving an overflowing token (e.g. a Python-int
+    literal beyond float64 range) is caught at the same guard before
+    the Int64 cast can mask it."""
+    p = tmp_path / "d.csv"
+    p.write_text("n\n1e400\n")
+    ing = make_csv_ingestor(schema={"n": "INT"})
+    with pytest.raises(ValueError, match="overflow"):
+        list(ing.read_data(str(p)))
+
+
+def test_float_missing_cells_still_pass_through_as_null(tmp_path):
+    """The overflow guard must NOT flag legitimate missing values:
+    an empty cell becomes NaN in `original` and stays NaN in `converted`
+    — the helper only flags non-finite values whose source was non-NA.
+    A naive `~np.isfinite(converted)` check would crash on this CSV."""
+    p = tmp_path / "d.csv"
+    # Two-column form so the second row's empty `x` is unambiguously a
+    # missing cell (rather than a blank line that pandas would skip).
+    p.write_text("x,n\n1.5,1\n,2\n3.0,3\n")
+    ing = make_csv_ingestor(
+        schema={"x": "FLOAT", "n": "INT"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    records = list(ing.read_data(str(p)))
+    assert records[0]["x"] == 1.5
+    assert pd.isna(records[1]["x"]), f"expected NaN, got {records[1]['x']!r}"
+    assert records[2]["x"] == 3.0

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -316,13 +316,71 @@ def test_text_with_nulls_is_valid():
     assert DataValidator(schema={"s": "TEXT"}).validate(df).is_valid
 
 
-def test_varchar_still_flags_real_non_strings():
-    # NULL tolerance must NOT mask a genuine type error: a real numeric value
-    # in a VARCHAR column is still non-string and must be reported.
-    df = pd.DataFrame({"s": ["abc", 5, "de"]})
+def test_varchar_accepts_numeric_scalars(make_csv):
+    # Issue #188: pd.read_csv infers numeric-looking columns as int64/float64,
+    # so an all-numeric VARCHAR column (zip / category code, 0/1 label
+    # declared VARCHAR) was rejected with "Column 'code' contains N
+    # non-string values" — an error the user could never clear because
+    # MySQL would happily bind the int as a string. Any scalar (int, float,
+    # bool) must pass the validator; MySQL handles the conversion at bind.
+    df = pd.DataFrame({"code": [100, 200, 300], "label": [0, 1, 0]})
+    result = DataValidator(
+        schema={"code": "VARCHAR(10)", "label": "VARCHAR(8)"}
+    ).validate(df)
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+
+
+def test_varchar_rejects_non_scalar_containers():
+    # The only real shape error left at this layer: a list/dict/set/tuple
+    # has no sensible single-string form, so flag it as non-scalar. This is
+    # what replaces the (over-broad) astype(str)!=value check the fix drops.
+    df = pd.DataFrame({"s": ["abc", [1, 2, 3], "de"]})
     result = DataValidator(schema={"s": "VARCHAR(255)"}).validate(df)
     assert not result.is_valid
-    assert "non-string" in result.errors[0]
+    assert "non-scalar" in result.errors[0]
+
+
+def test_varchar_length_still_enforced_on_numeric():
+    # Length check applies to the stringified form, so a numeric value whose
+    # decimal representation exceeds max_length is still rejected.
+    df = pd.DataFrame({"s": [12345]})
+    result = DataValidator(schema={"s": "VARCHAR(3)"}).validate(df)
+    assert not result.is_valid
+    assert "exceeding max length" in result.errors[0]
+
+
+def test_issue_188_full_repro_csv(make_csv):
+    # End-to-end repro from issue #188:
+    #   schema {id: INT, feat: FLOAT, code: VARCHAR(10), label: VARCHAR(8)}
+    #   id,feat,code,label
+    #   1,1.2,100,A
+    #   2,3.4,200,B
+    # Before the fix: is_valid=False, two "Column 'code' contains 2
+    # non-string values" + "Column 'label' …" errors. After the fix:
+    # passes (pandas reads `code` as int64, but VARCHAR accepts any scalar).
+    path = make_csv(
+        {"id": [1, 2], "feat": [1.2, 3.4], "code": [100, 200], "label": ["A", "B"]}
+    )
+    result = DataValidator(
+        schema={
+            "id": "INT", "feat": "FLOAT",
+            "code": "VARCHAR(10)", "label": "VARCHAR(8)",
+        }
+    ).validate(str(path))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+
+
+@pytest.mark.parametrize("dtype", ["VARCHAR(10)", "CHAR(3)", "TEXT"])
+def test_issue_188_numeric_scalars_pass_string_family(dtype):
+    # All three string-family validators share the same astype(str)!=value
+    # over-rejection; the fix is applied uniformly.
+    df = pd.DataFrame({"s": ["abc", 100, 200]})  # ints mixed in (CHAR case
+                                                 # is special — see below)
+    if "CHAR(" in dtype:
+        # CHAR enforces fixed length, so use values that all stringify to 3.
+        df = pd.DataFrame({"s": ["abc", 100, 200]})
+    result = DataValidator(schema={"s": dtype}).validate(df)
+    assert result.is_valid, f"{dtype}: errors={result.errors}"
 
 
 def test_char_wrong_length_fails():

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -265,13 +265,159 @@ def test_insert_batch_individual_failure_recorded(db, mock_engine_factory):
 
 
 def test_insert_batch_connection_error(db, mock_engine_factory):
+    """A failure of ``engine.connect()`` itself (different from a per-
+    statement error inside the connection) is caught at the outer ``try``
+    and reported as a 'Database connection error' failure. Tenacity's
+    retry covers transient per-statement errors; the connect-itself
+    path is separate (the engine has its own pool / pre-ping retry).
+    """
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
     engine.connect.side_effect = RuntimeError("no connection")
     ids, failures = db.insert_batch("tbl", [{"data_id": "a", "feat": 1}])
     assert ids == []
+    # #219 bugbot: restore the assertions that pin the outer-connect
+    # error path (one failure entry, message mentions the connection).
     assert len(failures) == 1
     assert "Database connection error" in failures[0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# Transient DB retry via tenacity — backend/#772 P2
+# ---------------------------------------------------------------------------
+
+def test_insert_batch_retries_on_transient_operational_error(db, mock_engine_factory):
+    """A transient MySQL hiccup (server-gone-away, lost connection,
+    deadlock) used to fail every in-flight batch permanently. tenacity
+    now retries up to 3 attempts with exponential backoff; the second
+    attempt succeeds in this test."""
+    from sqlalchemy.exc import OperationalError
+    ce, engine, conn = mock_engine_factory
+    _seed_table(db)
+
+    calls = {"n": 0}
+
+    def execute_side_effect(stmt, *a, **k):
+        calls["n"] += 1
+        # First execute (the bulk insert) raises a transient error once,
+        # then succeeds on attempt #2. Subsequent execute calls (the
+        # SELECT for ids) succeed.
+        if calls["n"] == 1:
+            raise OperationalError(
+                "INSERT …", {}, Exception("MySQL server has gone away")
+            )
+        result = MagicMock()
+        result.fetchall.return_value = [MagicMock(id=42)]
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    ids, failures = db.insert_batch("tbl", [{"data_id": "a", "feat": 1}])
+    # Retry kicked in: the bulk insert was attempted twice (fail, succeed),
+    # then the id SELECT ran once.
+    assert calls["n"] >= 2
+    assert ids == [42]
+    assert failures == []
+
+
+def test_insert_batch_does_not_retry_permanent_error_falls_to_per_row(
+    db, mock_engine_factory
+):
+    """Permanent errors (IntegrityError, DataError, …) must NOT be
+    retried — they reflect bad data, not a transient blip. They fall
+    straight through to the existing per-row fallback path so the
+    offending record can be identified."""
+    from sqlalchemy.exc import IntegrityError
+    ce, engine, conn = mock_engine_factory
+    _seed_table(db)
+
+    calls = {"bulk": 0, "row": 0}
+
+    def execute_side_effect(stmt, *a, **k):
+        # The very first execute is the bulk insert: raise a permanent
+        # error. Subsequent executes (per-row inserts + SELECTs) succeed.
+        compiled = str(stmt)
+        if "INSERT" in compiled.upper() and calls["bulk"] == 0:
+            calls["bulk"] += 1
+            raise IntegrityError("INSERT …", {}, Exception("dup key"))
+        calls["row"] += 1
+        result = MagicMock()
+        result.fetchone.return_value = MagicMock(id=7)
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    ids, failures = db.insert_batch("tbl", [{"data_id": "a", "feat": 1}])
+    # Bulk insert tried once (no retry on permanent error), then the
+    # per-record path took over and succeeded for this single row.
+    assert calls["bulk"] == 1, "permanent error must not be retried"
+    assert ids == [7]
+
+
+def test_insert_batch_gives_up_after_max_retries(db, mock_engine_factory):
+    """If a transient error persists, retry caps at 3 attempts and falls
+    to the per-row path (which will see the same error and record the
+    failure)."""
+    from sqlalchemy.exc import OperationalError
+    ce, engine, conn = mock_engine_factory
+    _seed_table(db)
+
+    err = OperationalError(
+        "INSERT …", {}, Exception("MySQL server has gone away")
+    )
+
+    def execute_side_effect(stmt, *a, **k):
+        raise err
+
+    conn.execute.side_effect = execute_side_effect
+    ids, failures = db.insert_batch("tbl", [{"data_id": "a", "feat": 1}])
+    # All paths fail; the record lands in failures with the underlying error.
+    assert ids == []
+    assert len(failures) == 1
+    assert "gone away" in failures[0]["error"]
+
+
+def test_insert_batch_rolls_back_between_transient_retries(db, mock_engine_factory):
+    """#219 bugbot: SQLAlchemy puts the connection into pending-rollback
+    state after a failed statement. Without an intervening rollback(),
+    the next attempt raises PendingRollbackError — a non-transient class
+    tenacity wouldn't retry — cutting the retries short. The helper must
+    rollback BETWEEN attempts so the connection's transactional state
+    is reset before the retry runs.
+    """
+    from sqlalchemy.exc import OperationalError
+    ce, engine, conn = mock_engine_factory
+    _seed_table(db)
+
+    events = []
+    rollback_orig = conn.rollback
+
+    def track_rollback(*a, **k):
+        events.append("rollback")
+        return rollback_orig(*a, **k)
+
+    conn.rollback.side_effect = track_rollback
+
+    def execute_side_effect(stmt, *a, **k):
+        events.append("execute")
+        # Fail the bulk insert twice; the third attempt succeeds.
+        n = sum(1 for e in events if e == "execute")
+        if n <= 2:
+            raise OperationalError(
+                "INSERT …", {}, Exception("MySQL server has gone away")
+            )
+        result = MagicMock()
+        result.fetchall.return_value = [MagicMock(id=99)]
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    ids, failures = db.insert_batch("tbl", [{"data_id": "a", "feat": 1}])
+    assert ids == [99]
+    # Each transient failure inside _execute_with_retry triggers a rollback
+    # before re-raising for the next retry. Two failures -> at least two
+    # rollback calls (plus the outer commit-or-rollback path's own).
+    rollback_count = sum(1 for e in events if e == "rollback")
+    assert rollback_count >= 2, (
+        f"expected at least 2 rollbacks between retries; events={events}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_file_pairing_validator.py
+++ b/tests/test_file_pairing_validator.py
@@ -55,3 +55,88 @@ def test_pairing_skips_when_sidecar_dir_missing(clean_env, tmp_path):
     (tmp_path / "images").mkdir()
     clean_env.setenv("SRC_PATH", str(tmp_path))
     assert FilePairingValidator().validate(None).is_valid
+
+
+# ---------------------------------------------------------------------------
+# #196 — semantic_segmentation _mask suffix convention
+# ---------------------------------------------------------------------------
+
+def test_pairing_mask_suffix_all_matched(clean_env, tmp_path):
+    # Documented + shipped convention: image_001.jpg <-> image_001_mask.png.
+    # Plain stem comparison treated them as unrelated, so the shipped
+    # template sample failed pairing out-of-box (#196).
+    _setup(
+        tmp_path,
+        ["image_001.jpg", "image_002.jpg", "image_003.jpg"],
+        ["image_001_mask.png", "image_002_mask.png", "image_003_mask.png"],
+        sidecar_dir="masks",
+    )
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator(
+        sidecar_path="masks", sidecar_label="mask", sidecar_suffix="_mask"
+    ).validate(None)
+    assert res.is_valid, f"errors={res.errors}"
+
+
+def test_pairing_mask_suffix_image_without_mask(clean_env, tmp_path):
+    # image_002 has no corresponding _mask file → flagged as missing.
+    _setup(
+        tmp_path,
+        ["image_001.jpg", "image_002.jpg"],
+        ["image_001_mask.png"],
+        sidecar_dir="masks",
+    )
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator(
+        sidecar_path="masks", sidecar_label="mask", sidecar_suffix="_mask"
+    ).validate(None)
+    assert not res.is_valid
+    assert "no matching mask" in res.errors[0]
+    assert "image_002" in res.errors[0]
+
+
+def test_pairing_mask_suffix_orphan_mask(clean_env, tmp_path):
+    # ghost_mask.png has no corresponding image → flagged as orphan
+    # (compared by stripped stem, "ghost", not in images).
+    _setup(
+        tmp_path,
+        ["image_001.jpg"],
+        ["image_001_mask.png", "ghost_mask.png"],
+        sidecar_dir="masks",
+    )
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator(
+        sidecar_path="masks", sidecar_label="mask", sidecar_suffix="_mask"
+    ).validate(None)
+    assert not res.is_valid
+    assert any("no matching image" in e for e in res.errors)
+    assert any("ghost" in e for e in res.errors)
+
+
+def test_pairing_mask_suffix_flags_non_conforming_filename(clean_env, tmp_path):
+    # A mask that doesn't follow the `_mask` convention at all (e.g. someone
+    # dropped a plain `image_001.png` into the masks/ folder) is reported
+    # as an orphan rather than silently accepted — naming the convention
+    # consistently matters because the training-time mask-loader will look
+    # for the suffix.
+    _setup(
+        tmp_path,
+        ["image_001.jpg"],
+        ["image_001.png"],  # missing the _mask suffix
+        sidecar_dir="masks",
+    )
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    res = FilePairingValidator(
+        sidecar_path="masks", sidecar_label="mask", sidecar_suffix="_mask"
+    ).validate(None)
+    assert not res.is_valid
+    assert any("image_001" in e and "no matching image" in e for e in res.errors)
+
+
+def test_pairing_no_suffix_object_detection_unchanged(clean_env, tmp_path):
+    # Object detection's plain-stem pairing must NOT regress: a.jpg pairs
+    # with a.xml, no suffix involved.
+    _setup(tmp_path, ["a.jpg", "b.jpg"], ["a.xml", "b.xml"])
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    # default sidecar_suffix="" preserves the old behaviour.
+    assert FilePairingValidator().validate(None).is_valid

--- a/tests/test_file_transfer_transfers.py
+++ b/tests/test_file_transfer_transfers.py
@@ -44,6 +44,7 @@ def _seed(src, subdir, name, content=b"data"):
 # helpers
 # ---------------------------------------------------------------------------
 
+
 def test_find_src_with_extension(dirs):
     src, _ = dirs
     _seed(src, "images", "cat.jpg")
@@ -88,6 +89,7 @@ def test_copy_file_with_retry_overwrites(dirs, tmp_path):
 # ---------------------------------------------------------------------------
 # image_transfer / text_transfer / annotation / mask success
 # ---------------------------------------------------------------------------
+
 
 def test_image_transfer_success(dirs):
     src, dest = dirs
@@ -143,6 +145,7 @@ def test_mask_transfer_success(dirs):
 # map_file_transfer routing
 # ---------------------------------------------------------------------------
 
+
 def test_map_image_classification(dirs):
     src, dest = dirs
     _seed(src, "images", "cat.jpg")
@@ -186,7 +189,8 @@ def test_map_semantic_segmentation_success(dirs):
     _seed(src, "masks", "m.png")
     rec = file_transfer.map_file_transfer(
         TaskCategory.SEMANTIC_SEGMENTATION,
-        {"filename": "x", "mask_id": "m"}, {"extension": ".jpg"},
+        {"filename": "x", "mask_id": "m"},
+        {"extension": ".jpg"},
     )
     assert rec is not None
     assert (dest / "m.png").exists()
@@ -206,10 +210,22 @@ def test_map_mlm_copies_tokenizer(dirs):
     _seed(src, "sequences", "seq.txt", b"tokens")
     (src / "tokenizer.json").write_text("{}")
     rec = file_transfer.map_file_transfer(
-        TaskCategory.MASKED_LANGUAGE_MODELING, {"filename": "seq"}, {"extension": ".txt"}
+        TaskCategory.MASKED_LANGUAGE_MODELING,
+        {"filename": "seq"},
+        {"extension": ".txt"},
     )
     assert rec is not None
     assert (dest / "tokenizer.json").exists()
+
+
+def test_map_token_classification(dirs):
+    src, dest = dirs
+    _seed(src, "texts", "doc.txt", b"John Smith")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.TOKEN_CLASSIFICATION, {"filename": "doc"}, {"extension": ".txt"}
+    )
+    assert rec is not None
+    assert (dest / "doc.txt").exists()
 
 
 def test_map_keypoint_detection(dirs):
@@ -223,3 +239,36 @@ def test_map_keypoint_detection(dirs):
 
 def test_map_unknown_category_returns_none(dirs):
     assert file_transfer.map_file_transfer("weird", {"filename": "x"}, {}) is None
+
+
+def test_map_text_classification_copies_optional_tokenizer(dirs):
+    src, dest = dirs
+    _seed(src, "texts", "doc.txt", b"hello world")
+    (src / "tokenizer.json").write_text("{}")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.TEXT_CLASSIFICATION, {"filename": "doc"}, {"extension": ".txt"}
+    )
+    assert rec is not None
+    assert (dest / "tokenizer.json").exists()
+
+
+def test_map_token_classification_copies_optional_tokenizer(dirs):
+    src, dest = dirs
+    _seed(src, "texts", "doc.txt", b"John Smith")
+    (src / "tokenizer.json").write_text("{}")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.TOKEN_CLASSIFICATION, {"filename": "doc"}, {"extension": ".txt"}
+    )
+    assert rec is not None
+    assert (dest / "tokenizer.json").exists()
+
+
+def test_map_token_classification_without_tokenizer_is_fine(dirs):
+    src, dest = dirs
+    _seed(src, "texts", "doc.txt", b"John Smith")  # no tokenizer.json
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.TOKEN_CLASSIFICATION, {"filename": "doc"}, {"extension": ".txt"}
+    )
+    assert rec is not None
+    assert (dest / "doc.txt").exists()
+    assert not (dest / "tokenizer.json").exists()

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -486,7 +486,180 @@ def test_check_csv_encoding_skips_non_csv_sources(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# SRC_PATH pre-flight (validate_data) — #772 P2
+# Concurrent-ingest table lock — backend/#772 P2
+# ---------------------------------------------------------------------------
+
+def test_acquire_table_lock_creates_lock_file(tmp_path):
+    """Lock file is created at STORAGE_PATH/.tracebloc-ingest-<table>.lock
+    with metadata (ingestor_id, pid, hostname, started_at) so a holder
+    can be identified on conflict."""
+    import json
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(table_name="dataset_a", category=None)
+        lock_path = ing._acquire_table_lock()
+        assert lock_path is not None
+        assert lock_path.endswith(".tracebloc-ingest-dataset_a.lock")
+        meta = json.loads(open(lock_path).read())
+        assert meta["table_name"] == "dataset_a"
+        assert meta["ingestor_id"] == ing.ingestor_id
+        ing._release_table_lock(lock_path)
+        assert not __import__("os").path.exists(lock_path)
+
+
+def test_acquire_table_lock_rejects_concurrent_ingest(tmp_path):
+    """A second ingest targeting the same table while a lock is held
+    fails fast with a message naming the holder. Without this guard,
+    two ingests would race create_table / interleave upserts (#772 P2)."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing_a = make_ingestor(table_name="dataset_a", category=None)
+        path_a = ing_a._acquire_table_lock()
+        try:
+            ing_b = make_ingestor(table_name="dataset_a", category=None)
+            with pytest.raises(RuntimeError, match="already running"):
+                ing_b._acquire_table_lock()
+        finally:
+            ing_a._release_table_lock(path_a)
+
+
+def test_acquire_table_lock_different_tables_dont_conflict(tmp_path):
+    """The lock is keyed by table_name — two different datasets can
+    ingest concurrently without blocking each other."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing_a = make_ingestor(table_name="dataset_a", category=None)
+        ing_b = make_ingestor(table_name="dataset_b", category=None)
+        path_a = ing_a._acquire_table_lock()
+        path_b = ing_b._acquire_table_lock()
+        assert path_a != path_b
+        ing_a._release_table_lock(path_a)
+        ing_b._release_table_lock(path_b)
+
+
+def test_acquire_table_lock_reclaims_stale_lock(tmp_path):
+    """A crashed ingest's lock auto-expires after the stale-cutoff so a
+    customer isn't blocked indefinitely. We simulate by writing a lock
+    file with an old timestamp."""
+    import json
+    from datetime import datetime, timedelta
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(table_name="dataset_stale", category=None)
+        lock_path = ing._table_lock_path()
+        old = (datetime.utcnow() - timedelta(days=2)).isoformat() + "Z"
+        with open(lock_path, "w") as f:
+            json.dump(
+                {"ingestor_id": "crashed-ingest", "started_at": old}, f
+            )
+        # Stale lock detected -> removed -> reacquired with the new holder.
+        path = ing._acquire_table_lock()
+        assert path == lock_path
+        meta = json.loads(open(lock_path).read())
+        assert meta["ingestor_id"] == ing.ingestor_id
+        ing._release_table_lock(lock_path)
+
+
+def test_acquire_table_lock_noop_when_storage_path_missing(tmp_path):
+    """No STORAGE_PATH (e.g. unit tests, local dev) -> the lock is
+    skipped. Returns None, _release_table_lock(None) is a no-op."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    missing = str(tmp_path / "never_exists")
+    with patch.object(CfgCls, "STORAGE_PATH", missing):
+        ing = make_ingestor(table_name="dataset_a", category=None)
+        assert ing._acquire_table_lock() is None
+        ing._release_table_lock(None)  # must not raise
+
+
+def test_release_table_lock_idempotent(tmp_path):
+    """Double-release (e.g. exception path + finally path both call it)
+    must not raise."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(table_name="dataset_a", category=None)
+        path = ing._acquire_table_lock()
+        ing._release_table_lock(path)
+        ing._release_table_lock(path)  # idempotent, no raise
+
+
+# ---------------------------------------------------------------------------
+# #221 bugbot — lock release on every exit + mtime fallback
+# ---------------------------------------------------------------------------
+
+def test_lock_released_when_validate_data_raises(tmp_path):
+    """#221 bugbot HIGH: the original code only released the lock on
+    validation errors / inner Session except. An exception escaping the
+    pre-Session region (e.g. an unexpected error during validate_data
+    that wasn't caught by the surrounding except) used to leak the lock
+    until the stale-cutoff. try/finally now releases on every exit."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(records=[], category=None)
+        with patch.object(ing, "validate_data", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError):
+                ing.ingest("src")
+        lock_path = ing._table_lock_path()
+        assert lock_path is not None
+        import os as _os
+        assert not _os.path.exists(lock_path), (
+            f"lock leaked at {lock_path} after validate_data raised"
+        )
+
+
+def test_lock_released_when_count_records_raises(tmp_path):
+    """#221 bugbot HIGH-severity scenario: a failure in
+    ``self._count_records`` (between validation and the Session block)
+    used to escape without releasing the lock — neither the validation
+    except nor the Session except covered it. try/finally fixes it."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(records=[], category=None)
+        with patch.object(ing, "validate_data", return_value=True), \
+             patch.object(ing, "_count_records", side_effect=RuntimeError("ouch")):
+            with pytest.raises(RuntimeError):
+                ing.ingest("src")
+        import os as _os
+        assert not _os.path.exists(ing._table_lock_path()), "lock leaked"
+
+
+def test_acquire_table_lock_recovers_from_corrupt_lock_via_mtime(tmp_path):
+    """#221 bugbot MED: when the lock metadata is unparseable (empty
+    file, invalid JSON, missing started_at), staleness used to skip the
+    cleanup — age stayed None and the lock blocked indefinitely. The
+    file's mtime now serves as a fallback age signal."""
+    import os as _os
+    import json
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(table_name="dataset_corrupt", category=None)
+        lock_path = ing._table_lock_path()
+        with open(lock_path, "w"):
+            pass  # empty file -> JSON parse fails
+        old = _os.path.getmtime(lock_path) - (13 * 3600)  # 13h ago
+        _os.utime(lock_path, (old, old))
+        path = ing._acquire_table_lock()
+        assert path == lock_path
+        meta = json.loads(open(lock_path).read())
+        assert meta["ingestor_id"] == ing.ingestor_id
+        ing._release_table_lock(lock_path)
+
+
+def test_acquire_table_lock_corrupt_but_fresh_blocks(tmp_path):
+    """A corrupt lock that's RECENT (not stale by mtime) still blocks
+    the second ingest — we don't auto-clear; the user has to remove it
+    manually. Boundary test against the mtime fallback."""
+    from tracebloc_ingestor.config import Config as CfgCls
+    with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
+        ing = make_ingestor(table_name="dataset_corrupt", category=None)
+        lock_path = ing._table_lock_path()
+        with open(lock_path, "w"):
+            pass  # empty, JSON parse fails, mtime is now (fresh)
+        with pytest.raises(RuntimeError, match="already running"):
+            ing._acquire_table_lock()
+
+
+# ---------------------------------------------------------------------------
+# SRC_PATH pre-flight (validate_data) — #772 P2 / PR #218 (already on develop)
 # ---------------------------------------------------------------------------
 
 def test_check_src_path_empty_raises(clean_env):

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -384,6 +384,50 @@ def test_ingest_fails_loud_when_backend_registration_step_fails(failing_step):
     ing.api_client.create_dataset.assert_not_called()
 
 
+def test_ingest_skips_edge_label_call_for_self_supervised_categories():
+    """Issue #213: self-supervised categories (MLM, …) have no `label` column,
+    so the backend's edge-label endpoint returns a misleading HTTP 400
+    ('No data found') even though the table has rows. Gate the call so it
+    only runs for label-carrying categories. The remaining registration
+    steps (send_global_meta_meta, prepare_dataset, create_dataset) still run."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(
+        records=records,
+        category=TaskCategory.MASKED_LANGUAGE_MODELING,
+        label_column=None,
+    )
+    # Patch validate_data + map_file_transfer to skip real-filesystem checks;
+    # the gate we're testing lives at the registration block AFTER ingest.
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(ing, "validate_data", return_value=True), \
+         patch.object(base_mod, "map_file_transfer", side_effect=lambda c, r, o: r):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    ing.api_client.send_generate_edge_label_meta.assert_not_called()
+    ing.api_client.send_global_meta_meta.assert_called_once()
+    ing.api_client.prepare_dataset.assert_called_once()
+    ing.api_client.create_dataset.assert_called_once()
+
+
+def test_ingest_still_calls_edge_label_for_label_carrying_categories():
+    """Regression guard for the gate above: a non-self-supervised category
+    still calls the edge-label endpoint."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(
+        records=records,
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(ing, "validate_data", return_value=True), \
+         patch.object(base_mod, "map_file_transfer", side_effect=lambda c, r, o: r):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    ing.api_client.send_generate_edge_label_meta.assert_called_once()
+
+
 def test_ingest_skips_records_that_fail_processing():
     # invalid intent -> process_record returns None -> counted as skipped
     records = [{"a": "1", "filename": "f1"}]

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -483,3 +483,69 @@ def test_check_csv_encoding_skips_non_csv_sources(tmp_path):
     BaseIngestor._check_csv_encoding(str(tmp_path))                   # a directory
     BaseIngestor._check_csv_encoding(None)                            # not a path
     BaseIngestor._check_csv_encoding(str(tmp_path / "missing.csv"))   # nonexistent
+
+
+# ---------------------------------------------------------------------------
+# SRC_PATH pre-flight (validate_data) — #772 P2
+# ---------------------------------------------------------------------------
+
+def test_check_src_path_empty_raises(clean_env):
+    # SRC_PATH unset / blank -> N copies of "Source image not found" with no
+    # actionable cause. Fail fast with the real reason.
+    clean_env.setenv("SRC_PATH", "")
+    with pytest.raises(RuntimeError, match="SRC_PATH is empty"):
+        BaseIngestor._check_src_path()
+
+
+def test_check_src_path_unset_raises(clean_env):
+    # SRC_PATH not in env at all -> same outcome.
+    clean_env.delenv("SRC_PATH", raising=False)
+    with pytest.raises(RuntimeError, match="SRC_PATH is empty"):
+        BaseIngestor._check_src_path()
+
+
+def test_check_src_path_relative_raises(clean_env):
+    # A relative SRC_PATH silently joins to a relative path at file-lookup
+    # time; the validator surfaces the misconfiguration before that point.
+    clean_env.setenv("SRC_PATH", "data/shared")  # not absolute
+    with pytest.raises(RuntimeError, match="not an absolute path"):
+        BaseIngestor._check_src_path()
+
+
+def test_check_src_path_nonexistent_raises(clean_env, tmp_path):
+    missing = tmp_path / "never_staged"
+    clean_env.setenv("SRC_PATH", str(missing))
+    with pytest.raises(RuntimeError, match="does not exist"):
+        BaseIngestor._check_src_path()
+
+
+def test_check_src_path_accepts_real_directory(clean_env, tmp_path):
+    # A properly-staged absolute directory passes — no raise.
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    BaseIngestor._check_src_path()  # must not raise
+
+
+def test_check_src_path_only_runs_for_file_bearing_categories():
+    """The guard is gated on category — tabular / time-series have no
+    sidecar dirs under SRC_PATH, so the preflight isn't applied (their
+    CSV path is checked separately). This keeps tabular-only ingests
+    working even when SRC_PATH isn't set."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+    from tracebloc_ingestor.ingestors.base import _SRC_PATH_REQUIRED_CATEGORIES
+    for cat in (
+        TaskCategory.TABULAR_CLASSIFICATION,
+        TaskCategory.TABULAR_REGRESSION,
+        TaskCategory.TIME_SERIES_FORECASTING,
+        TaskCategory.TIME_TO_EVENT_PREDICTION,
+    ):
+        assert cat not in _SRC_PATH_REQUIRED_CATEGORIES
+    # Image / text / segmentation / MLM all need a staged SRC_PATH.
+    for cat in (
+        TaskCategory.IMAGE_CLASSIFICATION,
+        TaskCategory.OBJECT_DETECTION,
+        TaskCategory.KEYPOINT_DETECTION,
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        TaskCategory.TEXT_CLASSIFICATION,
+        TaskCategory.MASKED_LANGUAGE_MODELING,
+    ):
+        assert cat in _SRC_PATH_REQUIRED_CATEGORIES

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -222,6 +222,49 @@ def test_process_record_treats_empty_string_as_null():
     assert rec["b"] is None
 
 
+def test_process_record_preserves_mask_id_for_semantic_segmentation():
+    """Regression: semantic_segmentation onboarding was broken end-to-end.
+
+    With the documented 8-line schema-less example yaml + the shipped CSV
+    (`filename, mask_id, image_label`), the cleaned_record comprehension's
+    `k in self.schema` filter drops every CSV column. The next stage
+    (file_transfer.py:401) does `record.get("mask_id")` and aborts with
+    "No mask_id found in record" — every record skipped, 0 rows ingested
+    even though #207's FilePairingValidator passes.
+
+    mask_id must round-trip from the raw record onto the cleaned dict
+    for SEMANTIC_SEGMENTATION (scoped narrowly because there's no mask_id
+    DB column — #212 bugbot — and _process_batch strips it before insert).
+    """
+    from tracebloc_ingestor.utils.constants import TaskCategory
+    ing = make_ingestor(
+        schema={}, category=TaskCategory.SEMANTIC_SEGMENTATION, label_column=None
+    )
+    rec = ing.process_record(
+        {"filename": "image_001", "mask_id": "image_001_mask", "image_label": "road"}
+    )
+    assert rec is not None
+    assert rec["mask_id"] == "image_001_mask"
+    assert rec["filename"] == "image_001"
+
+
+def test_process_record_omits_mask_id_for_non_semseg_categories():
+    """mask_id is a SEMANTIC_SEGMENTATION-only runtime indirection. Other
+    categories must NOT carry it on the cleaned record — there's no
+    mask_id column on the standard tracebloc table, so passing it
+    through would make SQLAlchemy treat it as an unconsumed column at
+    insert time (#212 bugbot)."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+    ing = make_ingestor(
+        schema={}, category=TaskCategory.IMAGE_CLASSIFICATION, label_column=None
+    )
+    rec = ing.process_record({"filename": "image_001", "mask_id": "stray"})
+    assert rec is not None
+    assert "mask_id" not in rec, (
+        f"non-semseg category should NOT carry mask_id; got {rec}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # _process_batch
 # ---------------------------------------------------------------------------
@@ -252,6 +295,26 @@ def test_process_batch_reraises_on_insert_error():
     ing.database.insert_batch.side_effect = err
     with pytest.raises(RuntimeError):
         ing._process_batch([{"data_id": "a"}], MagicMock())
+
+
+def test_process_batch_strips_mask_id_before_insert():
+    # #212 bugbot: mask_id is a SEMANTIC_SEGMENTATION-only runtime
+    # indirection consumed by file_transfer.map_file_transfer; it has no
+    # corresponding DB column, so leaving it on the dict at insert time
+    # makes SQLAlchemy reject the row as an unconsumed column. By the time
+    # we reach insert, file_transfer has already used the value — pop it.
+    ing = make_ingestor()
+    session = MagicMock()
+    batch = [
+        {"data_id": "a", "mask_id": "image_001_mask"},
+        {"data_id": "b", "mask_id": "image_002_mask"},
+    ]
+    ing._process_batch(batch, session)
+    # The dicts that reached insert_batch must not carry mask_id.
+    passed_batch = ing.database.insert_batch.call_args[0][1]
+    assert all("mask_id" not in r for r in passed_batch), (
+        f"mask_id leaked to insert: {passed_batch}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -722,3 +722,12 @@ def test_check_src_path_only_runs_for_file_bearing_categories():
         TaskCategory.MASKED_LANGUAGE_MODELING,
     ):
         assert cat in _SRC_PATH_REQUIRED_CATEGORIES
+
+
+def test_check_src_path_required_for_token_classification():
+    """token_classification reads per-row .txt sidecars from texts/ under
+    SRC_PATH (same layout as text_classification), so it must get the
+    early staging preflight instead of N file-transfer 'not found' errors."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+    from tracebloc_ingestor.ingestors.base import _SRC_PATH_REQUIRED_CATEGORIES
+    assert TaskCategory.TOKEN_CLASSIFICATION in _SRC_PATH_REQUIRED_CATEGORIES

--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -120,6 +120,127 @@ def test_validate_record_still_rejects_real_type_errors():
         ing._validate_record({"n": "not-an-int"})
 
 
+# ---------------------------------------------------------------------------
+# Issue #189: JSON validation must match CSV — bool()/int() were too lenient
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("garbage", ["maybe", "banana", 2, "yesno"])
+def test_validate_record_rejects_garbage_boolean(garbage):
+    # Regression: bool("maybe") is True, bool(2) is True, so the previous
+    # implementation silently accepted these. Match DataValidator's fixed
+    # valid-set so JSON and CSV give the same verdict.
+    ing = make_json_ingestor(schema={"flag": "BOOL"})
+    with pytest.raises(ValueError, match="Data type validation failed"):
+        ing._validate_record({"flag": garbage})
+
+
+@pytest.mark.parametrize("v", [True, False, "true", "FALSE", "yes", "n", 0, 1])
+def test_validate_record_accepts_real_booleans(v):
+    # The valid set: Python bools, the canonical strings DataValidator
+    # accepts, and 0/1.
+    ing = make_json_ingestor(schema={"flag": "BOOL"})
+    ing._validate_record({"flag": v})
+
+
+def test_validate_record_rejects_non_integer_float_for_int():
+    # Regression: int(3.5) silently truncated to 3 with no error — INT label
+    # could end up as 0/1 from a 0.4/1.6 source value, corrupting training.
+    # Reject anything that isn't integer-valued.
+    ing = make_json_ingestor(schema={"n": "INT"})
+    with pytest.raises(ValueError, match="not an integer"):
+        ing._validate_record({"n": 3.5})
+
+
+def test_validate_record_accepts_integer_valued_float_for_int():
+    # 3.0 is integer-valued and is fine (matches the CSV validator's
+    # tolerance for whole-number floats stored as INT).
+    ing = make_json_ingestor(schema={"n": "INT"})
+    ing._validate_record({"n": 3.0})
+
+
+def test_validate_record_rejects_overlong_varchar():
+    # Regression: VARCHAR length was never enforced on JSON. The CSV path
+    # rejects a too-long string; JSON must too.
+    ing = make_json_ingestor(schema={"code": "VARCHAR(3)"})
+    with pytest.raises(ValueError, match="exceeds the declared length 3"):
+        ing._validate_record({"code": "ABCDE"})
+
+
+def test_validate_record_accepts_numeric_in_varchar():
+    # Issue #188 parity: VARCHAR accepts numeric scalars (zip codes,
+    # numeric IDs declared VARCHAR). MySQL binds them as strings.
+    ing = make_json_ingestor(schema={"code": "VARCHAR(10)"})
+    ing._validate_record({"code": 12345})
+
+
+def test_validate_record_rejects_unparseable_date():
+    # Regression: DATE wasn't validated on JSON at all — a 'not-a-date'
+    # string flowed through to the DB.
+    ing = make_json_ingestor(schema={"d": "DATE"})
+    with pytest.raises(ValueError, match="not a valid DATE"):
+        ing._validate_record({"d": "not-a-date"})
+
+
+def test_validate_record_accepts_iso_date():
+    ing = make_json_ingestor(schema={"d": "DATE"})
+    ing._validate_record({"d": "2024-01-15"})
+
+
+# ---------------------------------------------------------------------------
+# #204 bugbot — non-finite (inf / NaN) must be rejected for INT and FLOAT
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("v", [float("inf"), float("-inf"), float("nan"), "Infinity"])
+def test_validate_record_rejects_non_finite_for_int(v):
+    # float("Infinity") returns +inf without raising, and float.is_integer()
+    # is False on inf/NaN — but the contract shouldn't depend on that detail.
+    # Mirror DataValidator's _non_finite_error on the CSV path and reject
+    # explicitly with an informative message.
+    ing = make_json_ingestor(schema={"n": "INT"})
+    with pytest.raises(ValueError, match="non-finite|not an integer"):
+        ing._validate_record({"n": v})
+
+
+@pytest.mark.parametrize("v", [float("inf"), float("-inf"), float("nan"), "Infinity"])
+def test_validate_record_rejects_non_finite_for_float(v):
+    # Bare float() lets inf through silently — DataValidator already rejects
+    # this for CSV (_non_finite_error). Match here so JSON and CSV agree.
+    ing = make_json_ingestor(schema={"x": "FLOAT"})
+    with pytest.raises(ValueError, match="non-finite"):
+        ing._validate_record({"x": v})
+
+
+# ---------------------------------------------------------------------------
+# #204 bugbot (2nd round) — JSON must not be stricter than CSV either,
+# else a record passes CSV-style preflight then drops at per-record check
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("v", [True, False])
+def test_validate_record_accepts_python_bool_for_int(v):
+    # DataValidator._validate_int accepts a bool column via pd.to_numeric
+    # (True -> 1, False -> 0). Rejecting them here would let a record pass
+    # CSV preflight and then be silently dropped mid-ingest.
+    ing = make_json_ingestor(schema={"n": "INT"})
+    ing._validate_record({"n": v})
+
+
+@pytest.mark.parametrize("v", ["00", "01", "1.0", "0.0", "1e0", "0e0"])
+def test_validate_record_accepts_numeric_string_for_bool(v):
+    # DataValidator._validate_boolean accepts any string that pd.to_numeric
+    # resolves to 0 or 1. JSON per-record validation must match.
+    ing = make_json_ingestor(schema={"flag": "BOOL"})
+    ing._validate_record({"flag": v})
+
+
+def test_validate_record_still_rejects_non_bool_numeric_string():
+    # The fallback only accepts values that resolve to exactly 0 or 1; "1.5"
+    # / "2" / "0.4" must still fail (matches DataValidator).
+    ing = make_json_ingestor(schema={"flag": "BOOL"})
+    for v in ("1.5", "2", "0.4"):
+        with pytest.raises(ValueError, match="Data type validation failed"):
+            ing._validate_record({"flag": v})
+
+
 def test_count_records_array(tmp_path):
     p = _write_json(tmp_path, [{"a": 1}, {"a": 2}, {"a": 3}])
     assert make_json_ingestor()._count_records(str(p)) == 3

--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -253,3 +253,139 @@ def test_count_records_object(tmp_path):
 
 def test_count_records_bad_path_returns_none():
     assert make_json_ingestor()._count_records("/no/such.json") is None
+
+
+# ---------------------------------------------------------------------------
+# Streaming via ijson — backend/#772 P2
+# ---------------------------------------------------------------------------
+
+def test_read_data_streams_array_does_not_materialise_whole_file(tmp_path):
+    """JSON ingestion used to call ``json.load`` and hold the whole file
+    in memory; a multi-GB array OOM'd the pod (Killed/137 — the deferred
+    half of #771's streaming item). Now we stream via ``ijson.items`` so
+    only one record at a time is in memory. The test pins the streaming
+    contract: the generator yields BEFORE the file is exhausted (i.e.
+    ``next()`` returns without reading the trailing records first).
+    """
+    import ijson as _ijson
+    import os
+
+    # Write a moderate-size array so the test is fast but the streaming
+    # behaviour is observable. We assert by checking that ijson.items is
+    # actually invoked — proves the streaming path, not the full-load path.
+    p = _write_json(tmp_path, [{"a": i} for i in range(1000)])
+    ing = make_json_ingestor()
+
+    spy_invocations = []
+    real_items = _ijson.items
+
+    def spy_items(file_obj, prefix, *args, **kwargs):
+        spy_invocations.append(prefix)
+        return real_items(file_obj, prefix, *args, **kwargs)
+
+    from unittest.mock import patch
+    with patch("tracebloc_ingestor.ingestors.json_ingestor.ijson.items",
+               side_effect=spy_items):
+        gen = ing.read_data(str(p))
+        first = next(gen)
+        # Now consume the rest.
+        rest = list(gen)
+
+    assert spy_invocations == ["item"], "ijson.items was not used"
+    assert first["a"] == 0
+    assert len(rest) == 999
+    assert rest[-1]["a"] == 999
+
+
+def test_count_records_array_streaming(tmp_path):
+    """Counting an array no longer materialises the whole file — proves
+    that the count path uses ``ijson.items`` rather than ``json.load``."""
+    p = _write_json(tmp_path, [{"a": i} for i in range(50)])
+    assert make_json_ingestor()._count_records(str(p)) == 50
+
+
+def test_read_data_single_object_skips_ijson(tmp_path):
+    """Single-object JSON (one record) shouldn't trigger ijson — it
+    short-circuits to a normal load since one record is by definition
+    tractable. Regression guard: the existing single-object contract
+    must not regress when the array path moved to streaming."""
+    from unittest.mock import patch
+    p = _write_json(tmp_path, {"a": 1, "b": "x"})
+    spy = []
+    real_items = __import__("ijson").items
+
+    def spy_items(*a, **k):
+        spy.append(1)
+        return real_items(*a, **k)
+
+    with patch("tracebloc_ingestor.ingestors.json_ingestor.ijson.items",
+               side_effect=spy_items):
+        records = list(make_json_ingestor().read_data(str(p)))
+    assert records == [{"a": 1, "b": "x"}]
+    assert spy == [], "single-object path must not invoke ijson.items"
+
+
+def test_read_data_invalid_top_level_still_rejected(tmp_path):
+    """A JSON file with neither an object nor an array at the top is
+    rejected with a clear ValueError — the streaming path must preserve
+    the same boundary the load-based path enforced."""
+    p = tmp_path / "bad.json"
+    p.write_text("42")  # bare number
+    with pytest.raises(ValueError, match="object or array"):
+        list(make_json_ingestor().read_data(str(p)))
+
+
+# ---------------------------------------------------------------------------
+# #222 bugbot — file-handle leak, count-skipped-parse, peek-hides-error
+# ---------------------------------------------------------------------------
+
+def test_array_streaming_closes_file_handle_on_partial_consume(tmp_path):
+    """#222 bugbot MED: the array path used to pass a bare
+    ``open(..., 'rb')`` into ``ijson.items``, so the descriptor stayed
+    open until the inner iterator and outer generator were GC'd —
+    leaking handles across repeated ingests. The file handle is now
+    inside a ``with`` block in read_data, so partial consumption
+    (close the generator early) deterministically closes the file."""
+    p = _write_json(tmp_path, [{"a": i} for i in range(100)])
+    ing = make_json_ingestor()
+    gen = ing.read_data(str(p))
+    first = next(gen)
+    assert first["a"] == 0
+    # Close the generator without consuming the rest — the contextmanager
+    # in read_data must close the underlying file.
+    gen.close()
+    # Subsequent reads should be possible (file isn't locked, descriptor
+    # was released). We re-open to confirm.
+    with open(p, "rb") as f:
+        assert f.read(1) == b"["
+
+
+def test_count_records_object_validates_parseability(tmp_path):
+    """#222 bugbot MED: returning 1 based on the peek alone for an
+    object-shaped file used to misreport a TRUNCATED object as one
+    record — the progress bar then expected 1, but ``read_data`` would
+    raise a decode error mid-ingest. Now the count path actually parses
+    the object via ijson; a broken object returns None."""
+    p = tmp_path / "broken.json"
+    p.write_text('{"a": 1, "b":')  # starts with `{`, truncated mid-value
+    # Peek -> "object", but the file isn't parseable -> count should be None.
+    assert make_json_ingestor()._count_records(str(p)) is None
+
+
+def test_count_records_object_well_formed_returns_one(tmp_path):
+    """Positive boundary for the previous test: a well-formed object
+    still reports 1 — the count path validates, doesn't reject good
+    input."""
+    p = _write_json(tmp_path, {"a": 1, "b": "ok"})
+    assert make_json_ingestor()._count_records(str(p)) == 1
+
+
+def test_peek_propagates_os_read_errors(tmp_path):
+    """#222 bugbot MED: ``_peek_json_shape`` used to swallow ``OSError``
+    into None, then ``read_data`` raised a misleading 'object or array'
+    error instead of the underlying permission-denied / read failure.
+    The OSError now propagates."""
+    from tracebloc_ingestor.ingestors.json_ingestor import _peek_json_shape
+    nonexistent = tmp_path / "no_such_dir" / "x.json"
+    with pytest.raises(OSError):
+        _peek_json_shape(nonexistent)

--- a/tests/test_numeric_columns_validator.py
+++ b/tests/test_numeric_columns_validator.py
@@ -23,15 +23,39 @@ def test_all_numeric_passes(make_csv):
     assert result.metadata["columns_to_validate"] == 2
 
 
-def test_null_value_fails(make_csv):
+def test_null_value_is_valid(make_csv):
+    # Issue #195: nulls in a numeric column are legitimate missing values
+    # (stored as SQL NULL), NOT a validation error. The shipped time-series
+    # template explicitly documents lag/window features as leading-null, and
+    # the validator was rejecting its own shipped sample. Null count is
+    # still surfaced via metadata for observability.
     path = make_csv({
         "timestamp": ["2024-01-01", "2024-01-02"],
         "value": [1.0, None],
         "count": [3, 4],
     })
     result = NumericColumnsValidator(schema=SCHEMA).validate(str(path))
-    assert not result.is_valid
-    assert any("null/missing" in e for e in result.errors)
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+    assert result.metadata["value_null_count"] == 1
+
+
+def test_time_series_lag_window_leading_nulls_pass(make_csv):
+    # End-to-end repro from #195: the shipped time-series template README
+    # documents `lag_1` as blank for row 1 and `moving_avg_7` as blank
+    # until enough history accumulates. The shipped sample CSV ships with
+    # exactly those nulls, and the validator rejected its own sample.
+    path = make_csv({
+        "timestamp": ["2024-01-0%d" % i for i in range(1, 9)],
+        "value": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0],
+        "lag_1":          [None, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+        "moving_avg_7":   [None, None, None, None, None, None, 13.0, 14.0],
+    })
+    schema = {
+        "timestamp": "TIMESTAMP", "value": "FLOAT",
+        "lag_1": "FLOAT", "moving_avg_7": "FLOAT",
+    }
+    result = NumericColumnsValidator(schema=schema).validate(str(path))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
 
 
 def test_non_numeric_fails(make_csv):

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -218,6 +218,27 @@ def test_tabular_without_schema_rejected(validator):
         validator.validate(config)
 
 
+def test_masked_language_modeling_with_label_rejected(validator):
+    """Issue #213: self-supervised categories (MLM, …) MUST NOT carry a
+    `label:` field. The CSV has no label column, and the framework registers
+    no edge-label metadata for them — setting `label:` anyway used to ingest
+    rows successfully then crash at backend registration with a misleading
+    HTTP 400 ('No data found'). Reject at submission so the user sees the
+    real cause."""
+    config = _load_example("masked_language_modeling.yaml")
+    config["label"] = "some_column"
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_masked_language_modeling_without_label_accepted(validator):
+    """The shipped MLM example yaml omits `label:` by design. Confirm it
+    still validates cleanly (the new constraint is strictly additive)."""
+    config = _load_example("masked_language_modeling.yaml")
+    assert "label" not in config, "test premise: the example yaml has no label"
+    validator.validate(config)  # must not raise
+
+
 # Regression-class tasks must specify label.policy explicitly; the shorthand
 # string form must be rejected for these categories.
 @pytest.mark.parametrize(

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -211,6 +211,20 @@ def test_text_classification_without_texts_rejected(validator):
         validator.validate(config)
 
 
+def test_token_classification_without_texts_rejected(validator):
+    config = _load_example("token_classification.yaml")
+    del config["texts"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_token_classification_without_label_rejected(validator):
+    config = _load_example("token_classification.yaml")
+    del config["label"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
 def test_tabular_without_schema_rejected(validator):
     config = _load_example("tabular_classification.yaml")
     del config["schema"]

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -210,7 +210,10 @@ CASES = [
             intent="train",
             csv="/data/labels.csv",
             texts="/data/texts/",
-            schema={"text_id": "VARCHAR(255)", "label": "VARCHAR(64)"},
+            # text_classification's filename + label are framework-managed
+            # (see #197); this synthetic schema only declares extra columns
+            # to exercise resolve()'s schema-bridging code path.
+            schema={"extra_feature": "VARCHAR(255)"},
             label="label",
         ),
         {

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -82,7 +82,9 @@ def _yaml(**fields) -> Dict[str, Any]:
 
 CASES = [
     # -----------------------------------------------------------------------
-    # image_classification — template uses 512×512, intent=TEST, label_column="label"
+    # image_classification — template + convention default now align with the
+    # bundled onboarding sample (256×256 .jpeg, #198). intent=TEST,
+    # label_column="label" unchanged.
     # -----------------------------------------------------------------------
     pytest.param(
         _yaml(
@@ -101,13 +103,16 @@ CASES = [
             "label_policy": PASSTHROUGH,
             "unique_id_column": None,
             "annotation_column": None,
-            "file_options": {"target_size": [512, 512], "extension": FileExtension.JPG},
+            "file_options": {"target_size": [256, 256], "extension": FileExtension.JPEG},
         },
         id="image_classification",
     ),
 
     # -----------------------------------------------------------------------
-    # object_detection — template uses 448×448, label_column="image_label"
+    # object_detection — template + convention default now align with the
+    # bundled VisDrone aerial sample (1920×1080, #199). The sample is kept at
+    # native resolution because aggressive downscaling obliterates the
+    # tiny-object content the sample exists to demonstrate.
     # -----------------------------------------------------------------------
     pytest.param(
         _yaml(
@@ -127,7 +132,7 @@ CASES = [
             "label_policy": PASSTHROUGH,
             "unique_id_column": None,
             "annotation_column": None,
-            "file_options": {"target_size": [448, 448], "extension": FileExtension.JPG},
+            "file_options": {"target_size": [1920, 1080], "extension": FileExtension.JPG},
         },
         id="object_detection",
     ),

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -230,6 +230,34 @@ CASES = [
     ),
 
     # -----------------------------------------------------------------------
+    # token_classification — same on-disk layout as text_classification
+    # (.txt in texts/, label_column="label"); the label is a space-separated
+    # BIO tag sequence rather than a single class.
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.TOKEN_CLASSIFICATION,
+            table="token_classification_train",
+            intent="train",
+            csv="/data/labels.csv",
+            texts="/data/texts/",
+            schema={"filename": "VARCHAR(255)", "label": "VARCHAR(2048)"},
+            label="label",
+        ),
+        {
+            "category": TaskCategory.TOKEN_CLASSIFICATION,
+            "data_format": DataFormat.TEXT,
+            "intent": Intent.TRAIN,
+            "label_column": "label",
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"extension": FileExtension.TXT},
+        },
+        id="token_classification",
+    ),
+
+    # -----------------------------------------------------------------------
     # masked_language_modeling — self-supervised, no label column. CSV manifest
     # points at .txt sidecar files containing space-separated token sequences;
     # the MLM client masks tokens on-the-fly during training. Sidecar dir is

--- a/tests/test_tokenizer_validator.py
+++ b/tests/test_tokenizer_validator.py
@@ -79,3 +79,35 @@ def test_extract_vocab_returns_none_when_empty():
 def test_custom_required_tokens():
     v = TokenizerValidator(required_tokens=("[CLS]",))
     assert v.required_tokens == {"[CLS]"}
+
+
+# ---------------------------------------------------------------------------
+# optional=True (text/token classification): missing tokenizer is a warning,
+# not an error; a present tokenizer is still validated.
+# ---------------------------------------------------------------------------
+
+
+def test_optional_missing_file_warns_and_passes(clean_env, tmp_path):
+    clean_env.setenv("SRC_PATH", str(tmp_path))  # no tokenizer.json
+    v = TokenizerValidator(required_tokens=("[PAD]",), optional=True)
+    result = v.validate(None)
+    assert result.is_valid
+    assert result.warnings and "tokenizer.json" in result.warnings[0]
+    assert result.metadata.get("tokenizer_present") is False
+
+
+def test_optional_present_without_pad_still_fails(clean_env, make_tokenizer):
+    src = make_tokenizer(vocab=("hello", "world"))  # no [PAD]
+    clean_env.setenv("SRC_PATH", str(src))
+    v = TokenizerValidator(required_tokens=("[PAD]",), optional=True)
+    result = v.validate(None)
+    assert not result.is_valid
+    assert "[PAD]" in result.errors[0]
+
+
+def test_optional_present_with_pad_passes(clean_env, make_tokenizer):
+    src = make_tokenizer(vocab=("hello", "world", "[PAD]"))
+    clean_env.setenv("SRC_PATH", str(src))
+    v = TokenizerValidator(required_tokens=("[PAD]",), optional=True)
+    result = v.validate(None)
+    assert result.is_valid

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -14,9 +14,15 @@ from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
 from tracebloc_ingestor.validators.xml_validator import PascalVOCXMLValidator
 from tracebloc_ingestor.validators.time_to_event_validator import TimeToEventValidator
 from tracebloc_ingestor.validators.time_format_validator import TimeFormatValidator
-from tracebloc_ingestor.validators.numeric_columns_validator import NumericColumnsValidator
-from tracebloc_ingestor.validators.keypoint_annotation_validator import KeypointAnnotationValidator
-from tracebloc_ingestor.validators.keypoint_visibility_validator import KeypointVisibilityValidator
+from tracebloc_ingestor.validators.numeric_columns_validator import (
+    NumericColumnsValidator,
+)
+from tracebloc_ingestor.validators.keypoint_annotation_validator import (
+    KeypointAnnotationValidator,
+)
+from tracebloc_ingestor.validators.keypoint_visibility_validator import (
+    KeypointVisibilityValidator,
+)
 from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
 
 
@@ -30,7 +36,10 @@ def _types(validators):
 def test_image_classification():
     v = map_validators(TaskCategory.IMAGE_CLASSIFICATION, IMAGE_OPTS)
     assert _types(v) == [
-        FileTypeValidator, ImageResolutionValidator, TableNameValidator, DuplicateValidator
+        FileTypeValidator,
+        ImageResolutionValidator,
+        TableNameValidator,
+        DuplicateValidator,
     ]
 
 
@@ -78,6 +87,37 @@ def test_text_classification_defaults_extension():
     assert _types(v)[0] is FileTypeValidator
 
 
+def test_token_classification_includes_bio_validator():
+    from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
+
+    v = map_validators(TaskCategory.TOKEN_CLASSIFICATION, {})
+    types = _types(v)
+    assert types[0] is FileTypeValidator
+    assert BIOLabelValidator in types
+    assert TableNameValidator in types and DuplicateValidator in types
+
+
+def test_token_classification_with_schema_adds_data_validator():
+    v = map_validators(TaskCategory.TOKEN_CLASSIFICATION, {"schema": {"a": "INT"}})
+    assert DataValidator in _types(v)
+
+
+def test_token_classification_threads_custom_label_column():
+    from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
+
+    v = map_validators(TaskCategory.TOKEN_CLASSIFICATION, {"label_column": "ner_tags"})
+    bio = next(x for x in v if isinstance(x, BIOLabelValidator))
+    assert bio.label_column == "ner_tags"
+
+
+def test_token_classification_defaults_label_column_when_unset():
+    from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
+
+    v = map_validators(TaskCategory.TOKEN_CLASSIFICATION, {"label_column": None})
+    bio = next(x for x in v if isinstance(x, BIOLabelValidator))
+    assert bio.label_column == "label"
+
+
 def test_time_series_forecasting_validator_set():
     v = map_validators(
         TaskCategory.TIME_SERIES_FORECASTING,
@@ -122,3 +162,14 @@ def test_masked_language_modeling_includes_tokenizer():
 
 def test_unknown_category_returns_empty():
     assert map_validators("not_a_category", {}) == []
+
+
+def test_text_and_token_classification_include_optional_tokenizer_validator():
+    from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
+
+    for cat in (TaskCategory.TEXT_CLASSIFICATION, TaskCategory.TOKEN_CLASSIFICATION):
+        v = map_validators(cat, {})
+        tok = [x for x in v if isinstance(x, TokenizerValidator)]
+        assert tok, f"{cat}: expected an (optional) TokenizerValidator"
+        assert tok[0].optional is True
+        assert tok[0].required_tokens == {"[PAD]"}

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -20,7 +20,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.7"
+__version__ = "0.3.8"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -20,7 +20,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.8"
+__version__ = "0.3.9"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -1,4 +1,5 @@
-from typing import List, Tuple, Dict, Any
+from typing import List, Tuple, Dict, Any, Optional
+import os
 import requests, json
 import logging
 from requests.adapters import HTTPAdapter
@@ -129,6 +130,90 @@ class APIClient:
             else:
                 raise ValueError(f"{RED}Error response: {e}{RESET}")
 
+    def _refresh_token(self) -> bool:
+        """Re-mint or re-read the auth token (#772 P2 — token captured
+        once, expires on multi-hour runs).
+
+        Three resolution paths matching ``__init__``:
+          - local mode: keep the mock token (no real auth in the loop)
+          - BACKEND_TOKEN: re-read ``os.environ`` in case jobs-manager /
+            secret-rotator wrote a fresh value into the env. (Re-reading
+            ``self.config.BACKEND_TOKEN`` first picks up Config layer
+            overrides; the env fallback covers rotation.)
+          - CLIENT_ID/PASSWORD (deprecated): re-call ``authenticate()``
+            to mint a new short-lived token.
+
+        Returns True iff the token actually changed; False signals
+        "tried to refresh but got the same value, nothing more we can
+        do" — caller should treat the next 401 as terminal.
+        """
+        if self.config.EDGE_ENV == "local":
+            return False
+        old = self.token
+        if self.config.BACKEND_TOKEN:
+            # Re-resolve via Config (which reads the env each time) so a
+            # rotated BACKEND_TOKEN is picked up between attempts.
+            new = self.config.BACKEND_TOKEN or os.environ.get("BACKEND_TOKEN")
+            if new and new != old:
+                self.token = new
+                logger.info(
+                    f"{GREEN}Re-read rotated BACKEND_TOKEN after 401.{RESET}"
+                )
+                return True
+            return False
+        # CLIENT_ID/PASSWORD path: mint a new token.
+        try:
+            self.token = self.authenticate()
+            return self.token != old
+        except Exception as exc:
+            logger.error(
+                f"{RED}Failed to re-authenticate after 401: {exc}{RESET}"
+            )
+            return False
+
+    def _authed_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        extra_headers: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """Issue an authenticated HTTP request with a single 401-refresh
+        retry (#772 P2).
+
+        Auth tokens captured at ``__init__`` used to expire silently on
+        multi-hour runs — the terminal ``create_dataset`` then failed
+        4xx, the ingest exited non-zero, and the rows were left
+        committed-but-unregistered. Now: on a 401, attempt one token
+        refresh and retry the request once. If the second attempt still
+        401s, the caller's existing error path runs as before.
+
+        Caller passes whatever ``session.request`` kwargs are needed
+        (json, data, params, timeout, …). The Authorization header is
+        injected here and overrides anything in ``extra_headers``.
+        """
+        headers = dict(extra_headers or {})
+        headers["Authorization"] = f"TOKEN {self.token}"
+        # Dispatch by method name (not session.request) so existing tests
+        # that monkeypatch ``session.post`` / ``session.get`` directly
+        # continue to work without rewrites.
+        send = getattr(self.session, method.lower())
+        response = send(url, headers=headers, **kwargs)
+        if response.status_code != 401:
+            return response
+        logger.warning(
+            f"{YELLOW}Backend returned 401 for {method} {url} — attempting "
+            f"token refresh and one retry.{RESET}"
+        )
+        if not self._refresh_token():
+            # Refresh did nothing; the second attempt would 401 again.
+            # Surface the original 401 so the caller's existing error
+            # path runs (it already logs the response body).
+            return response
+        headers["Authorization"] = f"TOKEN {self.token}"
+        return send(url, headers=headers, **kwargs)
+
     def send_batch(
         self,
         records: List[Tuple[int, Dict[str, Any]]],
@@ -166,15 +251,11 @@ class APIClient:
 
             logger.info(f"Data to send: {payload}")
 
-            headers = {
-                "Authorization": f"TOKEN {self.token}",
-                "Content-Type": "application/json",
-            }
-
-            response = self.session.post(
+            response = self._authed_request(
+                "POST",
                 f"{self.config.API_ENDPOINT}/global_meta/{table_name}/",
                 data=payload,
-                headers=headers,
+                extra_headers={"Content-Type": "application/json"},
                 timeout=API_TIMEOUT,
             )
 
@@ -221,15 +302,11 @@ class APIClient:
 
             logger.info(f"Global metadata to send: {(payload)}")
 
-            headers = {
-                "Authorization": f"TOKEN {self.token}",
-                "Content-Type": "application/json",
-            }
-
-            response = self.session.post(
+            response = self._authed_request(
+                "POST",
                 f"{self.config.API_ENDPOINT}/global_meta/global_metadata/",
                 data=payload,
-                headers=headers,
+                extra_headers={"Content-Type": "application/json"},
                 timeout=API_TIMEOUT,
             )
 
@@ -271,12 +348,11 @@ class APIClient:
 
         try:
             url = f"{self.config.API_ENDPOINT}/global_meta/generate-edge-labels-meta/?table_name={table_name}&injestor_id={ingestor_id}&data_intent={intent}"
-            headers = {"Authorization": f"TOKEN {self.token}"}
 
             logger.info(
                 f"Sending request to generate edge label metadata for dataset type: {table_name}"
             )
-            response = self.session.get(url, headers=headers, timeout=API_TIMEOUT)
+            response = self._authed_request("GET", url, timeout=API_TIMEOUT)
 
             # Check status after retries are exhausted
             if response.status_code >= 400:
@@ -324,12 +400,11 @@ class APIClient:
 
         try:
             url = f"{self.config.API_ENDPOINT}/global_meta/prepare/?category={category}&injestor_id={ingestor_id}&data_format={data_format}&data_intent={intent}"
-            headers = {"Authorization": f"TOKEN {self.token}"}
 
             logger.info(
                 f"Sending prepare request for category: {category}, injester_id: {ingestor_id}, data_format: {data_format} , data_intent: {intent}"
             )
-            response = self.session.get(url, headers=headers, timeout=API_TIMEOUT)
+            response = self._authed_request("GET", url, timeout=API_TIMEOUT)
 
             # Check status after retries are exhausted
             if response.status_code >= 400:
@@ -394,15 +469,11 @@ class APIClient:
 
             logger.info(f"{GREEN}Creating dataset with payload: {payload}{RESET}")
 
-            headers = {
-                "Authorization": f"TOKEN {self.token}",
-                "Content-Type": "application/json",
-            }
-
-            response = self.session.post(
+            response = self._authed_request(
+                "POST",
                 f"{self.config.API_ENDPOINT}/dataset/",
                 data=payload,
-                headers=headers,
+                extra_headers={"Content-Type": "application/json"},
                 timeout=API_TIMEOUT,
             )
 

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -259,18 +259,28 @@ class APIClient:
                 timeout=API_TIMEOUT,
             )
 
-            # Check status after retries are exhausted
+            # Check status after retries are exhausted. Attach the response
+            # so the handler below can log the status and body — a bare
+            # HTTPError has e.response = None, which used to route a DRF 400
+            # into the str(e)[:100] branch, truncating the message right
+            # after "HTTP 400: " and hiding the field error that explains
+            # why every batch was rejected.
             if response.status_code >= 400:
                 raise requests.exceptions.HTTPError(
-                    f"HTTP {response.status_code}: {response.text}"
+                    f"HTTP {response.status_code}: {response.text}",
+                    response=response,
                 )
             return True
 
         except requests.exceptions.RequestException as e:
-            if hasattr(e.response, "text"):
-                logger.error(f"{RED}Error response: {e.response.text}{RESET}")
+            if e.response is not None:
+                body = (e.response.text or "")[:2000]
+                logger.error(
+                    f"{RED}Error sending batch to API: "
+                    f"HTTP {e.response.status_code}: {body}{RESET}"
+                )
             else:
-                logger.error(f"{RED}Error sending batch to API: {str(e)[:100]}{RESET}")
+                logger.error(f"{RED}Error sending batch to API: {str(e)[:500]}{RESET}")
             return False
 
     def send_global_meta_meta(

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -45,6 +45,7 @@ IMAGE_CATEGORIES: FrozenSet[str] = frozenset({
 
 TEXT_CATEGORIES: FrozenSet[str] = frozenset({
     TaskCategory.TEXT_CLASSIFICATION,
+    TaskCategory.TOKEN_CLASSIFICATION,
 })
 
 TABULAR_CATEGORIES: FrozenSet[str] = frozenset({

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -96,9 +96,14 @@ DEFAULT_CSV_OPTIONS: Dict[str, Any] = {
 # customer-tuned values. Refining these defaults after first customer
 # migrations is explicitly out-of-scope for #44 per the ticket.
 DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY: Dict[str, Dict[str, Any]] = {
-    TaskCategory.IMAGE_CLASSIFICATION:    {"target_size": [512, 512], "extension": ".jpg"},
+    # IMAGE_CLASSIFICATION + OBJECT_DETECTION defaults now match the bundled
+    # onboarding samples under `templates/*/data/images/` (#198, #199) so the
+    # framework's own samples round-trip through the documented happy-path
+    # config with zero overrides. Production users with differently-sized data
+    # should set `spec.file_options` in their YAML.
+    TaskCategory.IMAGE_CLASSIFICATION:    {"target_size": [256, 256], "extension": ".jpeg"},
     TaskCategory.SEMANTIC_SEGMENTATION:   {"target_size": [512, 512], "extension": ".jpg"},
-    TaskCategory.OBJECT_DETECTION:        {"target_size": [448, 448], "extension": ".jpg"},
+    TaskCategory.OBJECT_DETECTION:        {"target_size": [1920, 1080], "extension": ".jpg"},
     # keypoint_detection: no target_size default — the customer's pose model
     # dictates input resolution, so the schema requires it top-level.
     TaskCategory.KEYPOINT_DETECTION:      {"extension": ".jpg"},

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -20,10 +20,18 @@ from sqlalchemy import (
 )
 from sqlalchemy.engine import Engine
 from sqlalchemy.dialects.mysql import insert, LONGBLOB, BLOB
+from sqlalchemy.exc import OperationalError, InterfaceError, DBAPIError
 import logging
 from urllib.parse import quote
 from typing import List, Dict, Any, Optional
 from datetime import datetime
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_exponential,
+    retry_if_exception_type,
+    before_sleep_log,
+)
 from .config import Config
 from .utils.logging import setup_logging
 
@@ -31,6 +39,63 @@ from .utils.logging import setup_logging
 config = Config()
 setup_logging(config)
 logger = logging.getLogger(__name__)
+
+
+# Transient MySQL/SQLAlchemy errors that warrant a retry. Roughly: anything
+# from the network / connection layer or a server-side temporary state. We
+# deliberately DO NOT retry IntegrityError / DataError / ProgrammingError —
+# those reflect bad data or schema and won't fix themselves on a retry.
+#   - OperationalError: "MySQL server has gone away", "Lost connection during
+#     query", "Deadlock found", connection-pool eviction, network blip.
+#   - InterfaceError: stale connection / lower-level driver fault.
+# Issue: backend #772 P2 — `insert_batch` had no DB-retry; a 5-second
+# MySQL restart in the middle of an 8-hour proteomics ingest failed every
+# in-flight batch permanently. file_transfer already uses tenacity for
+# file-copy retries; the DB path was just inconsistent.
+_DB_RETRY_EXCEPTIONS = (OperationalError, InterfaceError)
+
+
+_retry_on_transient_db_error = retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=8),
+    retry=retry_if_exception_type(_DB_RETRY_EXCEPTIONS),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    reraise=True,
+)
+
+
+@_retry_on_transient_db_error
+def _execute_with_retry(connection, stmt):
+    """Run ``connection.execute(stmt)`` with bounded retries on transient
+    DB errors (network blip, MySQL restart, stale pool connection). A
+    permanent error (IntegrityError, DataError, …) is NOT retried and
+    propagates immediately to the existing per-row fallback path.
+
+    Rollback between attempts (#219 bugbot): SQLAlchemy leaves the
+    connection in a pending-rollback state after a failed statement, so
+    the next ``connection.execute`` on the SAME connection would raise
+    ``PendingRollbackError`` — a NON-transient class tenacity doesn't
+    retry, which would cut the retries short and skip the intended
+    backoff. Rolling back here resets the connection's transactional
+    state so the next attempt sees a clean slate. The rollback runs on
+    EVERY transient failure (including the final one that propagates),
+    which is also fine — the per-row fallback path runs another
+    rollback at the top, so the double-rollback is a harmless no-op.
+    """
+    try:
+        return connection.execute(stmt)
+    except _DB_RETRY_EXCEPTIONS:
+        try:
+            connection.rollback()
+        except Exception as rb_exc:
+            # The rollback itself might fail on a truly dead connection.
+            # Swallow it so the original transient error propagates to
+            # tenacity for the retry (or, on the last attempt, to the
+            # caller's existing error path).
+            logger.debug(
+                f"connection.rollback() failed between retries: {rb_exc}"
+            )
+        raise
 
 
 class Database:
@@ -345,18 +410,26 @@ class Database:
                 }
 
                 try:
-                    # Execute upsert
-                    connection.execute(
+                    # Execute upsert. Wrapped in _execute_with_retry so a
+                    # transient MySQL hiccup (server-gone-away, lost
+                    # connection mid-query, brief deadlock, network blip)
+                    # is retried (3 attempts, exponential backoff) before
+                    # the per-record fallback below takes over. Permanent
+                    # errors (IntegrityError, DataError) bypass the retry
+                    # and fall straight through to the per-record path
+                    # which can identify the offending row.
+                    _execute_with_retry(
+                        connection,
                         insert_stmt.values(processed_records).on_duplicate_key_update(
                             **update_dict
-                        )
+                        ),
                     )
                     connection.commit()
 
                     # Get IDs for successfully processed records
                     data_ids = [record["data_id"] for record in records]
                     select_stmt = table.select().where(table.c.data_id.in_(data_ids))
-                    rows = connection.execute(select_stmt).fetchall()
+                    rows = _execute_with_retry(connection, select_stmt).fetchall()
                     result["success_ids"] = [row.id for row in rows]
 
                 except Exception as e:
@@ -371,14 +444,16 @@ class Database:
                             stmt = insert_stmt.values([record]).on_duplicate_key_update(
                                 **update_dict
                             )
-                            connection.execute(stmt)
+                            _execute_with_retry(connection, stmt)
                             connection.commit()
 
                             # Get ID for the successful record
                             select_stmt = table.select().where(
                                 table.c.data_id == record["data_id"]
                             )
-                            row = connection.execute(select_stmt).fetchone()
+                            row = _execute_with_retry(
+                                connection, select_stmt
+                            ).fetchone()
                             if row:
                                 result["success_ids"].append(row.id)
 

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -194,9 +194,7 @@ def annotation_transfer(
             return None
 
         if src_path is None:
-            src_path, filename_with_ext = _find_src(
-                "annotations", filename, extension
-            )
+            src_path, filename_with_ext = _find_src("annotations", filename, extension)
             if src_path is None:
                 logger.error(
                     f"{RED}Source file not found: {os.path.join(config.SRC_PATH, 'annotations', filename_with_ext)}{RESET}"
@@ -309,6 +307,21 @@ def mask_transfer(
         raise ValueError(f"{RED}Error processing mask file: {str(e)}{RESET}")
 
 
+def _copy_tokenizer_if_present() -> None:
+    """Copy a user-shipped ``tokenizer.json`` from SRC_PATH to DEST_PATH (once).
+
+    Optional for NLP datasets: the training client looks for
+    ``DEST_PATH/tokenizer.json`` and uses it as a custom tokenizer; if it's
+    absent the client falls back to the HuggingFace tokenizer_id / default.
+    No-op when no tokenizer.json was shipped, or when it was already copied.
+    """
+    tokenizer_src = os.path.join(config.SRC_PATH, "tokenizer.json")
+    tokenizer_dest = os.path.join(config.DEST_PATH, "tokenizer.json")
+    if os.path.isfile(tokenizer_src) and not os.path.exists(tokenizer_dest):
+        _copy_file_with_retry(tokenizer_src, tokenizer_dest)
+        logger.info(f"{GREEN}Copied tokenizer.json to {config.DEST_PATH}{RESET}")
+
+
 def map_file_transfer(
     task_category: TaskCategory, record: Dict[str, Any], options: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -357,25 +370,25 @@ def map_file_transfer(
         return result
     elif task_category == TaskCategory.TEXT_CLASSIFICATION:
         result = text_transfer(record, options)
+        # Optional: ship a custom tokenizer.json so the client uses it instead
+        # of the HF default; absent is fine (handled by the optional validator).
+        _copy_tokenizer_if_present()
+        return result
+    elif task_category == TaskCategory.TOKEN_CLASSIFICATION:
+        # Same on-disk layout as text classification: one .txt per sample in
+        # the ``texts`` subdir. BIO tags travel in the labels CSV, not on disk.
+        result = text_transfer(record, options)
+        # Optional custom tokenizer.json (same as text classification).
+        _copy_tokenizer_if_present()
         return result
     elif task_category == TaskCategory.MASKED_LANGUAGE_MODELING:
         result = text_transfer(record, options, src_subdir="sequences")
-        # Copy tokenizer.json once (if provided by the user).
-        # The client's MLM strategy looks for tokenizer.json at
-        # DEST_PATH/tokenizer.json to use the user's custom tokenizer
-        # instead of falling back to bert-base-uncased.  Without this
-        # copy the tokenizer vocab_size may mismatch the model's
-        # nn.Embedding, causing CUDA device-side assert at training.
-        tokenizer_src = os.path.join(config.SRC_PATH, "tokenizer.json")
-        tokenizer_dest = os.path.join(config.DEST_PATH, "tokenizer.json")
-        if (
-            os.path.isfile(tokenizer_src)
-            and not os.path.exists(tokenizer_dest)
-        ):
-            _copy_file_with_retry(tokenizer_src, tokenizer_dest)
-            logger.info(
-                f"{GREEN}Copied tokenizer.json to {config.DEST_PATH}{RESET}"
-            )
+        # Copy the user's tokenizer.json so the MLM client uses it instead of
+        # falling back to bert-base-uncased (a vocab_size mismatch with the
+        # model's nn.Embedding would cause a CUDA device-side assert at
+        # training). For MLM the tokenizer is mandatory — its presence and
+        # [MASK]/[PAD] tokens are enforced by TokenizerValidator at validation.
+        _copy_tokenizer_if_present()
         return result
     elif task_category == TaskCategory.SEMANTIC_SEGMENTATION:
         # Atomic: only copy image+mask together. Pre-verify both sources

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -478,6 +478,146 @@ class BaseIngestor(ABC):
                 f"'CSV UTF-8 (Comma delimited)'), then re-ingest.{RESET}"
             ) from exc
 
+    # Stale-lock cutoff (seconds). A crashed ingest leaves the lock file
+    # behind; if the lock is older than this we log + remove + reacquire
+    # so a customer isn't blocked indefinitely waiting for the writer
+    # whose pod has long since been garbage-collected. 12h covers any
+    # reasonable ingest (including multi-GB proteomics).
+    _TABLE_LOCK_STALE_SECONDS = 12 * 3600
+
+    def _table_lock_path(self) -> Optional[str]:
+        """Where the lock file lives — at the top of STORAGE_PATH (the
+        parent of every per-table DEST_PATH), so it's durable across pod
+        restarts on the cluster PVC. Returns None when STORAGE_PATH is
+        unset or not a directory (test configs / local runs without a
+        staging dir) — caller treats that as "no lock available, skip".
+        """
+        # Late import: keep this module free of a Config singleton at
+        # import time so unit tests can monkeypatch the env per test.
+        from ..config import Config
+        storage = Config().STORAGE_PATH
+        if not storage or not os.path.isdir(storage):
+            return None
+        return os.path.join(storage, f".tracebloc-ingest-{self.table_name}.lock")
+
+    def _acquire_table_lock(self) -> Optional[str]:
+        """Acquire an exclusive lock for ``self.table_name`` (#772 P2).
+
+        Two ingests targeting the same table used to race
+        ``create_table`` / interleave upserts. Atomic ``O_EXCL`` create
+        either succeeds (lock acquired) or fails with ``FileExistsError``
+        (another ingest is in flight). On conflict, read the existing
+        lock's metadata and surface it in the error so ops can find the
+        other run; if the lock is older than the stale-cutoff, remove
+        and reacquire.
+
+        Returns the lock path (or None if no STORAGE_PATH is configured)
+        so ``_release_table_lock`` can remove the right file.
+        """
+        import json as _json
+        import socket as _socket
+        from datetime import datetime as _datetime
+
+        lock_path = self._table_lock_path()
+        if lock_path is None:
+            return None
+
+        lock_info = {
+            "ingestor_id": self.ingestor_id,
+            "table_name": self.table_name,
+            "pid": os.getpid(),
+            "hostname": _socket.gethostname(),
+            "started_at": _datetime.utcnow().isoformat() + "Z",
+        }
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            # Read the existing lock so the error names the holder. Also
+            # check staleness and self-recover if so.
+            existing_info: Dict[str, Any] = {}
+            try:
+                with open(lock_path, "r") as f:
+                    existing_info = _json.load(f)
+            except Exception:
+                pass
+            age = None
+            try:
+                started = _datetime.fromisoformat(
+                    existing_info.get("started_at", "").rstrip("Z")
+                )
+                age = (_datetime.utcnow() - started).total_seconds()
+            except Exception:
+                # Lock metadata is corrupt (truncated file, malformed
+                # JSON, missing/un-parseable started_at). Fall back to
+                # the file's mtime as the age signal (#221 bugbot: a
+                # corrupt lock used to never auto-expire because age
+                # stayed None). Use time.time() rather than
+                # _datetime.utcnow().timestamp() — the latter is
+                # timezone-broken (naive datetime treated as local) so
+                # the cutoff would shift by the local UTC offset on
+                # non-UTC systems.
+                import time as _time
+                try:
+                    mtime = os.path.getmtime(lock_path)
+                    age = _time.time() - mtime
+                except OSError:
+                    pass
+            if age is not None and age > self._TABLE_LOCK_STALE_SECONDS:
+                logger.warning(
+                    f"{YELLOW}Stale lock at {lock_path} (age={age:.0f}s, "
+                    f"holder={existing_info!r}) — removing and reacquiring. "
+                    f"The holder's pod likely crashed before its finally "
+                    f"could run.{RESET}"
+                )
+                try:
+                    os.remove(lock_path)
+                except FileNotFoundError:
+                    pass
+                return self._acquire_table_lock()
+            raise RuntimeError(
+                f"{RED}Another ingest is already running for table "
+                f"'{self.table_name}' (lock at {lock_path}). "
+                f"Holder: {existing_info!r}. Wait for it to finish, or — "
+                f"if its pod crashed — remove the lock file manually. "
+                f"(The lock auto-clears after "
+                f"{self._TABLE_LOCK_STALE_SECONDS}s.){RESET}"
+            )
+        try:
+            with os.fdopen(fd, "w") as f:
+                _json.dump(lock_info, f)
+        except Exception:
+            # Couldn't write the metadata — drop the lock so we don't
+            # block ourselves on a malformed file.
+            try:
+                os.remove(lock_path)
+            except FileNotFoundError:
+                pass
+            raise
+        logger.info(
+            f"Acquired table lock for '{self.table_name}' at {lock_path}"
+        )
+        return lock_path
+
+    def _release_table_lock(self, lock_path: Optional[str]) -> None:
+        """Remove the lock file. No-op when ``_acquire_table_lock``
+        returned None (no STORAGE_PATH configured). Idempotent — a
+        double-release (e.g. exception path + finally path both call
+        it) silently swallows ``FileNotFoundError``.
+        """
+        if not lock_path:
+            return
+        try:
+            os.remove(lock_path)
+            logger.info(f"Released table lock for '{self.table_name}'")
+        except FileNotFoundError:
+            pass
+        except Exception as exc:
+            logger.warning(
+                f"Failed to remove table lock {lock_path}: {exc}. "
+                f"It will auto-clear after "
+                f"{self._TABLE_LOCK_STALE_SECONDS}s."
+            )
+
     def validate_data(self, source: Any) -> bool:
         """Validate data before ingestion using configured validators.
 
@@ -575,6 +715,29 @@ class BaseIngestor(ABC):
         Returns:
             List of failed records
         """
+        # Concurrent-ingest guard (backend/#772 P2). Two ingests targeting
+        # the same `table_name` used to race ``create_table`` and
+        # interleave upserts; the second submission would see a
+        # partially-populated table and fail mid-run, with the original
+        # ingestor unaware. Acquire an exclusive file-lock keyed by the
+        # table name; on conflict, fail fast naming the holder. The lock
+        # is released in the finally below — that wraps the ENTIRE
+        # post-acquire body so every exit path (#221 bugbot) releases,
+        # including ones the inner ``except Exception`` doesn't catch
+        # (Session() construction failure, _count_records exceptions,
+        # KeyboardInterrupt, etc.).
+        _lock_path = self._acquire_table_lock()
+        try:
+            return self._ingest_with_lock(source, batch_size)
+        finally:
+            self._release_table_lock(_lock_path)
+
+    def _ingest_with_lock(
+        self, source: Any, batch_size: int = 50
+    ) -> List[Dict[str, Any]]:
+        """Inner ingest body invoked once the table lock is held. Split
+        out from ``ingest`` so the lock-release lives in a finally that
+        covers every exit path (#221 bugbot — HIGH)."""
         # Validate data before ingestion
         logger.info(f"{CYAN}Starting data validation before ingestion...{RESET}")
         try:

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -353,6 +353,24 @@ class BaseIngestor(ABC):
             cleaned_record["ingestor_id"] = self.ingestor_id
             cleaned_record["filename"] = record.get("filename")
             cleaned_record["extension"] = record.get("extension")
+            # Preserve mask_id for semantic_segmentation ONLY. The
+            # cleaned_record comprehension above filters by ``k in
+            # self.schema``, but for the documented 8-line schema-less
+            # example yaml that filter drops every CSV column including
+            # mask_id — which file_transfer.py:401 needs to locate the
+            # per-row mask file. Without this, every record was skipped at
+            # file-transfer with "No mask_id found in record" despite
+            # #207's FilePairingValidator pass.
+            #
+            # Scoped to SEMANTIC_SEGMENTATION because mask_id is a runtime
+            # indirection only — there's no `mask_id` column on the
+            # standard tracebloc table (see database.py:standard_columns),
+            # so putting it on every category's cleaned_record would break
+            # SQL inserts on tables that don't have it (#212 bugbot).
+            # _process_batch additionally pops it before insert so even
+            # the semseg path doesn't try to bind it as a column.
+            if self.category == TaskCategory.SEMANTIC_SEGMENTATION:
+                cleaned_record["mask_id"] = record.get("mask_id")
             return cleaned_record
 
         except Exception as e:
@@ -688,6 +706,18 @@ class BaseIngestor(ABC):
             Exception: If batch processing fails
         """
         try:
+            # Strip framework-internal runtime indirections that don't
+            # correspond to a DB column before binding. ``mask_id`` is
+            # carried on semantic_segmentation records purely so
+            # ``file_transfer.map_file_transfer`` can locate the per-row
+            # mask file; the standard tracebloc table has no ``mask_id``
+            # column (see database.py:standard_columns), so leaving it on
+            # the record would cause SQLAlchemy to treat it as an
+            # unconsumed column on insert (#212 bugbot). By the time we
+            # reach this point, file_transfer has already used the value
+            # — it's safe to drop.
+            for r in batch:
+                r.pop("mask_id", None)
             # Insert batch and get IDs
             ids, db_failures = self.database.insert_batch(self.table_name, batch)
             api_success = False

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, Generator, List, Optional, NamedTuple
 from sqlalchemy.orm import Session
 from sqlalchemy.engine import Engine
 import logging
+import os
 import pandas as pd
 from tqdm import tqdm
 import uuid
@@ -43,6 +44,25 @@ _TABULAR_FAMILY_CATEGORIES = frozenset({
     TaskCategory.TIME_SERIES_FORECASTING,
     TaskCategory.TIME_TO_EVENT_PREDICTION,
 })
+
+# File-bearing categories resolve every per-row sidecar against
+# ``config.SRC_PATH``. If that path is empty/unset/missing, every file
+# lookup silently falls through to a relative path (``"" + "images/x.jpg"``
+# -> ``"images/x.jpg"``), file_transfer skips every record, and the user
+# sees N copies of "Source image not found: images/x.jpg" — blaming the
+# data when the real cause is "SRC_PATH was never staged on the PVC".
+# Tabular / time-series have no sidecar dirs under SRC_PATH, so they're
+# excluded from the guard (the CSV path itself is checked elsewhere).
+_SRC_PATH_REQUIRED_CATEGORIES = frozenset({
+    TaskCategory.IMAGE_CLASSIFICATION,
+    TaskCategory.OBJECT_DETECTION,
+    TaskCategory.KEYPOINT_DETECTION,
+    TaskCategory.SEMANTIC_SEGMENTATION,
+    TaskCategory.INSTANCE_SEGMENTATION,
+    TaskCategory.TEXT_CLASSIFICATION,
+    TaskCategory.MASKED_LANGUAGE_MODELING,
+})
+
 
 # Self-supervised categories have no `label` column — the CSV manifest just
 # points at sidecar files and the model creates its own targets at training
@@ -391,6 +411,50 @@ class BaseIngestor(ABC):
             return None
 
     @staticmethod
+    def _check_src_path() -> None:
+        """Fail fast with a clear message when ``config.SRC_PATH`` isn't set
+        or doesn't exist (#772 P2).
+
+        Every file-bearing category resolves its per-row sidecars against
+        ``config.SRC_PATH`` (file_transfer.py:105 etc.). If the env var
+        / ConfigMap key is empty, ``os.path.join("", "images", "x.jpg")``
+        returns the relative path ``"images/x.jpg"`` — every file lookup
+        fails and the user sees N copies of
+        ``Source image not found: images/x.jpg`` blaming the data, when
+        the real cause is "SRC_PATH was never set / the PVC wasn't
+        staged before the Job ran". One clear error at preflight beats
+        one cryptic error per row.
+        """
+        # Late import: keep this module free of a Config singleton at
+        # import time so unit tests can monkeypatch the env per test.
+        from ..config import Config
+        src = Config().SRC_PATH
+        if not src or not str(src).strip():
+            raise RuntimeError(
+                f"{RED}SRC_PATH is empty. Set it to the cluster-PVC path where "
+                f"your data is staged (e.g. /data/shared/<dataset>/). The "
+                f"chart's data-staging recipe (kubectl cp or init-container "
+                f"sync) must run before the ingest Job — see "
+                f"tracebloc/client/ingestor/README.md.{RESET}"
+            )
+        if not os.path.isabs(src):
+            raise RuntimeError(
+                f"{RED}SRC_PATH={src!r} is not an absolute path. The ingestor "
+                f"resolves every sidecar file against it via os.path.join, "
+                f"and a relative SRC_PATH silently falls through to the "
+                f"working directory — every file lookup then fails with a "
+                f"misleading 'Source image not found'. Use an absolute path "
+                f"(e.g. /data/shared/<dataset>/).{RESET}"
+            )
+        if not os.path.isdir(src):
+            raise RuntimeError(
+                f"{RED}SRC_PATH={src!r} does not exist or is not a directory. "
+                f"Did the data-staging step (kubectl cp / init-container sync) "
+                f"run before the ingest Job? Verify with "
+                f"`kubectl exec <pod> -- ls {src}`.{RESET}"
+            )
+
+    @staticmethod
     def _check_csv_encoding(source: Any) -> None:
         """Fail fast with a clear message if a CSV source is not valid UTF-8.
 
@@ -426,6 +490,14 @@ class BaseIngestor(ABC):
         Raises:
             ValueError: If validation fails
         """
+        # Pre-flight: SRC_PATH must be a real absolute directory or every
+        # file_transfer falls through and surfaces as N copies of
+        # "Source image not found: images/x.jpg" — blames the data when
+        # the real cause is "SRC_PATH was never staged / set" (#772 P2).
+        # File-bearing categories only (tabular has nothing under SRC_PATH).
+        if self.category in _SRC_PATH_REQUIRED_CATEGORIES:
+            self._check_src_path()
+
         # Pre-flight: a non-UTF-8 CSV otherwise surfaces as a misleading
         # "No data found" (validators read UTF-8 and swallow decode errors).
         # Catch it once here with a clear, actionable message.

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -833,19 +833,9 @@ class BaseIngestor(ABC):
 
                             if len(batch) >= batch_size:
                                 try:
-                                    inserted_ids, api_success, db_failures = (
-                                        self._process_batch(batch, session)
+                                    self._flush_batch(
+                                        batch, session, stats, failed_records
                                     )
-                                    # Only count records that were successfully inserted
-                                    if inserted_ids:
-                                        stats["inserted_records"] += len(inserted_ids)
-                                    if api_success:
-                                        stats["api_sent_records"] += len(inserted_ids)
-                                    if db_failures:
-                                        stats["failed_records"] += len(db_failures)
-                                        failed_records.extend(db_failures)
-                                except Exception as e:
-                                    logger.error(f"Batch processing failed: {str(e)}")
                                 finally:
                                     pbar.update(len(batch))
                                     batch = []
@@ -861,20 +851,9 @@ class BaseIngestor(ABC):
                 # Process remaining records
                 if batch:
                     try:
-                        inserted_ids, api_success, db_failures = self._process_batch(
-                            batch, session
-                        )
-                        # Only count records that were successfully inserted
-                        if inserted_ids:
-                            stats["inserted_records"] += len(inserted_ids)
-                        if api_success:
-                            stats["api_sent_records"] += len(inserted_ids)
-                        if db_failures:
-                            stats["failed_records"] += len(db_failures)
-                            failed_records.extend(db_failures)
+                        self._flush_batch(batch, session, stats, failed_records)
+                    finally:
                         pbar.update(len(batch))
-                    except Exception as e:
-                        logger.error(f"Final batch processing failed: {str(e)}")
 
                 session.commit()
                 pbar.close()
@@ -956,6 +935,74 @@ class BaseIngestor(ABC):
         """Cleanup when used as context manager"""
         pass
 
+    def _flush_batch(
+        self,
+        batch: List[Dict[str, Any]],
+        session: Session,
+        stats: Dict[str, int],
+        failed_records: List[Dict[str, Any]],
+    ) -> None:
+        """Process one batch and fold its outcome into ``stats`` /
+        ``failed_records``. Shared by the in-loop and final-batch flush
+        sites in ``_ingest_with_lock``.
+
+        Failure accounting is the point of this helper. A run where every
+        batch POST was rejected with HTTP 400 used to finish with
+        "All records processed successfully" and exit 0 — the rows were
+        in MySQL but the backend had zero records, and the next platform
+        call failed with "No data found for table name". Two swallow
+        points caused that:
+
+        - ``api_success=False`` only skipped the ``api_sent_records``
+          increment; the records never reached ``failed_records``, so
+          ``ingest()`` returned ``[]`` and the caller exited 0. Now each
+          inserted-but-unsent record is returned as a failed record with
+          ``error="api_send_failed"`` (the rows stay committed — they're
+          in MySQL but invisible to the platform until re-sent).
+        - an exception from ``_process_batch`` was logged and dropped,
+          leaving the whole batch out of every counter. Now the batch is
+          counted and returned as failed.
+
+        The summary needs no extra field: "Failed to Send to API" is
+        derived from ``inserted_records - api_sent_records``, and
+        ``IngestionSummary.has_failures`` already trips on that gap.
+        """
+        try:
+            inserted_ids, api_success, db_failures = self._process_batch(
+                batch, session
+            )
+            # Only count records that were successfully inserted
+            if inserted_ids:
+                stats["inserted_records"] += len(inserted_ids)
+                if api_success:
+                    stats["api_sent_records"] += len(inserted_ids)
+                else:
+                    # The inserted-but-unsent records are the batch minus
+                    # the DB failures. Don't assume they're the first
+                    # len(ids) entries: insert_batch's per-record fallback
+                    # appends successes in scan order, so a mid-batch DB
+                    # failure shifts which records were inserted. Failure
+                    # entries carry a *copy* of the record (processed_record
+                    # adds updated_at), so match by data_id — set on every
+                    # processed record by _map_unique_id — not by identity.
+                    db_failed_data_ids = {
+                        f.get("record", {}).get("data_id") for f in db_failures
+                    }
+                    failed_records.extend(
+                        {"record": record, "error": "api_send_failed"}
+                        for record in batch
+                        if record.get("data_id") not in db_failed_data_ids
+                    )
+            if db_failures:
+                stats["failed_records"] += len(db_failures)
+                failed_records.extend(db_failures)
+        except Exception as e:
+            logger.error(f"Batch processing failed: {str(e)}")
+            stats["failed_records"] += len(batch)
+            failed_records.extend(
+                {"record": record, "error": str(e)} for record in batch
+            )
+
     def _process_batch(
         self, batch: List[Dict[str, Any]], session: Session
     ) -> List[int]:
@@ -1003,8 +1050,14 @@ class BaseIngestor(ABC):
 
         except Exception as e:
             logger.error(f"{RED}Error processing batch: {str(e)}{RESET}")
-            if hasattr(e.response, "text"):
-                logger.error(f"{RED}Error response: {e.response.text}{RESET}")
+            # Guard the attribute chain: a non-HTTP exception (e.g. a DB
+            # error) has no .response at all, and the old
+            # hasattr(e.response, "text") raised AttributeError INSIDE the
+            # handler — replacing the real error with "'RuntimeError'
+            # object has no attribute 'response'".
+            response = getattr(e, "response", None)
+            if response is not None and hasattr(response, "text"):
+                logger.error(f"{RED}Error response: {response.text}{RESET}")
             raise
 
     def _log_summary(self, summary: IngestionSummary):

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -60,6 +60,7 @@ _SRC_PATH_REQUIRED_CATEGORIES = frozenset({
     TaskCategory.SEMANTIC_SEGMENTATION,
     TaskCategory.INSTANCE_SEGMENTATION,
     TaskCategory.TEXT_CLASSIFICATION,
+    TaskCategory.TOKEN_CLASSIFICATION,
     TaskCategory.MASKED_LANGUAGE_MODELING,
 })
 
@@ -643,7 +644,12 @@ class BaseIngestor(ABC):
         # Catch it once here with a clear, actionable message.
         self._check_csv_encoding(source)
 
-        validators = map_validators(self.category, self.file_options)
+        # Pass the configured label_column through (without permanently
+        # mutating file_options / metadata) so label-aware validators like
+        # BIOLabelValidator check the right column when a custom name is used.
+        validators = map_validators(
+            self.category, {**self.file_options, "label_column": self.label_column}
+        )
         logger.info(f"Running {len(validators)} validator(s) on data source")
         all_valid = True
         validation_errors = []
@@ -783,6 +789,7 @@ class BaseIngestor(ABC):
                                 TaskCategory.IMAGE_CLASSIFICATION,
                                 TaskCategory.OBJECT_DETECTION,
                                 TaskCategory.TEXT_CLASSIFICATION,
+                                TaskCategory.TOKEN_CLASSIFICATION,
                                 TaskCategory.SEMANTIC_SEGMENTATION,
                                 TaskCategory.KEYPOINT_DETECTION,
                                 TaskCategory.MASKED_LANGUAGE_MODELING,

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -44,6 +44,19 @@ _TABULAR_FAMILY_CATEGORIES = frozenset({
     TaskCategory.TIME_TO_EVENT_PREDICTION,
 })
 
+# Self-supervised categories have no `label` column — the CSV manifest just
+# points at sidecar files and the model creates its own targets at training
+# time (e.g. masked_language_modeling masks tokens on-the-fly). The backend
+# correspondingly stores no edge-label metadata for these datasets, so the
+# `send_generate_edge_label_meta` call is a no-op at best and a misleading
+# HTTP 400 ("No data found for table X") at worst — see issue #213.
+# The schema (schema/ingest.v1.json) now rejects `label:` on these categories
+# at submission time; this set + the gate below are the defensive in-ingestor
+# half (script-driven runs that bypass the schema still skip the wasted call).
+_SELF_SUPERVISED_CATEGORIES = frozenset({
+    TaskCategory.MASKED_LANGUAGE_MODELING,
+})
+
 
 class IngestionSummary(NamedTuple):
     """Data class to hold ingestion summary statistics.
@@ -636,14 +649,26 @@ class BaseIngestor(ABC):
                 # the failure surfaces (the CLI streams these logs live and marks
                 # the Job failed). The api_client has already logged the
                 # underlying HTTP detail before returning False.
-                if not self.api_client.send_generate_edge_label_meta(
-                    self.table_name, self.ingestor_id, self.intent
-                ):
-                    raise RuntimeError(
-                        "Backend rejected edge-label metadata; the dataset was "
-                        "NOT registered (its rows are already in the database). "
-                        "See the logged API error above."
-                    )
+                # Skip the edge-label backend call for self-supervised
+                # categories (#213). They have no `label` column on the rows;
+                # the backend's edge-label endpoint then returns a misleading
+                # HTTP 400 ("No data found for table X" — wrong, the table HAS
+                # rows, it just has no edge labels). Combined with PR #187's
+                # fail-loud behaviour, the user saw a registration crash that
+                # had nothing to do with the actual misconfiguration. The
+                # schema now rejects `label:` on these categories at
+                # submission, but this gate is the defensive in-ingestor half
+                # so script-driven / older-schema runs don't trip the same
+                # trap.
+                if self.category not in _SELF_SUPERVISED_CATEGORIES:
+                    if not self.api_client.send_generate_edge_label_meta(
+                        self.table_name, self.ingestor_id, self.intent
+                    ):
+                        raise RuntimeError(
+                            "Backend rejected edge-label metadata; the dataset was "
+                            "NOT registered (its rows are already in the database). "
+                            "See the logged API error above."
+                        )
 
                 schema_dict = self.database.get_table_schema(self.table_name)
                 if not self.api_client.send_global_meta_meta(

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -6,6 +6,7 @@ pandas-based reading and validation capabilities.
 
 from typing import Dict, Any, Generator, Optional, List
 import csv as _csv
+import numpy as np
 import pandas as pd
 import logging
 from pathlib import Path
@@ -18,6 +19,39 @@ from ..utils import label_policy as label_policy_module
 from ..config import Config
 
 config = Config()
+
+
+def _raise_on_overflow(
+    column: str, original: pd.Series, converted: pd.Series, dtype: str
+) -> None:
+    """Reject overflow ±inf in a numeric column at cast time.
+
+    ``pd.to_numeric("1e400")`` returns ``+inf`` silently (IEEE float
+    overflow). Without this guard the overflowed value lands in MySQL as
+    a legitimately-looking number. ``DataValidator`` already runs an inf
+    guard at the gate via ``_non_finite_error``; this is defense-in-depth
+    on the cast path so a bad token that slips through validation can't
+    corrupt the row silently.
+
+    Distinguishes overflow from legitimate missing: a genuinely empty
+    cell was ``NaN``/``NA`` in ``original`` *before* coercion, so we
+    only flag values that are non-finite in ``converted`` AND were
+    present (non-NA) in ``original``.
+    """
+    # Use np.isinf rather than ~np.isfinite to keep NaN tolerance:
+    # legitimate missing cells were NaN in `original` and stay NaN in
+    # `converted`; pd.to_numeric never produces NaN from an inf path.
+    overflowed = np.isinf(converted) | (np.isnan(converted) & original.notna())
+    if overflowed.any():
+        offenders = original[overflowed].head(5).tolist()
+        raise ValueError(
+            f"Column '{column}' (dtype {dtype}) contains "
+            f"{int(overflowed.sum())} value(s) that overflow IEEE float "
+            f"(±inf / NaN). Sample: {offenders}. ``pd.to_numeric`` "
+            f"silently converted overflow (e.g. ``1e400``) into ±inf; "
+            f"this guard surfaces it at cast time instead of letting it "
+            f"reach MySQL."
+        )
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
@@ -140,7 +174,9 @@ class CSVIngestor(BaseIngestor):
                     # Int64 keeps integers integral and stores missing as pd.NA
                     # (-> SQL NULL); default errors="raise" still surfaces a
                     # genuinely non-numeric value as a clear per-column error.
-                    df[column] = pd.to_numeric(df[column]).astype("Int64")
+                    converted = pd.to_numeric(df[column])
+                    _raise_on_overflow(column, df[column], converted, dtype)
+                    df[column] = converted.astype("Int64")
                 elif any(t in dtype.upper() for t in ("FLOAT", "DOUBLE", "DECIMAL", "NUMERIC")):
                     # float64 — NOT downcast='float' (float32), which corrupted
                     # precision: 3.14 -> '3.140000104904175'. Also covers DOUBLE/
@@ -149,7 +185,9 @@ class CSVIngestor(BaseIngestor):
                     # (the default) now rejects junk with a clear per-column
                     # error. MySQL still applies the column's own precision/scale
                     # on write.
-                    df[column] = pd.to_numeric(df[column])
+                    converted = pd.to_numeric(df[column])
+                    _raise_on_overflow(column, df[column], converted, dtype)
+                    df[column] = converted
                 elif "BOOL" in dtype.upper():
                     # Map the textual/numeric boolean forms DataValidator accepts
                     # (true/false, yes/no, t/f, y/n, 1/0) to a nullable boolean

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -65,6 +65,48 @@ __all__ = ["Ingestor"]
 # explicitly via csv_options; the YAML path can't express it because
 # schema/ingest.v1.json restricts spec.csv_options to a small whitelist.
 _TABULAR_NA_VALUES = ["", "NA", "NULL", "None"]
+
+
+def _cast_datetime_strict(series: pd.Series, column: str, dtype: str) -> pd.Series:
+    """Cast a CSV column to datetime with the SAME error policy as numeric
+    columns: an un-parseable token raises (instead of silently coercing
+    to NaT).
+
+    Backend #765 item 3: date cast was ``errors="coerce"`` (silent NULL)
+    while numeric cast was ``errors="raise"`` — opposite policies for
+    the same bad-input class, adjacent lines. Pick one: both ``raise``,
+    because ``DataValidator`` is the gate (catches bad dates with a
+    clear per-column error at preflight), and the cast layer trusts
+    what passed it. A token that reaches the cast and fails to parse
+    means either a validator gap or a schema-mismatch — both surface
+    here as a clear ``ValueError`` instead of becoming a silent NULL.
+
+    Genuine missing cells (already ``NaN`` / ``NA`` in the input) stay
+    that way: ``pd.to_datetime`` with ``errors="raise"`` treats pre-
+    existing NaN as missing (returns ``NaT``), it only raises on a
+    *present* value that fails to parse.
+    """
+    try:
+        return pd.to_datetime(series, errors="raise", format="mixed")
+    except Exception as exc:
+        # Surface the offender per the project convention: name the
+        # column, dtype, and a sample of the bad tokens.
+        offenders = (
+            series[
+                pd.to_datetime(series, errors="coerce", format="mixed").isna()
+                & series.notna()
+            ]
+            .astype(str)
+            .head(5)
+            .tolist()
+        )
+        raise ValueError(
+            f"Column '{column}' (dtype {dtype}) has un-parseable date "
+            f"value(s). Sample: {offenders}. The cast layer raises on "
+            f"un-parseable dates (matching the numeric branch); fix the "
+            f"value(s) or declare the column as VARCHAR if the content "
+            f"isn't actually a date. (Underlying parser error: {exc})"
+        ) from exc
 _TABULAR_FAMILY_CATEGORIES = frozenset({
     TaskCategory.TABULAR_CLASSIFICATION,
     TaskCategory.TABULAR_REGRESSION,
@@ -207,16 +249,16 @@ class CSVIngestor(BaseIngestor):
                     # Full date+time. Checked before DATE/TIME because the
                     # substrings "DATE" and "TIME" both appear in "DATETIME"
                     # (and "TIME" in "TIMESTAMP").
-                    df[column] = pd.to_datetime(df[column], errors="coerce", format="mixed")
+                    df[column] = _cast_datetime_strict(df[column], column, dtype)
                 elif "DATE" in dtype.upper():
                     # DATE only — emit a plain date so the value doesn't gain a
                     # spurious time ('2026-01-02' was becoming '2026-01-02 00:00:00').
-                    df[column] = pd.to_datetime(df[column], errors="coerce", format="mixed").dt.date
+                    df[column] = _cast_datetime_strict(df[column], column, dtype).dt.date
                 elif "TIME" in dtype.upper():
                     # TIME only — emit a plain time so the value doesn't gain a
                     # spurious (today's) date ('14:30:00' was becoming
                     # '2026-06-08 14:30:00', which MySQL TIME then truncates).
-                    df[column] = pd.to_datetime(df[column], errors="coerce", format="mixed").dt.time
+                    df[column] = _cast_datetime_strict(df[column], column, dtype).dt.time
                 elif any(t in dtype.upper() for t in ("STRING", "TEXT", "VARCHAR", "CHAR")):
                     # Coerce to pandas StringDtype so missing cells become pd.NA
                     # (not float NaN), then map pd.NA -> Python None so the DB

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -12,7 +12,48 @@ import math
 import re
 from pathlib import Path
 
+import ijson
 import pandas as pd
+
+
+def _peek_json_shape(path: Path) -> Optional[str]:
+    """Detect whether a JSON file is a single object or an array of
+    objects by peeking at the first non-whitespace character.
+
+    Returns ``"array"`` for ``[...]``, ``"object"`` for ``{...}``, or
+    None if the file is empty / starts with anything else (the caller
+    will raise the right error). The peek reads at most a few hundred
+    bytes — bounded by the leading whitespace.
+
+    OSError is intentionally NOT caught here (#222 bugbot): a permission-
+    denied / unreadable file used to be swallowed into None, then
+    ``read_data`` raised a misleading ``ValueError("object or array")``
+    instead of the underlying I/O error. Let the caller see the real
+    cause — ``read_data`` already had a ``FileNotFoundError`` guard
+    before this function runs, and any other OSError is a real problem
+    the user needs to know about.
+    """
+    with open(path, "rb") as f:
+        # Read in small chunks until we see a non-whitespace byte.
+        buf = b""
+        while True:
+            chunk = f.read(1024)
+            if not chunk:
+                break
+            buf += chunk
+            stripped = buf.lstrip()
+            if stripped:
+                first = stripped[:1]
+                if first == b"[":
+                    return "array"
+                if first == b"{":
+                    return "object"
+                return None  # neither — let downstream raise
+            if len(buf) > 65536:
+                # Defensive: 64 KB of leading whitespace is pathological;
+                # bail rather than read the whole file.
+                return None
+    return None
 
 from .base import BaseIngestor
 from ..database import Database
@@ -267,11 +308,13 @@ class JSONIngestor(BaseIngestor):
                 )
 
     def read_data(self, file_path: str) -> Generator[Dict[str, Any], None, None]:
-        """Read and validate JSON file.
+        """Read and validate JSON file, streaming records one at a time.
 
-        This method reads the JSON file and handles both single-object and
-        array-of-objects formats. It performs validation according to the schema
-        and yields records one at a time.
+        Handles both single-object and array-of-objects formats. For the
+        array case the file is parsed *incrementally* via ``ijson`` so a
+        multi-GB JSON ingest doesn't OOM the pod — the old implementation
+        called ``json.load`` and materialised the whole array in memory
+        (backend/#772 P2, deferred half of the streaming item in #771).
 
         Args:
             file_path: Path to the JSON file
@@ -282,67 +325,94 @@ class JSONIngestor(BaseIngestor):
         Raises:
             FileNotFoundError: If the JSON file doesn't exist
             ValueError: If the JSON data is not in the expected format
-            json.JSONDecodeError: If there's an error parsing the JSON
+            ijson.JSONError: If there's an error parsing the JSON
         """
         file_path = Path(file_path)
         if not file_path.exists():
             raise FileNotFoundError(f"{RED}JSON file not found: {file_path}{RESET}")
 
         try:
-            with open(file_path, "r", encoding="utf-8") as f:
-                # Load JSON data
-                data = json.load(f)
+            shape = _peek_json_shape(file_path)
+            if shape == "object":
+                # Single-object form: one record. Not OOM-risky (a single
+                # record is by definition tractable). Parse non-incrementally.
+                with open(file_path, "r", encoding="utf-8") as f:
+                    record = json.load(f)
+                yield from self._iter_validated_records([record])
+                return
+            if shape != "array":
+                raise ValueError(
+                    "JSON data must be an object or array of objects"
+                )
+            # Array form: stream item-by-item. Memory cost is bounded
+            # by the largest *record* (not the full file). The file
+            # handle is opened in a `with` so a partial-consume / early
+            # exit / parse error closes it deterministically (#222
+            # bugbot — previously a bare ``open(...)`` was passed to
+            # ``ijson.items``, leaking the descriptor until GC).
+            with open(file_path, "rb") as f:
+                yield from self._iter_validated_records(ijson.items(f, "item"))
 
-                # Handle both array and object formats
-                if isinstance(data, dict):
-                    data = [data]
-                elif not isinstance(data, list):
-                    raise ValueError("JSON data must be an object or array of objects")
-
-                # Process each record
-                for record in data:
-                    if not isinstance(record, dict):
-                        logger.warning(
-                            f"{YELLOW}Skipping invalid record: {record}{RESET}"
-                        )
-                        continue
-
-                    try:
-                        self._validate_record(record)
-                        yield record  # Let base class handle the cleaning and unique ID mapping
-                    except ValueError as e:
-                        logger.warning(
-                            f"{YELLOW}Skipping invalid record: {str(e)}{RESET}"
-                        )
-                        continue
-
-        except json.JSONDecodeError as e:
+        except (json.JSONDecodeError, ijson.JSONError) as e:
             logger.error(f"{RED}Error parsing JSON file: {str(e)}{RESET}")
+            raise
+
+        except FileNotFoundError:
             raise
 
         except Exception as e:
             logger.error(f"{RED}Unexpected error reading JSON: {str(e)}{RESET}")
             raise
 
+    def _iter_validated_records(
+        self, records: Any
+    ) -> Generator[Dict[str, Any], None, None]:
+        """Shared per-record validation + yield loop used by both the
+        single-object and array-streaming paths in ``read_data``. Factored
+        out so the array path can ``yield from`` it inside the ``with
+        open(...)`` block — the file handle stays open exactly as long as
+        the generator is being consumed."""
+        for record in records:
+            if not isinstance(record, dict):
+                logger.warning(
+                    f"{YELLOW}Skipping invalid record: {record}{RESET}"
+                )
+                continue
+            try:
+                self._validate_record(record)
+                yield record  # Let base class handle the cleaning and unique ID mapping
+            except ValueError as e:
+                logger.warning(
+                    f"{YELLOW}Skipping invalid record: {str(e)}{RESET}"
+                )
+                continue
+
     def _count_records(self, file_path: str) -> Optional[int]:
-        """Count total records in JSON file efficiently.
+        """Count total records in JSON file without materialising it.
 
-        This method provides an optimized way to count records in a JSON file
-        by loading the file once and checking its structure.
-
-        Args:
-            file_path: Path to the JSON file
-
-        Returns:
-            Total number of records if countable, None otherwise
+        Single-object form -> 1. Array form -> count by streaming via
+        ``ijson`` so even a multi-GB array reports its size without an
+        OOM. Returns None on any read error (the caller treats it as
+        'unknown total', which only affects the progress bar).
         """
         try:
-            with open(file_path, "r") as f:
-                data = json.load(f)
-                if isinstance(data, dict):
-                    return 1
-                elif isinstance(data, list):
-                    return len(data)
+            shape = _peek_json_shape(Path(file_path))
+            if shape == "object":
+                # #222 bugbot: don't return 1 based on the peek alone — a
+                # truncated / invalid JSON object would advertise 1 record
+                # to the progress bar and then make ``read_data`` raise a
+                # decode error mid-ingest. Validate parseability via
+                # ``json.load`` (single-object form ingests one record by
+                # definition — same as ``read_data`` does for this shape,
+                # so the parse cost is paid either way). A bad object
+                # returns None so the progress bar shows "unknown" rather
+                # than a misleading "1 record" that fails mid-ingest.
+                with open(file_path, "r", encoding="utf-8") as f:
+                    json.load(f)
+                return 1
+            if shape == "array":
+                with open(file_path, "rb") as f:
+                    return sum(1 for _ in ijson.items(f, "item"))
             return None
         except Exception as e:
             logger.debug(f"{YELLOW}Unable to count JSON records: {str(e)}{RESET}")

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -8,7 +8,11 @@ conversion capabilities.
 from typing import Dict, Any, Generator, Optional, List
 import json
 import logging
+import math
+import re
 from pathlib import Path
+
+import pandas as pd
 
 from .base import BaseIngestor
 from ..database import Database
@@ -19,6 +23,121 @@ from ..utils import label_policy as label_policy_module
 logger = logging.getLogger(__name__)
 
 __all__ = ["JSONIngestor"]
+
+
+# Boolean string forms DataValidator._validate_boolean accepts. Keep this list
+# in lockstep with that validator so the JSON per-record check and the CSV
+# preflight agree.
+_VALID_BOOL_STRINGS = {
+    "true", "false", "yes", "no", "y", "n", "t", "f", "1", "0", "1.0", "0.0"
+}
+
+
+def _validate_value_against_dtype(value: Any, dtype_upper: str) -> None:
+    """Raise ValueError if ``value`` doesn't fit the declared MySQL dtype.
+
+    Mirrors ``DataValidator``'s per-type rules so JSON and CSV give the same
+    verdict on the same record (issue #189). Caller guarantees ``value`` is
+    not None / "" (handled separately as NULL).
+    """
+    # Order matters: DATETIME / TIMESTAMP must match before DATE / TIME because
+    # "DATE" and "TIME" are substrings of "DATETIME" / "TIMESTAMP".
+    if "DATETIME" in dtype_upper or "TIMESTAMP" in dtype_upper:
+        ts = pd.to_datetime(str(value), errors="coerce")
+        if pd.isna(ts):
+            raise ValueError(
+                f"value {value!r} is not a valid {dtype_upper} (expected an "
+                f"ISO 8601 date-time)"
+            )
+    elif "DATE" in dtype_upper or "TIME" in dtype_upper:
+        ts = pd.to_datetime(str(value), errors="coerce")
+        if pd.isna(ts):
+            raise ValueError(
+                f"value {value!r} is not a valid {dtype_upper}"
+            )
+    elif "BOOL" in dtype_upper:
+        # ``bool(value)`` is truthy for any non-empty value, so "maybe" / 2
+        # / "banana" all "passed" — match DataValidator._validate_boolean's
+        # vocabulary instead. That validator also accepts string forms that
+        # ``pd.to_numeric`` maps to 0 or 1 (e.g. "00", "01", "1.0", "0.0"),
+        # so we try numeric coercion as a fallback before failing — keeps
+        # JSON and CSV in lockstep on the same input (#204 bugbot).
+        if isinstance(value, bool):
+            return
+        if isinstance(value, (int, float)) and value in (0, 1):
+            return
+        if isinstance(value, str):
+            s = value.strip().lower()
+            if s in _VALID_BOOL_STRINGS:
+                return
+            # Numeric-coercible strings ("00", "01", "1.0", "0.0", "1e0", …)
+            # that resolve to 0 or 1 are accepted by DataValidator; mirror that.
+            num = pd.to_numeric(s, errors="coerce")
+            if not pd.isna(num) and num in (0, 1):
+                return
+        raise ValueError(
+            f"value {value!r} is not a valid BOOLEAN (expected true/false, "
+            f"yes/no, 1/0, or a recognised string form)"
+        )
+    elif "INT" in dtype_upper:
+        # ``int(value)`` silently truncated 3.5 -> 3; require integer-valued
+        # input. Python booleans are intentionally allowed: ``True``/``False``
+        # are subclasses of int and ``DataValidator._validate_int`` accepts a
+        # bool column via ``pd.to_numeric`` (True -> 1, False -> 0). Rejecting
+        # them here would let a record pass CSV-style preflight and then be
+        # dropped mid-ingest by this check — the silent-drop pathway #204
+        # bugbot flagged. So a bool falls through to the numeric path below
+        # (True.is_integer() is True via float coercion).
+        try:
+            f = float(value)
+        except (TypeError, ValueError):
+            raise ValueError(f"value {value!r} is not numeric")
+        # Reject non-finite (inf / -inf / NaN) before is_integer(). inf and
+        # NaN both return False from is_integer() in CPython today, so the
+        # check below already rejects them — but make the guard explicit so
+        # the contract doesn't depend on a CPython detail and so the error
+        # message names the real problem (mirrors DataValidator's
+        # ``_non_finite_error`` on the CSV path).
+        if not math.isfinite(f):
+            raise ValueError(
+                f"value {value!r} is non-finite (inf/NaN) and cannot be "
+                f"stored in an INT column"
+            )
+        if not f.is_integer():
+            raise ValueError(
+                f"value {value!r} is not an integer (would silently truncate)"
+            )
+    elif any(t in dtype_upper for t in ("FLOAT", "DOUBLE", "DECIMAL", "NUMERIC")):
+        try:
+            f = float(value)
+        except (TypeError, ValueError):
+            raise ValueError(f"value {value!r} is not numeric")
+        # Reject inf / -inf / NaN. ``float("Infinity")`` returns +inf
+        # without raising, so the bare float() above lets non-finite values
+        # through silently; DataValidator's FLOAT branch already rejects
+        # them on the CSV path (``_non_finite_error``). Match that here so
+        # JSON and CSV give the same verdict on the same record.
+        if not math.isfinite(f):
+            raise ValueError(
+                f"value {value!r} is non-finite (inf/NaN) and cannot be "
+                f"stored in a numeric column"
+            )
+    elif any(t in dtype_upper for t in ("VARCHAR", "CHAR", "TEXT")):
+        # MySQL binds any scalar as a string against a string column (see
+        # issue #188), so accept ints/floats/bools too. The only constraint
+        # is the declared length (when present) — and the only shape error
+        # is a non-scalar container.
+        if isinstance(value, (list, dict, set, tuple)):
+            raise ValueError(
+                f"value {value!r} is a non-scalar container; cannot be "
+                f"stored as a {dtype_upper.split('(')[0]}"
+            )
+        m = re.search(r"\((\d+)\)", dtype_upper)
+        if m and len(str(value)) > int(m.group(1)):
+            raise ValueError(
+                f"value {value!r} exceeds the declared length "
+                f"{m.group(1)} (got {len(str(value))} characters)"
+            )
 
 
 class JSONIngestor(BaseIngestor):
@@ -123,31 +242,28 @@ class JSONIngestor(BaseIngestor):
                 f"{RED}Specified unique_id_column '{self.unique_id_column}' not found in record{RESET}"
             )
 
-        # Basic data type validation - only for fields that exist in the record
+        # Per-record type validation. The previous implementation used
+        # ``int(value)`` / ``float(value)`` / ``bool(value)`` to "check"
+        # types — but Python's casts are far too permissive:
+        #   bool("maybe")  -> True   (any non-empty string is truthy)
+        #   bool(2)        -> True   (any non-zero int is truthy)
+        #   int(3.5)       -> 3      (silent truncation, no error)
+        # …so JSON ingestion silently accepted data the CSV path correctly
+        # rejected (issue #189). Match the vocabulary DataValidator already
+        # enforces at file load (the same one CSV uses), so the two formats
+        # give the same verdict on the same record. NULL / "" are still
+        # tolerated as missing (mirrors #170).
         common_fields = schema_fields & record_fields
         for field in common_fields:
             value = record[field]
-            dtype = self.schema[field]
-            # NULL tolerance. A JSON ``null`` (Python ``None``) and an empty
-            # string are both legitimate missing values for any type; calling
-            # ``int(None)`` / ``float(None)`` raises TypeError, which the
-            # validator would otherwise surface as "Data type validation
-            # failed" — an error the user can never clear (JSON null IS the
-            # representation of missing). Mirrors the same NULL-tolerance the
-            # CSV-side validators got in #167 / #168.
+            dtype_upper = self.schema[field].upper()
             if value is None or value == "":
                 continue
             try:
-                if "INT" in dtype.upper():
-                    int(value)
-                elif "FLOAT" in dtype.upper():
-                    float(value)
-                elif "BOOL" in dtype.upper():
-                    bool(value)
-                # Add more type validations as needed
-            except Exception as e:
+                _validate_value_against_dtype(value, dtype_upper)
+            except ValueError as e:
                 raise ValueError(
-                    f"{RED}Data type validation failed for field {field}: {str(e)}{RESET}"
+                    f"{RED}Data type validation failed for field {field}: {e}{RESET}"
                 )
 
     def read_data(self, file_path: str) -> Generator[Dict[str, Any], None, None]:

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -397,6 +397,20 @@
         "required": ["category"]
       },
       "then": { "required": ["label"] }
+    },
+    {
+      "description": "Self-supervised categories MUST NOT set `label`. The shipped CSV has no label column, and the framework registers no edge-label metadata for them. Setting `label` anyway used to ingest rows successfully, then crash at backend registration with a misleading HTTP 400 'No data found' (issue #213). Reject at submission instead.",
+      "if": {
+        "properties": {
+          "category": {
+            "enum": [
+              "masked_language_modeling"
+            ]
+          }
+        },
+        "required": ["category"]
+      },
+      "then": { "not": { "required": ["label"] } }
     }
   ]
 }

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -143,7 +143,7 @@
       "items": { "type": "integer", "minimum": 1 },
       "minItems": 2,
       "maxItems": 2,
-      "description": "[height, width] to resize images to. Required for keypoint_detection (no default — depends on the customer's pose model). Other image categories use category defaults if unset."
+      "description": "[width, height] to resize images to. Required for keypoint_detection (no default — depends on the customer's pose model). Other image categories use category defaults if unset. The order matches PIL.Image.size and what ImageResolutionValidator expects."
     },
 
     "number_of_keypoints": {
@@ -198,7 +198,7 @@
               "items": { "type": "integer", "minimum": 1 },
               "minItems": 2,
               "maxItems": 2,
-              "description": "[height, width]. Image categories only. Default [512, 512]."
+              "description": "[width, height]. Image categories only. Default [512, 512]. The order matches PIL.Image.size and what ImageResolutionValidator expects."
             },
             "extension": {
               "type": "string",

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -32,6 +32,7 @@
         "semantic_segmentation",
         "instance_segmentation",
         "text_classification",
+        "token_classification",
         "tabular_classification",
         "tabular_regression",
         "time_series_forecasting",
@@ -86,7 +87,7 @@
     "texts": {
       "type": "string",
       "minLength": 1,
-      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification."
+      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification and token_classification."
     },
 
     "sequences": {
@@ -322,6 +323,14 @@
       "then": { "required": ["texts"] }
     },
     {
+      "description": "token_classification requires `texts`.",
+      "if": {
+        "properties": { "category": { "const": "token_classification" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["texts"] }
+    },
+    {
       "description": "masked_language_modeling requires `sequences`.",
       "if": {
         "properties": { "category": { "const": "masked_language_modeling" } },
@@ -390,6 +399,7 @@
               "semantic_segmentation",
               "instance_segmentation",
               "text_classification",
+              "token_classification",
               "tabular_classification"
             ]
           }

--- a/tracebloc_ingestor/utils/constants.py
+++ b/tracebloc_ingestor/utils/constants.py
@@ -39,6 +39,7 @@ class TaskCategory:
     OBJECT_DETECTION = "object_detection"
     KEYPOINT_DETECTION = "keypoint_detection"
     TEXT_CLASSIFICATION = "text_classification"
+    TOKEN_CLASSIFICATION = "token_classification"
     TABULAR_CLASSIFICATION = "tabular_classification"
     TABULAR_REGRESSION = "tabular_regression"
     TIME_SERIES_FORECASTING = "time_series_forecasting"
@@ -60,6 +61,7 @@ class TaskCategory:
             cls.OBJECT_DETECTION,
             cls.KEYPOINT_DETECTION,
             cls.TEXT_CLASSIFICATION,
+            cls.TOKEN_CLASSIFICATION,
             cls.TABULAR_CLASSIFICATION,
             cls.TABULAR_REGRESSION,
             cls.TIME_SERIES_FORECASTING,

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -9,12 +9,21 @@ from tracebloc_ingestor.validators.xml_validator import PascalVOCXMLValidator
 from tracebloc_ingestor.validators.time_to_event_validator import TimeToEventValidator
 from tracebloc_ingestor.validators.time_format_validator import TimeFormatValidator
 from tracebloc_ingestor.validators.time_ordered_validator import TimeOrderedValidator
-from tracebloc_ingestor.validators.time_before_today_validator import TimeBeforeTodayValidator
-from tracebloc_ingestor.validators.numeric_columns_validator import NumericColumnsValidator
-from tracebloc_ingestor.validators.keypoint_annotation_validator import KeypointAnnotationValidator
-from tracebloc_ingestor.validators.keypoint_visibility_validator import KeypointVisibilityValidator
+from tracebloc_ingestor.validators.time_before_today_validator import (
+    TimeBeforeTodayValidator,
+)
+from tracebloc_ingestor.validators.numeric_columns_validator import (
+    NumericColumnsValidator,
+)
+from tracebloc_ingestor.validators.keypoint_annotation_validator import (
+    KeypointAnnotationValidator,
+)
+from tracebloc_ingestor.validators.keypoint_visibility_validator import (
+    KeypointVisibilityValidator,
+)
 from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
 from tracebloc_ingestor.validators.file_pairing_validator import FilePairingValidator
+from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
 from tracebloc_ingestor.utils.constants import TaskCategory, FileExtension
 
 
@@ -34,7 +43,9 @@ def map_validators(
             FileTypeValidator(allowed_extension=".xml", path="annotations"),
             PascalVOCXMLValidator(),
             FilePairingValidator(
-                image_path="images", sidecar_path="annotations", sidecar_label="annotation"
+                image_path="images",
+                sidecar_path="annotations",
+                sidecar_label="annotation",
             ),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
             TableNameValidator(),
@@ -61,6 +72,44 @@ def map_validators(
             ),
         )
 
+        # Optional user-supplied tokenizer.json — warn (don't fail) if absent;
+        # if present, it must contain [PAD] (text classification pads batches).
+        validators.append(TokenizerValidator(required_tokens=("[PAD]",), optional=True))
+
+        # Add data validator if schema is provided
+        if options.get("schema"):
+            validators.append(DataValidator(schema=options["schema"]))
+
+        validators.append(TableNameValidator())
+        validators.append(DuplicateValidator())
+
+        return validators
+    elif task_category == TaskCategory.TOKEN_CLASSIFICATION:
+        validators = []
+
+        # Validate text file extensions (one .txt of whitespace-tokenized words
+        # per sample, same layout as text classification).
+        validators.append(
+            FileTypeValidator(
+                allowed_extension=options.get("extension", FileExtension.TXT),
+                path="texts",
+            ),
+        )
+
+        # Validate BIO labels: one tag per word, valid BIO/IOB2 format.
+        # Honor a custom label column name when one is configured in the YAML.
+        validators.append(
+            BIOLabelValidator(
+                texts_path="texts",
+                extension=options.get("extension", FileExtension.TXT),
+                label_column=options.get("label_column") or "label",
+            )
+        )
+
+        # Optional user-supplied tokenizer.json — warn (don't fail) if absent;
+        # if present, it must contain [PAD].
+        validators.append(TokenizerValidator(required_tokens=("[PAD]",), optional=True))
+
         # Add data validator if schema is provided
         if options.get("schema"):
             validators.append(DataValidator(schema=options["schema"]))
@@ -73,20 +122,19 @@ def map_validators(
         validators = []
 
         schema = options.get("schema", {})
-        
+
         validators.append(TimeFormatValidator(schema=schema))
         validators.append(TimeOrderedValidator())
         validators.append(TimeBeforeTodayValidator())
         validators.append(NumericColumnsValidator(schema=schema))
-        
+
         if options.get("schema"):
             schema_without_timestamp = {
-                k: v for k, v in options["schema"].items() 
-                if k.lower() != "timestamp"
+                k: v for k, v in options["schema"].items() if k.lower() != "timestamp"
             }
             if schema_without_timestamp:
                 validators.append(DataValidator(schema=schema_without_timestamp))
-        
+
         validators.append(TableNameValidator())
         validators.append(DuplicateValidator())
 

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -130,7 +130,15 @@ def map_validators(
             FileTypeValidator(allowed_extension=options["extension"], path="images"),
             FileTypeValidator(allowed_extension=FileExtension.PNG, path="masks"),
             FilePairingValidator(
-                image_path="images", sidecar_path="masks", sidecar_label="mask"
+                image_path="images",
+                sidecar_path="masks",
+                sidecar_label="mask",
+                # Documented + shipped convention for semantic_segmentation
+                # masks is `<filename>_mask.png` (#196). Strip the suffix
+                # before matching so image_001.jpg pairs with
+                # image_001_mask.png. object_detection's pairing above is
+                # plain stem (no suffix) — the default.
+                sidecar_suffix="_mask",
             ),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
             TableNameValidator(),

--- a/tracebloc_ingestor/validators/bio_label_validator.py
+++ b/tracebloc_ingestor/validators/bio_label_validator.py
@@ -1,0 +1,172 @@
+"""BIO Label Validator Module.
+
+Validates token-classification (NER/POS) labels before ingestion so bad
+annotations are caught at upload time rather than failing deep inside
+client-side training.
+
+For each row it checks, against the corresponding ``.txt`` file (one
+whitespace-tokenized word per token):
+
+1. **Count alignment** — the ``label`` column holds a space-separated string
+   of BIO tags, and there must be exactly one tag per word in the ``.txt``.
+   A mismatch is the exact condition that makes the client drop tokens to
+   ``-100`` (or raise), so we reject it here against the dataset author.
+2. **Tag format** — every tag must be ``O`` or ``B-XXX`` / ``I-XXX`` (IOB2).
+"""
+
+import logging
+import os
+import re
+from typing import Any, List, Optional
+
+import pandas as pd
+
+from .base import BaseValidator, ValidationResult
+from ..config import Config
+from ..utils.constants import FileExtension
+from ..utils.logging import setup_logging
+
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+# IOB2: "O", or "B-"/"I-" followed by a non-empty entity type.
+_BIO_TAG_RE = re.compile(r"^(?:O|[BI]-\S+)$")
+
+# Cap the number of per-row errors reported so a wholly-malformed dataset
+# produces an actionable message instead of tens of thousands of lines.
+_MAX_REPORTED_ERRORS = 50
+
+
+class BIOLabelValidator(BaseValidator):
+    """Validate BIO/IOB2 token-classification labels against their .txt files.
+
+    Attributes:
+        texts_path: Subdirectory under ``SRC_PATH`` holding the ``.txt`` files
+            (mirrors ``FileTypeValidator(path=...)``; ``"texts"`` for token
+            classification).
+        extension: Expected text-file extension (default ``.txt``).
+        filename_column: CSV column naming each sample's file (default
+            ``"filename"``; resolved case-insensitively).
+        label_column: CSV column holding the space-separated BIO tags
+            (default ``"label"``; resolved case-insensitively).
+    """
+
+    def __init__(
+        self,
+        texts_path: str = "texts",
+        extension: str = FileExtension.TXT,
+        filename_column: str = "filename",
+        label_column: str = "label",
+        name: str = "BIO Label",
+    ):
+        super().__init__(name)
+        self.texts_path = texts_path
+        ext = extension or FileExtension.TXT
+        self.extension = ext if ext.startswith(".") else f".{ext}"
+        self.filename_column = filename_column
+        self.label_column = label_column
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            df = self._load_data(data)
+            if df is None or df.empty:
+                return self._create_result(
+                    is_valid=False, errors=["No data found to validate"]
+                )
+
+            filename_col = self._resolve_column(df, self.filename_column)
+            label_col = self._resolve_column(df, self.label_column)
+            missing = []
+            if filename_col is None:
+                missing.append(self.filename_column)
+            if label_col is None:
+                missing.append(self.label_column)
+            if missing:
+                return self._create_result(
+                    is_valid=False,
+                    errors=[f"Missing required column(s): {', '.join(missing)}"],
+                )
+
+            texts_dir = os.path.join(config.SRC_PATH, self.texts_path)
+            errors: List[str] = []
+
+            for idx, row in df.iterrows():
+                if len(errors) >= _MAX_REPORTED_ERRORS:
+                    errors.append("... further errors suppressed.")
+                    break
+                errors.extend(
+                    self._validate_row(row, idx, filename_col, label_col, texts_dir)
+                )
+
+            return self._create_result(
+                is_valid=len(errors) == 0,
+                errors=errors,
+                metadata={"rows_checked": len(df)},
+            )
+
+        except Exception as e:  # noqa: BLE001 — mirror sibling validators
+            logger.error(f"Error during BIO label validation: {str(e)}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"BIO label validation error: {str(e)}"],
+            )
+
+    def _validate_row(
+        self, row: pd.Series, idx: Any, filename_col: str, label_col: str, texts_dir: str
+    ) -> List[str]:
+        row_label = f"Row {idx}"
+        filename = str(row[filename_col])
+        tags = str(row[label_col]).strip().split()
+
+        # Invalid tag format (independent of the file).
+        bad = [t for t in tags if not _BIO_TAG_RE.match(t)]
+        errors: List[str] = []
+        if bad:
+            errors.append(
+                f"{row_label} ('{filename}'): invalid BIO tag(s) {bad[:5]}; "
+                f"each tag must be 'O' or 'B-<TYPE>' / 'I-<TYPE>'."
+            )
+
+        # Resolve the .txt with text_transfer's exact rule (shared
+        # _has_extension): append the extension only when the CSV filename
+        # has none. Deterministic on purpose — probing the filesystem for
+        # alternatives here could validate one file while text_transfer
+        # copies a different one with the same BIO labels.
+        from ..file_transfer import _has_extension
+
+        resolved = (
+            filename if _has_extension(filename) else f"{filename}{self.extension}"
+        )
+        text_path = os.path.join(texts_dir, resolved)
+        if not os.path.isfile(text_path):
+            errors.append(
+                f"{row_label}: text file not found at "
+                f"'{self.texts_path}/{resolved}'."
+            )
+            return errors
+
+        try:
+            with open(text_path, "r", encoding="utf-8") as f:
+                word_count = len(f.read().strip().split())
+        except OSError as e:
+            errors.append(f"{row_label}: could not read text file: {e}")
+            return errors
+
+        if word_count != len(tags):
+            errors.append(
+                f"{row_label} ('{filename}'): token/label count mismatch — "
+                f"{word_count} word(s) in the .txt but {len(tags)} BIO tag(s) "
+                f"in the label column. Each word must have exactly one tag."
+            )
+
+        return errors
+
+    @staticmethod
+    def _resolve_column(df: pd.DataFrame, name: str) -> Optional[str]:
+        """Return the actual column name matching ``name`` case-insensitively."""
+        if name in df.columns:
+            return name
+        lowered = {c.lower(): c for c in df.columns}
+        return lowered.get(name.lower())

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -373,15 +373,24 @@ class DataValidator(BaseValidator):
         length_match = re.search(r"VARCHAR\((\d+)\)", expected_type.upper())
         max_length = int(length_match.group(1)) if length_match else None
 
-        # Check for non-string values. A NULL is valid for any column, and
-        # ``NaN != NaN`` would otherwise count every missing value as
-        # "non-string" — an error the user can never clear (inserting NaN
-        # doesn't help). Mirror the INT/FLOAT validators: only flag values
-        # that are non-null AND not strings.
-        non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
-        if non_string_count > 0:
+        # Issue #188: do NOT compare ``astype(str)`` to the original typed
+        # value. pd.read_csv infers numeric-looking columns as int64/float64,
+        # so for value 100 the check ``"100" != 100`` is True and the column
+        # was falsely rejected as "non-string" — blocking legitimate zip
+        # codes, numeric IDs kept as text, and 0/1 labels declared VARCHAR.
+        # MySQL binds any scalar as a string against a VARCHAR column, so the
+        # only real constraints to enforce here are presence/null tolerance
+        # (handled by other layers) and length. Flag genuinely non-scalar
+        # values (list/dict/set/tuple) — those have no sensible string form
+        # and indicate a real shape error — but let every scalar pass.
+        non_scalar_mask = series.apply(
+            lambda v: isinstance(v, (list, dict, set, tuple))
+        )
+        non_scalar_count = int(non_scalar_mask.sum())
+        if non_scalar_count > 0:
             errors.append(
-                f"Column '{column_name}' contains {non_string_count} non-string values"
+                f"Column '{column_name}' contains {non_scalar_count} non-scalar value(s) "
+                f"(list/dict/set/tuple) that cannot be stored as a string"
             )
 
         # Check length constraints
@@ -417,15 +426,18 @@ class DataValidator(BaseValidator):
         length_match = re.search(r"CHAR\((\d+)\)", expected_type.upper())
         max_length = int(length_match.group(1)) if length_match else None
 
-        # Check for non-string values. A NULL is valid for any column, and
-        # ``NaN != NaN`` would otherwise count every missing value as
-        # "non-string" — an error the user can never clear (inserting NaN
-        # doesn't help). Mirror the INT/FLOAT validators: only flag values
-        # that are non-null AND not strings.
-        non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
-        if non_string_count > 0:
+        # Issue #188: see _validate_varchar — same astype(str)!=value
+        # over-rejection bug. CHAR columns with numeric values (e.g. a
+        # 2-character state code "10") were blocked. Same fix: flag only
+        # genuinely non-scalar values, let any scalar through.
+        non_scalar_mask = series.apply(
+            lambda v: isinstance(v, (list, dict, set, tuple))
+        )
+        non_scalar_count = int(non_scalar_mask.sum())
+        if non_scalar_count > 0:
             errors.append(
-                f"Column '{column_name}' contains {non_string_count} non-string values"
+                f"Column '{column_name}' contains {non_scalar_count} non-scalar value(s) "
+                f"(list/dict/set/tuple) that cannot be stored as a string"
             )
 
         # Check length constraints (CHAR should be fixed length)
@@ -457,15 +469,18 @@ class DataValidator(BaseValidator):
         errors = []
         warnings = []
 
-        # Check for non-string values. A NULL is valid for any column, and
-        # ``NaN != NaN`` would otherwise count every missing value as
-        # "non-string" — an error the user can never clear (inserting NaN
-        # doesn't help). Mirror the INT/FLOAT validators: only flag values
-        # that are non-null AND not strings.
-        non_string_count = (series.notna() & series.astype(str).ne(series)).sum()
-        if non_string_count > 0:
+        # Issue #188: see _validate_varchar — same astype(str)!=value bug.
+        # TEXT columns with numeric values (notes that happen to be all
+        # digits, integer IDs kept as text) were blocked. Same fix:
+        # flag only genuinely non-scalar values; any scalar passes.
+        non_scalar_mask = series.apply(
+            lambda v: isinstance(v, (list, dict, set, tuple))
+        )
+        non_scalar_count = int(non_scalar_mask.sum())
+        if non_scalar_count > 0:
             errors.append(
-                f"Column '{column_name}' contains {non_string_count} non-string values"
+                f"Column '{column_name}' contains {non_scalar_count} non-scalar value(s) "
+                f"(list/dict/set/tuple) that cannot be stored as a string"
             )
 
         return {"is_valid": len(errors) == 0, "errors": errors, "warnings": warnings}

--- a/tracebloc_ingestor/validators/file_pairing_validator.py
+++ b/tracebloc_ingestor/validators/file_pairing_validator.py
@@ -3,7 +3,7 @@
 For datasets that pair every image with a sidecar file — object detection
 (image → annotation XML) and semantic segmentation (image → mask PNG) — this
 validator checks at ingestion time that each image has its sidecar and each
-sidecar has its image, matched by filename stem.
+sidecar has its image.
 
 Without this, a missing counterpart only surfaces mid-training as a
 ``FileNotFoundError`` on the offending row, after the job has run for a while.
@@ -28,8 +28,19 @@ class FilePairingValidator(BaseValidator):
     """Ensure images and their sidecar files (annotations / masks) pair up 1:1.
 
     Directories live under ``config.SRC_PATH`` (e.g. ``<src>/images`` and
-    ``<src>/annotations``). Matching is by filename stem, so ``cat.jpg`` pairs
-    with ``cat.xml`` / ``cat.png``.
+    ``<src>/annotations``). Pairing is by filename stem with an optional
+    ``sidecar_suffix`` appended on the sidecar side:
+
+    - **object_detection**: ``sidecar_suffix=""`` (default) — plain stem
+      match, so ``cat.jpg`` pairs with ``cat.xml``.
+    - **semantic_segmentation**: ``sidecar_suffix="_mask"`` — the shipped
+      template + documented convention is ``<filename>_mask.png``, so
+      ``image_001.jpg`` pairs with ``image_001_mask.png`` (issue #196).
+
+    Without the suffix support, the semantic_segmentation shipped sample
+    failed pairing — every image was reported "no matching mask" and every
+    mask "no matching image", because plain-stem comparison treated
+    ``image_001`` and ``image_001_mask`` as unrelated.
     """
 
     def __init__(
@@ -37,12 +48,14 @@ class FilePairingValidator(BaseValidator):
         image_path: str = "images",
         sidecar_path: str = "annotations",
         sidecar_label: str = "annotation",
+        sidecar_suffix: str = "",
         name: str = "File Pairing Validator",
     ):
         super().__init__(name)
         self.image_path = image_path
         self.sidecar_path = sidecar_path
         self.sidecar_label = sidecar_label
+        self.sidecar_suffix = sidecar_suffix
 
     @staticmethod
     def _stems(directory: Path) -> Set[str]:
@@ -66,10 +79,34 @@ class FilePairingValidator(BaseValidator):
                     metadata={"skipped": "image or sidecar directory not found"},
                 )
 
-            images = self._stems(image_dir)
-            sidecars = self._stems(sidecar_dir)
-            missing = sorted(images - sidecars)   # images with no sidecar
-            orphans = sorted(sidecars - images)   # sidecars with no image
+            image_stems = self._stems(image_dir)
+            sidecar_stems = self._stems(sidecar_dir)
+
+            # When a suffix is configured (e.g. semantic_segmentation's
+            # ``_mask``), strip it from sidecar stems before comparison so
+            # ``image_001_mask`` matches the image ``image_001``. Sidecars
+            # that don't carry the suffix are kept as-is so they still show
+            # up as orphans (a useful signal, not a silent miss).
+            if self.sidecar_suffix:
+                # Build: paired set after suffix-strip, plus the orphans
+                # (sidecars not following the convention).
+                stripped = set()
+                non_conforming = set()
+                for s in sidecar_stems:
+                    if s.endswith(self.sidecar_suffix):
+                        stripped.add(s[: -len(self.sidecar_suffix)])
+                    else:
+                        non_conforming.add(s)
+                sidecars_for_compare = stripped
+                # Non-conforming sidecars are orphans (named neither to match
+                # an image nor to follow the convention).
+                extra_orphans = sorted(non_conforming)
+            else:
+                sidecars_for_compare = sidecar_stems
+                extra_orphans = []
+
+            missing = sorted(image_stems - sidecars_for_compare)
+            orphans = sorted((sidecars_for_compare - image_stems)) + extra_orphans
 
             errors = []
             if missing:
@@ -89,8 +126,9 @@ class FilePairingValidator(BaseValidator):
                 is_valid=len(errors) == 0,
                 errors=errors,
                 metadata={
-                    "images": len(images),
-                    "sidecars": len(sidecars),
+                    "images": len(image_stems),
+                    "sidecars": len(sidecar_stems),
+                    "sidecar_suffix": self.sidecar_suffix,
                     "images_without_sidecar": len(missing),
                     "orphan_sidecars": len(orphans),
                 },

--- a/tracebloc_ingestor/validators/numeric_columns_validator.py
+++ b/tracebloc_ingestor/validators/numeric_columns_validator.py
@@ -77,19 +77,23 @@ class NumericColumnsValidator(BaseValidator):
                     metadata={**metadata, "message": "No schema columns to validate (only timestamp or non-existent columns)"},
                 )
 
-            # Step 1: Check for null values in all columns (except timestamp)
+            # NOTE on null handling (issue #195): the previous step rejected
+            # ANY null in a non-timestamp column as an error. That contract is
+            # wrong for time-series forecasting — the shipped template README
+            # explicitly documents lag/window feature columns as "blank for
+            # the first row" / "blank until enough history accumulates", and
+            # the shipped sample CSV ships with exactly those nulls. So the
+            # validator was rejecting its own shipped sample, and any real
+            # lag_1 / moving_avg_N / rolling_* feature in customer data.
+            #
+            # Treat nulls as legitimate (stored as SQL NULL), mirroring the
+            # null tolerance the rest of DataValidator gained in #167/#168.
+            # The downstream model preprocessor handles leading-NaN in
+            # lag/window features by design. We still surface the count via
+            # metadata for observability, but it isn't an error.
             for column in columns_to_validate:
-                null_count = df[column].isna().sum()
-                
+                null_count = int(df[column].isna().sum())
                 if null_count > 0:
-                    null_rows = [i+1 for i in df.index[df[column].isna()][:10]]
-                    error_msg = (
-                        f"Column '{column}' contains {null_count} null/missing value(s). "
-                        f"Null values found at rows: {null_rows}"
-                    )
-                    if null_count > 10:
-                        error_msg += f" (and {null_count - 10} more)"
-                    errors.append(error_msg)
                     metadata[f"{column}_null_count"] = null_count
 
             # Step 2: Check if all columns are numeric

--- a/tracebloc_ingestor/validators/tokenizer_validator.py
+++ b/tracebloc_ingestor/validators/tokenizer_validator.py
@@ -37,9 +37,16 @@ class TokenizerValidator(BaseValidator):
         self,
         required_tokens: tuple = ("[MASK]", "[PAD]"),
         name: str = "Tokenizer Validator",
+        optional: bool = False,
     ):
         super().__init__(name)
         self.required_tokens = set(required_tokens)
+        # When True, a missing tokenizer.json is a warning (not an error):
+        # the training client falls back to the HuggingFace tokenizer_id /
+        # default. Used by text/token classification, where the tokenizer is
+        # optional. MLM keeps optional=False — its vocab IS the prediction
+        # space, so a missing tokenizer must fail loud at ingest.
+        self.optional = optional
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         """Validate tokenizer.json at the configured source path.
@@ -55,6 +62,23 @@ class TokenizerValidator(BaseValidator):
             tokenizer_path = Path(config.SRC_PATH) / "tokenizer.json"
 
             if not tokenizer_path.exists():
+                if self.optional:
+                    warning = (
+                        f"No tokenizer.json found at {tokenizer_path}. This is "
+                        "optional for this category — the training client will "
+                        "use the HuggingFace tokenizer_id / model_id (default "
+                        "bert-base-uncased). Ship a tokenizer.json here only if "
+                        "you need a custom tokenizer."
+                    )
+                    logger.warning(warning)
+                    return self._create_result(
+                        is_valid=True,
+                        warnings=[warning],
+                        metadata={
+                            "path_checked": str(tokenizer_path),
+                            "tokenizer_present": False,
+                        },
+                    )
                 return self._create_result(
                     is_valid=False,
                     errors=[


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core ingest paths (DB retries, API auth, batch failure accounting, table locks) and changes default image resolutions/extensions—misconfiguration or lock edge cases could block or fail long-running K8s jobs until ops intervene.
> 
> **Overview**
> **Release 0.3.9** promotes develop to prod with ingest reliability fixes, expanded NLP support, and onboarding samples that match documented defaults.
> 
> **Ingest correctness & failure visibility:** API batch failures are now returned as failed records (with fuller HTTP error logging), template scripts call `sys.exit(1)` when any records fail, and `_flush_batch` fixes silent “100% success” runs when the backend rejected every batch. **API client** retries once on 401 after token refresh; **DB** `insert_batch` retries transient errors with rollback between attempts. **Concurrency:** per-table file locks (with stale/corrupt lock recovery) and **SRC_PATH** preflight for file-bearing categories.
> 
> **Validation & casting:** VARCHAR accepts numeric scalars (#188); JSON validation aligned with CSV; float/date overflow and unparseable dates raise at cast time; numeric columns allow nulls for lag features (#195); semantic segmentation gets `_mask` pairing (#196) and `mask_id` round-trip through file transfer; MLM skips edge-label registration and schema rejects `label` on self-supervised tasks (#213).
> 
> **Token classification:** New example YAML, template (sample data + script), `BIOLabelValidator`, optional tokenizer copy/validation, and convention mapping. **JSON:** `ijson` streaming for large arrays. **Defaults/docs:** image classification **256×256 .jpeg**, object detection **1920×1080**, keypoint **448×448**; fixed text/time-series YAML pitfalls (#197, #200).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 009bb556e02d083868044cf7d72f28d897bfd721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->