### PR TITLE
refactor: extract templates' run/report/exit block into shared run_ingestion

### DIFF
--- a/templates/image_classification/image_classification.py
+++ b/templates/image_classification/image_classification.py
@@ -6,9 +6,14 @@ supporting both binary data and file-based processing.
 """
 
 import logging
-import sys
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -41,56 +46,30 @@ csv_options = {
 
 def main():
     """Run the image classification data ingestion example."""
-    try:
 
-        # Initialize components
-        database = Database(config)
-        # Initialize API client
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    # Initialize API client
+    api_client = APIClient(config)
 
-        # Create ingestor for image classification data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            data_format=DataFormat.IMAGE,
-            category=TaskCategory.IMAGE_CLASSIFICATION,
-            csv_options=csv_options,
-            file_options=image_options,
-            label_column="label",
-            intent=Intent.TEST,  # Is the data for training or testing
-        )
+    # Create ingestor for image classification data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.IMAGE,
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        csv_options=csv_options,
+        file_options=image_options,
+        label_column="label",
+        intent=Intent.TEST,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting image classification ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        # Re-raise so the process exits non-zero — swallowing here let a
-        # hard failure (validation error, DB error, backend registration
-        # rejection raised by ingest()) end with exit code 0 and a K8s
-        # Job marked Succeeded.
-        raise
+    # Ingest data with validation
+    logger.info("Starting image classification ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/keypoint_detection/keypoint_detection.py
+++ b/templates/keypoint_detection/keypoint_detection.py
@@ -6,9 +6,14 @@ It processes image files along with JSON-based keypoint coordinate annotations.
 """
 
 import logging
-import sys
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -57,58 +62,36 @@ csv_options = {
 
 def main():
     """Run the keypoint detection ingestion example."""
-    try:
-        # Initialize components
-        database = Database(config)
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
 
-        # Visibility is kept in the schema so it survives process_record's
-        # schema-based filtering and is persisted alongside the annotation;
-        # without it the column is validated and then silently dropped.
-        schema = {"Visibility": "TEXT"}
+    # Visibility is kept in the schema so it survives process_record's
+    # schema-based filtering and is persisted alongside the annotation;
+    # without it the column is validated and then silently dropped.
+    schema = {"Visibility": "TEXT"}
 
-        # Create ingestor for keypoint detection data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            data_format=DataFormat.IMAGE,
-            category=TaskCategory.KEYPOINT_DETECTION,
-            schema=schema,
-            csv_options=csv_options,
-            file_options=file_options,
-            label_column="image_label",
-            annotation_column="Annotation",
-            unique_id_column="filename",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for keypoint detection data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.IMAGE,
+        category=TaskCategory.KEYPOINT_DETECTION,
+        schema=schema,
+        csv_options=csv_options,
+        file_options=file_options,
+        label_column="image_label",
+        annotation_column="Annotation",
+        unique_id_column="filename",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting keypoint detection ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        raise
+    # Ingest data with validation
+    logger.info("Starting keypoint detection ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/masked_language_modeling/masked_language_modeling.py
+++ b/templates/masked_language_modeling/masked_language_modeling.py
@@ -11,11 +11,16 @@ on-the-fly during training.
 """
 
 import logging
-import sys
 import os
 from typing import Dict, Any
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -45,50 +50,28 @@ csv_options = {
 
 def main():
     """Run the masked language modeling ingestion example."""
-    try:
-        # Initialize components
-        database = Database(config)
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
 
-        # Create ingestor for MLM data
-        # No label_column — MLM is self-supervised
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            data_format=DataFormat.TEXT,
-            category=TaskCategory.MASKED_LANGUAGE_MODELING,
-            csv_options=csv_options,
-            file_options=text_options,
-            intent=Intent.TRAIN,
-        )
+    # Create ingestor for MLM data
+    # No label_column — MLM is self-supervised
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.TEXT,
+        category=TaskCategory.MASKED_LANGUAGE_MODELING,
+        csv_options=csv_options,
+        file_options=text_options,
+        intent=Intent.TRAIN,
+    )
 
-        # Ingest data with validation
-        logger.info("Starting masked language modeling ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        raise
+    # Ingest data with validation
+    logger.info("Starting masked language modeling ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/object_detection/object_detection.py
+++ b/templates/object_detection/object_detection.py
@@ -6,14 +6,19 @@ corresponding XML annotation files from the VisDrone dataset format.
 """
 
 import logging
-import sys
 import shutil
 import xml.etree.ElementTree as ET
 from typing import Dict, Any
 import json
 import os
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -50,50 +55,28 @@ csv_options = {
 
 def main():
     """Run the object detection ingestion example."""
-    try:
-        # Initialize components
-        database = Database(config)
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
 
-        # Create ingestor for object detection data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            data_format=DataFormat.IMAGE,
-            category=TaskCategory.OBJECT_DETECTION,
-            csv_options=csv_options,
-            file_options=object_detection_options,
-            label_column="image_label",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for object detection data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.IMAGE,
+        category=TaskCategory.OBJECT_DETECTION,
+        csv_options=csv_options,
+        file_options=object_detection_options,
+        label_column="image_label",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting object detection ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        raise
+    # Ingest data with validation
+    logger.info("Starting object detection ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/semantic_segmentation/semantic_segmentation.py
+++ b/templates/semantic_segmentation/semantic_segmentation.py
@@ -6,10 +6,15 @@ both the image files and their corresponding mask annotation files.
 """
 
 import logging
-import sys
 from typing import Dict, Any
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -48,52 +53,30 @@ csv_options = {
 
 def main():
     """Run the semantic segmentation ingestion example."""
-    try:
-        # Initialize components
-        database = Database(config)
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
 
-        # Create ingestor for semantic segmentation data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            schema=schema,
-            data_format=DataFormat.IMAGE,
-            category=TaskCategory.SEMANTIC_SEGMENTATION,
-            csv_options=csv_options,
-            file_options=semantic_segmentation_options,
-            label_column="image_label",
-            unique_id_column="filename",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for semantic segmentation data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        schema=schema,
+        data_format=DataFormat.IMAGE,
+        category=TaskCategory.SEMANTIC_SEGMENTATION,
+        csv_options=csv_options,
+        file_options=semantic_segmentation_options,
+        label_column="image_label",
+        unique_id_column="filename",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting semantic segmentation ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        raise
+    # Ingest data with validation
+    logger.info("Starting semantic segmentation ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/tabular_classification/tabular_classification.py
+++ b/templates/tabular_classification/tabular_classification.py
@@ -6,9 +6,14 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
-import sys
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import TaskCategory, Intent, DataFormat
 
@@ -20,75 +25,51 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Run the tabular data ingestion example."""
-    try:
 
-        # Initialize components
-        database = Database(config)
-        # Initialize API client
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    # Initialize API client
+    api_client = APIClient(config)
 
-        # Schema definition for tabular data
-        # Schema should contain feature columns only
-        schema = {
-            "feature_00": "FLOAT ",
-            "feature_01": "FLOAT ",
-            "feature_02": "FLOAT ",
-        }
+    # Schema definition for tabular data
+    # Schema should contain feature columns only
+    schema = {
+        "feature_00": "FLOAT ",
+        "feature_01": "FLOAT ",
+        "feature_02": "FLOAT ",
+    }
 
-        # CSV specific options
-        csv_options = {
-            "chunk_size": 1000,
-            "delimiter": ",",
-            "quotechar": '"',
-            "escapechar": "\\",
-            "encoding": "utf-8",
-            "on_bad_lines": "warn",
-            "skip_blank_lines": True,
-            "na_values": ["", "NA", "NULL", "None"],
-        }
+    # CSV specific options
+    csv_options = {
+        "chunk_size": 1000,
+        "delimiter": ",",
+        "quotechar": '"',
+        "escapechar": "\\",
+        "encoding": "utf-8",
+        "on_bad_lines": "warn",
+        "skip_blank_lines": True,
+        "na_values": ["", "NA", "NULL", "None"],
+    }
 
-        # Create ingestor for tabular data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            schema=schema,
-            data_format=DataFormat.TABULAR,
-            category=TaskCategory.TABULAR_CLASSIFICATION,
-            csv_options=csv_options,
-            file_options={"number_of_columns": len(schema)},
-            label_column="label",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for tabular data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        schema=schema,
+        data_format=DataFormat.TABULAR,
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+        csv_options=csv_options,
+        file_options={"number_of_columns": len(schema)},
+        label_column="label",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting tabular data ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(f"Failed record: {record.get('name', 'Unknown')}")
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        # Re-raise so the process exits non-zero — swallowing here let a
-        # hard failure (validation error, DB error, backend registration
-        # rejection raised by ingest()) end with exit code 0 and a K8s
-        # Job marked Succeeded.
-        raise
+    # Ingest data with validation
+    logger.info("Starting tabular data ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/tabular_regression/tabular_regression.py
+++ b/templates/tabular_regression/tabular_regression.py
@@ -6,9 +6,14 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
-import sys
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import TaskCategory, Intent, DataFormat
 
@@ -20,75 +25,51 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Run the tabular data ingestion example."""
-    try:
 
-        # Initialize components
-        database = Database(config)
-        # Initialize API client
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    # Initialize API client
+    api_client = APIClient(config)
 
-        # Schema definition for tabular data
-        # Schema should contain feature columns only
-        schema = {
-            "square_feet": "FLOAT",
-            "bedrooms": "INT",
-            "age": "INT",
-        }
+    # Schema definition for tabular data
+    # Schema should contain feature columns only
+    schema = {
+        "square_feet": "FLOAT",
+        "bedrooms": "INT",
+        "age": "INT",
+    }
 
-        # CSV specific options
-        csv_options = {
-            "chunk_size": 1000,
-            "delimiter": ",",
-            "quotechar": '"',
-            "escapechar": "\\",
-            "encoding": "utf-8",
-            "on_bad_lines": "warn",
-            "skip_blank_lines": True,
-            "na_values": ["", "NA", "NULL", "None"],
-        }
+    # CSV specific options
+    csv_options = {
+        "chunk_size": 1000,
+        "delimiter": ",",
+        "quotechar": '"',
+        "escapechar": "\\",
+        "encoding": "utf-8",
+        "on_bad_lines": "warn",
+        "skip_blank_lines": True,
+        "na_values": ["", "NA", "NULL", "None"],
+    }
 
-        # Create ingestor for tabular data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            schema=schema,
-            data_format=DataFormat.TABULAR,
-            category=TaskCategory.TABULAR_REGRESSION,
-            csv_options=csv_options,
-            file_options={"number_of_columns": len(schema)},
-            label_column="price",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for tabular data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        schema=schema,
+        data_format=DataFormat.TABULAR,
+        category=TaskCategory.TABULAR_REGRESSION,
+        csv_options=csv_options,
+        file_options={"number_of_columns": len(schema)},
+        label_column="price",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting tabular data ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(f"Failed record: {record.get('name', 'Unknown')}")
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        # Re-raise so the process exits non-zero — swallowing here let a
-        # hard failure (validation error, DB error, backend registration
-        # rejection raised by ingest()) end with exit code 0 and a K8s
-        # Job marked Succeeded.
-        raise
+    # Ingest data with validation
+    logger.info("Starting tabular data ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/text_classification/text_classification.py
+++ b/templates/text_classification/text_classification.py
@@ -6,11 +6,16 @@ corresponding labels from a CSV file, similar to object detection format.
 """
 
 import logging
-import sys
 import os
 from typing import Dict, Any
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -40,50 +45,28 @@ csv_options = {
 
 def main():
     """Run the text classification ingestion example."""
-    try:
-        # Initialize components
-        database = Database(config)
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
 
-        # Create ingestor for text classification data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            data_format=DataFormat.TEXT,
-            category=TaskCategory.TEXT_CLASSIFICATION,
-            csv_options=csv_options,
-            file_options=text_options,
-            label_column="label",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for text classification data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.TEXT,
+        category=TaskCategory.TEXT_CLASSIFICATION,
+        csv_options=csv_options,
+        file_options=text_options,
+        label_column="label",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting text classification ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        raise
+    # Ingest data with validation
+    logger.info("Starting text classification ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/time_series_forecasting/time_series_forecasting.py
+++ b/templates/time_series_forecasting/time_series_forecasting.py
@@ -6,9 +6,14 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
-import sys
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import TaskCategory, Intent, DataFormat
 
@@ -20,80 +25,56 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Run the time series forecasting data ingestion example."""
-    try:
 
-        # Initialize components
-        database = Database(config)
-        # Initialize API client
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    # Initialize API client
+    api_client = APIClient(config)
 
-        # Schema definition for time series data
-        # Schema should contain feature columns only (excluding the target/label column)
-        schema = {
-            "timestamp": "TIMESTAMP",
-            "day_of_week": "INT",
-            "month": "INT",
-            "day_of_month": "INT",
-            "week_of_year": "INT",
-            "is_weekend": "INT",
-            "lag_1": "FLOAT",
-            "moving_avg_7": "FLOAT",
-        }
+    # Schema definition for time series data
+    # Schema should contain feature columns only (excluding the target/label column)
+    schema = {
+        "timestamp": "TIMESTAMP",
+        "day_of_week": "INT",
+        "month": "INT",
+        "day_of_month": "INT",
+        "week_of_year": "INT",
+        "is_weekend": "INT",
+        "lag_1": "FLOAT",
+        "moving_avg_7": "FLOAT",
+    }
 
-        # CSV specific options
-        csv_options = {
-            "chunk_size": 1000,
-            "delimiter": ",",
-            "quotechar": '"',
-            "escapechar": "\\",
-            "encoding": "utf-8",
-            "on_bad_lines": "warn",
-            "skip_blank_lines": True,
-            "na_values": ["", "NA", "NULL", "None"],
-        }
+    # CSV specific options
+    csv_options = {
+        "chunk_size": 1000,
+        "delimiter": ",",
+        "quotechar": '"',
+        "escapechar": "\\",
+        "encoding": "utf-8",
+        "on_bad_lines": "warn",
+        "skip_blank_lines": True,
+        "na_values": ["", "NA", "NULL", "None"],
+    }
 
-        # Create ingestor for time series forecasting data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            schema=schema,
-            data_format=DataFormat.TABULAR,
-            category=TaskCategory.TIME_SERIES_FORECASTING,
-            csv_options=csv_options,
-            file_options={"number_of_columns": len(schema)},
-            label_column="value",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for time series forecasting data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        schema=schema,
+        data_format=DataFormat.TABULAR,
+        category=TaskCategory.TIME_SERIES_FORECASTING,
+        csv_options=csv_options,
+        file_options={"number_of_columns": len(schema)},
+        label_column="value",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting time series forecasting data ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(f"Failed record: {record.get('name', 'Unknown')}")
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        # Re-raise so the process exits non-zero — swallowing here let a
-        # hard failure (validation error, DB error, backend registration
-        # rejection raised by ingest()) end with exit code 0 and a K8s
-        # Job marked Succeeded.
-        raise
+    # Ingest data with validation
+    logger.info("Starting time series forecasting data ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/time_to_event_prediction/time_to_event_prediction.py
+++ b/templates/time_to_event_prediction/time_to_event_prediction.py
@@ -6,9 +6,14 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
-import sys
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import TaskCategory, Intent, DataFormat
 
@@ -20,87 +25,63 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Run the time to event prediction data ingestion example."""
-    try:
 
-        # Initialize components
-        database = Database(config)
-        # Initialize API client
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    # Initialize API client
+    api_client = APIClient(config)
 
-        # Schema definition for tabular data
-        schema = {
-            "age": "FLOAT",
-            "anaemia": "INT",
-            "creatinine_phosphokinase": "FLOAT",
-            "diabetes": "INT",
-            "ejection_fraction": "FLOAT",
-            "high_blood_pressure": "INT",
-            "platelets": "FLOAT",
-            "serum_creatinine": "FLOAT",
-            "serum_sodium": "FLOAT",
-            "sex": "INT",
-            "smoking": "INT",
-            "time": "INT",
-        }
+    # Schema definition for tabular data
+    schema = {
+        "age": "FLOAT",
+        "anaemia": "INT",
+        "creatinine_phosphokinase": "FLOAT",
+        "diabetes": "INT",
+        "ejection_fraction": "FLOAT",
+        "high_blood_pressure": "INT",
+        "platelets": "FLOAT",
+        "serum_creatinine": "FLOAT",
+        "serum_sodium": "FLOAT",
+        "sex": "INT",
+        "smoking": "INT",
+        "time": "INT",
+    }
 
-        # CSV specific options
-        csv_options = {
-            "chunk_size": 1000,
-            "delimiter": ",",
-            "quotechar": '"',
-            "escapechar": "\\",
-            "encoding": "utf-8",
-            "on_bad_lines": "warn",
-            "skip_blank_lines": True,
-            "na_values": ["", "NA", "NULL", "None"],
-        }
+    # CSV specific options
+    csv_options = {
+        "chunk_size": 1000,
+        "delimiter": ",",
+        "quotechar": '"',
+        "escapechar": "\\",
+        "encoding": "utf-8",
+        "on_bad_lines": "warn",
+        "skip_blank_lines": True,
+        "na_values": ["", "NA", "NULL", "None"],
+    }
 
-        # Create ingestor for time to event prediction data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            schema=schema,
-            data_format=DataFormat.TABULAR,
-            category=TaskCategory.TIME_TO_EVENT_PREDICTION,
-            csv_options=csv_options,
-            file_options={
-                "number_of_columns": len(schema),
-                "schema": schema,
-                "time_column": "time",  # Specify the time column name
-            },
-            label_column="DEATH_EVENT",  # The event column is the target
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for time to event prediction data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        schema=schema,
+        data_format=DataFormat.TABULAR,
+        category=TaskCategory.TIME_TO_EVENT_PREDICTION,
+        csv_options=csv_options,
+        file_options={
+            "number_of_columns": len(schema),
+            "schema": schema,
+            "time_column": "time",  # Specify the time column name
+        },
+        label_column="DEATH_EVENT",  # The event column is the target
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting time to event prediction data ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(f"Failed record: {record.get('name', 'Unknown')}")
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        # Re-raise so the process exits non-zero — swallowing here let a
-        # hard failure (validation error, DB error, backend registration
-        # rejection raised by ingest()) end with exit code 0 and a K8s
-        # Job marked Succeeded.
-        raise
+    # Ingest data with validation
+    logger.info("Starting time to event prediction data ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/token_classification/token_classification.py
+++ b/templates/token_classification/token_classification.py
@@ -12,11 +12,16 @@ Example row:
 """
 
 import logging
-import sys
 import os
 from typing import Dict, Any
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -46,50 +51,28 @@ csv_options = {
 
 def main():
     """Run the token classification ingestion example."""
-    try:
-        # Initialize components
-        database = Database(config)
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
 
-        # Create ingestor for token classification data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            data_format=DataFormat.TEXT,
-            category=TaskCategory.TOKEN_CLASSIFICATION,
-            csv_options=csv_options,
-            file_options=text_options,
-            label_column="label",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for token classification data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.TEXT,
+        category=TaskCategory.TOKEN_CLASSIFICATION,
+        csv_options=csv_options,
+        file_options=text_options,
+        label_column="label",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting token classification ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        raise
+    # Ingest data with validation
+    logger.info("Starting token classification ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_batch_send_failure_accounting.py
+++ b/tests/test_batch_send_failure_accounting.py
@@ -277,18 +277,23 @@ _TEMPLATES = sorted(Path(__file__).parent.parent.glob("templates/*/*.py"))
 
 @pytest.mark.parametrize("template", _TEMPLATES, ids=lambda p: p.parent.name)
 def test_template_exits_nonzero_on_failed_records(template):
-    """Each template's failed-records branch must end in sys.exit(1) —
-    BEFORE the else that logs "All records processed successfully" — so a
-    run with failures can't leave the K8s Job marked Succeeded."""
+    """Each template must route its run through the shared
+    ``run_ingestion`` helper, which owns the exit contract this test used
+    to pin per-template: log every failed record, ``sys.exit(1)`` on
+    failed records, re-raise hard errors. The eleven inlined copies of
+    that block drifted (five swallowed exceptions and exited 0 — #230),
+    so the duplication was extracted; the behavioral guarantees are now
+    covered directly in tests/test_template_runner.py and this check pins
+    the call-site instead of the inlined pattern."""
     src = template.read_text(encoding="utf-8")
-    assert re.search(r"^import sys$", src, re.M), f"{template} missing 'import sys'"
+    # Imported from the package root (not a local re-implementation) …
     m = re.search(
-        r"if failed_records:(?P<branch>.*?)\n\s*else:\s*\n\s*"
-        r"logger\.info\(\"All records processed successfully\"\)",
-        src,
-        re.S,
+        r"^from tracebloc_ingestor import \((?P<names>[^)]*)\)", src, re.M | re.S
     )
-    assert m, f"{template}: failed_records/else block not found"
-    assert "sys.exit(1)" in m.group("branch"), (
-        f"{template}: failed_records branch does not sys.exit(1)"
+    assert m and "run_ingestion" in m.group("names"), (
+        f"{template}: does not import run_ingestion from tracebloc_ingestor"
+    )
+    # … and actually called with the constructed ingestor.
+    assert re.search(r"run_ingestion\(\s*ingestor,", src), (
+        f"{template}: main() does not call run_ingestion(ingestor, ...)"
     )

--- a/tests/test_modality_failure_accounting.py
+++ b/tests/test_modality_failure_accounting.py
@@ -179,35 +179,71 @@ def test_clean_run_has_no_failures_for_every_category(category):
 _TEMPLATES = sorted(Path(__file__).parent.parent.glob("templates/*/*.py"))
 
 
-def _main_except_handlers(template: Path):
-    """Yield every ``except Exception`` handler inside the template's
-    ``main()`` function."""
+def _main_node(template: Path):
     tree = ast.parse(template.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef) and node.name == "main":
-            for sub in ast.walk(node):
-                if isinstance(sub, ast.ExceptHandler):
-                    if isinstance(sub.type, ast.Name) and sub.type.id == "Exception":
-                        yield sub
+            return node
+    raise AssertionError(f"{template}: no main() function")
+
+
+def _swallowing_handlers(func: ast.FunctionDef):
+    """Yield every exception handler inside ``func`` that could swallow an
+    Exception: ``except Exception``, a tuple containing Exception, or a
+    bare ``except:``."""
+    for sub in ast.walk(func):
+        if not isinstance(sub, ast.ExceptHandler):
+            continue
+        catches_exception = (
+            sub.type is None  # bare except
+            or (isinstance(sub.type, ast.Name) and sub.type.id == "Exception")
+            or (
+                isinstance(sub.type, ast.Tuple)
+                and any(
+                    isinstance(el, ast.Name) and el.id == "Exception"
+                    for el in sub.type.elts
+                )
+            )
+        )
+        if catches_exception:
+            yield sub
 
 
 @pytest.mark.parametrize("template", _TEMPLATES, ids=lambda p: p.parent.name)
 def test_template_except_handler_reraises(template):
-    """A template's ``except Exception`` must re-raise. Log-and-swallow
-    turned any exception escaping ``ingest()`` — validation failure, DB
-    error, the backend-registration RuntimeErrors from base.py — into
-    exit code 0 and a K8s Job marked Succeeded, the same silent-success
-    class #223 fixed for batch POST failures."""
-    handlers = list(_main_except_handlers(template))
-    assert handlers, f"{template}: no except-Exception handler in main()"
-    for handler in handlers:
+    """main() must not swallow exceptions. Log-and-swallow turned any
+    exception escaping ``ingest()`` — validation failure, DB error, the
+    backend-registration RuntimeErrors from base.py — into exit code 0
+    and a K8s Job marked Succeeded, the same silent-success class #223
+    fixed for batch POST failures (#230).
+
+    Since the duplication extraction, the templates delegate the whole
+    run/report/exit contract to ``run_ingestion`` (which logs and
+    re-raises — covered in tests/test_template_runner.py) and carry no
+    handler of their own. This guard remains so a reintroduced
+    ``except Exception`` (or bare ``except``) around the run can't bring
+    the swallow back: if a handler exists, it must re-raise, and main()
+    must still route through run_ingestion either way."""
+    main_fn = _main_node(template)
+    for handler in _swallowing_handlers(main_fn):
         has_raise = any(
             isinstance(stmt, ast.Raise) for stmt in ast.walk(handler)
         )
         assert has_raise, (
-            f"{template}: except-Exception handler in main() does not "
-            f"re-raise — a hard ingest failure would exit 0"
+            f"{template}: exception handler in main() does not re-raise "
+            f"— a hard ingest failure would exit 0"
         )
+    calls_run_ingestion = any(
+        isinstance(sub, ast.Call)
+        and isinstance(sub.func, ast.Name)
+        and sub.func.id == "run_ingestion"
+        for sub in ast.walk(main_fn)
+    )
+    assert calls_run_ingestion, (
+        f"{template}: main() does not call run_ingestion — the exit "
+        f"contract (sys.exit(1) on failed records, re-raise on hard "
+        f"errors) would not apply"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_template_runner.py
+++ b/tests/test_template_runner.py
@@ -1,0 +1,113 @@
+"""Behavioral contract of ``run_ingestion`` — the shared run/report/exit
+wrapper the template scripts delegate to.
+
+The eleven templates used to inline this block and the copies drifted:
+five swallowed exceptions and exited 0 on hard failures (#230), and the
+failed-record log line was wrong in three different ways (wrapper-level
+``.get("filename")`` logged None; ``.get("name")`` always logged
+Unknown). The structural template tests pin that every template calls
+this helper; these tests pin what the helper actually guarantees.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from tracebloc_ingestor import run_ingestion as run_ingestion_from_root
+from tracebloc_ingestor.utils.template_runner import run_ingestion
+
+
+def _ingestor(failed_records=None, ingest_side_effect=None):
+    ing = MagicMock(name="ingestor")
+    ing.__enter__ = MagicMock(return_value=ing)
+    ing.__exit__ = MagicMock(return_value=False)
+    if ingest_side_effect is not None:
+        ing.ingest.side_effect = ingest_side_effect
+    else:
+        ing.ingest.return_value = failed_records or []
+    return ing
+
+
+_LOGGER = logging.getLogger("test_template_runner_template")
+
+
+def test_exported_from_package_root():
+    # Templates import it via `from tracebloc_ingestor import run_ingestion`.
+    assert run_ingestion_from_root is run_ingestion
+
+
+def test_clean_run_logs_success_and_returns(caplog):
+    ing = _ingestor(failed_records=[])
+    with caplog.at_level(logging.INFO, logger=_LOGGER.name):
+        assert run_ingestion(ing, "labels.csv", batch_size=7, logger=_LOGGER) is None
+    ing.ingest.assert_called_once_with("labels.csv", batch_size=7)
+    assert "All records processed successfully" in caplog.text
+
+
+def test_failed_records_exit_nonzero_and_log_each(caplog):
+    failures = [
+        {"record": {"filename": "f1", "data_id": "d1"}, "error": "api_send_failed"},
+        {"record": {"data_id": "d2"}, "error": "dup key"},  # tabular: no filename
+        {"record": {}, "error": "boom"},
+        {"error": "no record key at all"},
+    ]
+    ing = _ingestor(failed_records=failures)
+    with caplog.at_level(logging.WARNING, logger=_LOGGER.name):
+        with pytest.raises(SystemExit) as excinfo:
+            run_ingestion(ing, "labels.csv", batch_size=7, logger=_LOGGER)
+    assert excinfo.value.code == 1
+    assert "Failed to process 4 records" in caplog.text
+    # Identifier resolution: filename where present, else data_id, else Unknown.
+    assert "Failed record: f1" in caplog.text
+    assert "Failed record: d2" in caplog.text
+    assert "Failed record: Unknown" in caplog.text
+    assert "Error details: api_send_failed" in caplog.text
+    assert "Error details: dup key" in caplog.text
+    # SystemExit must pass through the except-Exception handler untouched —
+    # it must NOT be re-logged as a hard failure.
+    assert "Ingestion failed" not in caplog.text
+
+
+def test_exception_from_ingest_is_logged_and_reraised(caplog):
+    err = RuntimeError("Backend rejected edge-label metadata")
+    ing = _ingestor(ingest_side_effect=err)
+    with caplog.at_level(logging.ERROR, logger=_LOGGER.name):
+        with pytest.raises(RuntimeError) as excinfo:
+            run_ingestion(ing, "labels.csv", batch_size=7, logger=_LOGGER)
+    # Re-raised, not swallowed (the #230 silent-success class) — and it's
+    # the ORIGINAL exception, not a replacement.
+    assert excinfo.value is err
+    assert "Ingestion failed: Backend rejected edge-label metadata" in caplog.text
+
+
+def test_ingestor_used_as_context_manager():
+    ing = _ingestor(failed_records=[])
+    run_ingestion(ing, "labels.csv", batch_size=7, logger=_LOGGER)
+    ing.__enter__.assert_called_once()
+    ing.__exit__.assert_called_once()
+
+
+def test_context_manager_exited_on_failure_paths():
+    # SystemExit (failed records) and a hard error must both leave the
+    # with-block normally unwound.
+    ing = _ingestor(failed_records=[{"record": {}, "error": "x"}])
+    with pytest.raises(SystemExit):
+        run_ingestion(ing, "labels.csv", batch_size=7, logger=_LOGGER)
+    ing.__exit__.assert_called_once()
+
+    ing2 = _ingestor(ingest_side_effect=RuntimeError("db gone"))
+    with pytest.raises(RuntimeError):
+        run_ingestion(ing2, "labels.csv", batch_size=7, logger=_LOGGER)
+    ing2.__exit__.assert_called_once()
+
+
+def test_default_logger_used_when_none_passed(caplog):
+    ing = _ingestor(failed_records=[])
+    with caplog.at_level(
+        logging.INFO, logger="tracebloc_ingestor.utils.template_runner"
+    ):
+        run_ingestion(ing, "labels.csv", batch_size=7)
+    assert "All records processed successfully" in caplog.text

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -9,6 +9,7 @@ from .config import Config
 from .database import Database
 from .api.client import APIClient
 from .ingestors import BaseIngestor, CSVIngestor, JSONIngestor
+from .utils.template_runner import run_ingestion
 from .validators import (
     BaseValidator,
     ValidationResult,
@@ -34,4 +35,5 @@ __all__ = [
     "FileTypeValidator",
     "ImageResolutionValidator",
     "TableNameValidator",
+    "run_ingestion",
 ]

--- a/tracebloc_ingestor/utils/template_runner.py
+++ b/tracebloc_ingestor/utils/template_runner.py
@@ -1,0 +1,83 @@
+"""Shared run-and-report wrapper for the template scripts.
+
+Every ``templates/<category>/`` script used to inline the same ~20-line
+block: run ``ingest()``, log each failed record, ``sys.exit(1)`` on
+failures, re-raise hard errors. Eleven hand-maintained copies drifted —
+five templates swallowed exceptions and exited 0 on hard failures until
+#230 — so the contract now lives here once and the templates just call
+:func:`run_ingestion`.
+"""
+
+import logging
+import sys
+from typing import Any, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard, typing only
+    from ..ingestors.base import BaseIngestor
+
+# Underscored to stay distinct from run_ingestion's `logger` parameter.
+_logger = logging.getLogger(__name__)
+
+__all__ = ["run_ingestion"]
+
+
+def run_ingestion(
+    ingestor: "BaseIngestor",
+    source: Any,
+    batch_size: int,
+    logger: Optional[logging.Logger] = None,
+) -> None:
+    """Run ``ingestor.ingest(source)`` and enforce the template exit
+    contract:
+
+    - failed records -> log each one, then ``sys.exit(1)`` so the K8s Job
+      is marked failed instead of reporting silent success
+    - an exception escaping ``ingest()`` (validation error, DB error,
+      backend registration rejection) -> log and re-raise, so the process
+      exits non-zero. Swallowing here is what let five templates end a
+      hard failure with exit code 0 and a Job marked Succeeded (#230).
+    - clean run -> success log, normal return
+
+    Args:
+        ingestor: The constructed ingestor; used as a context manager,
+            mirroring the templates' previous ``with ingestor:`` usage.
+        source: Passed through to ``ingest()`` (the labels CSV / JSON path).
+        batch_size: Passed through to ``ingest()``.
+        logger: The template's logger, so log lines keep the template's
+            logger name. Falls back to this module's logger.
+    """
+    log = logger if logger is not None else _logger
+    try:
+        with ingestor:
+            failed_records = ingestor.ingest(source, batch_size=batch_size)
+            if failed_records:
+                log.warning(f"Failed to process {len(failed_records)} records")
+                for failure in failed_records:
+                    # ingest() returns {"record": <processed record>,
+                    # "error": <reason>} entries. Identify the record by
+                    # filename where the category has one (file-bearing
+                    # categories), else by data_id (tabular family) — the
+                    # old per-template copies got this wrong in three
+                    # different ways (wrapper-level .get("filename") logged
+                    # None; .get("name") always logged Unknown).
+                    record = failure.get("record") or {}
+                    identifier = (
+                        record.get("filename") or record.get("data_id") or "Unknown"
+                    )
+                    log.warning(f"Failed record: {identifier}")
+                    log.warning(
+                        f"Error details: {failure.get('error', 'Unknown error')}"
+                    )
+                # Failed records (file transfer, DB insert, API send, or
+                # processing) must fail the run — exit non-zero so the K8s
+                # Job is marked failed instead of reporting silent success
+                # (SystemExit bypasses the except Exception below).
+                sys.exit(1)
+            log.info("All records processed successfully")
+    except Exception as e:
+        # Re-raise so the process exits non-zero — swallowing here let a
+        # hard failure (validation error, DB error, backend registration
+        # rejection raised by ingest()) end with exit code 0 and a K8s
+        # Job marked Succeeded (#230).
+        log.error(f"Ingestion failed: {str(e)}")
+        raise


### PR DESCRIPTION
## Why

Follow-up to the review on #230 ([comment](https://github.com/tracebloc/data-ingestors/pull/230#discussion)): the ~20-line run-and-report block (run `ingest()`, log each failed record, `sys.exit(1)` on failures, re-raise hard errors) was inlined in all 11 template scripts. The hand-maintained copies had already drifted twice:

- five templates swallowed exceptions and exited 0 on hard failures (fixed in #230)
- the failed-record log line was wrong in three different ways (MLM/text templates called `.get("filename")` on the wrapper dict and logged `None`; the tabular templates' `.get("name")` always logged `Unknown`)

## What

- **`tracebloc_ingestor/utils/template_runner.py`** — new `run_ingestion(ingestor, source, batch_size, logger)`, exported from the package root. Owns the whole contract: failed records → log each + `SystemExit(1)`; exception escaping `ingest()` → log + re-raise; clean run → success log. Also fixes the failed-record identifier: `filename` where the category has one, else `data_id` (tabular family), else `Unknown`.
- **All 11 templates** — `main()` now just builds the modality-specific ingestor and calls `run_ingestion(...)`. The per-template `try/except`, `sys.exit(1)` block, and explanatory comments are gone; `import sys` removed.
- **Structural tests migrated** (their old assertions matched the inlined source pattern this change removes; the invariant is preserved, not weakened):
  - `test_template_exits_nonzero_on_failed_records` now pins that every template imports + calls `run_ingestion` from the package root.
  - `test_template_except_handler_reraises` now pins that any reintroduced `except Exception` / bare `except` in `main()` must re-raise, and that `main()` routes through `run_ingestion`.
- **`tests/test_template_runner.py`** (new) — behavioral coverage of the helper: `SystemExit(1)` on failed records with per-record logging, re-raise of the original exception on hard errors, SystemExit passes the handler untouched, context-manager unwinding on all paths, identifier fallback chain, package-root export.

## Tests

Full suite: **962 passed, 1 xfailed**; `template_runner.py` at 100% coverage, total 97% (gate: 95%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how ingestion jobs fail and report errors across all templates; incorrect helper behavior would mark K8s jobs successful on partial or hard failures, though behavior is heavily tested.
> 
> **Overview**
> Extracts the duplicated run/report/exit logic from all **11** modality templates into a shared **`run_ingestion`** helper in `tracebloc_ingestor/utils/template_runner.py`, exported from the package root. Templates now only wire up their `CSVIngestor` and delegate ingestion to that helper.
> 
> The helper centralizes the K8s-oriented exit contract: log each failed record (with **`filename` → `data_id` → `Unknown`** identifiers, fixing inconsistent per-template logging), **`sys.exit(1)`** when `ingest()` returns failures, and log + re-raise hard errors instead of exiting 0. Structural template tests now assert import/call of `run_ingestion` and guard against reintroduced swallowing handlers; **`tests/test_template_runner.py`** covers the helper behavior directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f71e4a887fe4449737e6bd16cde99651ae01dc18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->