### PR TITLE
fix(ux): four ingestion validation/UX papercuts (#238)

### DIFF
--- a/tests/test_config_lazy.py
+++ b/tests/test_config_lazy.py
@@ -157,3 +157,20 @@ def test_api_endpoint_follows_edge_env(clean_env, monkeypatch):
 
     monkeypatch.setenv("CLIENT_ENV", "local")
     assert config.API_ENDPOINT == "http://localhost:8000"
+
+
+@pytest.mark.parametrize("env,attr", [("MYSQL_PORT", "DB_PORT"), ("BATCH_SIZE", "BATCH_SIZE")])
+def test_non_numeric_int_field_raises_clear_error(clean_env, monkeypatch, env, attr):
+    # A non-numeric MYSQL_PORT / BATCH_SIZE must surface a clear config error
+    # naming the field, not a raw "invalid literal for int()" (#238).
+    monkeypatch.setenv(env, "abc")
+    with pytest.raises(ValueError, match="must be an integer"):
+        getattr(Config(), attr)
+
+
+def test_numeric_int_field_still_coerces(clean_env, monkeypatch):
+    monkeypatch.setenv("MYSQL_PORT", "3307")
+    monkeypatch.setenv("BATCH_SIZE", "500")
+    config = Config()
+    assert config.DB_PORT == 3307
+    assert config.BATCH_SIZE == 500

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -42,6 +42,24 @@ def test_read_data_missing_file_raises():
         list(ing.read_data("/no/such/file.csv"))
 
 
+@pytest.mark.parametrize(
+    "sep,needle",
+    [(";", "semicolon"), ("\t", "tab"), ("|", "pipe")],
+)
+def test_wrong_delimiter_hints_at_delimiter(tmp_path, sep, needle):
+    # A ;/tab/pipe-delimited file read as CSV parses as a single column; the
+    # error should hint at the real delimiter instead of the misleading
+    # "every column missing" (#238).
+    p = tmp_path / "f.csv"
+    p.write_text(f"a{sep}b{sep}label\n1{sep}2{sep}x\n")
+    ing = make_csv_ingestor(
+        schema={"a": "INT", "b": "INT", "label": "VARCHAR(10)"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    with pytest.raises(ValueError, match=needle):
+        list(ing.read_data(str(p)))
+
+
 def test_read_data_strips_column_whitespace(tmp_path):
     p = tmp_path / "d.csv"
     p.write_text(" a , b \n1,2\n")

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -485,6 +485,16 @@ def test_check_csv_encoding_skips_non_csv_sources(tmp_path):
     BaseIngestor._check_csv_encoding(str(tmp_path / "missing.csv"))   # nonexistent
 
 
+def test_check_csv_encoding_rejects_nul_byte(tmp_path):
+    # A NUL byte (0x00) is valid UTF-8 so it slips past the decode check, but
+    # pandas' C parser silently TRUNCATES the field at it ("a\x00b" -> "a").
+    # Reject it up front with a clear message (#238).
+    bad = tmp_path / "nul.csv"
+    bad.write_bytes(b"id,name\n1,a\x00b\n2,ok\n")
+    with pytest.raises(ValueError, match="NUL byte"):
+        BaseIngestor._check_csv_encoding(str(bad))
+
+
 # ---------------------------------------------------------------------------
 # Concurrent-ingest table lock — backend/#772 P2
 # ---------------------------------------------------------------------------

--- a/tests/test_table_name_validator.py
+++ b/tests/test_table_name_validator.py
@@ -35,7 +35,6 @@ def test_missing_table_name_fails(clean_env, validator):
         "my-table",       # hyphen
         "my table",       # space
         "table$",         # symbol
-        "_leading",       # underscore start (pattern requires a letter)
     ],
 )
 def test_invalid_characters_fail(clean_env, validator, bad_name):
@@ -44,6 +43,17 @@ def test_invalid_characters_fail(clean_env, validator, bad_name):
     assert not result.is_valid
     assert any("invalid characters" in e for e in result.errors)
     assert result.metadata["invalid_names"]
+
+
+@pytest.mark.parametrize("name", ["_tmp", "_leading", "_"])
+def test_leading_underscore_is_valid(clean_env, validator, name):
+    # The regex used to forbid a leading underscore while the error message +
+    # `valid_pattern` metadata both said it was allowed (#238). MySQL permits a
+    # leading underscore, so such names are now accepted — matching what the
+    # validator already advertised.
+    clean_env.setenv("TABLE_NAME", name)
+    result = validator.validate(None)
+    assert result.is_valid, result.errors
 
 
 def test_reserved_keyword_warns_but_passes(clean_env, validator):

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -72,6 +72,24 @@ class Config:
             return self._overrides[name]
         return default
 
+    @staticmethod
+    def _as_int(field: str, env_name: str, raw: Any) -> int:
+        """``int(raw)`` with a clear config error (#238).
+
+        A non-numeric ``MYSQL_PORT`` / ``BATCH_SIZE`` (e.g. a typo'd
+        ``MYSQL_PORT=abc``) otherwise surfaced as a raw
+        ``ValueError: invalid literal for int() with base 10: 'abc'`` at the
+        point of property access — opaque about which setting is wrong. Name
+        the field and the env var the user should fix instead.
+        """
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"{field} must be an integer, got {raw!r}. Set the "
+                f"{env_name} environment variable to a valid integer."
+            )
+
     # ===== Database =====
     # Cluster-internal MySQL ships with these credentials baked into its
     # image; they're connection conventions, not secrets. Override via env
@@ -85,7 +103,7 @@ class Config:
     def DB_PORT(self) -> int:
         ov = self._override("DB_PORT")
         raw = ov if ov is not _MISSING else os.environ.get("MYSQL_PORT", "3306")
-        return int(raw)
+        return self._as_int("DB_PORT", "MYSQL_PORT", raw)
 
     @property
     def DB_USER(self) -> str:
@@ -106,7 +124,7 @@ class Config:
     def BATCH_SIZE(self) -> int:
         ov = self._override("BATCH_SIZE")
         raw = ov if ov is not _MISSING else os.environ.get("BATCH_SIZE", "4000")
-        return int(raw)
+        return self._as_int("BATCH_SIZE", "BATCH_SIZE", raw)
 
     # ===== API =====
     @property

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -457,21 +457,39 @@ class BaseIngestor(ABC):
 
     @staticmethod
     def _check_csv_encoding(source: Any) -> None:
-        """Fail fast with a clear message if a CSV source is not valid UTF-8.
+        """Fail fast with a clear message on a CSV that isn't valid UTF-8 or
+        that contains a NUL byte.
 
         Every validator reads CSVs as UTF-8 and swallows decode errors into a
         misleading "No data found"; a non-UTF-8 export (e.g. a Latin-1/Windows
-        CSV with umlauts) would otherwise crash or mislead. Probe once, up front.
+        CSV with umlauts) would otherwise crash or mislead. A NUL byte (0x00)
+        is sneakier: it IS valid UTF-8 (U+0000) so it slips past the decode
+        check, but pandas' C parser silently TRUNCATES the field at the NUL
+        (``"a\\x00b"`` -> ``"a"``) — silent corruption (#238). Probe once, up
+        front, and reject both.
         """
         if not isinstance(source, (str, Path)):
             return
         path = Path(source)
         if path.suffix.lower() != ".csv" or not path.exists():
             return
+        offset = 0
         try:
             with open(path, "r", encoding="utf-8") as fh:
-                while fh.read(1 << 20):  # decode in 1 MB chunks; raises on a bad byte
-                    pass
+                while True:
+                    chunk = fh.read(1 << 20)  # 1 MB; decode raises on a bad byte
+                    if not chunk:
+                        break
+                    nul = chunk.find("\x00")
+                    if nul != -1:
+                        raise ValueError(
+                            f"{RED}'{path.name}' contains a NUL byte (0x00) at "
+                            f"character {offset + nul}. This is not valid CSV text "
+                            f"— the file is likely binary or a corrupt export, and "
+                            f"pandas would silently truncate the field at the NUL. "
+                            f"Remove the NUL byte(s) and re-ingest.{RESET}"
+                        )
+                    offset += len(chunk)
         except UnicodeDecodeError as exc:
             raise ValueError(
                 f"{RED}'{path.name}' is not valid UTF-8 — a non-UTF-8 byte was found at "

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -200,8 +200,30 @@ class CSVIngestor(BaseIngestor):
         # Log which schema columns are not in the CSV (for information only)
         missing_columns = set(self.schema.keys()) - set(df.columns)
         if missing_columns:
+            # A delimiter mismatch is the usual cause when EVERY schema column
+            # reads as "missing": a ;/tab/pipe-delimited file (European Excel
+            # export, or a TSV saved as .csv) parses as a single column whose
+            # header still contains the real delimiter. Surface that instead of
+            # the misleading "every column missing" (#238).
+            hint = ""
+            if len(df.columns) == 1:
+                only = str(df.columns[0])
+                for delim, label in (
+                    (";", "';' (semicolon)"),
+                    ("\t", "a tab"),
+                    ("|", "'|' (pipe)"),
+                ):
+                    if delim in only:
+                        hint = (
+                            f" The file parsed as a single column — it appears to "
+                            f"be delimited by {label}, not a comma. Set the "
+                            f"delimiter (csv_options 'delimiter') to match and "
+                            f"re-ingest."
+                        )
+                        break
             raise ValueError(
-                f"{RED}Schema columns not present in CSV: {', '.join(missing_columns)}{RESET}"
+                f"{RED}Schema columns not present in CSV: "
+                f"{', '.join(sorted(missing_columns))}.{hint}{RESET}"
             )
 
         # Type validation using pandas dtypes - only for columns that exist in the CSV

--- a/tracebloc_ingestor/validators/table_name_validator.py
+++ b/tracebloc_ingestor/validators/table_name_validator.py
@@ -37,9 +37,14 @@ class TableNameValidator(BaseValidator):
             name: Human-readable name of the validator
         """
         super().__init__(name)
-        # Pattern: only alphanumeric characters and underscores
-        # Must start with a letter
-        self.pattern = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
+        # Pattern: only alphanumeric characters and underscores; must start
+        # with a letter or underscore. The compiled regex used to forbid a
+        # leading underscore while the error message AND the advertised
+        # `valid_pattern` metadata both said it was allowed — so a name like
+        # `_tmp` was rejected with a message claiming it was valid (#238).
+        # MySQL identifiers may begin with an underscore, so the regex is
+        # relaxed to agree with the (already-correct) message/metadata.
+        self.pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         """Validate table names from config.


### PR DESCRIPTION
## Summary

**Closes #238** — four grouped, independent validation/UX papercuts found during ingestor stress-testing. Each verified against the real code path; each has a regression test.

### 1. Wrong delimiter → misleading error
A `;`/tab/pipe-delimited file (European Excel export, or a TSV saved as `.csv`) parses as a single column, and the error was the baffling `Schema columns not present in CSV: <every column>` — confusing because the columns are visibly in the file. When the file parses as **one** column whose header still contains a non-comma delimiter, `CSVIngestor._validate_csv` now appends a hint: *"appears to be delimited by ';' (semicolon), not a comma. Set the delimiter…"*.

### 2. NUL byte silently truncates a field
pandas' C parser truncates `"a\x00b"` → `"a"` at read time (verified) — silent corruption. A NUL byte is valid UTF-8 (U+0000), so it slipped past the existing UTF-8 preflight. `BaseIngestor._check_csv_encoding` now also rejects NUL bytes with a clear message. It's folded into the existing single raw-byte scan (which already runs before `read_data`), so no extra file pass.

### 3. `TableNameValidator` message/impl mismatch
The compiled regex was `^[a-zA-Z][a-zA-Z0-9_]*$` (no leading underscore), but the error message *and* the `valid_pattern` metadata both advertised `^[a-zA-Z_][a-zA-Z0-9_]*$` — so `_tmp` was rejected with a message claiming it was valid. MySQL permits a leading underscore, so the regex is **relaxed** to agree with the (already-correct) message/metadata. This only widens what's accepted — no previously-valid name becomes invalid.

### 4. Config numeric env coercion
A non-numeric `MYSQL_PORT` / `BATCH_SIZE` (e.g. `MYSQL_PORT=abc`) raised a raw `ValueError: invalid literal for int() with base 10: 'abc'` at property access. `Config` now raises a clear `<FIELD> must be an integer, got 'abc'. Set the <ENV> environment variable…` via a shared `_as_int` helper.

## Verification

New/updated tests in `test_csv_ingestor.py` (delimiter hint, parametrized over `;`/tab/`|`), `test_ingestor_base.py` (NUL rejection), `test_table_name_validator.py` (leading-underscore now valid; removed the stale "rejects `_leading`" case), and `test_config_lazy.py` (clear error on non-numeric, plus a control that valid ints still coerce). Full suite: **971 passed, 1 xfailed** (pre-existing semseg #136), coverage **97.2%**.

## Merge note

Touches `csv_ingestor.py` and `base.py`, which [#242](https://github.com/tracebloc/data-ingestors/pull/242) / [#243](https://github.com/tracebloc/data-ingestors/pull/243) also touch — but in **different functions/regions** (the missing-columns block + `_check_csv_encoding` here, vs the numeric casts/`read_data` na_values in #242 and the ingest-loop accounting in #243). They merge cleanly; if a trivial conflict surfaces depending on merge order it's a few adjacent lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
