### PR TITLE
refactor(P3b): move validator factories into the ModalityRegistry

### DIFF
--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 from typing import Dict
 
 from ..utils.constants import TaskCategory
+from . import validators as v
 from .spec import ModalitySpec
 
-# One entry per supported category. P3a populates the three behavior flags
-# that were hand-maintained frozensets in ingestors/base.py.
+# One entry per supported category — the single source of truth. P3a: the three
+# behavior flags (was three frozensets in ingestors/base.py). P3b: the
+# validator factory (was the map_validators if/elif arm).
 _SPECS = (
     # File-bearing categories (per-row sidecar files under SRC_PATH).
     ModalitySpec(
@@ -24,36 +26,42 @@ _SPECS = (
         is_file_bearing=True,
         is_tabular_family=False,
         is_self_supervised=False,
+        build_validators=v.image_classification,
     ),
     ModalitySpec(
         TaskCategory.OBJECT_DETECTION,
         is_file_bearing=True,
         is_tabular_family=False,
         is_self_supervised=False,
+        build_validators=v.object_detection,
     ),
     ModalitySpec(
         TaskCategory.KEYPOINT_DETECTION,
         is_file_bearing=True,
         is_tabular_family=False,
         is_self_supervised=False,
+        build_validators=v.keypoint_detection,
     ),
     ModalitySpec(
         TaskCategory.SEMANTIC_SEGMENTATION,
         is_file_bearing=True,
         is_tabular_family=False,
         is_self_supervised=False,
+        build_validators=v.semantic_segmentation,
     ),
     ModalitySpec(
         TaskCategory.TEXT_CLASSIFICATION,
         is_file_bearing=True,
         is_tabular_family=False,
         is_self_supervised=False,
+        build_validators=v.text_classification,
     ),
     ModalitySpec(
         TaskCategory.TOKEN_CLASSIFICATION,
         is_file_bearing=True,
         is_tabular_family=False,
         is_self_supervised=False,
+        build_validators=v.token_classification,
     ),
     # masked_language_modeling is file-bearing AND self-supervised (no label).
     ModalitySpec(
@@ -61,6 +69,7 @@ _SPECS = (
         is_file_bearing=True,
         is_tabular_family=False,
         is_self_supervised=True,
+        build_validators=v.masked_language_modeling,
     ),
     # Tabular family (structured feature tables; no sidecar files).
     ModalitySpec(
@@ -68,24 +77,28 @@ _SPECS = (
         is_file_bearing=False,
         is_tabular_family=True,
         is_self_supervised=False,
+        build_validators=v.tabular_classification,
     ),
     ModalitySpec(
         TaskCategory.TABULAR_REGRESSION,
         is_file_bearing=False,
         is_tabular_family=True,
         is_self_supervised=False,
+        build_validators=v.tabular_regression,
     ),
     ModalitySpec(
         TaskCategory.TIME_SERIES_FORECASTING,
         is_file_bearing=False,
         is_tabular_family=True,
         is_self_supervised=False,
+        build_validators=v.time_series_forecasting,
     ),
     ModalitySpec(
         TaskCategory.TIME_TO_EVENT_PREDICTION,
         is_file_bearing=False,
         is_tabular_family=True,
         is_self_supervised=False,
+        build_validators=v.time_to_event_prediction,
     ),
 )
 

--- a/tracebloc_ingestor/modalities/spec.py
+++ b/tracebloc_ingestor/modalities/spec.py
@@ -25,14 +25,19 @@ So the spec is intentionally small here and grows over P3b–P3d.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any, Callable, Dict, List
 
 
 @dataclass(frozen=True)
 class ModalitySpec:
-    """Per-category behavior flags (P3a). More fields land in P3b–P3d.
+    """Per-category behavior (built up over P3a–P3d). More fields land in P3c/P3d.
 
     Attributes:
         category: the ``TaskCategory`` value this spec describes.
+        build_validators: ``(file_options) -> [validators]`` — the validator
+            set this category runs (P3b). Replaces the corresponding
+            ``map_validators`` if/elif arm; the factory bodies live in
+            ``modalities/validators.py``.
         is_file_bearing: every record references sidecar files (images,
             annotations, masks, texts, sequences) under ``SRC_PATH`` that must
             be copied to ``DEST_PATH``. Drives both the SRC_PATH preflight and
@@ -50,3 +55,4 @@ class ModalitySpec:
     is_file_bearing: bool
     is_tabular_family: bool
     is_self_supervised: bool
+    build_validators: Callable[[Dict[str, Any]], List]

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -1,0 +1,222 @@
+"""Per-category validator factories (structural refactor — backend#796, P3b).
+
+One factory per task category, each ``(options) -> [validators]``. These are
+the bodies of the old ``utils.validators_mapping.map_validators`` if/elif arms,
+moved verbatim so the validator sets are byte-for-byte identical — now attached
+to each ModalitySpec (``build_validators``) instead of dispatched by a ladder.
+``map_validators`` is now a thin lookup over the registry.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..utils.constants import FileExtension
+from ..validators.base import BaseValidator
+from ..validators.bio_label_validator import BIOLabelValidator
+from ..validators.data_validator import DataValidator
+from ..validators.duplicate_validator import DuplicateValidator
+from ..validators.file_pairing_validator import FilePairingValidator
+from ..validators.file_validator import FileTypeValidator
+from ..validators.image_validator import ImageResolutionValidator
+from ..validators.keypoint_annotation_validator import KeypointAnnotationValidator
+from ..validators.keypoint_visibility_validator import KeypointVisibilityValidator
+from ..validators.numeric_columns_validator import NumericColumnsValidator
+from ..validators.table_name_validator import TableNameValidator
+from ..validators.time_before_today_validator import TimeBeforeTodayValidator
+from ..validators.time_format_validator import TimeFormatValidator
+from ..validators.time_ordered_validator import TimeOrderedValidator
+from ..validators.time_to_event_validator import TimeToEventValidator
+from ..validators.tokenizer_validator import TokenizerValidator
+from ..validators.xml_validator import PascalVOCXMLValidator
+
+
+def image_classification(options: Dict[str, Any]) -> List[BaseValidator]:
+    return [
+        FileTypeValidator(allowed_extension=options["extension"], path="images"),
+        ImageResolutionValidator(expected_resolution=options["target_size"]),
+        TableNameValidator(),
+        DuplicateValidator(),
+    ]
+
+
+def object_detection(options: Dict[str, Any]) -> List[BaseValidator]:
+    return [
+        FileTypeValidator(allowed_extension=options["extension"], path="images"),
+        FileTypeValidator(allowed_extension=".xml", path="annotations"),
+        PascalVOCXMLValidator(),
+        FilePairingValidator(
+            image_path="images",
+            sidecar_path="annotations",
+            sidecar_label="annotation",
+        ),
+        ImageResolutionValidator(expected_resolution=options["target_size"]),
+        TableNameValidator(),
+        DuplicateValidator(),
+    ]
+
+
+def tabular_classification(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    # Add data validator if schema is provided
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    validators.append(TableNameValidator())
+    validators.append(DuplicateValidator())
+    return validators
+
+
+def text_classification(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    # Add text file validator
+    validators.append(
+        FileTypeValidator(
+            allowed_extension=options.get("extension", FileExtension.TXT),
+            path="texts",
+        ),
+    )
+    # Optional user-supplied tokenizer.json — warn (don't fail) if absent;
+    # if present, it must contain [PAD] (text classification pads batches).
+    validators.append(TokenizerValidator(required_tokens=("[PAD]",), optional=True))
+    # Add data validator if schema is provided
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    validators.append(TableNameValidator())
+    validators.append(DuplicateValidator())
+    return validators
+
+
+def token_classification(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    # Validate text file extensions (one .txt of whitespace-tokenized words
+    # per sample, same layout as text classification).
+    validators.append(
+        FileTypeValidator(
+            allowed_extension=options.get("extension", FileExtension.TXT),
+            path="texts",
+        ),
+    )
+    # Validate BIO labels: one tag per word, valid BIO/IOB2 format. Honor a
+    # custom label column name when one is configured in the YAML.
+    validators.append(
+        BIOLabelValidator(
+            texts_path="texts",
+            extension=options.get("extension", FileExtension.TXT),
+            label_column=options.get("label_column") or "label",
+        )
+    )
+    # Optional user-supplied tokenizer.json — warn (don't fail) if absent;
+    # if present, it must contain [PAD].
+    validators.append(TokenizerValidator(required_tokens=("[PAD]",), optional=True))
+    # Add data validator if schema is provided
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    validators.append(TableNameValidator())
+    validators.append(DuplicateValidator())
+    return validators
+
+
+def time_series_forecasting(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    schema = options.get("schema", {})
+    validators.append(TimeFormatValidator(schema=schema))
+    validators.append(TimeOrderedValidator())
+    validators.append(TimeBeforeTodayValidator())
+    validators.append(NumericColumnsValidator(schema=schema))
+    if options.get("schema"):
+        schema_without_timestamp = {
+            k: v for k, v in options["schema"].items() if k.lower() != "timestamp"
+        }
+        if schema_without_timestamp:
+            validators.append(DataValidator(schema=schema_without_timestamp))
+    validators.append(TableNameValidator())
+    validators.append(DuplicateValidator())
+    return validators
+
+
+def tabular_regression(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    # Add data validator if schema is provided
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    validators.append(TableNameValidator())
+    validators.append(DuplicateValidator())
+    return validators
+
+
+def time_to_event_prediction(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    # Add time to event validator with schema to identify time column
+    if options.get("schema"):
+        validators.append(
+            TimeToEventValidator(
+                schema=options["schema"],
+                time_column=options.get("time_column"),
+            )
+        )
+    else:
+        # If no schema, use default time column name
+        validators.append(
+            TimeToEventValidator(time_column=options.get("time_column", "time"))
+        )
+    # Add data validator if schema is provided
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    validators.append(TableNameValidator())
+    validators.append(DuplicateValidator())
+    return validators
+
+
+def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
+    return [
+        FileTypeValidator(allowed_extension=options["extension"], path="images"),
+        FileTypeValidator(allowed_extension=FileExtension.PNG, path="masks"),
+        FilePairingValidator(
+            image_path="images",
+            sidecar_path="masks",
+            sidecar_label="mask",
+            # Documented + shipped convention for semantic_segmentation masks
+            # is `<filename>_mask.png` (#196). Strip the suffix before matching
+            # so image_001.jpg pairs with image_001_mask.png. object_detection's
+            # pairing is plain stem (no suffix) — the default.
+            sidecar_suffix="_mask",
+        ),
+        ImageResolutionValidator(expected_resolution=options["target_size"]),
+        TableNameValidator(),
+        DuplicateValidator(),
+    ]
+
+
+def keypoint_detection(options: Dict[str, Any]) -> List[BaseValidator]:
+    # ``number_of_keypoints`` is required by the ingest schema for
+    # keypoint_detection (see ``schema/ingest.v1.json``) and plumbed into
+    # ``file_options`` by ``cli/conventions.py``. Passing it to
+    # ``KeypointAnnotationValidator`` enables the per-row count check that
+    # rejects datasets whose annotations drift from the declared K.
+    return [
+        FileTypeValidator(allowed_extension=options["extension"], path="images"),
+        ImageResolutionValidator(expected_resolution=options["target_size"]),
+        KeypointAnnotationValidator(num_keypoints=options.get("number_of_keypoints")),
+        KeypointVisibilityValidator(),
+        TableNameValidator(),
+        DuplicateValidator(),
+    ]
+
+
+def masked_language_modeling(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    # Validate text file extensions
+    validators.append(
+        FileTypeValidator(
+            allowed_extension=options.get("extension", FileExtension.TXT),
+            path="sequences",
+        ),
+    )
+    # Validate tokenizer.json has required special tokens ([MASK], [PAD])
+    validators.append(TokenizerValidator())
+    # Add data validator if schema is provided
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    validators.append(TableNameValidator())
+    validators.append(DuplicateValidator())
+    return validators

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -1,236 +1,25 @@
-from typing import Dict, Any, List
-from tracebloc_ingestor.validators.file_validator import FileTypeValidator
-from tracebloc_ingestor.validators.base import BaseValidator
-from tracebloc_ingestor.validators.image_validator import ImageResolutionValidator
-from tracebloc_ingestor.validators.data_validator import DataValidator
-from tracebloc_ingestor.validators.table_name_validator import TableNameValidator
-from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
-from tracebloc_ingestor.validators.xml_validator import PascalVOCXMLValidator
-from tracebloc_ingestor.validators.time_to_event_validator import TimeToEventValidator
-from tracebloc_ingestor.validators.time_format_validator import TimeFormatValidator
-from tracebloc_ingestor.validators.time_ordered_validator import TimeOrderedValidator
-from tracebloc_ingestor.validators.time_before_today_validator import (
-    TimeBeforeTodayValidator,
-)
-from tracebloc_ingestor.validators.numeric_columns_validator import (
-    NumericColumnsValidator,
-)
-from tracebloc_ingestor.validators.keypoint_annotation_validator import (
-    KeypointAnnotationValidator,
-)
-from tracebloc_ingestor.validators.keypoint_visibility_validator import (
-    KeypointVisibilityValidator,
-)
-from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
-from tracebloc_ingestor.validators.file_pairing_validator import FilePairingValidator
-from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
-from tracebloc_ingestor.utils.constants import TaskCategory, FileExtension
+"""Resolve the validator set for a task category.
+
+The per-category validator factories now live on each ``ModalitySpec``
+(bodies in ``modalities/validators.py``, attached in ``modalities/registry.py``
+— structural refactor backend#796, P3b). This stays the entry point
+``BaseIngestor.validate_data`` calls; it is now a thin lookup over the registry
+rather than an 11-arm if/elif.
+
+An unknown / ``None`` category returns ``[]`` (no validators) — preserving the
+prior fall-through. That is kept loud at the gate by
+``tests/test_category_congruence.py``, which requires every schema-enum
+category to resolve a non-empty set.
+"""
+
+from typing import Any, Dict, List
+
+from ..modalities.registry import REGISTRY
+from ..validators.base import BaseValidator
 
 
-def map_validators(
-    task_category: TaskCategory, options: Dict[str, Any]
-) -> List[BaseValidator]:
-    if task_category == TaskCategory.IMAGE_CLASSIFICATION:
-        return [
-            FileTypeValidator(allowed_extension=options["extension"], path="images"),
-            ImageResolutionValidator(expected_resolution=options["target_size"]),
-            TableNameValidator(),
-            DuplicateValidator(),
-        ]
-    elif task_category == TaskCategory.OBJECT_DETECTION:
-        return [
-            FileTypeValidator(allowed_extension=options["extension"], path="images"),
-            FileTypeValidator(allowed_extension=".xml", path="annotations"),
-            PascalVOCXMLValidator(),
-            FilePairingValidator(
-                image_path="images",
-                sidecar_path="annotations",
-                sidecar_label="annotation",
-            ),
-            ImageResolutionValidator(expected_resolution=options["target_size"]),
-            TableNameValidator(),
-            DuplicateValidator(),
-        ]
-    elif task_category == TaskCategory.TABULAR_CLASSIFICATION:
-        validators = []
-
-        # Add data validator if schema is provided
-        if options.get("schema"):
-            validators.append(DataValidator(schema=options["schema"]))
-        validators.append(TableNameValidator())
-        validators.append(DuplicateValidator())
-
-        return validators
-    elif task_category == TaskCategory.TEXT_CLASSIFICATION:
-        validators = []
-
-        # Add text file validator
-        validators.append(
-            FileTypeValidator(
-                allowed_extension=options.get("extension", FileExtension.TXT),
-                path="texts",
-            ),
-        )
-
-        # Optional user-supplied tokenizer.json — warn (don't fail) if absent;
-        # if present, it must contain [PAD] (text classification pads batches).
-        validators.append(TokenizerValidator(required_tokens=("[PAD]",), optional=True))
-
-        # Add data validator if schema is provided
-        if options.get("schema"):
-            validators.append(DataValidator(schema=options["schema"]))
-
-        validators.append(TableNameValidator())
-        validators.append(DuplicateValidator())
-
-        return validators
-    elif task_category == TaskCategory.TOKEN_CLASSIFICATION:
-        validators = []
-
-        # Validate text file extensions (one .txt of whitespace-tokenized words
-        # per sample, same layout as text classification).
-        validators.append(
-            FileTypeValidator(
-                allowed_extension=options.get("extension", FileExtension.TXT),
-                path="texts",
-            ),
-        )
-
-        # Validate BIO labels: one tag per word, valid BIO/IOB2 format.
-        # Honor a custom label column name when one is configured in the YAML.
-        validators.append(
-            BIOLabelValidator(
-                texts_path="texts",
-                extension=options.get("extension", FileExtension.TXT),
-                label_column=options.get("label_column") or "label",
-            )
-        )
-
-        # Optional user-supplied tokenizer.json — warn (don't fail) if absent;
-        # if present, it must contain [PAD].
-        validators.append(TokenizerValidator(required_tokens=("[PAD]",), optional=True))
-
-        # Add data validator if schema is provided
-        if options.get("schema"):
-            validators.append(DataValidator(schema=options["schema"]))
-
-        validators.append(TableNameValidator())
-        validators.append(DuplicateValidator())
-
-        return validators
-    elif task_category == TaskCategory.TIME_SERIES_FORECASTING:
-        validators = []
-
-        schema = options.get("schema", {})
-
-        validators.append(TimeFormatValidator(schema=schema))
-        validators.append(TimeOrderedValidator())
-        validators.append(TimeBeforeTodayValidator())
-        validators.append(NumericColumnsValidator(schema=schema))
-
-        if options.get("schema"):
-            schema_without_timestamp = {
-                k: v for k, v in options["schema"].items() if k.lower() != "timestamp"
-            }
-            if schema_without_timestamp:
-                validators.append(DataValidator(schema=schema_without_timestamp))
-
-        validators.append(TableNameValidator())
-        validators.append(DuplicateValidator())
-
-        return validators
-    elif task_category == TaskCategory.TABULAR_REGRESSION:
-        validators = []
-
-        # Add data validator if schema is provided
-        if options.get("schema"):
-            validators.append(DataValidator(schema=options["schema"]))
-        validators.append(TableNameValidator())
-        validators.append(DuplicateValidator())
-
-        return validators
-    elif task_category == TaskCategory.TIME_TO_EVENT_PREDICTION:
-        validators = []
-
-        # Add time to event validator with schema to identify time column
-        if options.get("schema"):
-            validators.append(
-                TimeToEventValidator(
-                    schema=options["schema"],
-                    time_column=options.get("time_column"),
-                )
-            )
-        else:
-            # If no schema, use default time column name
-            validators.append(
-                TimeToEventValidator(time_column=options.get("time_column", "time"))
-            )
-
-        # Add data validator if schema is provided
-        if options.get("schema"):
-            validators.append(DataValidator(schema=options["schema"]))
-        validators.append(TableNameValidator())
-        validators.append(DuplicateValidator())
-
-        return validators
-    elif task_category == TaskCategory.SEMANTIC_SEGMENTATION:
-        return [
-            FileTypeValidator(allowed_extension=options["extension"], path="images"),
-            FileTypeValidator(allowed_extension=FileExtension.PNG, path="masks"),
-            FilePairingValidator(
-                image_path="images",
-                sidecar_path="masks",
-                sidecar_label="mask",
-                # Documented + shipped convention for semantic_segmentation
-                # masks is `<filename>_mask.png` (#196). Strip the suffix
-                # before matching so image_001.jpg pairs with
-                # image_001_mask.png. object_detection's pairing above is
-                # plain stem (no suffix) — the default.
-                sidecar_suffix="_mask",
-            ),
-            ImageResolutionValidator(expected_resolution=options["target_size"]),
-            TableNameValidator(),
-            DuplicateValidator(),
-        ]
-    elif task_category == TaskCategory.KEYPOINT_DETECTION:
-        # ``number_of_keypoints`` is required by the ingest schema for
-        # keypoint_detection (see ``schema/ingest.v1.json``) and
-        # plumbed into ``file_options`` by ``cli/conventions.py``.
-        # Passing it to ``KeypointAnnotationValidator`` enables the
-        # per-row count check that rejects datasets whose annotations
-        # drift from the declared K.
-        validators = [
-            FileTypeValidator(allowed_extension=options["extension"], path="images"),
-            ImageResolutionValidator(expected_resolution=options["target_size"]),
-            KeypointAnnotationValidator(
-                num_keypoints=options.get("number_of_keypoints")
-            ),
-            KeypointVisibilityValidator(),
-            TableNameValidator(),
-            DuplicateValidator(),
-        ]
-        return validators
-    elif task_category == TaskCategory.MASKED_LANGUAGE_MODELING:
-        validators = []
-
-        # Validate text file extensions
-        validators.append(
-            FileTypeValidator(
-                allowed_extension=options.get("extension", FileExtension.TXT),
-                path="sequences",
-            ),
-        )
-
-        # Validate tokenizer.json has required special tokens ([MASK], [PAD])
-        validators.append(TokenizerValidator())
-
-        # Add data validator if schema is provided
-        if options.get("schema"):
-            validators.append(DataValidator(schema=options["schema"]))
-
-        validators.append(TableNameValidator())
-        validators.append(DuplicateValidator())
-
-        return validators
-    else:
+def map_validators(task_category: str, options: Dict[str, Any]) -> List[BaseValidator]:
+    spec = REGISTRY.get(task_category)
+    if spec is None:
         return []
+    return spec.build_validators(options)


### PR DESCRIPTION
Second slice of P3 (epic backend#796). The 11-arm `map_validators` if/elif moves **verbatim** into one factory per `ModalitySpec` (`modalities/validators.py`, attached via `build_validators`). `map_validators` is now a thin registry lookup.

**Stacked on #253 (P3a)** — base is the P3a branch; retargets to `develop` when P3a merges. Diff shows only the P3b slice.

Behaviour-identical: validator sets byte-for-byte the same (verified per category). Full suite **1033 passed, 97.3%**; new modules 100%. `test_category_congruence` + `test_validators_mapping` pass unchanged.

P3c (sidecar transfer plan; kills the mask_id leak; closes semseg #136) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)