### PR TITLE
fix: report real MySQL column types from get_table_schema (dialect-type reflection)

### DIFF
--- a/e2e/test_database_e2e.py
+++ b/e2e/test_database_e2e.py
@@ -85,3 +85,34 @@ def test_non_ascii_data_roundtrip(db, table):
     db.create_table(table, {"name": "VARCHAR(64)"})
     db.insert_batch(table, [_rec("u", name="Größe-Meßwert")])
     assert _query(f"SELECT name FROM `{table}` WHERE data_id='u'")[0][0] == "Größe-Meßwert"
+
+
+def test_get_table_schema_reports_real_mysql_types(db, table):
+    """The schema sent to the backend must carry the REAL column types.
+
+    Reflection against a live MySQL returns dialect type classes (INTEGER,
+    FLOAT, DATETIME, ...). A mapping keyed by generic SQLAlchemy class names
+    (Integer, Float, ...) matched none of them, so every non-VARCHAR column
+    was reported to the backend as VARCHAR. The mocked unit test couldn't
+    catch that — it fed generic types into a fake inspector. This is the
+    test shape that does: declared type in, real CREATE TABLE, real
+    reflection out."""
+    db.create_table(table, {
+        "f_int": "INT",
+        "f_float": "FLOAT",
+        "f_dec": "DECIMAL(10,2)",
+        "f_bool": "BOOLEAN",
+        "f_dt": "DATETIME",
+        "f_name": "VARCHAR(64)",
+    })
+    schema = db.get_table_schema(table)
+    assert schema["f_int"] == "INT"
+    assert schema["f_float"] == "FLOAT"
+    assert schema["f_dec"] == "DECIMAL(10,2)"
+    assert schema["f_bool"] == "BOOLEAN"  # MySQL stores BOOL as TINYINT(1)
+    assert schema["f_dt"] == "DATETIME"
+    assert schema["f_name"] == "VARCHAR(64)"
+    # The framework's standard columns get their real types too.
+    assert schema["id"] == "BIGINT"
+    assert schema["created_at"] == "DATETIME"
+    assert schema["annotation"] == "TEXT"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -10,7 +10,18 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-from sqlalchemy import Integer, String, BigInteger, Column, Table
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    Integer,
+    Numeric,
+    String,
+    Table,
+)
+from sqlalchemy.dialects import mysql
 
 from tracebloc_ingestor import database as db_mod
 from tracebloc_ingestor.database import Database
@@ -424,22 +435,82 @@ def test_insert_batch_rolls_back_between_transient_retries(db, mock_engine_facto
 # get_table_schema
 # ---------------------------------------------------------------------------
 
-def test_get_table_schema(db):
+def test_get_table_schema_reflected_dialect_types(db):
+    """Regression: ``inspector.get_columns()`` against a real MySQL returns
+    DIALECT type classes (INTEGER, FLOAT, DATETIME, ...), not the generic
+    SQLAlchemy ones (Integer, Float, ...). The old mapping was keyed by the
+    generic class names, so every non-VARCHAR column fell through to the
+    VARCHAR default — the backend was told INT/FLOAT/DATETIME columns were
+    VARCHAR. (VARCHAR columns only came out right because the fallback
+    happened to be VARCHAR.)"""
+    inspector = MagicMock()
+    inspector.get_columns.return_value = [
+        {"name": "id", "type": mysql.BIGINT(display_width=20)},
+        {"name": "f_int", "type": mysql.INTEGER()},
+        {"name": "f_float", "type": mysql.FLOAT()},
+        {"name": "f_double", "type": mysql.DOUBLE()},
+        {"name": "f_dec", "type": mysql.DECIMAL(precision=10, scale=2)},
+        {"name": "f_bool", "type": mysql.TINYINT(display_width=1)},  # BOOL
+        {"name": "f_tiny", "type": mysql.TINYINT(display_width=4)},
+        {"name": "f_vc", "type": mysql.VARCHAR(length=255)},
+        {"name": "f_text", "type": mysql.TEXT()},
+        {"name": "f_date", "type": mysql.DATE()},
+        {"name": "f_dt", "type": mysql.DATETIME()},
+        {"name": "f_ts", "type": mysql.TIMESTAMP()},
+        {"name": "f_time", "type": mysql.TIME()},
+        {"name": "f_blob", "type": mysql.LONGBLOB()},
+    ]
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        schema = db.get_table_schema("tbl")
+    assert schema == {
+        "id": "BIGINT",
+        "f_int": "INT",
+        "f_float": "FLOAT",
+        "f_double": "DOUBLE",
+        "f_dec": "DECIMAL(10,2)",
+        "f_bool": "BOOLEAN",  # MySQL reflects BOOL as TINYINT(1)
+        "f_tiny": "TINYINT",
+        "f_vc": "VARCHAR(255)",
+        "f_text": "TEXT",
+        "f_date": "DATE",
+        "f_dt": "DATETIME",
+        "f_ts": "TIMESTAMP",
+        "f_time": "TIME",
+        "f_blob": "LONGBLOB",
+    }
+
+
+def test_get_table_schema_generic_types(db):
+    """Generic (in-process) SQLAlchemy types map to the same MySQL vocabulary
+    as their reflected dialect counterparts."""
     inspector = MagicMock()
     class Weird:  # unknown SQLAlchemy type, no 'length' attribute
         pass
 
     inspector.get_columns.return_value = [
         {"name": "id", "type": Integer()},
+        {"name": "big", "type": BigInteger()},
         {"name": "name", "type": String(255)},
+        {"name": "bare_str", "type": String()},  # no length declared
+        {"name": "ratio", "type": Float()},
+        {"name": "price", "type": Numeric(8, 3)},
+        {"name": "flag", "type": Boolean()},
+        {"name": "seen", "type": DateTime()},
         {"name": "weird", "type": Weird()},
     ]
     with patch.object(db_mod, "inspect", return_value=inspector):
         schema = db.get_table_schema("tbl")
     assert schema["id"] == "INT"
+    assert schema["big"] == "BIGINT"
     assert schema["name"] == "VARCHAR(255)"
-    # unknown SQLAlchemy type falls back to VARCHAR
-    assert schema["weird"] == "VARCHAR"
+    assert schema["bare_str"] == "VARCHAR"  # no "VARCHAR(None)"
+    assert schema["ratio"] == "FLOAT"
+    assert schema["price"] == "DECIMAL(8,3)"
+    assert schema["flag"] == "BOOLEAN"
+    assert schema["seen"] == "DATETIME"
+    # Unknown types pass through as their (upper-cased) class name instead of
+    # being mislabelled VARCHAR.
+    assert schema["weird"] == "WEIRD"
 
 
 def test_create_table_rejects_reserved_column():

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -492,34 +492,48 @@ class Database:
         # Get all columns from the table
         columns = inspector.get_columns(table_name)
 
-        # Convert SQLAlchemy types back to MySQL types
+        # Reflection against a live MySQL returns DIALECT type classes whose
+        # names already ARE the MySQL keywords (VARCHAR, INTEGER, DECIMAL,
+        # TINYINT, ...), while in-process metadata uses the GENERIC classes
+        # (String, Integer, Numeric, ...). Upper-casing the class name unifies
+        # the two; this map only covers names that differ from the platform's
+        # MySQL vocabulary (the keywords _get_sqlalchemy_type accepts).
         type_mapping = {
-            "String": "VARCHAR",
-            "Text": "TEXT",
-            "Integer": "INT",
-            "BigInteger": "BIGINT",
-            "Float": "FLOAT",
-            "Double": "DOUBLE",
-            "Boolean": "BOOLEAN",
-            "Date": "DATE",
-            "DateTime": "DATETIME",
-            "Timestamp": "TIMESTAMP",
-            "Time": "TIME",
-            "BLOB": "BLOB",
-            "LONGBLOB": "LONGBLOB",
+            "STRING": "VARCHAR",
+            "INTEGER": "INT",
+            "BIGINTEGER": "BIGINT",
+            "SMALLINTEGER": "SMALLINT",
+            "NUMERIC": "DECIMAL",
+            "DOUBLE_PRECISION": "DOUBLE",
+            "LARGEBINARY": "BLOB",
         }
 
         schema = {}
         for column in columns:
-            # Get the type name
-            type_name = column["type"].__class__.__name__
+            col_type = column["type"]
+            type_name = col_type.__class__.__name__.upper()
 
-            # Convert SQLAlchemy type to MySQL type
-            mysql_type = type_mapping.get(type_name, "VARCHAR")
+            # MySQL has no native BOOLEAN type: BOOL columns are created — and
+            # therefore reflected — as TINYINT(1).
+            if (
+                type_name == "TINYINT"
+                and getattr(col_type, "display_width", None) == 1
+            ):
+                schema[column["name"]] = "BOOLEAN"
+                continue
 
-            # Add length for VARCHAR types
-            if mysql_type == "VARCHAR" and hasattr(column["type"], "length"):
-                mysql_type = f"{mysql_type}({column['type'].length})"
+            mysql_type = type_mapping.get(type_name, type_name)
+
+            # Re-attach the parametrisation MySQL carries in the DDL string.
+            if mysql_type in ("VARCHAR", "CHAR", "BINARY", "VARBINARY"):
+                length = getattr(col_type, "length", None)
+                if length:
+                    mysql_type = f"{mysql_type}({length})"
+            elif mysql_type == "DECIMAL":
+                precision = getattr(col_type, "precision", None)
+                if precision is not None:
+                    scale = getattr(col_type, "scale", None) or 0
+                    mysql_type = f"DECIMAL({precision},{scale})"
 
             schema[column["name"]] = mysql_type
 


### PR DESCRIPTION
## Summary
`Database.get_table_schema` converted reflected column types back to MySQL type strings via a `type_mapping` keyed by **generic** SQLAlchemy class names (`Integer`, `String`, `Float`, …). Against a real MySQL, `inspect(engine).get_columns()` returns **dialect** type classes (`INTEGER`, `VARCHAR`, `FLOAT`, `DATETIME`, `DECIMAL`, …) — none of which matched — so every non-VARCHAR column fell through to the `"VARCHAR"` default. The schema POSTed to the backend via `send_global_meta_meta` therefore reported INT/FLOAT/DATETIME columns as VARCHAR; VARCHAR columns only came out right because the fallback happened to be VARCHAR.

The fix matches on the **upper-cased class name**: MySQL dialect class names already are the MySQL keywords, so the map now only translates the generic names that differ (`String`→`VARCHAR`, `Integer`→`INT`, `Numeric`→`DECIMAL`, …) and unknown types pass through verbatim instead of being mislabelled VARCHAR. Additionally:

- `DECIMAL`/`NUMERIC` now carry precision/scale: `DECIMAL(10,2)`
- `BOOL` columns report as `BOOLEAN` (MySQL has no native boolean — it creates and reflects them as `TINYINT(1)`)
- bare `String` no longer renders as `VARCHAR(None)`

**Which backend field consumes this:** the top-level `schema` field is stored in `GlobalMetaData.schema` and consumed by `common/validators/dataset_validators.py::check_same_schema`, which compares two datasets' schemas for **equality** to decide whether they can be combined (tabular regression / time-series forecasting / time-to-event / MLM). `meta_data.schema` (file_options) always carried the correct user-declared types and is unaffected.

**Behavior note for FR:** datasets ingested before this fix have all-VARCHAR schemas stored backend-side. Combining such an old dataset with a freshly ingested one will now (correctly) fail `check_same_schema` until the old dataset is re-pushed. Previously the check compared all-VARCHAR dicts on both sides, i.e. it validated column *names* only — types were vacuously equal.

## Type of change
- [x] Bug fix

## Test plan
- Replaced the mock-blind unit test (it fed generic types into a mocked inspector, so it passed despite the bug) with `test_get_table_schema_reflected_dialect_types`, which pins the dialect-type behaviour incl. `TINYINT(1)`→`BOOLEAN`, `DECIMAL(10,2)`, and `TINYINT(4)` staying `TINYINT`; kept a generic-types test for the in-process path incl. the unknown-type passthrough.
- New e2e test `test_get_table_schema_reports_real_mysql_types` (e2e/test_database_e2e.py): declared type → real `CREATE TABLE` → real reflection on MySQL 8 — the test shape that would have caught this. Asserts INT/FLOAT/DECIMAL/BOOLEAN/DATETIME/VARCHAR round-trip plus real types for the standard columns (`id`→BIGINT, `created_at`→DATETIME, `annotation`→TEXT).
- Ran locally: `pytest tests/` → 963 passed, 1 xfailed; `docker compose -f e2e/docker-compose.yml up -d` + `pytest e2e/` → 14 passed, 1 xpassed.

## Checklist
- [x] Tests added / updated and passing locally
- [x] Docs updated if behavior or config changed (N/A — internal mapping)
- [x] No secrets / credentials in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
