### PR TITLE
fix(database): CHAR(N) must map to a SQLAlchemy type in _get_sqlalchemy_type

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -115,6 +115,35 @@ def test_get_sqlalchemy_type_numeric_precision_scale(db):
     assert result.scale == 3
 
 
+def test_get_sqlalchemy_type_char_with_length(db):
+    """Regression: CHAR(N) was absent from `type_mapping`. The DataValidator
+    accepts CHAR(N) (see `_validate_char` in data_validator.py), so a user
+    could declare e.g. `code: CHAR(1)` in their schema, pass preflight, then
+    hit `ValueError: Unsupported MySQL type: CHAR(1)` at table creation —
+    the validator and DDL layers had divergent vocabularies. CHAR is a
+    valid MySQL type (fixed-width, padded), distinct from VARCHAR but same
+    SQLAlchemy semantics; add it to the mapping so the two layers agree.
+
+    Surfaced by an adversarial 'all-types' tabular schema run against
+    v0.3.10-rc1: a CSV declaring `code: CHAR(1)` failed at table creation
+    even though every column type the schema lists is documented as
+    supported.
+    """
+    result = db._get_sqlalchemy_type("CHAR(1)")
+    assert isinstance(result, db_mod.CHAR)
+    assert result.length == 1
+
+
+def test_get_sqlalchemy_type_char_bare(db):
+    """Bare ``CHAR`` (no length) is still valid SQL — MySQL defaults to
+    CHAR(1). Don't raise; map to the SQLAlchemy class so the column gets
+    created with the dialect default."""
+    result = db._get_sqlalchemy_type("CHAR")
+    # May be the class or an instance — either is acceptable as long as
+    # the dialect picks up the right default at DDL time.
+    assert isinstance(result, db_mod.CHAR) or result is db_mod.CHAR
+
+
 # ---------------------------------------------------------------------------
 # create_table
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -4,6 +4,7 @@ from sqlalchemy import (
     Table,
     Column,
     BigInteger,
+    CHAR,
     DateTime,
     Date,
     Time,
@@ -134,6 +135,7 @@ class Database:
         """
         type_mapping = {
             "VARCHAR": String,
+            "CHAR": CHAR,
             "TEXT": Text,
             "INT": Integer,
             "INTEGER": Integer,


### PR DESCRIPTION
## The bug

`DataValidator` accepts `CHAR(N)` (the validator has an explicit `_validate_char` with length enforcement + NULL tolerance, mirroring `_validate_varchar`). But `Database._get_sqlalchemy_type` (the DDL layer) had no `CHAR` entry in its `type_mapping`, so a user schema like:

\`\`\`yaml
schema:
  code: CHAR(1)
\`\`\`

passed every preflight validator and then died at table creation with:

\`\`\`
ValueError: Unsupported MySQL type: CHAR(1)
\`\`\`

The two layers had divergent type vocabularies — exactly the class of mismatch #192 already fixed for NUMERIC.

## Repro

Adversarial all-types tabular schema test against v0.3.10-rc1: a CSV declaring `code: CHAR(1)` (alongside other valid types) fails table creation despite CHAR being a fully supported MySQL type.

## Fix

Add `CHAR` to `type_mapping` (imported from sqlalchemy core), so:

- `CHAR(N)` → `CHAR(length=N)` — fixed-width, padded per MySQL's CHAR semantics
- bare `CHAR` → `CHAR` class, dialect picks the default length (1)

CHAR is close to VARCHAR but semantically distinct (MySQL right-pads CHAR to its declared length on storage), so using the SQLAlchemy `CHAR` type rather than aliasing to `String` preserves the declared intent.

## Test plan

- [ ] New regression tests pass:
  - `test_get_sqlalchemy_type_char_with_length` — `CHAR(1)` → CHAR instance with length 1
  - `test_get_sqlalchemy_type_char_bare` — bare `CHAR` → CHAR (class or dialect-defaulted instance)
- [ ] Existing parametrised type test continues to pass (VARCHAR, INT, BIGINT, TEXT, FLOAT, BOOLEAN, DATE, etc.)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow DDL mapping change with regression tests only; no auth, data migration, or broad refactor.
> 
> **Overview**
> **Aligns DDL with validation for `CHAR` columns** so schemas like `code: CHAR(1)` no longer pass preflight and then fail at `create_table` with `Unsupported MySQL type: CHAR(1)`.
> 
> `Database._get_sqlalchemy_type` now imports SQLAlchemy **`CHAR`** and adds **`"CHAR": CHAR`** to `type_mapping`, reusing the existing parenthesis parsing so `CHAR(N)` becomes a typed `CHAR(length=N)` and bare `CHAR` maps to the class (MySQL default length).
> 
> Regression tests cover **`CHAR(1)`** length and bare **`CHAR`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3210deb4cdc17e83c38e319306022a021053222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->