### PR TITLE
refactor(P2): extract ingestion-summary renderer into reporting.ConsoleRenderer

### DIFF
--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,74 @@
+"""Tests for ConsoleRenderer — the extracted ingestion-summary presentation.
+
+Pulling the summary box out of ``BaseIngestor._log_summary`` into
+``reporting.ConsoleRenderer`` (structural refactor — backend#796, P2) means
+the presentation is now testable in isolation, without a database or a full
+ingest. These lock the rendered output's contract.
+"""
+
+import contextlib
+import io
+
+import pytest
+
+from tracebloc_ingestor.ingestors.base import IngestionSummary
+from tracebloc_ingestor.reporting import ConsoleRenderer
+
+
+def _render(summary):
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ConsoleRenderer().render_summary(summary)
+    return buf.getvalue()
+
+
+def test_clean_run_renders_success_banner():
+    out = _render(IngestionSummary("ing-1", 10, 10, 10, 10, 0, 0, 0))
+    assert "📊 INGESTION SUMMARY" in out
+    assert "ing-1" in out
+    assert "100.0%" in out
+    assert "🎉 Ingestion completed successfully!" in out
+
+
+def test_dropped_records_disqualify_success_and_are_counted():
+    # 4 of 10 dropped during processing (skipped_records). Per #234 the banner
+    # must NOT claim success, and the failure count must include the drops.
+    out = _render(IngestionSummary("ing-2", 10, 6, 6, 6, 0, 4, 0))
+    assert "🎉" not in out
+    assert "with 4 failure(s)" in out
+
+
+def test_file_transfer_failures_disqualify_success():
+    out = _render(IngestionSummary("ing-3", 10, 10, 10, 10, 0, 0, 2))
+    assert "🎉" not in out
+    assert "with 2 failure(s)" in out
+
+
+def test_api_send_gap_counted_without_double_counting():
+    # 10 inserted, only 7 shipped to the API -> 3 api-only failures, and no
+    # other channel failed, so the total is exactly 3 (not double-counted
+    # against total_records).
+    out = _render(IngestionSummary("ing-4", 10, 10, 10, 7, 0, 0, 0))
+    assert "🎉" not in out
+    assert "with 3 failure(s)" in out
+
+
+@pytest.mark.parametrize(
+    "summary,needle",
+    [
+        # success_rate >= 80 -> mild banner
+        (IngestionSummary("a", 10, 9, 9, 9, 1, 0, 0), "see logs."),
+        # 60 <= rate < 80 -> "many records failed"
+        (IngestionSummary("b", 10, 7, 7, 7, 3, 0, 0), "many records failed"),
+        # rate < 60 -> "Critical"
+        (IngestionSummary("c", 10, 3, 3, 3, 7, 0, 0), "❌ Critical!"),
+    ],
+)
+def test_severity_thresholds(summary, needle):
+    assert needle in _render(summary)
+
+
+def test_zero_total_records_does_not_divide_by_zero():
+    # An empty source must render without raising (no success-rate bar).
+    out = _render(IngestionSummary("empty", 0, 0, 0, 0, 0, 0, 0))
+    assert "📊 INGESTION SUMMARY" in out

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -20,12 +20,12 @@ from ..utils.constants import (
     GREEN,
     RED,
     YELLOW,
-    BLUE,
     CYAN,
 )
 from ..utils import label_policy as label_policy_module
 from ..utils.validators_mapping import map_validators
 from ..file_transfer import map_file_transfer
+from ..reporting import ConsoleRenderer
 
 # Logger for this module. Level is set by `setup_logging()` on the root
 # logger when the user script calls it; child loggers inherit that level.
@@ -1139,122 +1139,13 @@ class BaseIngestor(ABC):
             raise
 
     def _log_summary(self, summary: IngestionSummary):
-        """Log ingestion summary in a clear, formatted way with enhanced visual appeal.
+        """Render the ingestion summary box.
 
-        A "success" here means the record was inserted to the DB, sent to
-        the API, AND its sidecar file (image / annotation / mask / text)
-        was copied to the destination. Records whose source file was
-        missing are subtracted from the success count even if the DB
-        row landed — see issue #99 for the silent-data-loss pattern that
-        motivated this.
+        Delegates to :class:`tracebloc_ingestor.reporting.ConsoleRenderer` so the
+        presentation (ANSI colours, emoji, the box layout) lives in one place,
+        out of the ingestion logic (structural refactor — backend#796, P2).
+        Kept as a method (rather than calling the renderer at the call site) so
+        existing callers and tests that reference ``BaseIngestor._log_summary``
+        keep working unchanged; the rendered output is byte-for-byte identical.
         """
-
-        # A successful record requires DB insert AND API send AND, where
-        # applicable, a successful file transfer. File-transfer failures
-        # short-circuit before the DB write (they're skipped from the
-        # batch), so subtracting them from total_records gives the
-        # denominator's effective ceiling. Use inserted_records (the
-        # actual durable outcome) as the numerator.
-        success_rate = 0
-        if summary.total_records > 0:
-            success_rate = (summary.inserted_records / summary.total_records) * 100
-
-        # Determine overall status color
-        status_color = (
-            GREEN if success_rate >= 90 and not summary.has_failures
-            else YELLOW if success_rate >= 70
-            else RED
-        )
-
-        print(f"\n{CYAN}{'═'*60}{RESET}")
-        print(f"{BOLD}{CYAN}📊 INGESTION SUMMARY 📊{RESET}")
-        print(f"{CYAN}{'═'*60}{RESET}")
-        print(
-            f"{BOLD}Ingestor ID:{RESET}                {BLUE}{summary.ingestor_id}{RESET}"
-        )
-        # Main statistics with icons and colors
-        print(
-            f"{BOLD}📈 Total Records Found:{RESET}     {BLUE}{summary.total_records:,}{RESET}"
-        )
-        print(
-            f"{BOLD}✅ Successfully Processed:{RESET}  {GREEN}{summary.processed_records:,}{RESET}"
-        )
-        print(
-            f"{BOLD}💾 Inserted to Database:{RESET}    {GREEN}{summary.inserted_records:,}{RESET}"
-        )
-        print(
-            f"{BOLD}🚀 Sent to API:{RESET}             {GREEN}{summary.api_sent_records:,}{RESET}"
-        )
-        print(
-            f"{BOLD}⏭️  Skipped Records:{RESET}        {YELLOW}{summary.skipped_records:,}{RESET}"
-        )
-        file_transfer_color = (
-            RED if summary.file_transfer_failures > 0 else GREEN
-        )
-        print(
-            f"{BOLD}📁 File Transfer Failures:{RESET}  {file_transfer_color}{summary.file_transfer_failures:,}{RESET}"
-        )
-        print(
-            f"{BOLD}❌ Failed DB Insertion:{RESET}     {RED}{summary.failed_records:,}{RESET}"
-        )
-        # Only count records that made it to a DB insert but didn't ship
-        # to the API. Using `total_records - api_sent_records` would also
-        # include file-transfer failures and DB failures (which never had
-        # a chance to ship), giving an inflated, double-counted total.
-        api_only_failures = max(
-            0, summary.inserted_records - summary.api_sent_records
-        )
-        print(
-            f"{BOLD}❌ Failed to Send to API:{RESET}   {RED}{api_only_failures:,}{RESET}"
-        )
-        print(f"{CYAN}{'─'*60}{RESET}")
-
-        # Success rate with visual indicator
-        if summary.total_records > 0:
-            # Progress bar
-            bar_length = 30
-            filled_length = int(bar_length * success_rate / 100)
-            bar = "█" * filled_length + "░" * (bar_length - filled_length)
-            print(
-                f"{BOLD}📊 Success Rate:{RESET} [{status_color}{bar}{RESET}] {status_color}{success_rate:.1f}%{RESET}"
-            )
-
-        # Status banner. Any non-trivial failure (DB, API, file-transfer, or a
-        # record dropped during processing) disqualifies the "completed
-        # successfully" message — a customer seeing 🎉 should be able to trust
-        # that no record was silently dropped. The four failure channels are
-        # mutually exclusive per record (a dropped record never reaches
-        # file-transfer; file-transfer failures never reach DB; DB failures
-        # never reach API; api_only_failures are records that hit DB but didn't
-        # ship), so summing them gives a clean unique count instead of the
-        # double-count `total_records - api_sent_records` would produce.
-        # ``skipped_records`` MUST be included or the count contradicts the
-        # severity text — a run that drops most rows printed "0 failure(s)"
-        # while success_rate said "most records failed" (#234).
-        total_failures = (
-            summary.failed_records
-            + summary.file_transfer_failures
-            + summary.skipped_records
-            + api_only_failures
-        )
-        if not summary.has_failures:
-            status_msg = "🎉 Ingestion completed successfully!"
-        elif success_rate >= 80:
-            status_msg = (
-                f"⚠️  Ingestion completed with {total_failures:,} failure(s), "
-                "see logs."
-            )
-        elif success_rate >= 60:
-            status_msg = (
-                f"⚠️  Ingestion completed with {total_failures:,} failure(s); "
-                "many records failed to process — see logs."
-            )
-        else:
-            status_msg = (
-                f"❌ Critical! Ingestion completed with {total_failures:,} "
-                "failure(s); most records failed — see logs."
-            )
-
-        print(f"{CYAN}{'─'*60}{RESET}")
-        print(f"{BOLD}{status_color}{status_msg}{RESET}")
-        print(f"{CYAN}{'═'*60}{RESET}\n")
+        ConsoleRenderer().render_summary(summary)

--- a/tracebloc_ingestor/reporting.py
+++ b/tracebloc_ingestor/reporting.py
@@ -1,0 +1,143 @@
+"""Console rendering for ingestion output.
+
+The single home for human-facing presentation of an ingestion run — the ANSI
+colours, the emoji, and the summary box. Business logic builds a pure
+``IngestionSummary`` (data only); this renderer turns it into the terminal
+output a customer sees.
+
+Keeping presentation here, out of ``BaseIngestor``, means the engine can run
+headless, the summary format can change without touching ingestion logic, and
+there is exactly one place that imports the ANSI constants for this path
+(structural refactor — backend#796, phase P2). Behaviour is unchanged: the
+rendered output is byte-for-byte what ``BaseIngestor._log_summary`` produced.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .utils.constants import BLUE, BOLD, CYAN, GREEN, RED, RESET, YELLOW
+
+if TYPE_CHECKING:  # import only for typing — avoids a runtime cycle, since
+    # base.py imports this module at load time.
+    from .ingestors.base import IngestionSummary
+
+
+class ConsoleRenderer:
+    """Renders ingestion results to stdout.
+
+    The only place the summary's ANSI / emoji formatting lives. Stateless for
+    now; a class (rather than a bare function) so later presentation concerns
+    — a no-colour mode, rendering validation errors — have a natural home.
+    """
+
+    def render_summary(self, summary: "IngestionSummary") -> None:
+        """Print the ingestion summary box (success rate, per-channel counts,
+        status banner). Moved verbatim from ``BaseIngestor._log_summary`` — the
+        success-rate / failure-count arithmetic stays with the rendering it
+        feeds, so the customer-facing output is identical."""
+        # A successful record requires DB insert AND API send AND, where
+        # applicable, a successful file transfer. File-transfer failures
+        # short-circuit before the DB write (they're skipped from the
+        # batch), so subtracting them from total_records gives the
+        # denominator's effective ceiling. Use inserted_records (the
+        # actual durable outcome) as the numerator.
+        success_rate = 0
+        if summary.total_records > 0:
+            success_rate = (summary.inserted_records / summary.total_records) * 100
+
+        # Determine overall status color
+        status_color = (
+            GREEN
+            if success_rate >= 90 and not summary.has_failures
+            else YELLOW if success_rate >= 70 else RED
+        )
+
+        print(f"\n{CYAN}{'═'*60}{RESET}")
+        print(f"{BOLD}{CYAN}📊 INGESTION SUMMARY 📊{RESET}")
+        print(f"{CYAN}{'═'*60}{RESET}")
+        print(
+            f"{BOLD}Ingestor ID:{RESET}                {BLUE}{summary.ingestor_id}{RESET}"
+        )
+        # Main statistics with icons and colors
+        print(
+            f"{BOLD}📈 Total Records Found:{RESET}     {BLUE}{summary.total_records:,}{RESET}"
+        )
+        print(
+            f"{BOLD}✅ Successfully Processed:{RESET}  {GREEN}{summary.processed_records:,}{RESET}"
+        )
+        print(
+            f"{BOLD}💾 Inserted to Database:{RESET}    {GREEN}{summary.inserted_records:,}{RESET}"
+        )
+        print(
+            f"{BOLD}🚀 Sent to API:{RESET}             {GREEN}{summary.api_sent_records:,}{RESET}"
+        )
+        print(
+            f"{BOLD}⏭️  Skipped Records:{RESET}        {YELLOW}{summary.skipped_records:,}{RESET}"
+        )
+        file_transfer_color = RED if summary.file_transfer_failures > 0 else GREEN
+        print(
+            f"{BOLD}📁 File Transfer Failures:{RESET}  {file_transfer_color}{summary.file_transfer_failures:,}{RESET}"
+        )
+        print(
+            f"{BOLD}❌ Failed DB Insertion:{RESET}     {RED}{summary.failed_records:,}{RESET}"
+        )
+        # Only count records that made it to a DB insert but didn't ship
+        # to the API. Using `total_records - api_sent_records` would also
+        # include file-transfer failures and DB failures (which never had
+        # a chance to ship), giving an inflated, double-counted total.
+        api_only_failures = max(0, summary.inserted_records - summary.api_sent_records)
+        print(
+            f"{BOLD}❌ Failed to Send to API:{RESET}   {RED}{api_only_failures:,}{RESET}"
+        )
+        print(f"{CYAN}{'─'*60}{RESET}")
+
+        # Success rate with visual indicator
+        if summary.total_records > 0:
+            # Progress bar
+            bar_length = 30
+            filled_length = int(bar_length * success_rate / 100)
+            bar = "█" * filled_length + "░" * (bar_length - filled_length)
+            print(
+                f"{BOLD}📊 Success Rate:{RESET} [{status_color}{bar}{RESET}] {status_color}{success_rate:.1f}%{RESET}"
+            )
+
+        # Status banner. Any non-trivial failure (DB, API, file-transfer, or a
+        # record dropped during processing) disqualifies the "completed
+        # successfully" message — a customer seeing 🎉 should be able to trust
+        # that no record was silently dropped. The four failure channels are
+        # mutually exclusive per record (a dropped record never reaches
+        # file-transfer; file-transfer failures never reach DB; DB failures
+        # never reach API; api_only_failures are records that hit DB but didn't
+        # ship), so summing them gives a clean unique count instead of the
+        # double-count `total_records - api_sent_records` would produce.
+        # ``skipped_records`` MUST be included or the count contradicts the
+        # severity text — a run that drops most rows printed "0 failure(s)"
+        # while success_rate said "most records failed" (#234).
+        total_failures = (
+            summary.failed_records
+            + summary.file_transfer_failures
+            + summary.skipped_records
+            + api_only_failures
+        )
+        if not summary.has_failures:
+            status_msg = "🎉 Ingestion completed successfully!"
+        elif success_rate >= 80:
+            status_msg = (
+                f"⚠️  Ingestion completed with {total_failures:,} failure(s), "
+                "see logs."
+            )
+        elif success_rate >= 60:
+            status_msg = (
+                f"⚠️  Ingestion completed with {total_failures:,} failure(s); "
+                "many records failed to process — see logs."
+            )
+        else:
+            status_msg = (
+                f"❌ Critical! Ingestion completed with {total_failures:,} "
+                "failure(s); most records failed — see logs."
+            )
+
+        print(f"{CYAN}{'─'*60}{RESET}")
+        print(f"{BOLD}{status_color}{status_msg}{RESET}")
+        print(f"{CYAN}{'═'*60}{RESET}\n")


### PR DESCRIPTION
## Summary

**Structural refactor — phase P2** (epic [backend#796](https://github.com/tracebloc/backend/issues/796)): pull human-facing presentation out of the ingestion logic. This is the first structural phase, now unblocked since #242–#245 merged.

The ingestion-summary box (success rate, per-channel counts, status banner) was **~114 lines of `print` + ANSI + emoji living inside the 1,196-line `BaseIngestor` god class**.

## Changes

- New **`tracebloc_ingestor/reporting.py`** with `ConsoleRenderer.render_summary` — the single home for that presentation. The body moved **verbatim**, so the customer-facing output is **byte-for-byte identical**.
- `BaseIngestor._log_summary` becomes a **thin delegate** (kept as a method so existing callers/tests that reference `BaseIngestor._log_summary` keep working). Net: `base.py` **−119 / +10**.
- Drops the now-unused `BLUE` import from `base.py`.
- `IngestionSummary` stays the pure data object the renderer consumes; the renderer type-hints it via `TYPE_CHECKING` to avoid a runtime import cycle.

## Payoff

The presentation is now **unit-testable without a DB or a full ingest** — `tests/test_reporting.py` (8 cases, `reporting.py` **100% covered**) locks the output contract, including #234's behavior that *dropped records count toward the failure total and disqualify the success banner*.

## Behaviour preservation (the gate)

- Summary code moved verbatim; output identical.
- Full unit suite: **1026 passed, 1 xfailed**, coverage **97.3%**.
- The characterization harness goldens ([#247](https://github.com/tracebloc/data-ingestors/pull/247): DB cells / DEST_PATH manifest / backend payloads) are **unaffected** — they don't assert the summary box. The CI **e2e job re-confirms against real MySQL** (Docker was unavailable locally this run, so the renderer was instead verified directly via the new unit tests; the data path is untouched).

## Scope note

This is P2 **step 1** — the largest single presentation block. The remainder of P2 (strip ANSI from raised exception messages; `print` → logging in validators) is a focused follow-up, kept separate so each PR is small and reviewable. No conflict with any open work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
