### PR TITLE
fix(ingest): catch single-label classification at preflight + surface backend reason (issue #251)

### DIFF
--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -157,6 +157,53 @@ def test_prepare_dataset_local_mode():
     get.assert_not_called()
 
 
+def test_prepare_dataset_error_captures_response_body():
+    """On HTTP error, `prepare_dataset` must stash the backend response body
+    on `self.last_prepare_error` so callers can surface the actual reason
+    in their user-visible error — instead of pointing at "the logged API
+    error above". Issue #251.
+
+    The body retained must include the status code and the response text
+    (capped) so a downstream RuntimeError can include both.
+    """
+    client = _client()
+    body = '{"message":"Please provide atleast 2 labels."}'
+    with patch.object(client.session, "get", return_value=_resp(400, text=body)):
+        ok = client.prepare_dataset(
+            TaskCategory.TABULAR_CLASSIFICATION, "ing", "tabular", "train"
+        )
+    assert ok is False
+    assert client.last_prepare_error is not None
+    # Status code + body both surface so the user sees the backend reason.
+    assert "HTTP 400" in client.last_prepare_error
+    assert "Please provide" in client.last_prepare_error
+
+
+def test_prepare_dataset_last_error_starts_unset():
+    """On a clean ingestor with no prior failure, `last_prepare_error`
+    is None — base.py falls back to its generic 'see logged API error
+    above' message only when this attribute is truly absent."""
+    client = _client()
+    assert client.last_prepare_error is None
+
+
+def test_prepare_dataset_network_error_captures_string():
+    """When `e.response` is None (DNS / connection refused / timeout),
+    last_prepare_error should still be populated with the stringified
+    exception — never silently fall through to None."""
+    import requests as _req
+
+    client = _client()
+    err = _req.exceptions.ConnectionError("name resolution failed")
+    with patch.object(client.session, "get", side_effect=err):
+        ok = client.prepare_dataset(
+            TaskCategory.TABULAR_CLASSIFICATION, "ing", "tabular", "train"
+        )
+    assert ok is False
+    assert client.last_prepare_error is not None
+    assert "name resolution failed" in client.last_prepare_error
+
+
 # ---------------------------------------------------------------------------
 # create_dataset
 # ---------------------------------------------------------------------------

--- a/tests/test_label_diversity_validator.py
+++ b/tests/test_label_diversity_validator.py
@@ -146,6 +146,57 @@ def test_csv_path_rejects_single_label(tmp_path):
     assert "'X'" in result.errors[0] or "'X'" in str(result.metadata.get("value_counts", {}))
 
 
+def test_csv_quoted_header_does_not_skew_multilabel(tmp_path):
+    """A quoted/comma-bearing header must not trip the column resolution.
+
+    Regression (bugbot #252, medium): the old loader resolved the label
+    column with a naive ``header_line.split(",")``, which splits inside
+    quoted headers and diverges from pandas. When it failed to find the
+    column it fell back to ``nrows=1`` and counted distinct labels on that
+    single row — rejecting a perfectly diverse dataset. Resolving against
+    pandas' own header parse (nrows=0) fixes it, so a header like
+    ``"feature,with,commas"`` alongside ``label`` reads the full column.
+    """
+    p = tmp_path / "quoted.csv"
+    # The first column's header literally contains commas (quoted).
+    p.write_text(
+        '"feature,with,commas",label\n'
+        + "\n".join(f"{i},{'A' if i % 2 else 'B'}" for i in range(20))
+        + "\n"
+    )
+    result = LabelDiversityValidator().validate(str(p))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+    assert result.metadata["distinct_count"] == 2
+
+
+def test_csv_read_error_fails_closed_not_skipped(tmp_path, monkeypatch):
+    """A read failure must FAIL the check, not silently pass.
+
+    Regression (bugbot #252, high): ``_load_data`` previously swallowed any
+    read exception and returned ``None``, which ``validate`` treats as an
+    empty/benign dataset → valid. A single-label CSV whose targeted read
+    errored could sail through preflight and hit the backend rejection this
+    validator exists to prevent. Read errors now propagate to ``validate``'s
+    handler and fail the check.
+    """
+    p = tmp_path / "boom.csv"
+    p.write_text("id,label\n1,X\n2,X\n")
+
+    real_read_csv = pd.read_csv
+
+    def _boom(path, *args, **kwargs):
+        # Let the cheap header probe (nrows=0) succeed, then blow up on the
+        # actual data read — mimics a usecols/encoding failure mid-load.
+        if kwargs.get("nrows") == 0:
+            return real_read_csv(path, *args, **kwargs)
+        raise ValueError("simulated CSV read failure")
+
+    monkeypatch.setattr(pd, "read_csv", _boom)
+    result = LabelDiversityValidator().validate(str(p))
+    assert not result.is_valid
+    assert "validation error" in result.errors[0].lower()
+
+
 # ---------------------------------------------------------------------------
 # Custom column name
 # ---------------------------------------------------------------------------

--- a/tests/test_label_diversity_validator.py
+++ b/tests/test_label_diversity_validator.py
@@ -197,6 +197,46 @@ def test_csv_read_error_fails_closed_not_skipped(tmp_path, monkeypatch):
     assert "validation error" in result.errors[0].lower()
 
 
+def test_schema_label_sentinel_tokens_count_as_missing(tmp_path):
+    """When the label IS a schema column, NA sentinels ("null", "NA", …) must
+    be read as missing — matching CSVIngestor/DataValidator — so a CSV whose
+    only real class is "X" plus sentinel rows is correctly flagged
+    single-label (bugbot #252)."""
+    p = tmp_path / "schema_label.csv"
+    p.write_text("id,label\n1,X\n2,null\n3,NA\n4,X\n")
+    result = LabelDiversityValidator(
+        label_column="label", schema={"id": "INT", "label": "VARCHAR(8)"}
+    ).validate(str(p))
+    assert not result.is_valid
+    assert "1 distinct" in result.errors[0]
+
+
+def test_non_schema_label_keeps_sentinel_as_real_class(tmp_path):
+    """When the label is NOT a schema column (image/text classification),
+    the ingestor keeps "NA"/"null" as literal class values — so the validator
+    must too, or it would miss / mis-count classes (bugbot #252). Here "X"
+    and "NA" are two genuine classes; the dataset must pass."""
+    p = tmp_path / "non_schema_label.csv"
+    p.write_text("filename,label\na.jpg,X\nb.jpg,NA\nc.jpg,X\nd.jpg,NA\n")
+    result = LabelDiversityValidator(label_column="label").validate(str(p))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+    assert result.metadata["distinct_count"] == 2
+
+
+def test_string_schema_label_no_numeric_collapse(tmp_path):
+    """A VARCHAR label column with numeric-looking values ("1.0", "1.00",
+    "01") must keep them distinct as strings — matching the ingestor's
+    string-dtype pin — rather than collapsing to a single float class and
+    wrongly rejecting a diverse dataset (bugbot #252)."""
+    p = tmp_path / "numeric_strings.csv"
+    p.write_text("id,label\n1,01\n2,1\n3,1.0\n4,02\n")
+    result = LabelDiversityValidator(
+        label_column="label", schema={"id": "INT", "label": "VARCHAR(8)"}
+    ).validate(str(p))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+    assert result.metadata["distinct_count"] == 4
+
+
 # ---------------------------------------------------------------------------
 # Custom column name
 # ---------------------------------------------------------------------------

--- a/tests/test_label_diversity_validator.py
+++ b/tests/test_label_diversity_validator.py
@@ -146,6 +146,37 @@ def test_csv_path_rejects_single_label(tmp_path):
     assert "'X'" in result.errors[0] or "'X'" in str(result.metadata.get("value_counts", {}))
 
 
+def test_csv_whitespace_header_still_checked(tmp_path):
+    """A label header with surrounding whitespace (" label ") must still be
+    found and checked, not skipped.
+
+    Regression (bugbot #252): CSVIngestor strips column-name whitespace on
+    read, so " label " is ingested as `label`. The validator resolved against
+    the raw header, treated the column as missing, skipped the diversity check
+    with a warning, and a single-class CSV sailed through preflight to fail at
+    backend prepare. _resolve_column now strips, matching the ingestor.
+    """
+    p = tmp_path / "ws_header.csv"
+    p.write_text("id, label \n1,X\n2,X\n3,X\n")
+    result = LabelDiversityValidator().validate(str(p))
+    assert not result.is_valid
+    assert "1 distinct" in result.errors[0]
+
+
+def test_csv_whitespace_header_schema_na_rules_apply(tmp_path):
+    """A whitespace label header that IS a schema column must still get the
+    schema NA rules — " label " strips to `label`, matches the schema entry,
+    so "null" reads as missing and a single-class dataset is flagged
+    (bugbot #252)."""
+    p = tmp_path / "ws_schema.csv"
+    p.write_text("id, label \n1,X\n2,null\n3,X\n")
+    result = LabelDiversityValidator(
+        label_column="label", schema={"id": "INT", "label": "VARCHAR(8)"}
+    ).validate(str(p))
+    assert not result.is_valid
+    assert "1 distinct" in result.errors[0]
+
+
 def test_csv_quoted_header_does_not_skew_multilabel(tmp_path):
     """A quoted/comma-bearing header must not trip the column resolution.
 

--- a/tests/test_label_diversity_validator.py
+++ b/tests/test_label_diversity_validator.py
@@ -1,0 +1,161 @@
+"""Tests for LabelDiversityValidator — fail-fast on single-label classification.
+
+Surfaces the cause locally (with the actual distinct label values) instead
+of letting the backend reject with the misleading "Backend failed to
+prepare the dataset; it was NOT registered" cascade once rows have already
+landed in MySQL. Issue #251.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.label_diversity_validator import (
+    LabelDiversityValidator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Positive cases — must pass
+# ---------------------------------------------------------------------------
+
+def test_two_distinct_labels_passes():
+    df = pd.DataFrame({"a": [1, 2, 3, 4], "label": ["A", "B", "A", "B"]})
+    result = LabelDiversityValidator().validate(df)
+    assert result.is_valid
+
+
+def test_many_distinct_labels_passes():
+    df = pd.DataFrame({"label": ["A", "B", "C", "D", "E"]})
+    result = LabelDiversityValidator().validate(df)
+    assert result.is_valid
+
+
+def test_distinct_labels_with_nulls_counts_only_non_null():
+    """Null cells don't count toward distinct labels; if there are still
+    ≥2 distinct non-null values the dataset is fine."""
+    df = pd.DataFrame({"label": ["A", "B", None, None]})
+    result = LabelDiversityValidator().validate(df)
+    assert result.is_valid
+    assert result.metadata["distinct_count"] == 2
+
+
+def test_label_column_case_insensitive_match():
+    """A CSV header ``Label`` should still resolve when the validator is
+    configured for ``label`` (default). Matches the case-insensitive
+    pattern BIOLabelValidator uses."""
+    df = pd.DataFrame({"a": [1, 2], "Label": ["X", "Y"]})
+    result = LabelDiversityValidator().validate(df)
+    assert result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# Failure cases — must reject with a CLEAR message
+# ---------------------------------------------------------------------------
+
+def test_single_label_fails_with_distinct_value_listed():
+    """A 10-row dataset where every row has ``label = "X"`` is not a
+    classification dataset. The error must name the offending distinct
+    value(s) and the count so the user immediately sees what's wrong."""
+    df = pd.DataFrame({"label": ["X"] * 10})
+    result = LabelDiversityValidator().validate(df)
+    assert not result.is_valid
+    err = result.errors[0]
+    # User-facing message must include the actual single value found.
+    assert "'X'" in err or "'X'" in str(result.metadata.get("value_counts", {}))
+    # And explain WHY it's rejected.
+    assert "classification" in err.lower()
+    assert "distinct" in err.lower()
+
+
+def test_single_label_only_nulls_fails():
+    """All-null label column → 0 distinct → rejected."""
+    df = pd.DataFrame({"label": [None, None, None]})
+    result = LabelDiversityValidator().validate(df)
+    assert not result.is_valid
+
+
+def test_single_label_one_value_with_some_nulls_fails():
+    """One distinct value plus nulls is still only 1 distinct value."""
+    df = pd.DataFrame({"label": ["A", "A", None, "A", None]})
+    result = LabelDiversityValidator().validate(df)
+    assert not result.is_valid
+
+
+def test_error_mentions_regression_alternative():
+    """A user who has a continuous target shouldn't be told 'add a fake
+    second label' — the error should point them at regression-family
+    categories which legitimately accept a single target column."""
+    df = pd.DataFrame({"label": ["A"] * 5})
+    result = LabelDiversityValidator().validate(df)
+    assert not result.is_valid
+    assert "regression" in result.errors[0].lower()
+
+
+# ---------------------------------------------------------------------------
+# Defensive paths — must not double-report (other validators own those)
+# ---------------------------------------------------------------------------
+
+def test_empty_dataframe_passes_silently():
+    """Empty input is the 'no rows' / empty-CSV class — handled by other
+    validators with their own clear messages. Don't double-report."""
+    result = LabelDiversityValidator().validate(pd.DataFrame())
+    assert result.is_valid
+    assert result.metadata["rows_checked"] == 0
+
+
+def test_label_column_missing_passes_with_warning():
+    """If the CSV has no label column at all, that's a schema-mismatch
+    case handled by other layers. This validator just warns and skips."""
+    df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    result = LabelDiversityValidator().validate(df)
+    assert result.is_valid
+    assert any("not found in CSV" in w for w in (result.warnings or []))
+
+
+# ---------------------------------------------------------------------------
+# CSV-path streaming check — must not load the whole wide CSV into memory
+# ---------------------------------------------------------------------------
+
+def test_csv_path_reads_only_the_label_column(tmp_path):
+    """For a wide CSV (one label + many feature columns), the validator
+    must read only the label column — counting distinct labels doesn't
+    need the features, and a multi-GB proteomics panel would otherwise
+    OOM. Mirrors the streaming-first patterns elsewhere in the codebase
+    (DataValidator's chunked path)."""
+    p = tmp_path / "wide.csv"
+    cols = ",".join([f"f{i:02d}" for i in range(50)] + ["label"])
+    rows = "\n".join(
+        [",".join(["0.5"] * 50 + [("A" if i % 2 else "B")]) for i in range(20)]
+    )
+    p.write_text(cols + "\n" + rows + "\n")
+    result = LabelDiversityValidator().validate(str(p))
+    assert result.is_valid
+    assert result.metadata["distinct_count"] == 2
+
+
+def test_csv_path_rejects_single_label(tmp_path):
+    """End-to-end CSV-path test of the failure case — mirrors the
+    adversarial test against v0.3.10-rc1 that surfaced #251."""
+    p = tmp_path / "single.csv"
+    p.write_text("id,label\n1,X\n2,X\n3,X\n")
+    result = LabelDiversityValidator().validate(str(p))
+    assert not result.is_valid
+    assert "1 distinct" in result.errors[0]
+    assert "'X'" in result.errors[0] or "'X'" in str(result.metadata.get("value_counts", {}))
+
+
+# ---------------------------------------------------------------------------
+# Custom column name
+# ---------------------------------------------------------------------------
+
+def test_custom_label_column_name():
+    """When the user configures a non-default label column, the
+    validator must check THAT column (mirrors BIOLabelValidator's
+    behavior with custom columns)."""
+    df = pd.DataFrame({"target": ["A", "B"], "label": ["X", "X"]})
+    # Custom column is the diverse one — should pass.
+    assert LabelDiversityValidator(label_column="target").validate(df).is_valid
+    # The default `label` column is single-value here — should fail.
+    assert not LabelDiversityValidator(label_column="label").validate(df).is_valid

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -24,6 +24,9 @@ from tracebloc_ingestor.validators.keypoint_visibility_validator import (
     KeypointVisibilityValidator,
 )
 from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
+from tracebloc_ingestor.validators.label_diversity_validator import (
+    LabelDiversityValidator,
+)
 
 
 IMAGE_OPTS = {"extension": FileExtension.JPG, "target_size": [224, 224]}
@@ -38,9 +41,38 @@ def test_image_classification():
     assert _types(v) == [
         FileTypeValidator,
         ImageResolutionValidator,
+        LabelDiversityValidator,
         TableNameValidator,
         DuplicateValidator,
     ]
+
+
+def test_classification_categories_include_label_diversity():
+    """Single-label classification is caught at preflight across every
+    classification-family category — image/object/semantic/keypoint/
+    tabular/text — but NOT token_classification (its label is a per-token
+    BIO sequence, not a single class) or the regression / self-supervised
+    families (issue #251)."""
+    for cat in (
+        TaskCategory.IMAGE_CLASSIFICATION,
+        TaskCategory.OBJECT_DETECTION,
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        TaskCategory.KEYPOINT_DETECTION,
+        TaskCategory.TABULAR_CLASSIFICATION,
+        TaskCategory.TEXT_CLASSIFICATION,
+    ):
+        assert LabelDiversityValidator in _types(map_validators(cat, IMAGE_OPTS)), cat
+
+    for cat in (
+        TaskCategory.TOKEN_CLASSIFICATION,
+        TaskCategory.TABULAR_REGRESSION,
+        TaskCategory.TIME_SERIES_FORECASTING,
+        TaskCategory.TIME_TO_EVENT_PREDICTION,
+        TaskCategory.MASKED_LANGUAGE_MODELING,
+    ):
+        assert LabelDiversityValidator not in _types(
+            map_validators(cat, {"schema": {"a": "INT"}})
+        ), cat
 
 
 def test_object_detection_includes_xml_validator():

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -75,6 +75,30 @@ def test_classification_categories_include_label_diversity():
         ), cat
 
 
+def test_label_diversity_uses_full_schema_for_label_type():
+    """base.py strips the label column out of file_options["schema"] (it's a
+    framework column, not a table column) but passes the UNSTRIPPED schema as
+    `full_schema`. The label-diversity validator must read the label's type
+    from `full_schema`, else it never applies the ingestor's NA/dtype rules to
+    the label column (bugbot #252)."""
+    ldv = next(
+        v
+        for v in map_validators(
+            TaskCategory.TABULAR_CLASSIFICATION,
+            {
+                # file_options["schema"] — label already stripped by base.py.
+                "schema": {"age": "INT"},
+                "label_column": "churned",
+                # full, unstripped schema base.py also passes.
+                "full_schema": {"age": "INT", "churned": "VARCHAR(8)"},
+            },
+        )
+        if isinstance(v, LabelDiversityValidator)
+    )
+    # The validator must see the label column's type via the full schema.
+    assert ldv._schema_type_for("churned") == "VARCHAR(8)"
+
+
 def test_object_detection_includes_xml_validator():
     v = map_validators(TaskCategory.OBJECT_DETECTION, IMAGE_OPTS)
     types = _types(v)

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -41,6 +41,13 @@ class APIClient:
         self.config = config
         self.session = self._create_session()
 
+        # Last `prepare_dataset` HTTP-error body, retained so callers
+        # can include the actual backend reason in the user-visible
+        # RuntimeError instead of just pointing at "the logged API
+        # error above" (issue #251). Set by `prepare_dataset`'s error
+        # handler; remains None on a clean run.
+        self.last_prepare_error: Optional[str] = None
+
         # Auth resolution order:
         #   1. local mode  → mock token, no network call
         #   2. BACKEND_TOKEN set → use it directly (preferred; mirrors the
@@ -454,8 +461,18 @@ class APIClient:
                     f"{RED}Error preparing data: "
                     f"HTTP {e.response.status_code}: {body}{RESET}"
                 )
+                # Stash the backend's response so callers can surface the
+                # actual reason (e.g. "Please provide atleast 2 labels.")
+                # in the user-visible error — instead of pointing at "the
+                # logged API error above" which the user has to grep for.
+                # Issue #251: misleading "Backend failed to prepare the
+                # dataset" message that buried a clear backend reason.
+                self.last_prepare_error = (
+                    f"HTTP {e.response.status_code}: {body}"
+                )
             else:
                 logger.error(f"{RED}Error preparing data: {str(e)[:500]}{RESET}")
+                self.last_prepare_error = str(e)[:500]
             return False
 
     def create_dataset(

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -421,6 +421,13 @@ class APIClient:
         Returns:
             bool: True if successful, False otherwise
         """
+        # Clear any error stashed by a previous prepare_dataset call up front,
+        # so an early `return False` below (local mode, invalid category)
+        # can't leave a stale message that base.py then attaches to an
+        # unrelated failure (bugbot #252). Only the exception handler in THIS
+        # call should ever populate it.
+        self.last_prepare_error = None
+
         # Skip API calls in local mode
         if self.config.EDGE_ENV == "local":
             logger.info(f"Mock: Would prepare dataset {category}")

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -677,7 +677,21 @@ class BaseIngestor(ABC):
         # mutating file_options / metadata) so label-aware validators like
         # BIOLabelValidator check the right column when a custom name is used.
         validators = map_validators(
-            self.category, {**self.file_options, "label_column": self.label_column}
+            self.category,
+            {
+                **self.file_options,
+                "label_column": self.label_column,
+                # file_options["schema"] has the label/annotation/id columns
+                # stripped (they're framework columns, not table columns), but
+                # CSVIngestor reads the file with NA/dtype rules from the FULL
+                # schema — so the label column DOES get NA-sentinel treatment at
+                # ingest. Pass the full schema so LabelDiversityValidator counts
+                # distinct labels the same way the data is actually ingested,
+                # rather than letting "null"/"NA" inflate the distinct count and
+                # sneak an effectively single-class dataset past the gate
+                # (bugbot #252).
+                "full_schema": self.schema,
+            },
         )
         logger.info(f"Running {len(validators)} validator(s) on data source")
         all_valid = True

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -966,10 +966,20 @@ class BaseIngestor(ABC):
                     self.data_format,
                     self.intent,
                 ):
+                    # Surface the BACKEND'S actual reason in the user-visible
+                    # error — not just "see the logged API error above" which
+                    # forces the user to grep the log for the real cause.
+                    # Issue #251: a misleading "Backend failed to prepare the
+                    # dataset" message buried the real reason (e.g. "Please
+                    # provide atleast 2 labels.") in a preceding ERROR line.
+                    detail = (
+                        getattr(self.api_client, "last_prepare_error", None)
+                        or "see the logged API error above"
+                    )
                     raise RuntimeError(
-                        "Backend failed to prepare the dataset; it was NOT "
-                        "registered (its rows are already in the database). See "
-                        "the logged API error above."
+                        f"Backend failed to prepare the dataset; it was NOT "
+                        f"registered (its rows are already in the database). "
+                        f"Backend response: {detail}"
                     )
 
                 self.api_client.create_dataset(

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -45,11 +45,14 @@ def _label_diversity_validator(options: Dict[str, Any]) -> LabelDiversityValidat
     """
     return LabelDiversityValidator(
         label_column=options.get("label_column") or "label",
-        # Pass the schema so the label column is read with the SAME NA /
-        # dtype rules CSVIngestor and DataValidator use — otherwise the
-        # distinct-label count can disagree with what's actually ingested
-        # (bugbot #252).
-        schema=options.get("schema"),
+        # Read the label column with the SAME NA / dtype rules CSVIngestor
+        # uses, or the distinct-label count disagrees with what's actually
+        # ingested (bugbot #252). Prefer ``full_schema`` (base.py passes the
+        # UNSTRIPPED schema here): ``schema``/``file_options["schema"]`` has
+        # the label column removed, so it can't carry the label's type — the
+        # very column this validator reads. Fall back to ``schema`` for
+        # direct callers / tests that pass an unstripped map.
+        schema=options.get("full_schema") or options.get("schema"),
     )
 
 

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -45,6 +45,11 @@ def _label_diversity_validator(options: Dict[str, Any]) -> LabelDiversityValidat
     """
     return LabelDiversityValidator(
         label_column=options.get("label_column") or "label",
+        # Pass the schema so the label column is read with the SAME NA /
+        # dtype rules CSVIngestor and DataValidator use — otherwise the
+        # distinct-label count can disagree with what's actually ingested
+        # (bugbot #252).
+        schema=options.get("schema"),
     )
 
 

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -24,7 +24,28 @@ from tracebloc_ingestor.validators.keypoint_visibility_validator import (
 from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
 from tracebloc_ingestor.validators.file_pairing_validator import FilePairingValidator
 from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
+from tracebloc_ingestor.validators.label_diversity_validator import (
+    LabelDiversityValidator,
+)
 from tracebloc_ingestor.utils.constants import TaskCategory, FileExtension
+
+
+def _label_diversity_validator(options: Dict[str, Any]) -> LabelDiversityValidator:
+    """Construct a LabelDiversityValidator using the user-configured
+    label column name (or the framework default ``label``). Centralised
+    so every classification-family branch wires the same instance shape.
+
+    Issue #251: a classification dataset with one distinct label value
+    is unlearnable and the backend rejects it at ``/global_meta/prepare/``
+    with ``HTTP 400: "Please provide atleast 2 labels."``. Catching it
+    at preflight surfaces the actual cause (and lists the offending
+    label value(s)) instead of cascading to a misleading
+    "Backend failed to prepare the dataset" message after the rows
+    have already landed in MySQL.
+    """
+    return LabelDiversityValidator(
+        label_column=options.get("label_column") or "label",
+    )
 
 
 def map_validators(
@@ -34,6 +55,7 @@ def map_validators(
         return [
             FileTypeValidator(allowed_extension=options["extension"], path="images"),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
+            _label_diversity_validator(options),
             TableNameValidator(),
             DuplicateValidator(),
         ]
@@ -48,6 +70,7 @@ def map_validators(
                 sidecar_label="annotation",
             ),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
+            _label_diversity_validator(options),
             TableNameValidator(),
             DuplicateValidator(),
         ]
@@ -57,6 +80,7 @@ def map_validators(
         # Add data validator if schema is provided
         if options.get("schema"):
             validators.append(DataValidator(schema=options["schema"]))
+        validators.append(_label_diversity_validator(options))
         validators.append(TableNameValidator())
         validators.append(DuplicateValidator())
 
@@ -80,6 +104,7 @@ def map_validators(
         if options.get("schema"):
             validators.append(DataValidator(schema=options["schema"]))
 
+        validators.append(_label_diversity_validator(options))
         validators.append(TableNameValidator())
         validators.append(DuplicateValidator())
 
@@ -189,6 +214,7 @@ def map_validators(
                 sidecar_suffix="_mask",
             ),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
+            _label_diversity_validator(options),
             TableNameValidator(),
             DuplicateValidator(),
         ]
@@ -206,6 +232,7 @@ def map_validators(
                 num_keypoints=options.get("number_of_keypoints")
             ),
             KeypointVisibilityValidator(),
+            _label_diversity_validator(options),
             TableNameValidator(),
             DuplicateValidator(),
         ]

--- a/tracebloc_ingestor/validators/label_diversity_validator.py
+++ b/tracebloc_ingestor/validators/label_diversity_validator.py
@@ -26,12 +26,13 @@ label column at all.
 
 import logging
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import pandas as pd
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
+from ..utils import coercion
 from ..utils.logging import setup_logging
 
 config = Config()
@@ -49,17 +50,23 @@ class LabelDiversityValidator(BaseValidator):
         min_distinct: Minimum required distinct non-null label values
             (default 2). The backend's contract is exactly 2; the
             parameter is exposed only for future stricter use cases.
+        schema: Optional column→SQL-type map. When the label column is a
+            schema column, it's read with the same NA / dtype rules
+            CSVIngestor and DataValidator apply, so the distinct-label
+            count matches what's actually ingested (bugbot #252).
     """
 
     def __init__(
         self,
         label_column: str = "label",
         min_distinct: int = 2,
+        schema: Optional[Dict[str, str]] = None,
         name: str = "Label Diversity Validator",
     ):
         super().__init__(name)
         self.label_column = label_column
         self.min_distinct = min_distinct
+        self.schema = schema or {}
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         try:
@@ -173,11 +180,52 @@ class LabelDiversityValidator(BaseValidator):
                     return None
                 # Load only the label column — for a 50-feature wide CSV
                 # (or a multi-GB proteomics panel) we don't need the rest
-                # to count distinct labels.
-                return pd.read_csv(path, usecols=[actual], encoding="utf-8")
+                # to count distinct labels. Read it with the SAME NA / dtype
+                # rules CSVIngestor + DataValidator use so the distinct count
+                # agrees with what's ingested (bugbot #252).
+                return pd.read_csv(
+                    path,
+                    usecols=[actual],
+                    encoding="utf-8",
+                    **self._label_read_kwargs(actual),
+                )
             if path.suffix.lower() == ".json":
                 return pd.read_json(path, orient="records")
         return None
+
+    def _label_read_kwargs(self, actual: str) -> Dict[str, Any]:
+        """``pd.read_csv`` kwargs for the label column that mirror how
+        CSVIngestor / DataValidator read it, so the distinct-label count
+        matches what's actually ingested (bugbot #252).
+
+        - ``keep_default_na=False`` always: pandas' shifting global NA set
+          must not silently turn a literal ``"NA"``/``"null"`` label into a
+          missing value here when the ingestor keeps it as a real class.
+        - ``na_values``: the full :data:`coercion.NA_SENTINELS` set, but only
+          when the label is a *schema* column — the ingestor coerces only
+          schema columns; a non-schema classification label keeps
+          ``"NA"``/``"null"`` as a genuine class.
+        - ``dtype=str``: when the label is a string-family schema column,
+          matching the ingestor's string pin so numeric-looking labels
+          (``"007"``, ``"1.0"``) aren't collapsed by numeric inference and
+          under-counted.
+        """
+        kwargs: Dict[str, Any] = {"keep_default_na": False}
+        schema_type = self._schema_type_for(actual)
+        if schema_type is not None:
+            kwargs["na_values"] = {actual: list(coercion.NA_SENTINELS)}
+            base = str(schema_type).upper().split("(")[0].strip()
+            if base in ("VARCHAR", "CHAR", "TEXT", "STRING"):
+                kwargs["dtype"] = {actual: str}
+        return kwargs
+
+    def _schema_type_for(self, actual: str) -> Optional[str]:
+        """Case-insensitive lookup of the label column's declared SQL type,
+        or ``None`` when the label isn't a schema column."""
+        if actual in self.schema:
+            return self.schema[actual]
+        lowered = {k.lower(): v for k, v in self.schema.items()}
+        return lowered.get(actual.lower())
 
     @staticmethod
     def _resolve_column(df: pd.DataFrame, name: str) -> Optional[str]:

--- a/tracebloc_ingestor/validators/label_diversity_validator.py
+++ b/tracebloc_ingestor/validators/label_diversity_validator.py
@@ -1,0 +1,181 @@
+"""Label Diversity Validator Module.
+
+Classification categories need at least 2 distinct label values to be
+learnable — a single-class dataset is not a classification problem (and
+the backend's ``/global_meta/prepare/`` endpoint correctly rejects it
+with ``HTTP 400: "Please provide atleast 2 labels."``).
+
+Without a preflight check, a degenerate single-label CSV:
+  1. passes per-record validation (every cell is fine in isolation),
+  2. inserts every row into MySQL,
+  3. dies at backend ``prepare_dataset`` with the message above, and
+  4. surfaces to the user as the generic "Backend failed to prepare the
+     dataset; it was NOT registered" — the actual cause is buried in a
+     preceding log line.
+
+This validator catches the degenerate case at the gate, before any DB
+or backend round-trip, and names the actual distinct label(s) found in
+the message so the user immediately knows what's wrong with the input.
+
+Skipped for regression-family categories (tabular_regression,
+time_series_forecasting, time_to_event_prediction) — those have
+continuous targets where uniqueness is meaningless — and for
+self-supervised categories (masked_language_modeling) which have no
+label column at all.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+
+from .base import BaseValidator, ValidationResult
+from ..config import Config
+from ..utils.logging import setup_logging
+
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+
+class LabelDiversityValidator(BaseValidator):
+    """Reject classification datasets with fewer than 2 distinct label values.
+
+    Attributes:
+        label_column: CSV column holding the class label. Resolved
+            case-insensitively against the actual header.
+        min_distinct: Minimum required distinct non-null label values
+            (default 2). The backend's contract is exactly 2; the
+            parameter is exposed only for future stricter use cases.
+    """
+
+    def __init__(
+        self,
+        label_column: str = "label",
+        min_distinct: int = 2,
+        name: str = "Label Diversity Validator",
+    ):
+        super().__init__(name)
+        self.label_column = label_column
+        self.min_distinct = min_distinct
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            df = self._load_data(data)
+            if df is None or df.empty:
+                # An empty input is the empty-CSV / no-data class —
+                # other validators surface that with their own clear
+                # messages (CSV ingestor raises at read; DataValidator
+                # returns "No data found to validate"). Don't double-
+                # report here.
+                return self._create_result(
+                    is_valid=True,
+                    metadata={"rows_checked": 0, "label_column": self.label_column},
+                )
+
+            col = self._resolve_column(df, self.label_column)
+            if col is None:
+                # The label column isn't in the CSV — caller's
+                # responsibility to surface (DataValidator or the
+                # ingestor will reject). Don't double-report.
+                return self._create_result(
+                    is_valid=True,
+                    warnings=[
+                        f"label column '{self.label_column}' not found in CSV; "
+                        f"skipping label-diversity check"
+                    ],
+                    metadata={"label_column": self.label_column},
+                )
+
+            distinct = df[col].dropna().unique()
+            n = len(distinct)
+            if n < self.min_distinct:
+                # Show the actual values found, capped — a user with a
+                # 50k-row degenerate dataset doesn't need the full list,
+                # but the first few values plus the count tell them
+                # exactly what's wrong with the input.
+                sample = list(distinct[:5])
+                # Surface counts per distinct value to make "all one
+                # class" stand out clearly: "{'X': 10}" vs "{'X': 10000}"
+                # both clearly read as single-class but the latter gives
+                # the user the full row count for free.
+                value_counts = df[col].value_counts(dropna=True).head(5).to_dict()
+                return self._create_result(
+                    is_valid=False,
+                    errors=[
+                        f"Classification category requires at least "
+                        f"{self.min_distinct} distinct label values in column "
+                        f"'{col}'; this dataset has {n} distinct value(s): "
+                        f"{sample}. Value counts: {value_counts}. If this is "
+                        f"intentional (e.g. you have a continuous target), "
+                        f"pick a regression-family category like "
+                        f"tabular_regression or time_series_forecasting "
+                        f"instead."
+                    ],
+                    metadata={
+                        "label_column": col,
+                        "distinct_count": n,
+                        "value_counts": value_counts,
+                    },
+                )
+
+            return self._create_result(
+                is_valid=True,
+                metadata={
+                    "label_column": col,
+                    "distinct_count": n,
+                },
+            )
+
+        except Exception as e:  # noqa: BLE001 — mirror sibling validators
+            logger.error(f"Error during label-diversity validation: {str(e)}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Label-diversity validation error: {str(e)}"],
+            )
+
+    def _load_data(self, data: Any) -> Optional[pd.DataFrame]:
+        """Load just the label column from CSV (memory-efficient) or pass
+        through a DataFrame as-is. Mirrors DataValidator's loader shape but
+        only reads the one column it needs."""
+        try:
+            if isinstance(data, pd.DataFrame):
+                return data
+            if isinstance(data, (str, Path)):
+                path = Path(data)
+                if not path.exists():
+                    return None
+                if path.suffix.lower() == ".csv":
+                    # Load only the label column — for a 50-feature wide
+                    # CSV (or a multi-GB proteomics panel) we don't need
+                    # the other columns to count distinct labels. usecols
+                    # is resolved case-insensitively against the actual
+                    # header by reading the header row first.
+                    with open(path, "r", encoding="utf-8") as fh:
+                        header_line = fh.readline().rstrip("\n\r")
+                    headers = [h.strip() for h in header_line.split(",")]
+                    actual = next(
+                        (h for h in headers if h.lower() == self.label_column.lower()),
+                        None,
+                    )
+                    if actual is None:
+                        return pd.read_csv(path, nrows=1, encoding="utf-8")
+                    return pd.read_csv(
+                        path, usecols=[actual], encoding="utf-8"
+                    )
+                if path.suffix.lower() == ".json":
+                    return pd.read_json(path, orient="records")
+            return None
+        except Exception as e:
+            logger.error(f"Error loading data for label-diversity check: {e}")
+            return None
+
+    @staticmethod
+    def _resolve_column(df: pd.DataFrame, name: str) -> Optional[str]:
+        """Return the actual column name matching ``name`` case-insensitively."""
+        if name in df.columns:
+            return name
+        lowered = {c.lower(): c for c in df.columns}
+        return lowered.get(name.lower())

--- a/tracebloc_ingestor/validators/label_diversity_validator.py
+++ b/tracebloc_ingestor/validators/label_diversity_validator.py
@@ -139,38 +139,45 @@ class LabelDiversityValidator(BaseValidator):
     def _load_data(self, data: Any) -> Optional[pd.DataFrame]:
         """Load just the label column from CSV (memory-efficient) or pass
         through a DataFrame as-is. Mirrors DataValidator's loader shape but
-        only reads the one column it needs."""
-        try:
-            if isinstance(data, pd.DataFrame):
-                return data
-            if isinstance(data, (str, Path)):
-                path = Path(data)
-                if not path.exists():
+        only reads the one column it needs.
+
+        Read errors are deliberately NOT swallowed — they propagate to
+        ``validate``'s handler, which fails the check. A CSV that can't be
+        read must not silently skip the single-label gate this validator
+        exists to enforce (bugbot #252, high severity). Only the genuinely
+        not-applicable cases — missing file, unsupported suffix, label
+        column absent — return ``None``, which ``validate`` treats as a
+        benign skip that sibling validators surface.
+        """
+        if isinstance(data, pd.DataFrame):
+            return data
+        if isinstance(data, (str, Path)):
+            path = Path(data)
+            if not path.exists():
+                return None
+            if path.suffix.lower() == ".csv":
+                # Resolve the label column against pandas' OWN header
+                # parsing (nrows=0 reads only the header row, cheaply),
+                # not a naive ``split(",")``. The old hand-rolled split
+                # diverged from pandas on quoted headers / alternate
+                # delimiters: it could (a) miss a column pandas does
+                # expose, then fall back to a 1-row read and miscount
+                # distinct labels — rejecting a diverse dataset (bugbot
+                # #252, medium) — or (b) build a ``usecols`` spelling
+                # pandas then rejected, erroring the read.
+                header_df = pd.read_csv(path, nrows=0, encoding="utf-8")
+                actual = self._resolve_column(header_df, self.label_column)
+                if actual is None:
+                    # Label column genuinely absent — benign skip; the
+                    # ingestor / DataValidator report the missing column.
                     return None
-                if path.suffix.lower() == ".csv":
-                    # Load only the label column — for a 50-feature wide
-                    # CSV (or a multi-GB proteomics panel) we don't need
-                    # the other columns to count distinct labels. usecols
-                    # is resolved case-insensitively against the actual
-                    # header by reading the header row first.
-                    with open(path, "r", encoding="utf-8") as fh:
-                        header_line = fh.readline().rstrip("\n\r")
-                    headers = [h.strip() for h in header_line.split(",")]
-                    actual = next(
-                        (h for h in headers if h.lower() == self.label_column.lower()),
-                        None,
-                    )
-                    if actual is None:
-                        return pd.read_csv(path, nrows=1, encoding="utf-8")
-                    return pd.read_csv(
-                        path, usecols=[actual], encoding="utf-8"
-                    )
-                if path.suffix.lower() == ".json":
-                    return pd.read_json(path, orient="records")
-            return None
-        except Exception as e:
-            logger.error(f"Error loading data for label-diversity check: {e}")
-            return None
+                # Load only the label column — for a 50-feature wide CSV
+                # (or a multi-GB proteomics panel) we don't need the rest
+                # to count distinct labels.
+                return pd.read_csv(path, usecols=[actual], encoding="utf-8")
+            if path.suffix.lower() == ".json":
+                return pd.read_json(path, orient="records")
+        return None
 
     @staticmethod
     def _resolve_column(df: pd.DataFrame, name: str) -> Optional[str]:

--- a/tracebloc_ingestor/validators/label_diversity_validator.py
+++ b/tracebloc_ingestor/validators/label_diversity_validator.py
@@ -220,17 +220,30 @@ class LabelDiversityValidator(BaseValidator):
         return kwargs
 
     def _schema_type_for(self, actual: str) -> Optional[str]:
-        """Case-insensitive lookup of the label column's declared SQL type,
-        or ``None`` when the label isn't a schema column."""
+        """Look up the label column's declared SQL type, or ``None`` when the
+        label isn't a schema column. Matched case- AND whitespace-insensitively
+        so a CSV header like ``" label "`` (which CSVIngestor strips to
+        ``label`` on read) still finds its schema entry (bugbot #252)."""
         if actual in self.schema:
             return self.schema[actual]
-        lowered = {k.lower(): v for k, v in self.schema.items()}
-        return lowered.get(actual.lower())
+        target = str(actual).strip().lower()
+        normalised = {str(k).strip().lower(): v for k, v in self.schema.items()}
+        return normalised.get(target)
 
     @staticmethod
     def _resolve_column(df: pd.DataFrame, name: str) -> Optional[str]:
-        """Return the actual column name matching ``name`` case-insensitively."""
+        """Return the actual column name matching ``name`` case- AND
+        whitespace-insensitively.
+
+        CSVIngestor strips column-name whitespace on read
+        (``chunk.columns.str.strip()``), so a header like ``" label "`` is
+        ingested as ``label``. Resolving against the raw header without the
+        same strip treated the column as missing, skipped the diversity check
+        with a warning, and let a single-class CSV pass preflight (bugbot
+        #252). Match the strip here so the gate sees the same column the
+        ingestor does."""
         if name in df.columns:
             return name
-        lowered = {c.lower(): c for c in df.columns}
-        return lowered.get(name.lower())
+        target = str(name).strip().lower()
+        normalised = {str(c).strip().lower(): c for c in df.columns}
+        return normalised.get(target)


### PR DESCRIPTION
Closes #251.

Two coupled improvements to the user experience when a classification dataset has fewer than 2 distinct label values — surfaced by adversarial testing against v0.3.10-rc1.

## The cascade we hit

Submit a \`tabular_classification\` (or any classification-family) dataset where the \`label\` column has ONE distinct value across all rows (e.g. all rows labelled \`\"X\"\`):

1. Validators pass — no per-record issue, just label uniformity
2. All rows insert into MySQL successfully
3. \`prepare_dataset\` calls \`/global_meta/prepare/\`
4. Backend returns **HTTP 400**: \`{\"message\":\"Please provide atleast 2 labels.\"}\`
5. Framework raises generic: *\"Backend failed to prepare the dataset; it was NOT registered (its rows are already in the database). **See the logged API error above.**\"*

The user-visible error tells you to grep the log. The actual reason is one ERROR-line up. Rows are orphaned in MySQL by the time anything surfaces.

## Fix 1 — `LabelDiversityValidator` at preflight

New validator: \`tracebloc_ingestor/validators/label_diversity_validator.py\`.

- Reads **only** the label column when given a CSV path (\`usecols=[...]\` — a multi-GB proteomics panel doesn't get materialised just to count labels).
- Counts non-null distinct values; rejects when \`< min_distinct\` (default **2** — matches the backend's exact contract).
- Error message names the offending distinct value(s) **and** value-count breakdown:

  \`\`\`
  Classification category requires at least 2 distinct label values in
  column 'label'; this dataset has 1 distinct value(s): ['X'].
  Value counts: {'X': 10}. If this is intentional (e.g. you have a
  continuous target), pick a regression-family category like
  tabular_regression or time_series_forecasting instead.
  \`\`\`

- Suggests regression-family categories so users with continuous targets get a pointer instead of being told to fake a second class.
- Gracefully no-ops on empty input / missing label column — other validators already surface those.

Wired in via \`validators_mapping.py\` for every classification-family category:
- \`tabular_classification\`, \`image_classification\`, \`text_classification\`, \`object_detection\`, \`semantic_segmentation\`, \`keypoint_detection\`

NOT wired for regression (\`tabular_regression\`, \`time_series_forecasting\`, \`time_to_event_prediction\` — continuous targets) or self-supervised (\`masked_language_modeling\`, \`token_classification\`).

## Fix 2 — propagate backend body into the user-visible error

\`APIClient.prepare_dataset\` now stashes the formatted backend response on \`self.last_prepare_error\` (\`HTTP <status>: <body>\`). \`base.py\`'s \"Backend failed to prepare\" RuntimeError reads it and includes the actual backend reason verbatim.

**Before:**
> Backend failed to prepare the dataset; it was NOT registered (its rows are already in the database). **See the logged API error above.**

**After:**
> Backend failed to prepare the dataset; it was NOT registered (its rows are already in the database). **Backend response: HTTP 400: {\"message\":\"Please provide atleast 2 labels.\"}**

A user piping the log through filtered output (CI, error tooling, paste-into-Slack) sees the cause in the visible line — no more grep.

## What this PR does NOT do

- The backend typo \`\"atleast\"\` → \`\"at least\"\` lives in the backend repo, not here. Flagged in #251 for whoever owns that endpoint.

## Test plan

- [ ] **14 new tests** in \`tests/test_label_diversity_validator.py\`:
  - Positive: 2+ labels, many labels, nulls don't count, case-insensitive column match
  - Failure: single label (with value-counts in message), all-null, one-value-plus-nulls
  - Error message mentions the regression alternative
  - Defensive: empty input / missing column → silent pass (other validators own those)
  - CSV-path: reads only the label column; rejects single-label CSV at the file level
  - Custom label column name
- [ ] **3 new tests** in \`tests/test_api_client_methods.py\`:
  - On HTTP error, \`last_prepare_error\` populated with status + body
  - Clean ingestor: \`last_prepare_error is None\`
  - Network error (no response): still populated with stringified exception
- [ ] CI green
- [ ] Re-run S5/S8 from the adversarial pass:
  - Single-label data → fails fast at preflight with the value-counts message (no MySQL writes, no backend round-trip)
  - Multi-label data → continues to pass end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preflight gating and post-commit registration error messaging on a critical ingest path; mis-tuned label counting could block valid datasets or still allow bad ones, though extensive tests target parity with CSV ingest rules.
> 
> **Overview**
> Adds **`LabelDiversityValidator`** so classification-family ingests fail **before** MySQL writes when the label column has fewer than two distinct non-null values, with errors that list offending values/counts and suggest regression categories when appropriate. It is wired through **`validators_mapping`** for tabular/image/text/object/semantic/keypoint classification (not token classification or regression/self-supervised), reads CSVs via **label-only `usecols`** with **NA/dtype rules aligned to ingest** via **`full_schema`** from **`base.py`**, and includes hardening for headers, read failures, and schema vs non-schema NA handling (#252).
> 
> **`APIClient.prepare_dataset`** now clears and sets **`last_prepare_error`** on HTTP/network failures; **`base.py`** includes that text in the **RuntimeError** when prepare fails so users see the backend body (e.g. “Please provide atleast 2 labels.”) instead of only “see the logged API error above.”
> 
> Tests cover the validator, mapping, and **`last_prepare_error`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d24151b286b0a3a62006d1db9e12360a9a9b41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->