### PR TITLE
fix(security): block path traversal via manifest filename/mask_id (#239)

### DIFF
--- a/tests/test_file_transfer_path_traversal.py
+++ b/tests/test_file_transfer_path_traversal.py
@@ -1,0 +1,151 @@
+"""Security: path traversal via the manifest's filename / mask_id columns (#239).
+
+Those per-row values come straight from the user's CSV/JSON manifest and used
+to flow unsanitised into ``os.path.join`` on both the read (SRC_PATH) and write
+(DEST_PATH) sides. A crafted value — an absolute path or ``..`` traversal —
+escaped both sandboxes:
+
+  - read: a file outside SRC_PATH was resolved and copied INTO the dataset
+    (exfiltration of another tenant's data / a pod-mounted secret), and
+  - write: the copy destination landed outside DEST_PATH (arbitrary write,
+    e.g. ``/etc/cron.d/evil``) on the shared cluster PVC.
+
+``_safe_join`` now rejects any join that resolves outside its root. These tests
+demonstrate each primitive is blocked and that the legitimate basename path is
+unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tracebloc_ingestor import file_transfer
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+@pytest.fixture
+def dirs(tmp_path, monkeypatch):
+    """Point file_transfer's Config at tmp src + storage dirs, and plant a
+    'secret' file OUTSIDE both sandboxes."""
+    src = tmp_path / "src"
+    storage = tmp_path / "storage"
+    src.mkdir()
+    storage.mkdir()
+    monkeypatch.setenv("SRC_PATH", str(src))
+    monkeypatch.setenv("TABLE_NAME", "tbl")
+    monkeypatch.setattr(file_transfer.config, "STORAGE_PATH", str(storage))
+    secret = tmp_path / "SECRET.txt"
+    secret.write_text("top secret")
+    return src, storage / "tbl", secret
+
+
+# ── _safe_join unit ─────────────────────────────────────────────────────────
+
+
+def test_safe_join_allows_basename(tmp_path):
+    root = str(tmp_path)
+    assert file_transfer._safe_join(root, "images", "cat.jpg") == os.path.abspath(
+        os.path.join(root, "images", "cat.jpg")
+    )
+
+
+@pytest.mark.parametrize(
+    "evil",
+    ["../evil", "../../etc/passwd", "/etc/passwd", "a/../../evil", "../../../x"],
+)
+def test_safe_join_rejects_escape(tmp_path, evil):
+    with pytest.raises(ValueError, match="escapes"):
+        file_transfer._safe_join(str(tmp_path), evil)
+
+
+# ── read primitive: _find_src / _find_mask_src ──────────────────────────────
+
+
+def test_find_src_rejects_absolute_filename(dirs):
+    _, _, secret = dirs
+    with pytest.raises(ValueError, match="escapes"):
+        file_transfer._find_src("images", str(secret), ".txt")
+
+
+def test_find_src_rejects_traversal_filename(dirs):
+    with pytest.raises(ValueError, match="escapes"):
+        file_transfer._find_src("images", "../../SECRET", ".txt")
+
+
+def test_find_src_allows_legit_missing(dirs):
+    # A normal basename that simply doesn't exist -> (None, fname), a tolerated
+    # skip — NOT a raise. The traversal guard must not turn missing files into
+    # hard errors.
+    path, fname = file_transfer._find_src("images", "cat", ".jpg")
+    assert path is None and fname == "cat.jpg"
+
+
+def test_find_mask_src_rejects_absolute(dirs):
+    # An absolute mask_id (no leading '.') survives the extension-split and
+    # reaches _safe_join, which rejects it for escaping masks/.
+    with pytest.raises(ValueError, match="escapes"):
+        file_transfer._find_mask_src("/etc/hostname")
+
+
+def test_find_mask_src_traversal_does_not_escape(dirs):
+    # A dotted '..' mask_id is neutralised by the extension-split
+    # (mask_id.split(".")[0] collapses "../../SECRET" to ""), so it resolves to
+    # a missing file inside the sandbox -> (None, ...), never to a path outside
+    # masks/. Either way no file outside the sandbox is reached; _safe_join is
+    # the backstop if the split ever lets a real traversal through.
+    src_path, ext, _ = file_transfer._find_mask_src("../../SECRET")
+    assert src_path is None
+
+
+# ── write primitive: image_transfer / text_transfer DEST ────────────────────
+
+
+def test_image_transfer_rejects_traversal_dest(dirs):
+    src, dest, secret = dirs
+    # src_path provided (atomic-branch style) so we reach the DEST join with a
+    # crafted filename_with_ext; the write target must not escape DEST.
+    with pytest.raises(ValueError):
+        file_transfer.image_transfer(
+            {"filename": "x"},
+            {"extension": ".jpg"},
+            src_path=str(secret),
+            filename_with_ext="../../PWNED.jpg",
+        )
+    # Nothing was written outside the dataset directory.
+    assert not (dest.parent.parent / "PWNED.jpg").exists()
+
+
+def test_text_transfer_rejects_traversal(dirs):
+    with pytest.raises(ValueError):
+        file_transfer.text_transfer({"filename": "../../PWNED"}, {"extension": ".txt"})
+
+
+# ── end-to-end via map_file_transfer ────────────────────────────────────────
+
+
+def test_map_file_transfer_rejects_absolute_filename(dirs):
+    # image_classification -> image_transfer -> _find_src raises on the absolute
+    # path. (The base ingest loop catches this per-record as a failure, so the
+    # record is rejected + counted, not silently ingested.)
+    with pytest.raises(ValueError):
+        file_transfer.map_file_transfer(
+            TaskCategory.IMAGE_CLASSIFICATION,
+            {"filename": "/etc/hostname"},
+            {"extension": ".jpg"},
+        )
+
+
+# ── the legitimate path is unchanged ────────────────────────────────────────
+
+
+def test_legit_basename_copies_inside_dest(dirs):
+    src, dest, _ = dirs
+    (src / "images").mkdir()
+    (src / "images" / "cat.jpg").write_bytes(b"img")
+
+    rec = file_transfer.image_transfer({"filename": "cat"}, {"extension": ".jpg"})
+
+    assert rec is not None
+    assert (dest / "cat.jpg").exists()  # copied INSIDE the dataset directory

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -62,6 +62,38 @@ def _copy_file_with_retry(src_path: str, dest_path: str) -> None:
     logger.debug(f"Successfully copied file from {src_path} to {dest_path}")
 
 
+def _safe_join(root: str, *parts: str) -> str:
+    """Join ``parts`` under ``root`` and guarantee the result stays inside it.
+
+    The per-row ``filename`` / ``mask_id`` come straight from the user's
+    manifest and are joined onto ``SRC_PATH`` / ``DEST_PATH`` to read and write
+    sidecar files. ``os.path.join`` makes two unsafe moves on hostile input:
+
+      - an absolute component drops everything before it
+        (``os.path.join("/data/shared", "images", "/etc/passwd")`` ->
+        ``"/etc/passwd"``), and
+      - ``..`` segments walk up out of ``root``.
+
+    On the shared cluster PVC that lets a crafted manifest read another
+    tenant's files into the dataset, or clobber files anywhere the Job can
+    write (#239). Normalise the join and reject anything that resolves outside
+    ``root``. ``os.path.abspath`` (not ``realpath``) collapses ``.`` / ``..``
+    and makes the path absolute WITHOUT resolving symlinks, so legitimately
+    symlinked PVC mounts keep working while traversal / absolute injection is
+    blocked.
+    """
+    root_abs = os.path.abspath(root)
+    candidate = os.path.abspath(os.path.join(root_abs, *parts))
+    if candidate != root_abs and not candidate.startswith(root_abs + os.sep):
+        raise ValueError(
+            f"{RED}Refusing path that escapes {root_abs!r}: the manifest value "
+            f"{os.path.join(*parts)!r} resolved to {candidate!r}. A filename / "
+            f"mask_id must stay within the dataset directory — absolute paths "
+            f"and '..' traversal are rejected (path-traversal guard, #239).{RESET}"
+        )
+    return candidate
+
+
 def _has_extension(filename: str) -> bool:
     """Check if filename has an extension, handling multiple dots correctly.
 
@@ -102,7 +134,10 @@ def _find_src(subdirectory: str, filename: str, extension: str):
     filename_with_ext = (
         filename if _has_extension(filename) else f"{filename}{extension}"
     )
-    candidate = os.path.join(config.SRC_PATH, subdirectory, filename_with_ext)
+    # _safe_join raises on a traversal/absolute filename (#239); a genuinely
+    # missing file still returns None below (skip), so a malicious manifest
+    # value is rejected loudly while an absent sidecar is tolerated.
+    candidate = _safe_join(config.SRC_PATH, subdirectory, filename_with_ext)
     if os.path.exists(candidate):
         return candidate, filename_with_ext
     return None, filename_with_ext
@@ -146,8 +181,8 @@ def image_transfer(
                 )
                 return None
 
-        # Save the resized image
-        image_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)
+        # Save the resized image (write target guarded against escaping DEST — #239)
+        image_dest_path = _safe_join(config.DEST_PATH, filename_with_ext)
         # Copy file with retry logic
         _copy_file_with_retry(src_path, image_dest_path)
 
@@ -201,8 +236,8 @@ def annotation_transfer(
                 )
                 return None
 
-        # Save the file
-        file_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)
+        # Save the file (write target guarded against escaping DEST — #239)
+        file_dest_path = _safe_join(config.DEST_PATH, filename_with_ext)
         # Copy file with retry logic
         _copy_file_with_retry(src_path, file_dest_path)
 
@@ -247,14 +282,15 @@ def text_transfer(
         else:
             filename_with_ext = filename
 
-        # Process the text file
-        text_src_path = os.path.join(config.SRC_PATH, src_subdir, filename_with_ext)
+        # Process the text file (both ends guarded against escaping the
+        # SRC/DEST sandboxes via a crafted filename — #239)
+        text_src_path = _safe_join(config.SRC_PATH, src_subdir, filename_with_ext)
         if not os.path.exists(text_src_path):
             logger.error(f"{RED}Source text file not found: {text_src_path}{RESET}")
             return None
 
         # Save the text file
-        text_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)
+        text_dest_path = _safe_join(config.DEST_PATH, filename_with_ext)
         # Copy file with retry logic
         _copy_file_with_retry(text_src_path, text_dest_path)
 
@@ -276,7 +312,8 @@ def _find_mask_src(mask_id: str):
     """
     mask_name = mask_id.split(".")[0] if "." in mask_id else mask_id
     for ext in [".png", ".jpg", ".jpeg"]:
-        candidate = os.path.join(config.SRC_PATH, "masks", f"{mask_name}{ext}")
+        # _safe_join raises on a traversal/absolute mask_id (#239).
+        candidate = _safe_join(config.SRC_PATH, "masks", f"{mask_name}{ext}")
         if os.path.exists(candidate):
             return candidate, ext, mask_name
     return None, None, mask_name
@@ -297,7 +334,8 @@ def mask_transfer(
     os.makedirs(config.DEST_PATH, exist_ok=True)
 
     try:
-        mask_dest_path = os.path.join(config.DEST_PATH, f"{mask_name}{mask_ext}")
+        # Write target guarded against escaping DEST via a crafted mask_id (#239)
+        mask_dest_path = _safe_join(config.DEST_PATH, f"{mask_name}{mask_ext}")
         _copy_file_with_retry(mask_src_path, mask_dest_path)
 
         logger.info(f"{GREEN}Successfully copied mask: {mask_name}{RESET}")


### PR DESCRIPTION
## Summary

**Security fix — path traversal. Closes #239.** Targets `develop` (promote on the normal cadence).

The per-row `filename` and `mask_id` come straight from the user's CSV/JSON manifest and flowed **unsanitised** into `os.path.join` on both the read (`SRC_PATH`) and write (`DEST_PATH`) sides of `file_transfer.py`. A crafted value escapes both sandboxes:

- An **absolute** value drops the sandbox prefix entirely — `os.path.join("/data/shared", "images", "/etc/passwd") == "/etc/passwd"`.
- A **`../../`** value walks up out of the sandbox.

### Confirmed both primitives on the current code

```
READ  absolute filename -> .../SECRET.txt            escaped SRC sandbox? True
READ  '../../SECRET'     -> .../src/images/../../SECRET.txt   escaped SRC sandbox? True
WRITE '../../PWNED.txt'  -> .../PWNED.txt             escaped DEST sandbox? True
WRITE '/etc/cron.d/evil' -> /etc/cron.d/evil          escaped DEST sandbox? True
```

On the shared cluster PVC (multi-tenant / federated deployments) this is:
- a **read** primitive — copy another tenant's file or a pod-mounted secret *into* the dataset, whose metadata then syncs to the platform; and
- an **arbitrary-write** primitive — land the copy outside `DEST_PATH` (e.g. `/etc/cron.d/evil`).

Affects every file-bearing category (image classification, object/keypoint/semantic detection, text/token classification, masked language modeling).

## Fix

`_safe_join(root, *parts)` normalises the join with `os.path.abspath` and **rejects anything resolving outside `root`**. Wired at all **seven** user-influenced join sites: `_find_src`; the image / annotation / text / mask **DEST** writes; the text **SRC** read; `_find_mask_src`.

- A traversal / absolute value now raises a clear `ValueError`. It's caught per-record by the ingest loop, so the malicious record is **rejected and counted as a failure** (run exits non-zero) rather than DoS-ing the whole dataset.
- A legitimately-missing sidecar still returns `None` (tolerated skip) — the guard doesn't turn absent files into hard errors.
- `abspath` (not `realpath`): legitimately symlinked PVC mounts keep working. The threat is manifest-driven `..`/absolute injection, not attacker-controlled symlinks on the user's own staged data.

The remaining `os.path.join(config.…)` occurrences in the file are display-only error strings (reached only for legitimately-missing files, since `_find_src` raises on traversal first) and the fixed `tokenizer.json` constant — neither takes user input.

## Verification

`tests/test_file_transfer_path_traversal.py` (new, 15 cases) demonstrates each read/write primitive is blocked (`_safe_join`, `_find_src`, `_find_mask_src`, `image_transfer`, `text_transfer`, end-to-end via `map_file_transfer`) and that the legitimate basename path still copies inside the dataset dir. Full suite: **977 passed, 1 xfailed** (pre-existing semseg #136), coverage **97.2%**; `file_transfer.py` 99% (the one uncovered line pre-dates this change).

## Independent of #242 / #243

Touches only `file_transfer.py` (+ a new test) — no overlap with the coercion ([#242](https://github.com/tracebloc/data-ingestors/pull/242)) or accounting ([#243](https://github.com/tracebloc/data-ingestors/pull/243)) PRs; all three merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
