### PR TITLE
Release v0.3.9 (raw-data hardening + #772 reliability fixes + token_classification)

### DIFF
--- a/examples/yaml/token_classification.yaml
+++ b/examples/yaml/token_classification.yaml
@@ -2,6 +2,13 @@
 # Each .txt holds whitespace-tokenized words; the `label` column holds the
 # space-separated BIO tags — exactly one tag per word.
 # `texts:` is convention-mapped; default extension is .txt.
+#
+# Required CSV columns: `filename` (the .txt sidecar's filename) and the
+# label column you set below. Both are framework-managed (`filename` is
+# reserved by the DB layer), so they do NOT belong in a `schema:` block —
+# declaring them there fails ingestor init with a reserved-column
+# collision. `schema:` is optional here (only for additional feature
+# columns to type-check). Same contract as text_classification (#197).
 apiVersion: tracebloc.io/v1
 kind: IngestConfig
 table: ner_conll_train
@@ -9,7 +16,4 @@ intent: train
 category: token_classification
 csv: /data/shared/ner/labels.csv
 texts: /data/shared/ner/texts/
-schema:
-  filename: VARCHAR(255)
-  label: VARCHAR(2048)
 label: label

--- a/templates/token_classification/README.md
+++ b/templates/token_classification/README.md
@@ -22,11 +22,10 @@ table: ner_conll_train
 intent: train
 csv: /data/shared/ner/labels.csv
 texts: /data/shared/ner/texts/
-schema:
-  filename: VARCHAR(255)
-  label: VARCHAR(2048)
 label: label
 ```
+
+> **Note:** `filename` and the label column are framework-managed (`filename` is reserved by the DB layer) and must **not** be declared in a `schema:` block — doing so fails ingestor init with a reserved-column collision. `schema:` is only for additional feature columns.
 
 **3. Install:**
 

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -20,7 +20,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.8"
+__version__ = "0.3.9"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
## Summary

Release v0.3.9. Bundles 19 PRs merged to develop since v0.3.7.

**Backend #765 / #771 — raw-data validate/cast hardening**
- VARCHAR/CHAR/TEXT accept numeric scalars (#203)
- JSON per-record validation aligned with CSV (#204)
- Time-series feature columns tolerate nulls (#205)
- IEEE float overflow surfaces at cast time (#215)
- Date cast error policy aligned with numeric — raise, not coerce (#216)

**Backend #772 — reliability fixes (P1/P2)**
- SRC_PATH guard for empty/unset env (#218)
- DB transient-error retry via tenacity (#219)
- Auth token refresh on 401 + single retry (#220)
- Concurrent-ingest table-name file lock (#221)
- JSON streamed via ijson (no OOM on large arrays) (#222)

**Other fixes**
- Self-supervised categories must not set label (#217, fixes #213)
- Preserve mask_id through process_record for semantic_segmentation (#212)
- _mask suffix honored in file pairing (#207, fixes #196)
- Sample/yaml/doc alignment (#206, #208, #209, #210, #211)

**Feature**
- New \`token_classification\` (NER/POS) ingestion category (#169)

## Test plan

- [ ] \`pytest\` passes locally
- [ ] CI green on \`release/v0.3.9\`
- [ ] \`python setup.py sdist bdist_wheel\` builds cleanly
- [ ] Smoke: \`pip install dist/tracebloc_ingestor-0.3.9-py3-none-any.whl\` then \`python -c \"import tracebloc_ingestor; print(tracebloc_ingestor.__version__)\"\` → \`0.3.9\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ingest paths (validation, DB batch insert, API auth, file locks) and registration behavior for several categories; changes are well-tested but affect long-running production ingests and data integrity at cast time.
> 
> **Overview**
> **Release v0.3.9** bumps the package version and ships reliability, validation, and onboarding fixes across the ingestor.
> 
> Adds **`token_classification`** (NER/POS): schema/conventions, `BIOLabelValidator`, template + sample data, optional tokenizer copy, and `SRC_PATH` preflight—parallel to text classification with per-token BIO tags.
> 
> **Raw-data validation/cast** is tightened and aligned between CSV and JSON: VARCHAR accepts numeric scalars but rejects non-scalar containers; JSON mirrors CSV rules (booleans, INT truncation, VARCHAR length, non-finite values); CSV rejects float overflow and raises on bad dates instead of silent NULL; time-series numeric columns allow legitimate nulls.
> 
> **#772 reliability**: `SRC_PATH` preflight for file-bearing categories; per-table ingest file locks with stale recovery; DB `insert_batch` retries transient errors with rollback between attempts; API **401 → one token refresh + retry**; large JSON arrays streamed via **`ijson`** (with handle/count fixes).
> 
> **Category-specific ingest fixes**: semantic segmentation **`mask_id`** preserved through `process_record` and stripped before DB insert; **`_mask`** suffix in mask file pairing; skip edge-label API for self-supervised (MLM); schema rejects `label` on MLM; optional `TokenizerValidator` for text/token classification.
> 
> **Defaults/docs** align bundled samples (e.g. image classification **256×256 `.jpeg`**, object detection **1920×1080**, keypoint **448×448**); example YAML fixes for text classification schema, time-series `TIMESTAMP`, and related issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b6cd1aa4201add1a2ae47720f7aa9bd6d8dbe97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->