### PR TITLE
fix(csv): empty CSV must fail fast with clear input-error message

### DIFF
--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -96,11 +96,24 @@ def test_read_data_unique_id_column_missing_raises(make_csv):
         list(ing.read_data(str(path)))
 
 
-def test_read_data_empty_file_returns_nothing(tmp_path):
+def test_read_data_empty_file_raises_with_clear_message(tmp_path):
+    """An empty (zero-byte) CSV is a hard input error, not a successful
+    '0 rows' run. The old code logged a WARNING and silently returned an
+    empty generator — the ingestor then created an empty MySQL table and
+    called `send_generate_edge_label_meta`, which 400'd with the misleading
+    'No data found for table X' message (same cascade #213 traced for
+    self-supervised + label mismatch). The user blamed the backend.
+
+    Fail fast at the read layer with a clear, source-truthful message
+    naming the path and pointing at staging as the likely cause —
+    DataValidator's existing 'No data found to validate' path catches it
+    before any backend round-trip.
+    """
     p = tmp_path / "empty.csv"
     p.write_text("")
     ing = make_csv_ingestor(schema={})
-    assert list(ing.read_data(str(p))) == []
+    with pytest.raises(ValueError, match="Empty CSV file"):
+        list(ing.read_data(str(p)))
 
 
 def test_validate_csv_type_coercion():

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -490,8 +490,24 @@ class CSVIngestor(BaseIngestor):
                     yield record
 
         except pd.errors.EmptyDataError:
-            logger.warning(f"{YELLOW}Empty CSV file: {file_path}{RESET}")
-            return
+            # An empty (zero-byte) CSV is a hard input error, not a
+            # successful "0 rows" run. Previously this branch logged a
+            # WARNING and silently returned an empty generator — the
+            # ingestor then proceeded to create an empty MySQL table and
+            # called `send_generate_edge_label_meta`, which 400'd with
+            # the misleading "No data found for table X" message that
+            # blamed the BACKEND instead of the input. (Same misleading
+            # cascade #213 traced for self-supervised + label mismatch.)
+            # Raise here so DataValidator's existing "No data found to
+            # validate" error path surfaces the empty-input cause with a
+            # clear, source-truthful message — and no backend round-trip.
+            raise ValueError(
+                f"{RED}Empty CSV file: {file_path}. The file has no "
+                f"header and no rows. Either stage a non-empty CSV at "
+                f"this path, or check the cluster-side path (the chart "
+                f"mounts your PVC at /data/shared/ — confirm staging "
+                f"completed before helm install).{RESET}"
+            )
 
         except (pd.errors.ParserError, Exception):
             raise


### PR DESCRIPTION
## The cascade

\`CSVIngestor.read_data\` caught \`pd.errors.EmptyDataError\` and **silently returned an empty generator** with only a YELLOW warning. From there:

1. Ingestor proceeded with an empty record stream
2. Created an empty MySQL table
3. Called \`send_generate_edge_label_meta\` against zero rows
4. Backend returned HTTP 400: \`{"table_name":"No data found for table X and injestor_id Y"}\`
5. PR #187's fail-loud handler surfaced that as: \`Backend rejected edge-label metadata; the dataset was NOT registered (its rows are already in the database).\`

The user-visible message **blames the backend** and (worse) **falsely tells the user their rows are in the database**, when the real cause is an empty input file. Same shape #213 documents for self-supervised + label mismatch — a fault at one layer surfaces with a misleading message several layers down.

## Repro

Adversarial test F8 on v0.3.10-rc1: a zero-byte CSV produced:

\`\`\`
WARNING | csv_ingestor.py:493 | Empty CSV file: /data/shared/divya-adv2/F8_empty.csv
ERROR   | api/client.py:393   | Error generating edge label metadata: HTTP 400: {"table_name":"No data found for table name e2etest_adv2_f8_... and injestor_id ..."}
ERROR   | base.py:985         | Error during ingestion: Backend rejected edge-label metadata; the dataset was NOT registered (its rows are already in the database).
\`\`\`

— the empty-file cause is buried in a WARNING that's easy to miss, and the visible ERROR is misdirection.

## Fix

Raise \`ValueError\` at the read layer with a source-truthful message:

\`\`\`
Empty CSV file: <path>. The file has no header and no rows. Either
stage a non-empty CSV at this path, or check the cluster-side path
(the chart mounts your PVC at /data/shared/ — confirm staging
completed before helm install).
\`\`\`

DataValidator's existing "No data found to validate" / preflight path catches the ValueError BEFORE any backend round-trip, so the user sees the right reason at the right layer.

## Test plan

- [ ] Updated \`test_read_data_empty_file_raises_with_clear_message\` (renamed from \`..._returns_nothing\` to reflect the new contract) asserts the new fail-fast behavior with \`pytest.raises(ValueError, match="Empty CSV file")\`
- [ ] Existing parser-error path (ragged rows, etc.) still propagates as before
- [ ] CI green
- [ ] Re-run F8 against rc2 → empty-CSV error surfaces at preflight, no backend call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CSV read-path behavior change with clearer errors; no auth, security, or broad API surface impact.
> 
> **Overview**
> **Empty zero-byte CSVs are now treated as hard input errors** instead of a successful zero-row read.
> 
> `CSVIngestor.read_data` no longer catches `pd.errors.EmptyDataError` with a warning and an empty generator. It **raises `ValueError`** with a message that names the path and suggests staging / `/data/shared/` checks, so users see an input problem at read time rather than a backend HTTP 400 (“No data found for table…”) after an empty table and metadata call.
> 
> The test **`test_read_data_empty_file_raises_with_clear_message`** replaces the old contract that expected `[]` and now asserts `pytest.raises(ValueError, match="Empty CSV file")`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f37a155ee44c382590a63bbc4efb5956d24a509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->