### PR TITLE
refactor(P3c): move sidecar-transfer factories into the ModalityRegistry

### DIFF
--- a/tests/test_category_congruence.py
+++ b/tests/test_category_congruence.py
@@ -23,20 +23,18 @@ The enum ↔ ``TaskCategory`` equality itself is pinned separately by
 
 from __future__ import annotations
 
-import inspect
 import json
-import re
 from pathlib import Path
 
 import pytest
 
-from tracebloc_ingestor import file_transfer
 from tracebloc_ingestor.cli.conventions import (
     DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY,
     IMAGE_CATEGORIES,
     _data_format_for,
 )
 from tracebloc_ingestor.ingestors.base import _FILE_BEARING_CATEGORIES
+from tracebloc_ingestor.modalities import spec_for
 from tracebloc_ingestor.utils.constants import DataFormat, TaskCategory
 from tracebloc_ingestor.utils.validators_mapping import map_validators
 
@@ -103,29 +101,23 @@ def test_file_bearing_categories_match_file_transfer_gate():
     )
 
 
-def test_every_file_bearing_category_has_file_transfer_branch():
-    """Site 4: ``map_file_transfer`` falls through to ``None`` for
-    categories it doesn't know; the ingest loop counts that as a
-    file-transfer failure for EVERY record. Inspect the dispatch source
-    for an explicit ``TaskCategory.X`` branch per file-bearing category.
-
-    (Source inspection because calling the real branches touches the
-    filesystem, and the unwired fall-through returns the same ``None`` as
-    a wired branch handling a missing file — behaviorally ambiguous. If
-    map_file_transfer is ever refactored away from explicit TaskCategory
-    comparisons, update this test alongside it.)
-    """
-    source = inspect.getsource(file_transfer.map_file_transfer)
-    mentioned_names = set(re.findall(r"TaskCategory\.([A-Z_][A-Z0-9_]*)", source))
-    mentioned = {getattr(TaskCategory, name) for name in mentioned_names}
-
-    missing = {c for c in SCHEMA_CATEGORIES if _file_bearing(c)} - mentioned
-    assert not missing, (
-        f"map_file_transfer has no branch for file-bearing categories "
-        f"{sorted(missing)} — every record would be dropped as a "
-        f"file-transfer failure. Add a branch in file_transfer.py or "
-        f"remove the category from the schema enum."
-    )
+def test_every_file_bearing_category_has_transfer():
+    """Site 4 (post-P3c): ``map_file_transfer`` is now a registry lookup —
+    a file-bearing category must carry a ``transfer`` factory on its spec, or
+    the lookup returns ``None`` and the ingest loop drops EVERY record as a
+    file-transfer failure. The invariant is now structural, not a
+    source-inspection: ``is_file_bearing`` iff ``transfer is not None``."""
+    for category in SCHEMA_CATEGORIES:
+        spec = spec_for(category)
+        assert spec.is_file_bearing == (spec.transfer is not None), (
+            f"{category}: is_file_bearing={spec.is_file_bearing} but transfer is "
+            f"{'set' if spec.transfer else 'None'} — these must agree."
+        )
+        if _file_bearing(category):
+            assert spec.transfer is not None, (
+                f"file-bearing category {category} has no transfer factory; "
+                f"map_file_transfer would drop every record."
+            )
 
 
 def test_every_image_category_has_file_options_defaults():

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -7,28 +7,30 @@ supporting both binary data and file-based image processing.
 
 import logging
 import os
-from typing import Dict, Any, Optional
 import shutil
-import time
+from typing import Any, Dict, Optional
 
 from tenacity import (
+    before_sleep_log,
     retry,
+    retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
-    retry_if_exception_type,
-    before_sleep_log,
 )
+
 from tracebloc_ingestor import Config
-from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
+    GREEN,
+    RED,
+    RESET,
     RETRY_MAX_ATTEMPTS,
-    RETRY_WAIT_MULTIPLIER,
-    RETRY_WAIT_MIN,
     RETRY_WAIT_MAX,
-    TaskCategory,
+    RETRY_WAIT_MIN,
+    RETRY_WAIT_MULTIPLIER,
     FileExtension,
+    TaskCategory,
 )
-from tracebloc_ingestor.utils.constants import RESET, GREEN, RED
+from tracebloc_ingestor.utils.logging import setup_logging
 
 # Initialize config and configure logging
 config = Config()
@@ -362,108 +364,30 @@ def _copy_tokenizer_if_present() -> None:
 
 def map_file_transfer(
     task_category: TaskCategory, record: Dict[str, Any], options: Dict[str, Any]
-) -> Dict[str, Any]:
-    """Map file transfer function based on task category.
+) -> Optional[Dict[str, Any]]:
+    """Stage a record's per-row sidecar file(s), dispatched by category.
+
+    Thin lookup over the ModalityRegistry: each file-bearing category's spec
+    carries a ``transfer`` factory (the per-category bodies — atomic
+    image+annotation / image+mask pre-checks and all — now live in
+    ``modalities/transfer.py``; structural refactor backend#796, P3c). A
+    non-file-bearing or unknown category has ``transfer is None`` and returns
+    None (no sidecars to stage), exactly as the prior ``else`` branch did.
+
+    The registry import is lazy to avoid an import cycle at module load
+    (registry -> modalities.transfer -> this module).
 
     Args:
-        task_category: The type of task (IMAGE_CLASSIFICATION, OBJECT_DETECTION, TEXT_CLASSIFICATION, etc.)
-        record: Dictionary containing filename, data_id, and other record data
-        options: Dictionary containing transfer options
+        task_category: the task category.
+        record: the record (filename / data_id / …).
+        options: transfer options (extension, …).
 
     Returns:
-        Updated record dictionary or tuple of results for multi-file tasks
+        The (possibly mutated) record, or None if a required sidecar is missing.
     """
-    if task_category == TaskCategory.IMAGE_CLASSIFICATION:
-        result = image_transfer(record, options)
-        return result
-    elif task_category == TaskCategory.OBJECT_DETECTION:
-        # Atomic: only copy image+annotation together. Pre-verify both
-        # sources so a missing image (image_transfer returns the record,
-        # not None, on missing source) doesn't let annotation_transfer
-        # leave an orphan annotation on disk — and vice versa.
-        filename = record.get("filename")
-        if not filename:
-            logger.error(f"{RED}No filename found in record{RESET}")
-            return None
-        image_src_path, image_filename = _find_src(
-            "images", filename, options.get("extension")
-        )
-        if image_src_path is None:
-            logger.error(
-                f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', image_filename)} — skipping record{RESET}"
-            )
-            return None
-        annotation_src_path, annotation_filename = _find_src(
-            "annotations", filename, ".xml"
-        )
-        if annotation_src_path is None:
-            logger.error(
-                f"{RED}Source annotation not found: {os.path.join(config.SRC_PATH, 'annotations', annotation_filename)} — skipping record{RESET}"
-            )
-            return None
-        record = image_transfer(record, options, image_src_path, image_filename)
-        result = annotation_transfer(
-            record, options, ".xml", annotation_src_path, annotation_filename
-        )
-        return result
-    elif task_category == TaskCategory.TEXT_CLASSIFICATION:
-        result = text_transfer(record, options)
-        # Optional: ship a custom tokenizer.json so the client uses it instead
-        # of the HF default; absent is fine (handled by the optional validator).
-        _copy_tokenizer_if_present()
-        return result
-    elif task_category == TaskCategory.TOKEN_CLASSIFICATION:
-        # Same on-disk layout as text classification: one .txt per sample in
-        # the ``texts`` subdir. BIO tags travel in the labels CSV, not on disk.
-        result = text_transfer(record, options)
-        # Optional custom tokenizer.json (same as text classification).
-        _copy_tokenizer_if_present()
-        return result
-    elif task_category == TaskCategory.MASKED_LANGUAGE_MODELING:
-        result = text_transfer(record, options, src_subdir="sequences")
-        # Copy the user's tokenizer.json so the MLM client uses it instead of
-        # falling back to bert-base-uncased (a vocab_size mismatch with the
-        # model's nn.Embedding would cause a CUDA device-side assert at
-        # training). For MLM the tokenizer is mandatory — its presence and
-        # [MASK]/[PAD] tokens are enforced by TokenizerValidator at validation.
-        _copy_tokenizer_if_present()
-        return result
-    elif task_category == TaskCategory.SEMANTIC_SEGMENTATION:
-        # Atomic: only copy image+mask together. Pre-verify both sources
-        # before either copy, since image_transfer returns the record (not
-        # None) when the source image is missing — without this pre-check
-        # a missing image would still let mask_transfer leave an orphan
-        # mask on disk. Both sides resolve their source via shared
-        # helpers (`_find_src` / `_find_mask_src`) so the pre-check stays
-        # in lockstep with what the copy functions actually look for.
-        filename = record.get("filename")
-        if not filename:
-            logger.error(f"{RED}No filename found in record{RESET}")
-            return None
-        image_src_path, image_filename = _find_src(
-            "images", filename, options.get("extension")
-        )
-        if image_src_path is None:
-            logger.error(
-                f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', image_filename)} — skipping record{RESET}"
-            )
-            return None
+    from .modalities.registry import REGISTRY
 
-        mask_id = record.get("mask_id")
-        if not mask_id:
-            logger.error(f"{RED}No mask_id found in record{RESET}")
-            return None
-        mask_src_path, mask_ext, mask_name = _find_mask_src(mask_id)
-        if mask_src_path is None:
-            logger.error(
-                f"{RED}Source mask not found: {mask_name} in {config.SRC_PATH}/masks/ — skipping record{RESET}"
-            )
-            return None
-        record = image_transfer(record, options, image_src_path, image_filename)
-        record = mask_transfer(record, mask_src_path, mask_ext, mask_name)
-        return record
-    elif task_category == TaskCategory.KEYPOINT_DETECTION:
-        result = image_transfer(record, options)
-        return result
-    else:
+    spec = REGISTRY.get(task_category)
+    if spec is None or spec.transfer is None:
         return None
+    return spec.transfer(record, options)

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 from typing import Dict
 
 from ..utils.constants import TaskCategory
+from . import transfer as t
 from . import validators as v
 from .spec import ModalitySpec
 
 # One entry per supported category — the single source of truth. P3a: the three
 # behavior flags (was three frozensets in ingestors/base.py). P3b: the
-# validator factory (was the map_validators if/elif arm).
+# validator factory (was the map_validators if/elif arm). P3c: the sidecar
+# transfer factory (was the map_file_transfer if/elif arm).
 _SPECS = (
     # File-bearing categories (per-row sidecar files under SRC_PATH).
     ModalitySpec(
@@ -27,6 +29,7 @@ _SPECS = (
         is_tabular_family=False,
         is_self_supervised=False,
         build_validators=v.image_classification,
+        transfer=t.image_classification,
     ),
     ModalitySpec(
         TaskCategory.OBJECT_DETECTION,
@@ -34,6 +37,7 @@ _SPECS = (
         is_tabular_family=False,
         is_self_supervised=False,
         build_validators=v.object_detection,
+        transfer=t.object_detection,
     ),
     ModalitySpec(
         TaskCategory.KEYPOINT_DETECTION,
@@ -41,6 +45,7 @@ _SPECS = (
         is_tabular_family=False,
         is_self_supervised=False,
         build_validators=v.keypoint_detection,
+        transfer=t.keypoint_detection,
     ),
     ModalitySpec(
         TaskCategory.SEMANTIC_SEGMENTATION,
@@ -48,6 +53,7 @@ _SPECS = (
         is_tabular_family=False,
         is_self_supervised=False,
         build_validators=v.semantic_segmentation,
+        transfer=t.semantic_segmentation,
     ),
     ModalitySpec(
         TaskCategory.TEXT_CLASSIFICATION,
@@ -55,6 +61,7 @@ _SPECS = (
         is_tabular_family=False,
         is_self_supervised=False,
         build_validators=v.text_classification,
+        transfer=t.text_classification,
     ),
     ModalitySpec(
         TaskCategory.TOKEN_CLASSIFICATION,
@@ -62,6 +69,7 @@ _SPECS = (
         is_tabular_family=False,
         is_self_supervised=False,
         build_validators=v.token_classification,
+        transfer=t.token_classification,
     ),
     # masked_language_modeling is file-bearing AND self-supervised (no label).
     ModalitySpec(
@@ -70,8 +78,9 @@ _SPECS = (
         is_tabular_family=False,
         is_self_supervised=True,
         build_validators=v.masked_language_modeling,
+        transfer=t.masked_language_modeling,
     ),
-    # Tabular family (structured feature tables; no sidecar files).
+    # Tabular family (structured feature tables; no sidecar files -> no transfer).
     ModalitySpec(
         TaskCategory.TABULAR_CLASSIFICATION,
         is_file_bearing=False,

--- a/tracebloc_ingestor/modalities/spec.py
+++ b/tracebloc_ingestor/modalities/spec.py
@@ -25,7 +25,7 @@ So the spec is intentionally small here and grows over P3b–P3d.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 
 @dataclass(frozen=True)
@@ -38,6 +38,12 @@ class ModalitySpec:
             set this category runs (P3b). Replaces the corresponding
             ``map_validators`` if/elif arm; the factory bodies live in
             ``modalities/validators.py``.
+        transfer: ``(record, file_options) -> record | None`` — stages this
+            category's per-row sidecar file(s); ``None`` for non-file-bearing
+            (tabular / time-series) categories (P3c). Replaces the
+            ``map_file_transfer`` if/elif arm; bodies in
+            ``modalities/transfer.py``. Invariant: ``transfer is not None``
+            iff ``is_file_bearing`` (pinned by tests).
         is_file_bearing: every record references sidecar files (images,
             annotations, masks, texts, sequences) under ``SRC_PATH`` that must
             be copied to ``DEST_PATH``. Drives both the SRC_PATH preflight and
@@ -56,3 +62,6 @@ class ModalitySpec:
     is_tabular_family: bool
     is_self_supervised: bool
     build_validators: Callable[[Dict[str, Any]], List]
+    transfer: Optional[
+        Callable[[Dict[str, Any], Dict[str, Any]], Optional[Dict[str, Any]]]
+    ] = None

--- a/tracebloc_ingestor/modalities/transfer.py
+++ b/tracebloc_ingestor/modalities/transfer.py
@@ -1,0 +1,153 @@
+"""Per-category sidecar-transfer factories (structural refactor — backend#796, P3c).
+
+One transfer function per file-bearing category, each
+``(record, options) -> record | None`` (None = the record's sidecar file(s)
+could not be staged, so the record is dropped). These are the bodies of the
+old ``file_transfer.map_file_transfer`` if/elif arms, moved VERBATIM so the
+copy behavior — including the atomic image+annotation / image+mask pre-checks —
+is byte-for-byte identical. They are attached to each ModalitySpec
+(``transfer``); ``map_file_transfer`` is now a thin lookup over the registry.
+
+The copy primitives (image_transfer, _find_src, _find_mask_src, …) still live
+in file_transfer.py; this module orchestrates them per category exactly as
+before.
+
+NOTE: semantic_segmentation still reads ``mask_id`` off the record here, as
+today. Moving that per-row sidecar pointer off the DB-bound record (the
+cross-layer leak: process_record sets it, this reads it, _process_batch pops
+it) is deferred to P5, where the record/sidecar split happens — it is out of
+scope for this behavior-preserving slice.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+from ..file_transfer import (
+    _copy_tokenizer_if_present,
+    _find_mask_src,
+    _find_src,
+    annotation_transfer,
+    config,
+    image_transfer,
+    logger,
+    mask_transfer,
+    text_transfer,
+)
+from ..utils.constants import RED, RESET
+
+
+def image_classification(
+    record: Dict[str, Any], options: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    return image_transfer(record, options)
+
+
+def keypoint_detection(
+    record: Dict[str, Any], options: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    return image_transfer(record, options)
+
+
+def object_detection(
+    record: Dict[str, Any], options: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    # Atomic: only copy image+annotation together. Pre-verify both sources so a
+    # missing image (image_transfer returns the record, not None, on missing
+    # source) doesn't let annotation_transfer leave an orphan annotation on
+    # disk — and vice versa.
+    filename = record.get("filename")
+    if not filename:
+        logger.error(f"{RED}No filename found in record{RESET}")
+        return None
+    image_src_path, image_filename = _find_src(
+        "images", filename, options.get("extension")
+    )
+    if image_src_path is None:
+        logger.error(
+            f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', image_filename)} — skipping record{RESET}"
+        )
+        return None
+    annotation_src_path, annotation_filename = _find_src(
+        "annotations", filename, ".xml"
+    )
+    if annotation_src_path is None:
+        logger.error(
+            f"{RED}Source annotation not found: {os.path.join(config.SRC_PATH, 'annotations', annotation_filename)} — skipping record{RESET}"
+        )
+        return None
+    record = image_transfer(record, options, image_src_path, image_filename)
+    return annotation_transfer(
+        record, options, ".xml", annotation_src_path, annotation_filename
+    )
+
+
+def text_classification(
+    record: Dict[str, Any], options: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    result = text_transfer(record, options)
+    # Optional: ship a custom tokenizer.json so the client uses it instead of
+    # the HF default; absent is fine (handled by the optional validator).
+    _copy_tokenizer_if_present()
+    return result
+
+
+def token_classification(
+    record: Dict[str, Any], options: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    # Same on-disk layout as text classification: one .txt per sample in the
+    # ``texts`` subdir. BIO tags travel in the labels CSV, not on disk.
+    result = text_transfer(record, options)
+    # Optional custom tokenizer.json (same as text classification).
+    _copy_tokenizer_if_present()
+    return result
+
+
+def masked_language_modeling(
+    record: Dict[str, Any], options: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    result = text_transfer(record, options, src_subdir="sequences")
+    # Copy the user's tokenizer.json so the MLM client uses it instead of
+    # falling back to bert-base-uncased (a vocab_size mismatch with the model's
+    # nn.Embedding would cause a CUDA device-side assert at training). For MLM
+    # the tokenizer is mandatory — its presence and [MASK]/[PAD] tokens are
+    # enforced by TokenizerValidator at validation.
+    _copy_tokenizer_if_present()
+    return result
+
+
+def semantic_segmentation(
+    record: Dict[str, Any], options: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    # Atomic: only copy image+mask together. Pre-verify both sources before
+    # either copy, since image_transfer returns the record (not None) when the
+    # source image is missing — without this pre-check a missing image would
+    # still let mask_transfer leave an orphan mask on disk. Both sides resolve
+    # their source via shared helpers (`_find_src` / `_find_mask_src`) so the
+    # pre-check stays in lockstep with what the copy functions actually look for.
+    filename = record.get("filename")
+    if not filename:
+        logger.error(f"{RED}No filename found in record{RESET}")
+        return None
+    image_src_path, image_filename = _find_src(
+        "images", filename, options.get("extension")
+    )
+    if image_src_path is None:
+        logger.error(
+            f"{RED}Source image not found: {os.path.join(config.SRC_PATH, 'images', image_filename)} — skipping record{RESET}"
+        )
+        return None
+
+    mask_id = record.get("mask_id")
+    if not mask_id:
+        logger.error(f"{RED}No mask_id found in record{RESET}")
+        return None
+    mask_src_path, mask_ext, mask_name = _find_mask_src(mask_id)
+    if mask_src_path is None:
+        logger.error(
+            f"{RED}Source mask not found: {mask_name} in {config.SRC_PATH}/masks/ — skipping record{RESET}"
+        )
+        return None
+    record = image_transfer(record, options, image_src_path, image_filename)
+    return mask_transfer(record, mask_src_path, mask_ext, mask_name)


### PR DESCRIPTION
Third slice of P3 (epic backend#796). The 7-arm `map_file_transfer` if/elif moves **verbatim** into one transfer factory per file-bearing `ModalitySpec` (`modalities/transfer.py`, attached via `spec.transfer`) — atomic image+annotation / image+mask pre-checks unchanged. `map_file_transfer` is now a thin registry lookup (lazy import to avoid the registry→transfer→file_transfer cycle).

**Stacked on #255 (P3b)** — base is the P3b branch; retargets as parents merge.

Behaviour-identical: the existing `test_file_transfer_*` suites pass unchanged (the behavior gate — they exercise `map_file_transfer` with real tmp dirs). Full suite **1033 passed, 97.3%**; `modalities/transfer.py` 100%. The `test_category_congruence` site-4 test is upgraded from source-inspection to the structural invariant `is_file_bearing ⟺ transfer is not None`. Also drops a pre-existing unused `time` import.

**Deferred & flagged** (not blind without local e2e): the semseg `mask_id` cross-layer leak (→ P5) and adding semseg to the #247 harness + closing #136 (needs an e2e run).

P3d (conventions defaults) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)