### PR TITLE
refactor(packaging): split runtime vs dev requirements; declare numpy

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install package + deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt   # runtime (-r requirements.txt) + test tools
           pip install -e .
 
       - name: Run e2e ingestion suite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install package + test deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt   # runtime (-r requirements.txt) + test/lint tools
           pip install -e .
 
       - name: Run pytest with coverage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,24 @@
+# Development / CI dependencies: everything needed to test, lint, type-check,
+# and publish the package — but NOT required at runtime. Kept out of
+# requirements.txt so `pip install tracebloc_ingestor` and the signed Docker
+# image stay lean.
+#
+# Local dev / CI install:  pip install -r requirements-dev.txt
+-r requirements.txt
+
+# Testing
+pytest>=7.0.0
+pytest-cov>=4.1.0
+
+# Type checking
+mypy>=1.0.0
+types-requests
+types-urllib3
+
+# Linting / formatting
+black>=23.0.0
+isort>=5.12.0
+flake8>=6.0.0
+
+# Release / publishing
+twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
+# Runtime dependencies for the tracebloc_ingestor package.
+#
+# Dev / test / lint / release tooling lives in requirements-dev.txt so it is
+# NOT pulled into `pip install tracebloc_ingestor` or baked into the signed
+# Docker image. setup.py reads THIS file for install_requires (comment and
+# -r/-c lines are filtered out there).
+
 # Database
 sqlalchemy>=2.0.0
 mysql-connector-python>=8.0.0
@@ -9,37 +16,25 @@ urllib3
 # Retry mechanism
 tenacity>=8.0.1
 
-# Image processing (for image processor)
+# Image processing (image validators / file transfer)
 Pillow>=10.0.0
 
-# CSV/JSON handling
+# CSV / JSON handling
 pandas>=2.0.0
+# numpy is imported DIRECTLY by csv_ingestor / data_validator (not only via
+# pandas), so declare it explicitly instead of relying on it transitively.
+numpy>=1.23
 
-# Streaming JSON parser (used by JSONIngestor.read_data so multi-GB JSON
-# datasets ingest without materialising the whole file — backend/#772 P2).
+# Streaming JSON parser — JSONIngestor.read_data streams multi-GB JSON without
+# materialising the whole file (backend/#772 P2).
 ijson>=3.2.0
 
-# YAML config + JSON Schema validation (for the declarative ingest.yaml flow)
+# YAML config + JSON Schema validation (declarative ingest.yaml flow)
 PyYAML>=6.0
 jsonschema>=4.0.0
 
-# Logging and monitoring
+# Structured logging
 python-json-logger>=2.0.0
 
-# Type checking
-mypy>=1.0.0
-types-requests
-types-urllib3
-
-# Testing
-pytest>=7.0.0
-pytest-cov>=4.1.0
-
-# Development tools
-black>=23.0.0
-isort>=5.12.0
-flake8>=6.0.0
-twine
-
 # Progress bar
-tqdm>=4.65.0 
+tqdm>=4.65.0

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,25 @@ def _read_version():
     return match.group(1)
 
 
-with open("requirements.txt", "r") as f:
-    requirements = f.read().splitlines()
+def _read_requirements(filename):
+    """Return the runtime requirement strings from a pip requirements file,
+    skipping blank lines, comments, and ``-r`` / ``-c`` include directives.
+
+    Without the filter, a section header like ``# Database`` (and the blank
+    separators) were fed verbatim into ``install_requires`` — only tolerated
+    by luck of the installer. Filtering keeps install_requires to actual
+    requirement specifiers now that runtime/dev deps are split across
+    requirements.txt and requirements-dev.txt.
+    """
+    lines = (this_directory / filename).read_text().splitlines()
+    return [
+        s
+        for line in lines
+        if (s := line.strip()) and not s.startswith(("#", "-"))
+    ]
+
+
+requirements = _read_requirements("requirements.txt")
 
 setup(
     name="tracebloc_ingestor",


### PR DESCRIPTION
## Summary

**Phase 1 of the data-ingestors refactor — packaging hygiene.** Fixes a real, user-visible defect with zero behavior change to the package code.

Today `pip install tracebloc_ingestor` **and the cosign-signed production Docker image** both pull in `pytest`, `black`, `flake8`, `mypy`, `isort`, and `twine`. Cause: `setup.py` feeds the entire `requirements.txt` — which mixed runtime + dev tooling — into `install_requires`, and it even fed the section-**comment** lines (`# Database`, …) in verbatim.

## Changes

- **`requirements.txt`** → runtime-only, and now declares **`numpy`** explicitly (it's imported *directly* by `csv_ingestor` / `data_validator`; was relied on only transitively via pandas — a latent breakage if pandas ever dropped it).
- **`requirements-dev.txt`** (new) → the test / lint / type / release tooling, plus `-r requirements.txt` so one install gets everything for dev.
- **`setup.py`** → `_read_requirements` filters blank / comment / `-r` lines, so `install_requires` only ever contains real specifiers.
- **`tests.yml` / `e2e.yml`** → install `requirements-dev.txt`.

## Verified

Built the wheel and inspected its metadata — `Requires-Dist` is now **exactly the 13 runtime deps**, no dev tooling:

```
Requires-Dist: sqlalchemy>=2.0.0 … pandas>=2.0.0 … numpy>=1.23 … tqdm>=4.65.0
OK: no dev tooling in wheel Requires-Dist
```

So the signed image (Dockerfile installs `requirements.txt`, slimmer now) and PyPI consumers stop shipping test/lint tooling. **Publish workflows are unaffected** — they install `setuptools`/`wheel`/`twine` directly, never via `requirements.txt`. Full suite green: **962 passed, 1 xfailed**, coverage **97.2%**.

## Where this sits in the refactor

This is the lowest-risk, highest-immediate-value phase and the only one that's **unblocked right now** — it touches `requirements*.txt` / `setup.py` / workflows, files none of the in-flight fix PRs (#242–#245) touch, so zero conflict.

The structural phases — a `ModalityRegistry` collapsing the five category-dispatch sites, constructor-injected `Config` (killing the ~20 module-level singletons + the env-var bridge), and decomposing the 1,200-line `BaseIngestor` — are deliberately **gated on #242–#245 merging**, since they restructure the exact files those PRs change. A `pyproject.toml` migration (modernizing the build off `setup.py`) is a separate follow-up because it touches the release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
