### PR TITLE
fix(validators): accept single-dict JSON top-level shape (issue #232)

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -131,6 +131,46 @@ def test_loads_from_json_empty_string_is_missing(tmp_path):
     assert result.is_valid, f"expected valid; errors={result.errors}"
 
 
+def test_loads_from_json_single_dict_normalised_to_one_record(tmp_path):
+    """A top-level JSON dict (one record, not wrapped in `[...]`) must validate
+    the same way `[{...}]` does — matching JSONIngestor.read_data's contract.
+
+    Regression: `JSONIngestor.read_data` is explicit:
+
+        # Handle both array and object formats
+        if isinstance(data, dict):
+            data = [data]
+        elif not isinstance(data, list):
+            raise ValueError("JSON data must be an object or array of objects")
+
+    And its docstring promises "handles both single-object and
+    array-of-objects formats". But `DataValidator._load_data`'s .json branch
+    used `pd.read_json(orient="records")`, which expects a list — a
+    top-level dict produced a DataFrame the validator then rejected with
+    "No data found to validate", before `read_data` ever ran. A user
+    submitting a single-record JSON file got the same "0 rows" treatment
+    as an empty file even though their data was perfectly well-formed.
+
+    Surfaced by adversarial testing against v0.3.9-rc1 (issue #232).
+    """
+    p = tmp_path / "single.json"
+    p.write_text('{"id": 1, "age": 30, "label": "A"}')
+    result = DataValidator(
+        schema={"id": "INT", "age": "INT", "label": "VARCHAR(8)"}
+    ).validate(str(p))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+
+
+def test_loads_from_json_non_object_top_level_still_fails(tmp_path):
+    """A top-level JSON value that's neither a dict nor a list (a bare
+    string, number, etc.) must still be rejected — the normalisation only
+    wraps dicts, not arbitrary scalars."""
+    p = tmp_path / "bare.json"
+    p.write_text('"just a string"')
+    result = DataValidator(schema={"a": "INT"}).validate(str(p))
+    assert not result.is_valid
+
+
 def test_unknown_type_fails():
     df = pd.DataFrame({"a": [1]})
     result = DataValidator(schema={"a": "WEIRDTYPE"}).validate(df)

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -171,6 +171,41 @@ def test_loads_from_json_non_object_top_level_still_fails(tmp_path):
     assert not result.is_valid
 
 
+def test_loads_from_json_scalar_array_fails_not_silently_passes(tmp_path):
+    """A top-level JSON array of scalars (numbers/strings, no objects) must be
+    rejected, not pass validation against an unrelated schema.
+
+    Regression: after #232 switched `_load_data` from `pd.read_json` to
+    `json.load` + `pd.DataFrame(raw)`, a top-level scalar array like
+    `[1, 2, 3]` became a non-empty 1-column DataFrame, so schema validation
+    could pass even though `JSONIngestor._iter_validated_records` skips every
+    non-dict element and ingests *zero* records — a validate-pass →
+    ingest-nothing trap. `_load_data` now drops non-dict items to mirror the
+    ingestor, so an all-scalar array collapses to empty and is rejected with
+    "No data found to validate" (bugbot #233).
+    """
+    p = tmp_path / "scalars.json"
+    p.write_text("[1, 2, 3]")
+    result = DataValidator(schema={"id": "INT", "label": "VARCHAR(8)"}).validate(
+        str(p)
+    )
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_loads_from_json_mixed_array_keeps_only_objects(tmp_path):
+    """A top-level array mixing objects and scalars must validate only the
+    objects — matching `JSONIngestor`, which skips the scalars and ingests
+    the dict records (bugbot #233)."""
+    p = tmp_path / "mixed.json"
+    p.write_text('[{"id": 1, "label": "A"}, 42, {"id": 2, "label": "B"}]')
+    result = DataValidator(schema={"id": "INT", "label": "VARCHAR(8)"}).validate(
+        str(p)
+    )
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+    assert result.metadata["rows_checked"] == 2
+
+
 def test_unknown_type_fails():
     df = pd.DataFrame({"a": [1]})
     result = DataValidator(schema={"a": "WEIRDTYPE"}).validate(df)

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -6,6 +6,7 @@ in the schema and provides clear errors when mismatches are found.
 """
 
 import csv as _csv
+import json
 import logging
 import re
 from pathlib import Path
@@ -236,14 +237,20 @@ class DataValidator(BaseValidator):
                     )
                     return df
                 elif suffix == ".json":
-                    # Mirror JSONIngestor.read_data: file is a top-level JSON
-                    # array of records. Without this branch DataValidator
-                    # returned None for every JSON input, the caller raised
-                    # "No data found to validate", and JSON ingestion was
-                    # impossible end-to-end — the recent per-record
-                    # null-tolerance fix (#170) lived behind an unreachable
-                    # gate.
-                    df = pd.read_json(path, orient="records").head(sample_size)
+                    # Mirror JSONIngestor.read_data, which accepts BOTH a
+                    # top-level array of records AND a top-level single dict
+                    # (one record). Its docstring is explicit: "handles both
+                    # single-object and array-of-objects formats", and the
+                    # implementation wraps a dict as `[data]` before iterating.
+                    # Read raw + normalise here so a single-dict JSON file
+                    # doesn't get rejected at the preflight gate with
+                    # "No data found to validate" while the ingestor itself
+                    # would have happily processed it — surfaced by #232.
+                    with open(path, "r", encoding="utf-8") as f:
+                        raw = json.load(f)
+                    if isinstance(raw, dict):
+                        raw = [raw]
+                    df = pd.DataFrame(raw).head(sample_size)
                     # pd.read_json (unlike pd.read_csv with keep_default_na=True)
                     # preserves "" as the literal empty string. Normalise to NaN
                     # so per-type validators below treat "" identically to JSON

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -250,6 +250,18 @@ class DataValidator(BaseValidator):
                         raw = json.load(f)
                     if isinstance(raw, dict):
                         raw = [raw]
+                    # Mirror JSONIngestor._iter_validated_records, which skips
+                    # every non-dict element (`if not isinstance(record, dict)`).
+                    # A top-level scalar array like [1, 2, 3] or ["a", "b"]
+                    # would otherwise become a non-empty 1-column DataFrame via
+                    # pd.DataFrame(raw), so schema validation could pass while
+                    # the ingestor skips all rows and ingests nothing
+                    # (validate-pass → ingest-nothing). Drop non-dict items here
+                    # so the resulting frame matches what actually gets ingested;
+                    # an all-scalar array collapses to empty → "No data found to
+                    # validate" at the gate (bugbot #233).
+                    if isinstance(raw, list):
+                        raw = [item for item in raw if isinstance(item, dict)]
                     df = pd.DataFrame(raw).head(sample_size)
                     # pd.read_json (unlike pd.read_csv with keep_default_na=True)
                     # preserves "" as the literal empty string. Normalise to NaN


### PR DESCRIPTION
Closes #232.

## The asymmetry

[`JSONIngestor.read_data`](../blob/develop/tracebloc_ingestor/ingestors/json_ingestor.py) is explicit about supporting BOTH top-level shapes:

\`\`\`python
# Handle both array and object formats
if isinstance(data, dict):
    data = [data]
elif not isinstance(data, list):
    raise ValueError("JSON data must be an object or array of objects")
\`\`\`

Its docstring also promises: *"handles both single-object and array-of-objects formats"*.

But `DataValidator._load_data`'s .json branch (added in #173) used `pd.read_json(orient=\"records\")` — which expects a list. A top-level single dict like \`{\"id\":1,\"age\":30}\` produced a NaN-laden DataFrame, then the \`.replace(\"\",np.nan)\` step collapsed it to empty, and the validator rejected with **\"No data found to validate\"** — before \`read_data\` ever ran.

Net effect: a perfectly well-formed single-record JSON file got the same treatment as an empty file.

## Repro

\`\`\`json
{\"id\": 1, \"age\": 30, \"label\": \"A\"}
\`\`\`

With an \`ingest.yaml\` declaring \`json:\` and a typed schema, the run fails at the DataValidator gate with \"No data found to validate\". Wrapping the same content in \`[...]\` (1-element array) ingests fine.

## Fix

Read raw via \`json.load\`, wrap a top-level dict in a single-element list (mirroring \`read_data\`), then build the DataFrame. A top-level scalar (string/number) still falls through \`pd.DataFrame\`'s own type check → \"No data found\" — same as before.

## Test plan

- [ ] \`test_loads_from_json_single_dict_normalised_to_one_record\` — single-dict JSON validates against a typed schema
- [ ] \`test_loads_from_json_non_object_top_level_still_fails\` — bare top-level string still fails (the normalisation only wraps dicts, not arbitrary scalars)
- [ ] Existing JSON tests continue to pass (\`test_loads_from_json\`, \`..._genuine_type_error_still_caught\`, \`..._empty_string_is_missing\`)
- [ ] CI green

## Surface

Adversarial testing pass against v0.3.9-rc1: 14 scenarios designed to break the validators, 13 produced correct behavior with clear errors; this was the only behavior-vs-docs mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preflight JSON parsing on the ingestion path; scope is limited to validator loading logic with targeted regression tests, but mismatches here previously blocked or misled users on JSON runs.
> 
> **Overview**
> **JSON preflight** in `DataValidator._load_data` no longer uses `pd.read_json(orient="records")`. It **`json.load`s** the file, **wraps a top-level object** as a one-element list (same as `JSONIngestor.read_data`), and **keeps only dict elements** in top-level arrays so the DataFrame matches what the ingestor actually processes.
> 
> That fixes single-record JSON files (`{"id": 1, ...}`) being rejected with **"No data found to validate"** while ingestion would accept them (#232). It also closes a **validate-pass → ingest-nothing** gap where scalar-only arrays like `[1, 2, 3]` could pass schema checks but yield zero ingested rows (#233); mixed arrays now validate only the object records. Existing **`""` → NaN** normalization for missing JSON fields is unchanged.
> 
> New tests cover single-dict success, bare scalar top-level failure, scalar-array rejection, and mixed arrays with `rows_checked == 2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73c9cb8ef1fff32b2a7edca035b6a1f76e2e5ffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->