### PR TITLE
fix(cli): surface schema descriptions in validation errors instead of raw JSON-schema mechanic

### DIFF
--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -119,7 +119,16 @@ def test_malformed_yaml_fails_fast(clean_env, mock_runtime, monkeypatch, capsys,
 
 def test_schema_violation_fails_fast(clean_env, mock_runtime, monkeypatch, capsys, tmp_path):
     """A config that passes YAML parsing but fails schema validation must
-    exit before any DB/network call, listing the failures."""
+    exit before any DB/network call, listing the failures.
+
+    Also pins that primitive checks ('X is a required property') keep
+    jsonschema's clear default message — they must NOT be replaced by
+    the schema's generic root description ("Declarative configuration
+    for the tracebloc data ingestor..."), which would happen if the
+    description-walker captured the root node's description (bugbot
+    #254). Schemas only attach their description when an INNER node
+    along the failing rule's path has one.
+    """
     bad = tmp_path / "bad.yaml"
     bad.write_text(
         # Missing `table`, `csv`, `images`, `label` — schema must reject.
@@ -139,6 +148,12 @@ def test_schema_violation_fails_fast(clean_env, mock_runtime, monkeypatch, capsy
     assert "validation failed" in err
     # Should mention at least one of the missing fields.
     assert "table" in err or "csv" in err or "images" in err or "label" in err
+    # The schema's GENERIC root description must NOT leak into primitive
+    # errors — bugbot #254 caught the walker capturing the root.
+    assert "Declarative configuration" not in err
+    # Primitive 'required property' messages must reach the user
+    # unmodified, NOT be replaced with a description + (rule:) line.
+    assert "is a required property" in err
     mock_runtime["Database"].assert_not_called()
     mock_runtime["APIClient"].assert_not_called()
 
@@ -191,6 +206,50 @@ def test_schema_violation_surfaces_description_not_raw_mechanic(
     assert "{'apiVersion'" not in headline  # raw dict dump suppressed
     mock_runtime["Database"].assert_not_called()
     mock_runtime["APIClient"].assert_not_called()
+
+
+def test_describe_from_schema_path_skips_root_description():
+    """Unit-test for the description walker:
+
+    The schema's ROOT description ("Declarative configuration for the
+    tracebloc data ingestor...") is a generic blurb about the schema
+    as a whole, not about any specific rule. It must NOT be returned
+    for primitive errors whose path doesn't dig into an `allOf`/`oneOf`
+    branch — otherwise EVERY validation error gets blanketed with the
+    same generic text and jsonschema's clear messages get hidden
+    (bugbot #254).
+
+    A primitive error like 'required' has schema_path == ('required',),
+    which walks into the schema's `required` list — a list with no
+    `description`. The walker must return None for that case.
+
+    The MLM+label case has schema_path == ('allOf', N, 'then', 'not'),
+    which DOES walk into a dict with the rule-specific description.
+    The walker must return THAT description.
+    """
+    from tracebloc_ingestor.cli.run import _describe_from_schema_path
+
+    schema = {
+        "description": "Generic root blurb that should NEVER be returned",
+        "properties": {"x": {"type": "integer"}},
+        "required": ["x"],
+        "allOf": [
+            {
+                "description": "Rule-specific prose with rationale and fix.",
+                "if": {"properties": {"category": {"const": "abc"}}},
+                "then": {"not": {"required": ["label"]}},
+            }
+        ],
+    }
+    # Primitive 'required' error path → no inner description → None
+    assert _describe_from_schema_path(schema, ["required"]) is None
+    # Generic top-level type error path → no inner description → None
+    assert _describe_from_schema_path(schema, ["properties", "x", "type"]) is None
+    # AllOf branch path → inner description is returned
+    assert (
+        _describe_from_schema_path(schema, ["allOf", 0, "then", "not"])
+        == "Rule-specific prose with rationale and fix."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -143,6 +143,56 @@ def test_schema_violation_fails_fast(clean_env, mock_runtime, monkeypatch, capsy
     mock_runtime["APIClient"].assert_not_called()
 
 
+def test_schema_violation_surfaces_description_not_raw_mechanic(
+    clean_env, mock_runtime, monkeypatch, capsys, tmp_path
+):
+    """Setting ``label:`` for masked_language_modeling violates the
+    schema's allOf rule. The user-visible error must surface the rule
+    AUTHOR'S description (which names the self-supervised category, the
+    fix, and #213's history) — NOT just the raw JSON-schema mechanic
+    "<{full yaml dump}> should not be valid under {'required':
+    ['label']}", which is technically correct but unreadable: it dumps
+    the entire submission as a Python dict and uses JSON-schema
+    vocabulary the customer didn't write.
+
+    Verified end-to-end against v0.3.10-rc1: a user who copy-pasted
+    `label: label` from another category's yaml saw only the raw
+    mechanic and had no way to know that MLM is self-supervised.
+    """
+    bad = tmp_path / "mlm_with_label.yaml"
+    bad.write_text(
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: masked_language_modeling\n"
+        "table: ssh_test\n"
+        "intent: test\n"
+        "csv: /tmp/ignored.csv\n"
+        "sequences: /tmp/ignored/\n"
+        "label: label\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(bad))
+
+    from tracebloc_ingestor.cli.run import main
+    rc = main()
+
+    err = capsys.readouterr().err
+    assert rc == 2
+    # The schema's description is what the user needs to see — it names
+    # the actual rationale and the fix.
+    assert "Self-supervised" in err
+    assert "MUST NOT set `label`" in err
+    # Don't drop the mechanic entirely — it's still on a follow-up line
+    # for power-user debugging.
+    assert "rule:" in err
+    # Should NOT dump the entire YAML body as a Python dict in the
+    # headline (the old behavior).
+    headline = err.split("\n", 1)[0]
+    assert "{'apiVersion'" not in headline  # raw dict dump suppressed
+    mock_runtime["Database"].assert_not_called()
+    mock_runtime["APIClient"].assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Happy path — CSV
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -207,20 +207,24 @@ def _describe_from_schema_path(
     (``'label' is a required property``, ``'foo' is not one of [...]``)
     still surface their existing clear messages.
     """
+    # Walk step-by-step, only capturing descriptions on nodes we DESCEND
+    # INTO — never the root's. The root description in ingest.v1.json is a
+    # generic blurb ("Declarative configuration for the tracebloc data
+    # ingestor…") that's correct for the schema as a whole but would
+    # blanket-attach to every primitive error, overwriting jsonschema's
+    # clear `'X' is a required property` messages with the generic prose
+    # (bugbot #254). Only INNER descriptions — the ones authored on
+    # `allOf` branches, sub-property definitions, etc. — are rule-specific
+    # enough to be worth surfacing.
     description = None
     node: Any = schema
     for step in schema_path:
-        # The CURRENT node's description applies to its sub-tree, so
-        # capture before descending.
-        if isinstance(node, dict) and isinstance(node.get("description"), str):
-            description = node["description"]
         try:
             node = node[step]
         except (KeyError, IndexError, TypeError):
             return description
-    # Capture the leaf's description too (deepest wins).
-    if isinstance(node, dict) and isinstance(node.get("description"), str):
-        description = node["description"]
+        if isinstance(node, dict) and isinstance(node.get("description"), str):
+            description = node["description"]
     return description
 
 

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -44,7 +44,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, NoReturn
+from typing import Any, Dict, Iterable, List, NoReturn, Optional
 
 import yaml
 from jsonschema import Draft7Validator, ValidationError
@@ -184,17 +184,74 @@ def _validate(raw_config: Dict[str, Any]) -> Iterable[ValidationError]:
     return sorted(validator.iter_errors(raw_config), key=lambda e: list(e.absolute_path))
 
 
-def _format_errors(errors: List[ValidationError]) -> str:
-    """Format errors as ``<json-pointer>: <message>``, one per line.
+def _describe_from_schema_path(
+    schema: Dict[str, Any], schema_path: List[Any]
+) -> Optional[str]:
+    """Walk the schema from root toward the failing rule, returning the
+    deepest ``description`` field encountered along the way.
 
-    Real line numbers (per the ticket) require a YAML loader that preserves
-    position info. v1.1 follow-up — for now, the JSON-pointer path is
-    enough to grep the customer's YAML.
+    JSON Schema ``allOf`` rules in ``schema/ingest.v1.json`` carry rich
+    ``description`` fields explaining each branch (e.g. "Self-supervised
+    categories MUST NOT set `label`. The shipped CSV has no label column,
+    and the framework registers no edge-label metadata for them…"), but
+    ``ValidationError.message`` only surfaces the mechanic
+    ("``{full yaml dump}`` should not be valid under ``{'required':
+    ['label']}``"). That raw message is correct but practically
+    unreadable: it dumps the entire submission as a Python dict and uses
+    JSON-schema vocabulary that the customer didn't write.
+
+    Walking from root captures the description nearest the failing rule,
+    so the user sees the rule author's intent (and the suggested fix)
+    instead of the mechanic. Returns ``None`` when no description applies
+    — the caller falls back to ``e.message`` so primitive checks
+    (``'label' is a required property``, ``'foo' is not one of [...]``)
+    still surface their existing clear messages.
     """
+    description = None
+    node: Any = schema
+    for step in schema_path:
+        # The CURRENT node's description applies to its sub-tree, so
+        # capture before descending.
+        if isinstance(node, dict) and isinstance(node.get("description"), str):
+            description = node["description"]
+        try:
+            node = node[step]
+        except (KeyError, IndexError, TypeError):
+            return description
+    # Capture the leaf's description too (deepest wins).
+    if isinstance(node, dict) and isinstance(node.get("description"), str):
+        description = node["description"]
+    return description
+
+
+def _format_errors(errors: List[ValidationError]) -> str:
+    """Format errors as ``<json-pointer>: <description-or-message>``,
+    one per line. When a failing rule has a ``description`` field in the
+    schema, surface THAT (with the underlying mechanic on a follow-up
+    line) — the descriptions in ``schema/ingest.v1.json`` are
+    customer-facing prose with rationale and fix hints, and the mechanic
+    is JSON-schema vocabulary the customer didn't write.
+
+    Real line numbers (per the ticket) require a YAML loader that
+    preserves position info. v1.1 follow-up — for now, the JSON-pointer
+    path is enough to grep the customer's YAML.
+    """
+    schema = _load_schema()
     lines = []
     for e in errors:
         path = ".".join(str(p) for p in e.absolute_path) or "<root>"
-        lines.append(f"  {path}: {e.message}")
+        description = _describe_from_schema_path(
+            schema, list(e.absolute_schema_path)
+        )
+        if description:
+            lines.append(f"  {path}: {description}")
+            # Keep the mechanic on a follow-up line for power-user
+            # debugging without burying it in the headline.
+            lines.append(
+                f"      (rule: {e.validator}={e.validator_value!r})"
+            )
+        else:
+            lines.append(f"  {path}: {e.message}")
     return "\n".join(lines)
 
 


### PR DESCRIPTION
The ingest.yaml schema (\`schema/ingest.v1.json\`) carries beautifully written \`description\` fields explaining each \`allOf\` rule's intent, rationale, and fix hint. The customer-facing error emitter only printed the raw JSON-schema mechanic — burying the helpful prose under unreadable internals.

## What the user sees TODAY (v0.3.10-rc1)

Submitting MLM with \`label: label\` (a common mistake — users copy-paste from another category's YAML):

\`\`\`
ingest.yaml validation failed:
  <root>: {'apiVersion': 'tracebloc.io/v1', 'kind': 'IngestConfig',
          'category': 'masked_language_modeling', 'table': '...',
          'intent': 'test', 'csv': '...', 'sequences': '...',
          'label': 'label'} should not be valid under
          {'required': ['label']}
\`\`\`

Technically correct, practically unreadable:
- Dumps the entire submission as a Python dict
- Uses JSON-schema vocabulary (\`should not be valid under {'required'...}\`)
- Doesn't tell the user that MLM is self-supervised
- Doesn't suggest the fix (drop the \`label:\` line)

The schema itself has all of this in a \`description\` field on the \`allOf\` rule:

> *\"Self-supervised categories MUST NOT set \`label\`. The shipped CSV has no label column, and the framework registers no edge-label metadata for them. Setting \`label\` anyway used to ingest rows successfully, then crash at backend registration with a misleading HTTP 400 'No data found' (issue #213). Reject at submission instead.\"*

…but \`_format_errors\` never reached for it.

## What the user sees AFTER this PR

\`\`\`
ingest.yaml validation failed:
  <root>: Self-supervised categories MUST NOT set \`label\`. The shipped
          CSV has no label column, and the framework registers no
          edge-label metadata for them. Setting \`label\` anyway used to
          ingest rows successfully, then crash at backend registration
          with a misleading HTTP 400 'No data found' (issue #213).
          Reject at submission instead.
      (rule: not={'required': ['label']})
\`\`\`

## How

New helper \`_describe_from_schema_path(schema, absolute_schema_path)\` walks the schema from root toward the failing rule, capturing the **deepest** \`description\` field encountered along the way (descriptions are inherited by sub-trees per JSON-schema convention; the deepest one is the most specific).

\`_format_errors\` uses the helper when a description is available, falling back to \`e.message\` when none exists. Primitive checks (\`'label' is a required property\`, enum violations) keep their existing clear messages — descriptions only attach when the schema has one.

## What this PR does NOT do

- **Real line numbers**. Still deferred — requires a YAML loader that preserves position info (\`ruamel.yaml\` or a custom \`SafeLoader\`). Tracked in the existing TODO in \`_format_errors\`.
- **Translate JSON-schema vocabulary**. The mechanic line still uses \`not=...\` / \`oneOf=...\`. That's deliberate — it's secondary information, kept for power-user debugging.

## Test plan

- [ ] New \`test_schema_violation_surfaces_description_not_raw_mechanic\`:
  - Submits MLM with \`label: label\`
  - Asserts the user-visible error contains the schema's description keywords (\"Self-supervised\", \"MUST NOT set \`label\`\")
  - Asserts the rule mechanic still appears on a follow-up \`rule:\` line
  - Asserts the old behavior (full YAML dict dumped in the headline) is NOT present
  - Asserts no DB / network I/O happens before validation rejects
- [ ] Existing \`test_schema_violation_fails_fast\` (missing required fields) continues to pass — primitive \"X is a required property\" messages don't have schema descriptions and fall through to \`e.message\` unchanged
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only validation messaging change before DB/network I/O; behavior for errors without inner descriptions is unchanged.
> 
> **Overview**
> **Ingest YAML validation errors** now prefer **rule-specific `description` text** from `ingest.v1.json` (e.g. self-supervised / no `label` guidance) instead of dumping the full config and raw `not`/`required` mechanics as the headline.
> 
> `_format_errors` walks `absolute_schema_path` via new `_describe_from_schema_path`, which only picks up **inner** schema descriptions—not the generic root blurb—so primitive failures still show jsonschema’s usual messages (`is a required property`). When a description exists, the validator mechanic is kept on a secondary `(rule: …)` line.
> 
> Tests cover MLM-with-`label`, missing-field fast-fail (no root description leak), and the walker unit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e63a210bc8122e726a4950215ceca91764396595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->