### PR TITLE
fix: remove instance_segmentation zombie category, add dispatch-site congruence guard

### DIFF
--- a/tests/test_category_congruence.py
+++ b/tests/test_category_congruence.py
@@ -1,0 +1,141 @@
+"""Congruence tests across the per-category dispatch sites.
+
+A category accepted by the schema enum flows through four dispatch sites,
+each of which silently no-ops on a category it doesn't know:
+
+    1. ``conventions._data_format_for``        (raises — the only loud one)
+    2. ``utils.validators_mapping.map_validators``  (falls through to ``[]``)
+    3. ``ingestors.base._FILE_BEARING_CATEGORIES``  (gate: skips file transfer)
+    4. ``file_transfer.map_file_transfer``          (falls through to ``None``)
+
+instance_segmentation shipped wired into the enum and conventions but
+missing from sites 2-4: configs validated, validation "passed" with zero
+checks, rows reached MySQL and the backend API, and not a single image was
+staged to DEST_PATH — training then failed on missing files (the
+silent-half-ingest pattern from #99). It has been removed from the enum;
+these tests make the invariant structural so the next category cannot ship
+half-wired: every category the schema accepts must be fully dispatched
+everywhere, no carve-outs.
+
+The enum ↔ ``TaskCategory`` equality itself is pinned separately by
+``test_schema_validation.test_schema_category_enum_matches_engine_categories``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from tracebloc_ingestor import file_transfer
+from tracebloc_ingestor.cli.conventions import (
+    DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY,
+    IMAGE_CATEGORIES,
+    _data_format_for,
+)
+from tracebloc_ingestor.ingestors.base import _FILE_BEARING_CATEGORIES
+from tracebloc_ingestor.utils.constants import DataFormat, TaskCategory
+from tracebloc_ingestor.utils.validators_mapping import map_validators
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "tracebloc_ingestor" / "schema" / "ingest.v1.json"
+
+SCHEMA_CATEGORIES = sorted(
+    json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))["properties"]["category"]["enum"]
+)
+
+# Deliberately over-provisioned: carries every key any map_validators branch
+# constructs from (image branches index `extension`/`target_size` directly;
+# the rest use .get). Values only need to satisfy validator constructors —
+# no validation runs here, so semantic fit per category doesn't matter.
+GENEROUS_OPTIONS = {
+    "extension": ".jpg",
+    "target_size": [256, 256],
+    "schema": {"feature_a": "INT", "timestamp": "TIMESTAMP"},
+    "number_of_keypoints": 9,
+    "time_column": "time",
+    "label_column": "label",
+}
+
+
+def _file_bearing(category: str) -> bool:
+    """A category is file-bearing iff its data format implies per-row
+    sidecar files (image/text). Derived from the same production helper
+    the resolver uses, so this test can't drift from the engine — and
+    ``_data_format_for`` raises on a category missing from every
+    conventions grouping, which makes that gap loud here too."""
+    return _data_format_for(category) in (DataFormat.IMAGE, DataFormat.TEXT)
+
+
+@pytest.mark.parametrize("category", SCHEMA_CATEGORIES)
+def test_every_schema_category_resolves_validators(category: str):
+    """Site 2: ``map_validators`` falls through to ``[]`` for categories it
+    doesn't know, which makes validation trivially "pass" with zero checks.
+    Every wired branch returns at least TableName + Duplicate validators,
+    so non-empty is exactly the wired/unwired distinction."""
+    validators = map_validators(category, dict(GENEROUS_OPTIONS))
+    assert validators, (
+        f"map_validators({category!r}) returned no validators — the schema "
+        f"accepts this category but validation would trivially pass with "
+        f"zero checks. Add a branch in utils/validators_mapping.py or "
+        f"remove the category from the schema enum."
+    )
+
+
+def test_file_bearing_categories_match_file_transfer_gate():
+    """Site 3: ``_FILE_BEARING_CATEGORIES`` gates both the SRC_PATH
+    preflight and the per-record ``map_file_transfer`` call. Equality in
+    both directions: a file-bearing category missing from the set ingests
+    rows without ever staging files; a tabular category in the set would
+    fail every record on a file transfer it doesn't need."""
+    expected = {c for c in SCHEMA_CATEGORIES if _file_bearing(c)}
+    assert _FILE_BEARING_CATEGORIES == expected, (
+        "ingestors/base.py _FILE_BEARING_CATEGORIES has drifted from the "
+        "schema enum's file-bearing categories:\n"
+        f"  file-bearing but NOT gated (records ingest with zero files "
+        f"staged): {sorted(expected - _FILE_BEARING_CATEGORIES)}\n"
+        f"  gated but not file-bearing (every record would fail transfer): "
+        f"{sorted(_FILE_BEARING_CATEGORIES - expected)}"
+    )
+
+
+def test_every_file_bearing_category_has_file_transfer_branch():
+    """Site 4: ``map_file_transfer`` falls through to ``None`` for
+    categories it doesn't know; the ingest loop counts that as a
+    file-transfer failure for EVERY record. Inspect the dispatch source
+    for an explicit ``TaskCategory.X`` branch per file-bearing category.
+
+    (Source inspection because calling the real branches touches the
+    filesystem, and the unwired fall-through returns the same ``None`` as
+    a wired branch handling a missing file — behaviorally ambiguous. If
+    map_file_transfer is ever refactored away from explicit TaskCategory
+    comparisons, update this test alongside it.)
+    """
+    source = inspect.getsource(file_transfer.map_file_transfer)
+    mentioned_names = set(re.findall(r"TaskCategory\.([A-Z_][A-Z0-9_]*)", source))
+    mentioned = {getattr(TaskCategory, name) for name in mentioned_names}
+
+    missing = {c for c in SCHEMA_CATEGORIES if _file_bearing(c)} - mentioned
+    assert not missing, (
+        f"map_file_transfer has no branch for file-bearing categories "
+        f"{sorted(missing)} — every record would be dropped as a "
+        f"file-transfer failure. Add a branch in file_transfer.py or "
+        f"remove the category from the schema enum."
+    )
+
+
+def test_every_image_category_has_file_options_defaults():
+    """Companion to site 1: ``_default_file_options_for`` indexes
+    ``DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[category]`` for image
+    categories — a missing entry is a KeyError at resolve time for every
+    config of that category."""
+    missing = set(IMAGE_CATEGORIES) - set(DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY)
+    assert not missing, (
+        f"IMAGE_CATEGORIES {sorted(missing)} have no entry in "
+        f"DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY — resolve() raises "
+        f"KeyError for every config using them."
+    )

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -332,7 +332,6 @@ def test_image_categories_set_matches_schema_requirements():
         TaskCategory.OBJECT_DETECTION,
         TaskCategory.KEYPOINT_DETECTION,
         TaskCategory.SEMANTIC_SEGMENTATION,
-        TaskCategory.INSTANCE_SEGMENTATION,
     }
     assert IMAGE_CATEGORIES == expected
 

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -704,14 +704,14 @@ def test_check_src_path_only_runs_for_file_bearing_categories():
     CSV path is checked separately). This keeps tabular-only ingests
     working even when SRC_PATH isn't set."""
     from tracebloc_ingestor.utils.constants import TaskCategory
-    from tracebloc_ingestor.ingestors.base import _SRC_PATH_REQUIRED_CATEGORIES
+    from tracebloc_ingestor.ingestors.base import _FILE_BEARING_CATEGORIES
     for cat in (
         TaskCategory.TABULAR_CLASSIFICATION,
         TaskCategory.TABULAR_REGRESSION,
         TaskCategory.TIME_SERIES_FORECASTING,
         TaskCategory.TIME_TO_EVENT_PREDICTION,
     ):
-        assert cat not in _SRC_PATH_REQUIRED_CATEGORIES
+        assert cat not in _FILE_BEARING_CATEGORIES
     # Image / text / segmentation / MLM all need a staged SRC_PATH.
     for cat in (
         TaskCategory.IMAGE_CLASSIFICATION,
@@ -721,7 +721,7 @@ def test_check_src_path_only_runs_for_file_bearing_categories():
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
     ):
-        assert cat in _SRC_PATH_REQUIRED_CATEGORIES
+        assert cat in _FILE_BEARING_CATEGORIES
 
 
 def test_check_src_path_required_for_token_classification():
@@ -729,5 +729,5 @@ def test_check_src_path_required_for_token_classification():
     SRC_PATH (same layout as text_classification), so it must get the
     early staging preflight instead of N file-transfer 'not found' errors."""
     from tracebloc_ingestor.utils.constants import TaskCategory
-    from tracebloc_ingestor.ingestors.base import _SRC_PATH_REQUIRED_CATEGORIES
-    assert TaskCategory.TOKEN_CLASSIFICATION in _SRC_PATH_REQUIRED_CATEGORIES
+    from tracebloc_ingestor.ingestors.base import _FILE_BEARING_CATEGORIES
+    assert TaskCategory.TOKEN_CLASSIFICATION in _FILE_BEARING_CATEGORIES

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -80,8 +80,14 @@ def test_image_classification_is_eight_lines():
 
 
 def test_all_task_categories_covered():
-    """Every value in the schema's category enum has a corresponding example,
-    except instance_segmentation which has no template/validator support yet."""
+    """Every value in the schema's category enum has a corresponding example.
+
+    No carve-outs: a category the schema accepts must be fully supported,
+    example included. instance_segmentation used to be exempted here while
+    sitting in the enum with no validators and no file transfer — configs
+    half-ingested (rows + API records, zero files staged). It was removed
+    from the enum instead; see tests/test_category_congruence.py for the
+    guard that keeps every enum value fully wired."""
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     enum_values = set(schema["properties"]["category"]["enum"])
 
@@ -91,10 +97,7 @@ def test_all_task_categories_covered():
         if name != "custom_processor.yaml"  # uses tabular_classification, already covered
     }
 
-    # instance_segmentation is in the enum but has no map_validators branch
-    # yet (no template either) — tracked separately.
-    expected = enum_values - {"instance_segmentation"}
-    missing = expected - covered
+    missing = enum_values - covered
     assert not missing, f"No example for categories: {missing}"
 
 

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -40,7 +40,6 @@ IMAGE_CATEGORIES: FrozenSet[str] = frozenset({
     TaskCategory.OBJECT_DETECTION,
     TaskCategory.KEYPOINT_DETECTION,
     TaskCategory.SEMANTIC_SEGMENTATION,
-    TaskCategory.INSTANCE_SEGMENTATION,
 })
 
 TEXT_CATEGORIES: FrozenSet[str] = frozenset({
@@ -108,9 +107,6 @@ DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY: Dict[str, Dict[str, Any]] = {
     # keypoint_detection: no target_size default — the customer's pose model
     # dictates input resolution, so the schema requires it top-level.
     TaskCategory.KEYPOINT_DETECTION:      {"extension": ".jpg"},
-    # No template exists yet for instance_segmentation; mirror semantic for
-    # forward-compatibility, revisit when the template lands.
-    TaskCategory.INSTANCE_SEGMENTATION:   {"target_size": [512, 512], "extension": ".jpg"},
 }
 
 DEFAULT_TEXT_FILE_OPTIONS: Dict[str, Any] = {

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -45,20 +45,29 @@ _TABULAR_FAMILY_CATEGORIES = frozenset({
     TaskCategory.TIME_TO_EVENT_PREDICTION,
 })
 
-# File-bearing categories resolve every per-row sidecar against
-# ``config.SRC_PATH``. If that path is empty/unset/missing, every file
-# lookup silently falls through to a relative path (``"" + "images/x.jpg"``
-# -> ``"images/x.jpg"``), file_transfer skips every record, and the user
-# sees N copies of "Source image not found: images/x.jpg" — blaming the
-# data when the real cause is "SRC_PATH was never staged on the PVC".
+# File-bearing categories: every record references sidecar files (images,
+# annotations, masks, texts, sequences) that live under ``config.SRC_PATH``
+# and must be copied to DEST_PATH by ``map_file_transfer``. This single set
+# drives BOTH uses:
+#   1. the SRC_PATH preflight in ``validate_data`` — if SRC_PATH is
+#      empty/unset/missing, every file lookup silently falls through to a
+#      relative path and the user sees N copies of "Source image not
+#      found: images/x.jpg", blaming the data when the real cause is
+#      "SRC_PATH was never staged on the PVC";
+#   2. the per-record ``map_file_transfer`` gate in ``_ingest_with_lock``.
+# Keeping these two on one set is deliberate: when they were separate
+# lists, instance_segmentation sat in one but not the other and shipped
+# half-wired — rows reached MySQL and the backend API with zero files
+# staged (the silent-half-ingest pattern from #99).
+# ``tests/test_category_congruence.py`` anchors this set to the schema
+# enum's file-bearing categories.
 # Tabular / time-series have no sidecar dirs under SRC_PATH, so they're
-# excluded from the guard (the CSV path itself is checked elsewhere).
-_SRC_PATH_REQUIRED_CATEGORIES = frozenset({
+# excluded (the CSV path itself is checked elsewhere).
+_FILE_BEARING_CATEGORIES = frozenset({
     TaskCategory.IMAGE_CLASSIFICATION,
     TaskCategory.OBJECT_DETECTION,
     TaskCategory.KEYPOINT_DETECTION,
     TaskCategory.SEMANTIC_SEGMENTATION,
-    TaskCategory.INSTANCE_SEGMENTATION,
     TaskCategory.TEXT_CLASSIFICATION,
     TaskCategory.TOKEN_CLASSIFICATION,
     TaskCategory.MASKED_LANGUAGE_MODELING,
@@ -636,7 +645,7 @@ class BaseIngestor(ABC):
         # "Source image not found: images/x.jpg" — blames the data when
         # the real cause is "SRC_PATH was never staged / set" (#772 P2).
         # File-bearing categories only (tabular has nothing under SRC_PATH).
-        if self.category in _SRC_PATH_REQUIRED_CATEGORIES:
+        if self.category in _FILE_BEARING_CATEGORIES:
             self._check_src_path()
 
         # Pre-flight: a non-UTF-8 CSV otherwise surfaces as a misleading
@@ -785,15 +794,7 @@ class BaseIngestor(ABC):
                         if processed_record:
                             stats["processed_records"] += 1
 
-                            if self.category in [
-                                TaskCategory.IMAGE_CLASSIFICATION,
-                                TaskCategory.OBJECT_DETECTION,
-                                TaskCategory.TEXT_CLASSIFICATION,
-                                TaskCategory.TOKEN_CLASSIFICATION,
-                                TaskCategory.SEMANTIC_SEGMENTATION,
-                                TaskCategory.KEYPOINT_DETECTION,
-                                TaskCategory.MASKED_LANGUAGE_MODELING,
-                            ]:
+                            if self.category in _FILE_BEARING_CATEGORIES:
                                 processed_record = map_file_transfer(
                                     self.category, processed_record, self.file_options
                                 )

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -30,7 +30,6 @@
         "object_detection",
         "keypoint_detection",
         "semantic_segmentation",
-        "instance_segmentation",
         "text_classification",
         "token_classification",
         "tabular_classification",
@@ -289,8 +288,7 @@
               "image_classification",
               "object_detection",
               "keypoint_detection",
-              "semantic_segmentation",
-              "instance_segmentation"
+              "semantic_segmentation"
             ]
           }
         },
@@ -397,7 +395,6 @@
               "object_detection",
               "keypoint_detection",
               "semantic_segmentation",
-              "instance_segmentation",
               "text_classification",
               "token_classification",
               "tabular_classification"

--- a/tracebloc_ingestor/utils/constants.py
+++ b/tracebloc_ingestor/utils/constants.py
@@ -45,8 +45,13 @@ class TaskCategory:
     TIME_SERIES_FORECASTING = "time_series_forecasting"
     TIME_TO_EVENT_PREDICTION = "time_to_event_prediction"
     SEMANTIC_SEGMENTATION = "semantic_segmentation"
-    INSTANCE_SEGMENTATION = "instance_segmentation"
     MASKED_LANGUAGE_MODELING = "masked_language_modeling"
+
+    # instance_segmentation is deliberately absent: it briefly shipped here
+    # and in the schema enum with no validators and no file transfer, so
+    # configs half-ingested (DB rows + API records, zero files staged).
+    # Re-adding a category requires wiring every dispatch site — enforced
+    # by tests/test_category_congruence.py.
 
     @classmethod
     def get_all_categories(cls) -> list[str]:
@@ -67,7 +72,6 @@ class TaskCategory:
             cls.TIME_SERIES_FORECASTING,
             cls.TIME_TO_EVENT_PREDICTION,
             cls.SEMANTIC_SEGMENTATION,
-            cls.INSTANCE_SEGMENTATION,
             cls.MASKED_LANGUAGE_MODELING,
         ]
 


### PR DESCRIPTION
## Summary

`instance_segmentation` was a zombie category in the declarative path: the schema enum accepted it and `conventions.py` resolved defaults for it, but `map_validators` had no branch (validation trivially passed with **zero checks**), `map_file_transfer` had no branch, and the file-transfer gate in `BaseIngestor._ingest_with_lock` excluded it. A customer submitting `category: instance_segmentation` got rows in MySQL, records at the backend API, and a registered dataset — with **zero files staged** to `DEST_PATH`. Training then failed on missing files: the silent-half-ingest pattern from #99.

This PR makes it fail fast and adds a structural guard so the next category can't ship half-wired:

1. **Remove `instance_segmentation` from the schema enum** (3 sites), `TaskCategory`, and `conventions.py`. Submissions now fail at validation, before any DB/network I/O:
   ```
   ingest.yaml validation failed:
     category: 'instance_segmentation' is not one of ['image_classification', 'object_detection', 'keypoint_detection', 'semantic_segmentation', 'text_classification', 'token_classification', 'tabular_classification', 'tabular_regression', 'time_series_forecasting', 'time_to_event_prediction', 'masked_language_modeling']
   ```
2. **Unify `_SRC_PATH_REQUIRED_CATEGORIES` and the inline file-transfer gate list** into one `_FILE_BEARING_CATEGORIES` set in `base.py`. Their divergence (instance_segmentation sat in the first, not the second) is exactly how this shipped half-wired.
3. **Add `tests/test_category_congruence.py`** — every schema-accepted category must resolve a non-empty validator set; file-bearing categories (derived from `_data_format_for`, not a test-side copy) must equal the file-transfer gate and have an explicit `map_file_transfer` branch; every image category must have `file_options` defaults. Also removes the instance_segmentation carve-outs that previous tests had codified.

### Design decision to review: enum removal vs. runtime rejection

The alternative was keeping the enum value and adding a bespoke "not yet supported" rejection in `conventions.resolve()` / `cli/run.py`. I went with removal because:

- The schema is the **published submit contract** (`$id: https://tracebloc.io/schemas/ingest.v1.json`, vendored by jobs-manager as its submit gate per `test_schema_category_enum_matches_engine_categories`) — advertising a value that always fails pushes the failure later and into every schema-consuming tool.
- That same test requires enum == `TaskCategory` exactly, so a runtime rejection would mean carve-outs in the anti-drift test — the exact mechanism that let this zombie survive (`test_all_task_categories_covered` had an explicit instance_segmentation exemption).
- Repo precedent: #213 already narrowed v1 acceptance to kill a silent failure (MLM `label:` rejection). Configs that stop validating never worked — they produced corrupt datasets.
- Re-adding when real support lands is purely additive; the congruence tests now spell out the full wiring checklist.

Full implementation stays blocked behind the declarative mask-sidecar wiring anyway (#136 xfail in e2e). Whether instance_segmentation returns to the roadmap is tracked internally in tracebloc/backend#795.

## Related

Ref #99 (silent-half-ingest pattern), #136 (mask sidecar blocker), #213 (v1-narrowing precedent), #44 (declarative path origin). Tracking re-introduction: tracebloc/backend#795.

## Type of change

- [x] Bug fix

## Test plan

- Full suite: **977 passed, 1 xfailed** (the pre-existing #136 xfail) — includes the new congruence tests.
- New `tests/test_category_congruence.py` covers all four dispatch sites (parametrized per category).
- Manual repro: `INGEST_CONFIG=<yaml with category: instance_segmentation> python -m tracebloc_ingestor.cli.run` → exits 2 with the error above, no DB/network I/O (output quoted in Summary).
- Verified no behavior change for the 11 supported categories: the gate-list → `_FILE_BEARING_CATEGORIES` swap is set-identical for them.

## Deployment notes

- jobs-manager vendors the category enum as its submit gate; until it re-vendors the updated schema, its gate may still accept `instance_segmentation` — the ingestor then rejects at validation (strictly better than today's silent half-ingest). No env vars, no migrations.
- No PyPI version bump here; release PRs handle that per repo convention.

## Checklist

- [x] Tests added / updated and passing locally
- [x] Docs updated if behavior or config changed (checked `docs` repo — no instance_segmentation mentions)
- [x] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
