### PR TITLE
Develop to prod 0.3.10

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install package + deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt   # runtime (-r requirements.txt) + test tools
           pip install -e .
 
       - name: Run e2e ingestion suite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install package + test deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt   # runtime (-r requirements.txt) + test/lint tools
           pip install -e .
 
       - name: Run pytest with coverage

--- a/e2e/test_characterization.py
+++ b/e2e/test_characterization.py
@@ -1,0 +1,362 @@
+"""Characterization harness — the safety net for the upcoming structural refactor.
+
+For each bundled ``templates/`` dataset this runs the REAL engine into REAL
+MySQL and pins the three observable dimensions a refactor MUST preserve:
+
+  1. **MySQL rows** — count matches the source manifest, and the standard
+     columns carry the right semantics (``data_intent`` == configured intent,
+     a single non-null ``ingestor_id``, unique non-null ``data_id``). For the
+     tabular family a feature column is round-tripped value-for-value (catches
+     type corruption — leading zeros, NA handling, numeric coercion).
+  2. **DEST_PATH file manifest** — exactly the sidecar files that should be
+     copied for file-bearing categories (catches a category that inserts rows
+     but copies no files — the silent-half-ingest class).
+  3. **Backend payloads** — the records + metadata the engine hands the
+     APIClient. ``CLIENT_ENV=local`` short-circuits the HTTP call *before* the
+     payload is serialised, so we spy on the APIClient method ARGS (which are
+     passed regardless of mode) rather than the HTTP mock.
+
+Why this is stable on ``develop`` today: it characterises CLEAN-input
+behavior. The in-flight fix PRs (#242–#245) only change MALFORMED-input
+handling (bad cells, NA tokens, traversal filenames, dropped-record
+accounting), so these goldens hold now and become the contract the refactor
+is checked against. Expectations are DERIVED from the source files (no
+hardcoded magic values), so the harness stays honest if a template changes.
+"""
+
+import os
+from pathlib import Path
+
+import mysql.connector
+import pandas as pd
+import pytest
+import yaml
+
+import tracebloc_ingestor.api.client as client_mod
+from tracebloc_ingestor.cli import run
+from tracebloc_ingestor.config import Config
+
+REPO = Path(__file__).resolve().parents[1]
+T = REPO / "templates"
+
+
+def _cfg(**kw):
+    base = {"apiVersion": "tracebloc.io/v1", "kind": "IngestConfig", "intent": "train"}
+    base.update(kw)
+    return base
+
+
+# One entry per modality that ingests cleanly from its bundled data. Each
+# carries the matched config plus the facts the assertions derive from:
+#   source_csv  — the manifest (its row count is the expected DB row count)
+#   sidecars    — {dest-subdir-is-flat: source dir} files expected in DEST_PATH
+#                 ({} for tabular/time-series, which copy nothing)
+#   label_field — the manifest column holding the label (None if unlabeled)
+CASES = [
+    dict(
+        id="tabular_classification",
+        cfg=_cfg(
+            table="char_tabclf",
+            category="tabular_classification",
+            csv=str(
+                T
+                / "tabular_classification/tabular_classification_sample_in_csv_format.csv"
+            ),
+            schema={
+                "feature_00": "FLOAT",
+                "feature_01": "FLOAT",
+                "feature_02": "FLOAT",
+                "label": "INT",
+            },
+            label="label",
+        ),
+        sidecars=[],
+        roundtrip_col="feature_00",
+    ),
+    dict(
+        id="tabular_regression",
+        cfg=_cfg(
+            table="char_tabreg",
+            category="tabular_regression",
+            csv=str(
+                T / "tabular_regression/tabular_regression_sample_in_csv_format.csv"
+            ),
+            schema={
+                "square_feet": "FLOAT",
+                "bedrooms": "INT",
+                "age": "INT",
+                "price": "FLOAT",
+            },
+            label={"column": "price", "policy": "bucket"},
+        ),
+        sidecars=[],
+        roundtrip_col="bedrooms",
+    ),
+    dict(
+        id="image_classification",
+        cfg=_cfg(
+            table="char_img",
+            category="image_classification",
+            csv=str(T / "image_classification/data/labels_file_sample.csv"),
+            images=str(T / "image_classification/data/images"),
+            label="label",
+            spec={"file_options": {"extension": ".jpeg", "target_size": [256, 256]}},
+        ),
+        sidecars=[str(T / "image_classification/data/images")],
+        roundtrip_col=None,
+    ),
+    dict(
+        id="text_classification",
+        cfg=_cfg(
+            table="char_text",
+            category="text_classification",
+            csv=str(T / "text_classification/data/labels_file_sample.csv"),
+            texts=str(T / "text_classification/data/texts"),
+            label="label",
+        ),
+        sidecars=[str(T / "text_classification/data/texts")],
+        roundtrip_col=None,
+    ),
+    dict(
+        id="time_to_event_prediction",
+        cfg=_cfg(
+            table="char_tte",
+            category="time_to_event_prediction",
+            csv=str(
+                T
+                / "time_to_event_prediction/time_to_event_prediction_sample_in_csv_format.csv"
+            ),
+            time_column="time",
+            schema={
+                "age": "INT",
+                "anaemia": "INT",
+                "creatinine_phosphokinase": "INT",
+                "diabetes": "INT",
+                "ejection_fraction": "INT",
+                "high_blood_pressure": "INT",
+                "platelets": "FLOAT",
+                "serum_creatinine": "FLOAT",
+                "serum_sodium": "INT",
+                "sex": "INT",
+                "smoking": "INT",
+                "time": "INT",
+                "DEATH_EVENT": "INT",
+            },
+            label={"column": "DEATH_EVENT", "policy": "bucket"},
+        ),
+        sidecars=[],
+        roundtrip_col="age",
+    ),
+    dict(
+        id="time_series_forecasting",
+        cfg=_cfg(
+            table="char_tsf",
+            category="time_series_forecasting",
+            csv=str(
+                T
+                / "time_series_forecasting/time_series_forecasting_sample_in_csv_format.csv"
+            ),
+            schema={
+                "timestamp": "TIMESTAMP",
+                "day_of_week": "INT",
+                "month": "INT",
+                "day_of_month": "INT",
+                "week_of_year": "INT",
+                "is_weekend": "INT",
+                "value": "FLOAT",
+            },
+            label={"column": "value", "policy": "bucket"},
+        ),
+        sidecars=[],
+        roundtrip_col="month",
+    ),
+    dict(
+        id="keypoint_detection",
+        cfg=_cfg(
+            table="char_kp",
+            category="keypoint_detection",
+            csv=str(T / "keypoint_detection/data/labels_file_sample.csv"),
+            images=str(T / "keypoint_detection/data/images"),
+            label="image_label",
+            target_size=[448, 448],
+            number_of_keypoints=9,
+        ),
+        sidecars=[str(T / "keypoint_detection/data/images")],
+        roundtrip_col=None,
+    ),
+    dict(
+        id="object_detection",
+        cfg=_cfg(
+            table="char_od",
+            category="object_detection",
+            csv=str(T / "object_detection/data/labels_file_sample.csv"),
+            images=str(T / "object_detection/data/images"),
+            annotations=str(T / "object_detection/data/annotations"),
+            label="image_label",
+            target_size=[1920, 1080],
+        ),
+        sidecars=[
+            str(T / "object_detection/data/images"),
+            str(T / "object_detection/data/annotations"),
+        ],
+        roundtrip_col=None,
+    ),
+    dict(
+        id="masked_language_modeling",
+        cfg=_cfg(
+            table="char_mlm",
+            category="masked_language_modeling",
+            csv=str(T / "masked_language_modeling/data/labels_file_sample.csv"),
+            sequences=str(T / "masked_language_modeling/data/sequences"),
+        ),
+        sidecars=[str(T / "masked_language_modeling/data/sequences")],
+        roundtrip_col=None,
+    ),
+]
+
+
+def _connect():
+    return mysql.connector.connect(
+        host=os.environ["MYSQL_HOST"],
+        port=int(os.environ["MYSQL_PORT"]),
+        user=os.environ["DB_USER"],
+        password=os.environ["DB_PASSWORD"],
+        database=os.environ["DB_NAME"],
+    )
+
+
+def _drop(table):
+    conn = _connect()
+    cur = conn.cursor()
+    cur.execute(f"DROP TABLE IF EXISTS `{table}`")
+    conn.commit()
+    cur.close()
+    conn.close()
+
+
+def _fetch_rows(table):
+    conn = _connect()
+    cur = conn.cursor(dictionary=True)
+    cur.execute(f"SELECT * FROM `{table}`")
+    rows = cur.fetchall()
+    cur.close()
+    conn.close()
+    return rows
+
+
+@pytest.fixture
+def capture_api(monkeypatch):
+    """Record the args every APIClient backend method is called with, then
+    delegate to the original (which returns the local-mode value). Captures the
+    engine's INTENT to send even though local mode skips the actual POST."""
+    calls = {
+        n: []
+        for n in (
+            "send_batch",
+            "send_global_meta_meta",
+            "prepare_dataset",
+            "create_dataset",
+        )
+    }
+    for name in calls:
+        orig = getattr(client_mod.APIClient, name)
+
+        def make(name, orig):
+            def wrapper(self, *args, **kwargs):
+                calls[name].append({"args": args, "kwargs": kwargs})
+                return orig(self, *args, **kwargs)
+
+            return wrapper
+
+        monkeypatch.setattr(client_mod.APIClient, name, make(name, orig))
+    return calls
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_characterization(case, tmp_path, monkeypatch, capture_api):
+    cfg = case["cfg"]
+    table = cfg["table"]
+    _drop(table)  # deterministic on re-run
+
+    config_path = tmp_path / "ingest.yaml"
+    config_path.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("INGEST_CONFIG", str(config_path))
+
+    rc = run.main()
+    assert rc == 0, f"{case['id']}: ingest exited {rc}"
+
+    source = pd.read_csv(cfg["csv"])
+    expected_rows = len(source)
+    rows = _fetch_rows(table)
+
+    # ── Dimension 1: MySQL rows ──────────────────────────────────────────
+    assert (
+        len(rows) == expected_rows
+    ), f"{case['id']}: {len(rows)} rows in DB, {expected_rows} in source manifest"
+    assert {r["data_intent"] for r in rows} == {cfg["intent"]}
+    ingestor_ids = {r["ingestor_id"] for r in rows}
+    assert len(ingestor_ids) == 1 and None not in ingestor_ids
+    data_ids = [r["data_id"] for r in rows]
+    assert all(data_ids) and len(set(data_ids)) == len(
+        data_ids
+    ), "data_id not unique/non-null"
+
+    # Feature round-trip for tabular: the column's values must survive the
+    # read → coerce → insert path unchanged (catches type corruption).
+    if case["roundtrip_col"]:
+        col = case["roundtrip_col"]
+        got = sorted(float(r[col]) for r in rows)
+        want = sorted(float(v) for v in source[col].tolist())
+        # rel=1e-4 tolerates MySQL FLOAT being 32-bit single precision (a
+        # legitimate ~1e-6 round-trip delta) while still catching real
+        # corruption (off by whole numbers, dropped/duplicated values, NaN).
+        assert got == pytest.approx(
+            want, rel=1e-4
+        ), f"{case['id']}: {col} did not round-trip"
+
+    # ── Dimension 2: DEST_PATH file manifest ─────────────────────────────
+    dest = Path(Config.STORAGE_PATH) / table
+    if case["sidecars"]:
+        copied = {p.name for p in dest.iterdir()} if dest.exists() else set()
+        expected_files = set()
+        for src_dir in case["sidecars"]:
+            expected_files |= {p.name for p in Path(src_dir).iterdir() if p.is_file()}
+        # Every source sidecar referenced by the manifest must have been copied.
+        assert (
+            expected_files <= copied
+        ), f"{case['id']}: missing copied files {expected_files - copied}"
+    else:
+        # Tabular/time-series copy nothing: DEST_PATH should hold no data files.
+        if dest.exists():
+            assert not [
+                p for p in dest.iterdir() if p.is_file()
+            ], f"{case['id']}: tabular ingest copied unexpected files"
+
+    # ── Dimension 3: backend payloads ────────────────────────────────────
+    # send_batch(records, table_name, ingestor_id) — records is [(id, dict)].
+    sent = [rec for c in capture_api["send_batch"] for (_id, rec) in c["args"][0]]
+    assert (
+        len(sent) == expected_rows
+    ), f"{case['id']}: {len(sent)} records sent to API, {expected_rows} expected"
+    for rec in sent:
+        assert rec.get("data_id"), "sent record missing data_id"
+        assert rec.get("data_intent") == cfg["intent"]
+    # The dataset-registration trio each fires exactly once.
+    assert len(capture_api["send_global_meta_meta"]) == 1
+    assert len(capture_api["prepare_dataset"]) == 1
+    assert len(capture_api["create_dataset"]) == 1
+    # global_meta carries the table name + a schema whose columns are a
+    # superset of the user schema (plus the framework's standard columns).
+    meta_args = capture_api["send_global_meta_meta"][0]["args"]
+    assert meta_args[0] == table
+    schema_sent = meta_args[1]
+    # The label column is mapped onto the framework's standard `label` column,
+    # not stored under its own name (e.g. regression's `price` -> `label`), so
+    # exclude it: the remaining FEATURE columns must all be in the payload.
+    label = cfg.get("label")
+    label_col = label.get("column") if isinstance(label, dict) else label
+    feature_cols = set(cfg.get("schema", {})) - {label_col}
+    assert feature_cols <= set(schema_sent), (
+        f"{case['id']}: schema payload missing feature columns "
+        f"{feature_cols - set(schema_sent)}"
+    )

--- a/e2e/test_database_e2e.py
+++ b/e2e/test_database_e2e.py
@@ -85,3 +85,34 @@ def test_non_ascii_data_roundtrip(db, table):
     db.create_table(table, {"name": "VARCHAR(64)"})
     db.insert_batch(table, [_rec("u", name="Größe-Meßwert")])
     assert _query(f"SELECT name FROM `{table}` WHERE data_id='u'")[0][0] == "Größe-Meßwert"
+
+
+def test_get_table_schema_reports_real_mysql_types(db, table):
+    """The schema sent to the backend must carry the REAL column types.
+
+    Reflection against a live MySQL returns dialect type classes (INTEGER,
+    FLOAT, DATETIME, ...). A mapping keyed by generic SQLAlchemy class names
+    (Integer, Float, ...) matched none of them, so every non-VARCHAR column
+    was reported to the backend as VARCHAR. The mocked unit test couldn't
+    catch that — it fed generic types into a fake inspector. This is the
+    test shape that does: declared type in, real CREATE TABLE, real
+    reflection out."""
+    db.create_table(table, {
+        "f_int": "INT",
+        "f_float": "FLOAT",
+        "f_dec": "DECIMAL(10,2)",
+        "f_bool": "BOOLEAN",
+        "f_dt": "DATETIME",
+        "f_name": "VARCHAR(64)",
+    })
+    schema = db.get_table_schema(table)
+    assert schema["f_int"] == "INT"
+    assert schema["f_float"] == "FLOAT"
+    assert schema["f_dec"] == "DECIMAL(10,2)"
+    assert schema["f_bool"] == "BOOLEAN"  # MySQL stores BOOL as TINYINT(1)
+    assert schema["f_dt"] == "DATETIME"
+    assert schema["f_name"] == "VARCHAR(64)"
+    # The framework's standard columns get their real types too.
+    assert schema["id"] == "BIGINT"
+    assert schema["created_at"] == "DATETIME"
+    assert schema["annotation"] == "TEXT"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,24 @@
+# Development / CI dependencies: everything needed to test, lint, type-check,
+# and publish the package — but NOT required at runtime. Kept out of
+# requirements.txt so `pip install tracebloc_ingestor` and the signed Docker
+# image stay lean.
+#
+# Local dev / CI install:  pip install -r requirements-dev.txt
+-r requirements.txt
+
+# Testing
+pytest>=7.0.0
+pytest-cov>=4.1.0
+
+# Type checking
+mypy>=1.0.0
+types-requests
+types-urllib3
+
+# Linting / formatting
+black>=23.0.0
+isort>=5.12.0
+flake8>=6.0.0
+
+# Release / publishing
+twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
+# Runtime dependencies for the tracebloc_ingestor package.
+#
+# Dev / test / lint / release tooling lives in requirements-dev.txt so it is
+# NOT pulled into `pip install tracebloc_ingestor` or baked into the signed
+# Docker image. setup.py reads THIS file for install_requires (comment and
+# -r/-c lines are filtered out there).
+
 # Database
 sqlalchemy>=2.0.0
 mysql-connector-python>=8.0.0
@@ -9,37 +16,25 @@ urllib3
 # Retry mechanism
 tenacity>=8.0.1
 
-# Image processing (for image processor)
+# Image processing (image validators / file transfer)
 Pillow>=10.0.0
 
-# CSV/JSON handling
+# CSV / JSON handling
 pandas>=2.0.0
+# numpy is imported DIRECTLY by csv_ingestor / data_validator (not only via
+# pandas), so declare it explicitly instead of relying on it transitively.
+numpy>=1.23
 
-# Streaming JSON parser (used by JSONIngestor.read_data so multi-GB JSON
-# datasets ingest without materialising the whole file — backend/#772 P2).
+# Streaming JSON parser — JSONIngestor.read_data streams multi-GB JSON without
+# materialising the whole file (backend/#772 P2).
 ijson>=3.2.0
 
-# YAML config + JSON Schema validation (for the declarative ingest.yaml flow)
+# YAML config + JSON Schema validation (declarative ingest.yaml flow)
 PyYAML>=6.0
 jsonschema>=4.0.0
 
-# Logging and monitoring
+# Structured logging
 python-json-logger>=2.0.0
 
-# Type checking
-mypy>=1.0.0
-types-requests
-types-urllib3
-
-# Testing
-pytest>=7.0.0
-pytest-cov>=4.1.0
-
-# Development tools
-black>=23.0.0
-isort>=5.12.0
-flake8>=6.0.0
-twine
-
 # Progress bar
-tqdm>=4.65.0 
+tqdm>=4.65.0

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,25 @@ def _read_version():
     return match.group(1)
 
 
-with open("requirements.txt", "r") as f:
-    requirements = f.read().splitlines()
+def _read_requirements(filename):
+    """Return the runtime requirement strings from a pip requirements file,
+    skipping blank lines, comments, and ``-r`` / ``-c`` include directives.
+
+    Without the filter, a section header like ``# Database`` (and the blank
+    separators) were fed verbatim into ``install_requires`` — only tolerated
+    by luck of the installer. Filtering keeps install_requires to actual
+    requirement specifiers now that runtime/dev deps are split across
+    requirements.txt and requirements-dev.txt.
+    """
+    lines = (this_directory / filename).read_text().splitlines()
+    return [
+        s
+        for line in lines
+        if (s := line.strip()) and not s.startswith(("#", "-"))
+    ]
+
+
+requirements = _read_requirements("requirements.txt")
 
 setup(
     name="tracebloc_ingestor",

--- a/templates/image_classification/image_classification.py
+++ b/templates/image_classification/image_classification.py
@@ -85,7 +85,12 @@ def main():
                 logger.info("All records processed successfully")
 
     except Exception as e:
-        logger.error(f"{str(e)}")
+        logger.error(f"Ingestion failed: {str(e)}")
+        # Re-raise so the process exits non-zero — swallowing here let a
+        # hard failure (validation error, DB error, backend registration
+        # rejection raised by ingest()) end with exit code 0 and a K8s
+        # Job marked Succeeded.
+        raise
 
 
 if __name__ == "__main__":

--- a/templates/image_classification/image_classification.py
+++ b/templates/image_classification/image_classification.py
@@ -6,9 +6,14 @@ supporting both binary data and file-based processing.
 """
 
 import logging
-import sys
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -41,56 +46,30 @@ csv_options = {
 
 def main():
     """Run the image classification data ingestion example."""
-    try:
 
-        # Initialize components
-        database = Database(config)
-        # Initialize API client
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    # Initialize API client
+    api_client = APIClient(config)
 
-        # Create ingestor for image classification data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            data_format=DataFormat.IMAGE,
-            category=TaskCategory.IMAGE_CLASSIFICATION,
-            csv_options=csv_options,
-            file_options=image_options,
-            label_column="label",
-            intent=Intent.TEST,  # Is the data for training or testing
-        )
+    # Create ingestor for image classification data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.IMAGE,
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        csv_options=csv_options,
+        file_options=image_options,
+        label_column="label",
+        intent=Intent.TEST,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting image classification ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        # Re-raise so the process exits non-zero — swallowing here let a
-        # hard failure (validation error, DB error, backend registration
-        # rejection raised by ingest()) end with exit code 0 and a K8s
-        # Job marked Succeeded.
-        raise
+    # Ingest data with validation
+    logger.info("Starting image classification ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/keypoint_detection/keypoint_detection.py
+++ b/templates/keypoint_detection/keypoint_detection.py
@@ -6,9 +6,14 @@ It processes image files along with JSON-based keypoint coordinate annotations.
 """
 
 import logging
-import sys
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -57,58 +62,36 @@ csv_options = {
 
 def main():
     """Run the keypoint detection ingestion example."""
-    try:
-        # Initialize components
-        database = Database(config)
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
 
-        # Visibility is kept in the schema so it survives process_record's
-        # schema-based filtering and is persisted alongside the annotation;
-        # without it the column is validated and then silently dropped.
-        schema = {"Visibility": "TEXT"}
+    # Visibility is kept in the schema so it survives process_record's
+    # schema-based filtering and is persisted alongside the annotation;
+    # without it the column is validated and then silently dropped.
+    schema = {"Visibility": "TEXT"}
 
-        # Create ingestor for keypoint detection data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            data_format=DataFormat.IMAGE,
-            category=TaskCategory.KEYPOINT_DETECTION,
-            schema=schema,
-            csv_options=csv_options,
-            file_options=file_options,
-            label_column="image_label",
-            annotation_column="Annotation",
-            unique_id_column="filename",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for keypoint detection data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.IMAGE,
+        category=TaskCategory.KEYPOINT_DETECTION,
+        schema=schema,
+        csv_options=csv_options,
+        file_options=file_options,
+        label_column="image_label",
+        annotation_column="Annotation",
+        unique_id_column="filename",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting keypoint detection ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        raise
+    # Ingest data with validation
+    logger.info("Starting keypoint detection ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/masked_language_modeling/masked_language_modeling.py
+++ b/templates/masked_language_modeling/masked_language_modeling.py
@@ -11,11 +11,16 @@ on-the-fly during training.
 """
 
 import logging
-import sys
 import os
 from typing import Dict, Any
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -45,50 +50,28 @@ csv_options = {
 
 def main():
     """Run the masked language modeling ingestion example."""
-    try:
-        # Initialize components
-        database = Database(config)
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
 
-        # Create ingestor for MLM data
-        # No label_column — MLM is self-supervised
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            data_format=DataFormat.TEXT,
-            category=TaskCategory.MASKED_LANGUAGE_MODELING,
-            csv_options=csv_options,
-            file_options=text_options,
-            intent=Intent.TRAIN,
-        )
+    # Create ingestor for MLM data
+    # No label_column — MLM is self-supervised
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.TEXT,
+        category=TaskCategory.MASKED_LANGUAGE_MODELING,
+        csv_options=csv_options,
+        file_options=text_options,
+        intent=Intent.TRAIN,
+    )
 
-        # Ingest data with validation
-        logger.info("Starting masked language modeling ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        raise
+    # Ingest data with validation
+    logger.info("Starting masked language modeling ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/object_detection/object_detection.py
+++ b/templates/object_detection/object_detection.py
@@ -6,14 +6,19 @@ corresponding XML annotation files from the VisDrone dataset format.
 """
 
 import logging
-import sys
 import shutil
 import xml.etree.ElementTree as ET
 from typing import Dict, Any
 import json
 import os
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -50,50 +55,28 @@ csv_options = {
 
 def main():
     """Run the object detection ingestion example."""
-    try:
-        # Initialize components
-        database = Database(config)
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
 
-        # Create ingestor for object detection data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            data_format=DataFormat.IMAGE,
-            category=TaskCategory.OBJECT_DETECTION,
-            csv_options=csv_options,
-            file_options=object_detection_options,
-            label_column="image_label",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for object detection data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.IMAGE,
+        category=TaskCategory.OBJECT_DETECTION,
+        csv_options=csv_options,
+        file_options=object_detection_options,
+        label_column="image_label",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting object detection ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        raise
+    # Ingest data with validation
+    logger.info("Starting object detection ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/semantic_segmentation/semantic_segmentation.py
+++ b/templates/semantic_segmentation/semantic_segmentation.py
@@ -6,10 +6,15 @@ both the image files and their corresponding mask annotation files.
 """
 
 import logging
-import sys
 from typing import Dict, Any
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -48,52 +53,30 @@ csv_options = {
 
 def main():
     """Run the semantic segmentation ingestion example."""
-    try:
-        # Initialize components
-        database = Database(config)
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
 
-        # Create ingestor for semantic segmentation data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            schema=schema,
-            data_format=DataFormat.IMAGE,
-            category=TaskCategory.SEMANTIC_SEGMENTATION,
-            csv_options=csv_options,
-            file_options=semantic_segmentation_options,
-            label_column="image_label",
-            unique_id_column="filename",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for semantic segmentation data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        schema=schema,
+        data_format=DataFormat.IMAGE,
+        category=TaskCategory.SEMANTIC_SEGMENTATION,
+        csv_options=csv_options,
+        file_options=semantic_segmentation_options,
+        label_column="image_label",
+        unique_id_column="filename",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting semantic segmentation ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('record', {}).get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        raise
+    # Ingest data with validation
+    logger.info("Starting semantic segmentation ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/tabular_classification/tabular_classification.py
+++ b/templates/tabular_classification/tabular_classification.py
@@ -6,9 +6,14 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
-import sys
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import TaskCategory, Intent, DataFormat
 
@@ -20,75 +25,51 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Run the tabular data ingestion example."""
-    try:
 
-        # Initialize components
-        database = Database(config)
-        # Initialize API client
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    # Initialize API client
+    api_client = APIClient(config)
 
-        # Schema definition for tabular data
-        # Schema should contain feature columns only
-        schema = {
-            "feature_00": "FLOAT ",
-            "feature_01": "FLOAT ",
-            "feature_02": "FLOAT ",
-        }
+    # Schema definition for tabular data
+    # Schema should contain feature columns only
+    schema = {
+        "feature_00": "FLOAT ",
+        "feature_01": "FLOAT ",
+        "feature_02": "FLOAT ",
+    }
 
-        # CSV specific options
-        csv_options = {
-            "chunk_size": 1000,
-            "delimiter": ",",
-            "quotechar": '"',
-            "escapechar": "\\",
-            "encoding": "utf-8",
-            "on_bad_lines": "warn",
-            "skip_blank_lines": True,
-            "na_values": ["", "NA", "NULL", "None"],
-        }
+    # CSV specific options
+    csv_options = {
+        "chunk_size": 1000,
+        "delimiter": ",",
+        "quotechar": '"',
+        "escapechar": "\\",
+        "encoding": "utf-8",
+        "on_bad_lines": "warn",
+        "skip_blank_lines": True,
+        "na_values": ["", "NA", "NULL", "None"],
+    }
 
-        # Create ingestor for tabular data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            schema=schema,
-            data_format=DataFormat.TABULAR,
-            category=TaskCategory.TABULAR_CLASSIFICATION,
-            csv_options=csv_options,
-            file_options={"number_of_columns": len(schema)},
-            label_column="label",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for tabular data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        schema=schema,
+        data_format=DataFormat.TABULAR,
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+        csv_options=csv_options,
+        file_options={"number_of_columns": len(schema)},
+        label_column="label",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting tabular data ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(f"Failed record: {record.get('name', 'Unknown')}")
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        # Re-raise so the process exits non-zero — swallowing here let a
-        # hard failure (validation error, DB error, backend registration
-        # rejection raised by ingest()) end with exit code 0 and a K8s
-        # Job marked Succeeded.
-        raise
+    # Ingest data with validation
+    logger.info("Starting tabular data ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/tabular_classification/tabular_classification.py
+++ b/templates/tabular_classification/tabular_classification.py
@@ -83,7 +83,12 @@ def main():
                 logger.info("All records processed successfully")
 
     except Exception as e:
-        logger.error(f"{str(e)}")
+        logger.error(f"Ingestion failed: {str(e)}")
+        # Re-raise so the process exits non-zero — swallowing here let a
+        # hard failure (validation error, DB error, backend registration
+        # rejection raised by ingest()) end with exit code 0 and a K8s
+        # Job marked Succeeded.
+        raise
 
 
 if __name__ == "__main__":

--- a/templates/tabular_regression/tabular_regression.py
+++ b/templates/tabular_regression/tabular_regression.py
@@ -83,7 +83,12 @@ def main():
                 logger.info("All records processed successfully")
 
     except Exception as e:
-        logger.error(f"{str(e)}")
+        logger.error(f"Ingestion failed: {str(e)}")
+        # Re-raise so the process exits non-zero — swallowing here let a
+        # hard failure (validation error, DB error, backend registration
+        # rejection raised by ingest()) end with exit code 0 and a K8s
+        # Job marked Succeeded.
+        raise
 
 
 if __name__ == "__main__":

--- a/templates/tabular_regression/tabular_regression.py
+++ b/templates/tabular_regression/tabular_regression.py
@@ -6,9 +6,14 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
-import sys
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import TaskCategory, Intent, DataFormat
 
@@ -20,75 +25,51 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Run the tabular data ingestion example."""
-    try:
 
-        # Initialize components
-        database = Database(config)
-        # Initialize API client
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    # Initialize API client
+    api_client = APIClient(config)
 
-        # Schema definition for tabular data
-        # Schema should contain feature columns only
-        schema = {
-            "square_feet": "FLOAT",
-            "bedrooms": "INT",
-            "age": "INT",
-        }
+    # Schema definition for tabular data
+    # Schema should contain feature columns only
+    schema = {
+        "square_feet": "FLOAT",
+        "bedrooms": "INT",
+        "age": "INT",
+    }
 
-        # CSV specific options
-        csv_options = {
-            "chunk_size": 1000,
-            "delimiter": ",",
-            "quotechar": '"',
-            "escapechar": "\\",
-            "encoding": "utf-8",
-            "on_bad_lines": "warn",
-            "skip_blank_lines": True,
-            "na_values": ["", "NA", "NULL", "None"],
-        }
+    # CSV specific options
+    csv_options = {
+        "chunk_size": 1000,
+        "delimiter": ",",
+        "quotechar": '"',
+        "escapechar": "\\",
+        "encoding": "utf-8",
+        "on_bad_lines": "warn",
+        "skip_blank_lines": True,
+        "na_values": ["", "NA", "NULL", "None"],
+    }
 
-        # Create ingestor for tabular data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            schema=schema,
-            data_format=DataFormat.TABULAR,
-            category=TaskCategory.TABULAR_REGRESSION,
-            csv_options=csv_options,
-            file_options={"number_of_columns": len(schema)},
-            label_column="price",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for tabular data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        schema=schema,
+        data_format=DataFormat.TABULAR,
+        category=TaskCategory.TABULAR_REGRESSION,
+        csv_options=csv_options,
+        file_options={"number_of_columns": len(schema)},
+        label_column="price",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting tabular data ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(f"Failed record: {record.get('name', 'Unknown')}")
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        # Re-raise so the process exits non-zero — swallowing here let a
-        # hard failure (validation error, DB error, backend registration
-        # rejection raised by ingest()) end with exit code 0 and a K8s
-        # Job marked Succeeded.
-        raise
+    # Ingest data with validation
+    logger.info("Starting tabular data ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/text_classification/text_classification.py
+++ b/templates/text_classification/text_classification.py
@@ -6,11 +6,16 @@ corresponding labels from a CSV file, similar to object detection format.
 """
 
 import logging
-import sys
 import os
 from typing import Dict, Any
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -40,50 +45,28 @@ csv_options = {
 
 def main():
     """Run the text classification ingestion example."""
-    try:
-        # Initialize components
-        database = Database(config)
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
 
-        # Create ingestor for text classification data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            data_format=DataFormat.TEXT,
-            category=TaskCategory.TEXT_CLASSIFICATION,
-            csv_options=csv_options,
-            file_options=text_options,
-            label_column="label",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for text classification data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.TEXT,
+        category=TaskCategory.TEXT_CLASSIFICATION,
+        csv_options=csv_options,
+        file_options=text_options,
+        label_column="label",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting text classification ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        raise
+    # Ingest data with validation
+    logger.info("Starting text classification ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/time_series_forecasting/time_series_forecasting.py
+++ b/templates/time_series_forecasting/time_series_forecasting.py
@@ -6,9 +6,14 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
-import sys
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import TaskCategory, Intent, DataFormat
 
@@ -20,80 +25,56 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Run the time series forecasting data ingestion example."""
-    try:
 
-        # Initialize components
-        database = Database(config)
-        # Initialize API client
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    # Initialize API client
+    api_client = APIClient(config)
 
-        # Schema definition for time series data
-        # Schema should contain feature columns only (excluding the target/label column)
-        schema = {
-            "timestamp": "TIMESTAMP",
-            "day_of_week": "INT",
-            "month": "INT",
-            "day_of_month": "INT",
-            "week_of_year": "INT",
-            "is_weekend": "INT",
-            "lag_1": "FLOAT",
-            "moving_avg_7": "FLOAT",
-        }
+    # Schema definition for time series data
+    # Schema should contain feature columns only (excluding the target/label column)
+    schema = {
+        "timestamp": "TIMESTAMP",
+        "day_of_week": "INT",
+        "month": "INT",
+        "day_of_month": "INT",
+        "week_of_year": "INT",
+        "is_weekend": "INT",
+        "lag_1": "FLOAT",
+        "moving_avg_7": "FLOAT",
+    }
 
-        # CSV specific options
-        csv_options = {
-            "chunk_size": 1000,
-            "delimiter": ",",
-            "quotechar": '"',
-            "escapechar": "\\",
-            "encoding": "utf-8",
-            "on_bad_lines": "warn",
-            "skip_blank_lines": True,
-            "na_values": ["", "NA", "NULL", "None"],
-        }
+    # CSV specific options
+    csv_options = {
+        "chunk_size": 1000,
+        "delimiter": ",",
+        "quotechar": '"',
+        "escapechar": "\\",
+        "encoding": "utf-8",
+        "on_bad_lines": "warn",
+        "skip_blank_lines": True,
+        "na_values": ["", "NA", "NULL", "None"],
+    }
 
-        # Create ingestor for time series forecasting data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            schema=schema,
-            data_format=DataFormat.TABULAR,
-            category=TaskCategory.TIME_SERIES_FORECASTING,
-            csv_options=csv_options,
-            file_options={"number_of_columns": len(schema)},
-            label_column="value",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for time series forecasting data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        schema=schema,
+        data_format=DataFormat.TABULAR,
+        category=TaskCategory.TIME_SERIES_FORECASTING,
+        csv_options=csv_options,
+        file_options={"number_of_columns": len(schema)},
+        label_column="value",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting time series forecasting data ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(f"Failed record: {record.get('name', 'Unknown')}")
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        # Re-raise so the process exits non-zero — swallowing here let a
-        # hard failure (validation error, DB error, backend registration
-        # rejection raised by ingest()) end with exit code 0 and a K8s
-        # Job marked Succeeded.
-        raise
+    # Ingest data with validation
+    logger.info("Starting time series forecasting data ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/time_series_forecasting/time_series_forecasting.py
+++ b/templates/time_series_forecasting/time_series_forecasting.py
@@ -88,7 +88,12 @@ def main():
                 logger.info("All records processed successfully")
 
     except Exception as e:
-        logger.error(f"{str(e)}")
+        logger.error(f"Ingestion failed: {str(e)}")
+        # Re-raise so the process exits non-zero — swallowing here let a
+        # hard failure (validation error, DB error, backend registration
+        # rejection raised by ingest()) end with exit code 0 and a K8s
+        # Job marked Succeeded.
+        raise
 
 
 if __name__ == "__main__":

--- a/templates/time_to_event_prediction/time_to_event_prediction.py
+++ b/templates/time_to_event_prediction/time_to_event_prediction.py
@@ -6,9 +6,14 @@ and supports various CSV formats with comprehensive configuration options.
 """
 
 import logging
-import sys
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import TaskCategory, Intent, DataFormat
 
@@ -20,87 +25,63 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Run the time to event prediction data ingestion example."""
-    try:
 
-        # Initialize components
-        database = Database(config)
-        # Initialize API client
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    # Initialize API client
+    api_client = APIClient(config)
 
-        # Schema definition for tabular data
-        schema = {
-            "age": "FLOAT",
-            "anaemia": "INT",
-            "creatinine_phosphokinase": "FLOAT",
-            "diabetes": "INT",
-            "ejection_fraction": "FLOAT",
-            "high_blood_pressure": "INT",
-            "platelets": "FLOAT",
-            "serum_creatinine": "FLOAT",
-            "serum_sodium": "FLOAT",
-            "sex": "INT",
-            "smoking": "INT",
-            "time": "INT",
-        }
+    # Schema definition for tabular data
+    schema = {
+        "age": "FLOAT",
+        "anaemia": "INT",
+        "creatinine_phosphokinase": "FLOAT",
+        "diabetes": "INT",
+        "ejection_fraction": "FLOAT",
+        "high_blood_pressure": "INT",
+        "platelets": "FLOAT",
+        "serum_creatinine": "FLOAT",
+        "serum_sodium": "FLOAT",
+        "sex": "INT",
+        "smoking": "INT",
+        "time": "INT",
+    }
 
-        # CSV specific options
-        csv_options = {
-            "chunk_size": 1000,
-            "delimiter": ",",
-            "quotechar": '"',
-            "escapechar": "\\",
-            "encoding": "utf-8",
-            "on_bad_lines": "warn",
-            "skip_blank_lines": True,
-            "na_values": ["", "NA", "NULL", "None"],
-        }
+    # CSV specific options
+    csv_options = {
+        "chunk_size": 1000,
+        "delimiter": ",",
+        "quotechar": '"',
+        "escapechar": "\\",
+        "encoding": "utf-8",
+        "on_bad_lines": "warn",
+        "skip_blank_lines": True,
+        "na_values": ["", "NA", "NULL", "None"],
+    }
 
-        # Create ingestor for time to event prediction data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            schema=schema,
-            data_format=DataFormat.TABULAR,
-            category=TaskCategory.TIME_TO_EVENT_PREDICTION,
-            csv_options=csv_options,
-            file_options={
-                "number_of_columns": len(schema),
-                "schema": schema,
-                "time_column": "time",  # Specify the time column name
-            },
-            label_column="DEATH_EVENT",  # The event column is the target
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for time to event prediction data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        schema=schema,
+        data_format=DataFormat.TABULAR,
+        category=TaskCategory.TIME_TO_EVENT_PREDICTION,
+        csv_options=csv_options,
+        file_options={
+            "number_of_columns": len(schema),
+            "schema": schema,
+            "time_column": "time",  # Specify the time column name
+        },
+        label_column="DEATH_EVENT",  # The event column is the target
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting time to event prediction data ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(f"Failed record: {record.get('name', 'Unknown')}")
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        # Re-raise so the process exits non-zero — swallowing here let a
-        # hard failure (validation error, DB error, backend registration
-        # rejection raised by ingest()) end with exit code 0 and a K8s
-        # Job marked Succeeded.
-        raise
+    # Ingest data with validation
+    logger.info("Starting time to event prediction data ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/templates/time_to_event_prediction/time_to_event_prediction.py
+++ b/templates/time_to_event_prediction/time_to_event_prediction.py
@@ -95,7 +95,12 @@ def main():
                 logger.info("All records processed successfully")
 
     except Exception as e:
-        logger.error(f"{str(e)}")
+        logger.error(f"Ingestion failed: {str(e)}")
+        # Re-raise so the process exits non-zero — swallowing here let a
+        # hard failure (validation error, DB error, backend registration
+        # rejection raised by ingest()) end with exit code 0 and a K8s
+        # Job marked Succeeded.
+        raise
 
 
 if __name__ == "__main__":

--- a/templates/token_classification/token_classification.py
+++ b/templates/token_classification/token_classification.py
@@ -12,11 +12,16 @@ Example row:
 """
 
 import logging
-import sys
 import os
 from typing import Dict, Any
 
-from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
 from tracebloc_ingestor.utils.logging import setup_logging
 from tracebloc_ingestor.utils.constants import (
     TaskCategory,
@@ -46,50 +51,28 @@ csv_options = {
 
 def main():
     """Run the token classification ingestion example."""
-    try:
-        # Initialize components
-        database = Database(config)
-        api_client = APIClient(config)
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
 
-        # Create ingestor for token classification data with validators
-        ingestor = CSVIngestor(
-            database=database,
-            api_client=api_client,
-            table_name=config.TABLE_NAME,
-            data_format=DataFormat.TEXT,
-            category=TaskCategory.TOKEN_CLASSIFICATION,
-            csv_options=csv_options,
-            file_options=text_options,
-            label_column="label",
-            intent=Intent.TRAIN,  # Is the data for training or testing
-        )
+    # Create ingestor for token classification data with validators
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.TEXT,
+        category=TaskCategory.TOKEN_CLASSIFICATION,
+        csv_options=csv_options,
+        file_options=text_options,
+        label_column="label",
+        intent=Intent.TRAIN,  # Is the data for training or testing
+    )
 
-        # Ingest data with validation
-        logger.info("Starting token classification ingestion with data validation...")
-        with ingestor:
-            failed_records = ingestor.ingest(
-                config.LABEL_FILE, batch_size=config.BATCH_SIZE
-            )
-            if failed_records:
-                logger.warning(f"Failed to process {len(failed_records)} records")
-                for record in failed_records:
-                    logger.warning(
-                        f"Failed record: {record.get('filename', 'Unknown')}"
-                    )
-                    logger.warning(
-                        f"Error details: {record.get('error', 'Unknown error')}"
-                    )
-                # Failed records (DB insert, API send, or processing) must
-                # fail the run — exit non-zero so the K8s Job is marked
-                # failed instead of reporting silent success (SystemExit
-                # bypasses the except Exception handler below).
-                sys.exit(1)
-            else:
-                logger.info("All records processed successfully")
-
-    except Exception as e:
-        logger.error(f"Ingestion failed: {str(e)}")
-        raise
+    # Ingest data with validation
+    logger.info("Starting token classification ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -157,6 +157,53 @@ def test_prepare_dataset_local_mode():
     get.assert_not_called()
 
 
+def test_prepare_dataset_error_captures_response_body():
+    """On HTTP error, `prepare_dataset` must stash the backend response body
+    on `self.last_prepare_error` so callers can surface the actual reason
+    in their user-visible error — instead of pointing at "the logged API
+    error above". Issue #251.
+
+    The body retained must include the status code and the response text
+    (capped) so a downstream RuntimeError can include both.
+    """
+    client = _client()
+    body = '{"message":"Please provide atleast 2 labels."}'
+    with patch.object(client.session, "get", return_value=_resp(400, text=body)):
+        ok = client.prepare_dataset(
+            TaskCategory.TABULAR_CLASSIFICATION, "ing", "tabular", "train"
+        )
+    assert ok is False
+    assert client.last_prepare_error is not None
+    # Status code + body both surface so the user sees the backend reason.
+    assert "HTTP 400" in client.last_prepare_error
+    assert "Please provide" in client.last_prepare_error
+
+
+def test_prepare_dataset_last_error_starts_unset():
+    """On a clean ingestor with no prior failure, `last_prepare_error`
+    is None — base.py falls back to its generic 'see logged API error
+    above' message only when this attribute is truly absent."""
+    client = _client()
+    assert client.last_prepare_error is None
+
+
+def test_prepare_dataset_network_error_captures_string():
+    """When `e.response` is None (DNS / connection refused / timeout),
+    last_prepare_error should still be populated with the stringified
+    exception — never silently fall through to None."""
+    import requests as _req
+
+    client = _client()
+    err = _req.exceptions.ConnectionError("name resolution failed")
+    with patch.object(client.session, "get", side_effect=err):
+        ok = client.prepare_dataset(
+            TaskCategory.TABULAR_CLASSIFICATION, "ing", "tabular", "train"
+        )
+    assert ok is False
+    assert client.last_prepare_error is not None
+    assert "name resolution failed" in client.last_prepare_error
+
+
 # ---------------------------------------------------------------------------
 # create_dataset
 # ---------------------------------------------------------------------------

--- a/tests/test_batch_send_failure_accounting.py
+++ b/tests/test_batch_send_failure_accounting.py
@@ -277,18 +277,23 @@ _TEMPLATES = sorted(Path(__file__).parent.parent.glob("templates/*/*.py"))
 
 @pytest.mark.parametrize("template", _TEMPLATES, ids=lambda p: p.parent.name)
 def test_template_exits_nonzero_on_failed_records(template):
-    """Each template's failed-records branch must end in sys.exit(1) —
-    BEFORE the else that logs "All records processed successfully" — so a
-    run with failures can't leave the K8s Job marked Succeeded."""
+    """Each template must route its run through the shared
+    ``run_ingestion`` helper, which owns the exit contract this test used
+    to pin per-template: log every failed record, ``sys.exit(1)`` on
+    failed records, re-raise hard errors. The eleven inlined copies of
+    that block drifted (five swallowed exceptions and exited 0 — #230),
+    so the duplication was extracted; the behavioral guarantees are now
+    covered directly in tests/test_template_runner.py and this check pins
+    the call-site instead of the inlined pattern."""
     src = template.read_text(encoding="utf-8")
-    assert re.search(r"^import sys$", src, re.M), f"{template} missing 'import sys'"
+    # Imported from the package root (not a local re-implementation) …
     m = re.search(
-        r"if failed_records:(?P<branch>.*?)\n\s*else:\s*\n\s*"
-        r"logger\.info\(\"All records processed successfully\"\)",
-        src,
-        re.S,
+        r"^from tracebloc_ingestor import \((?P<names>[^)]*)\)", src, re.M | re.S
     )
-    assert m, f"{template}: failed_records/else block not found"
-    assert "sys.exit(1)" in m.group("branch"), (
-        f"{template}: failed_records branch does not sys.exit(1)"
+    assert m and "run_ingestion" in m.group("names"), (
+        f"{template}: does not import run_ingestion from tracebloc_ingestor"
+    )
+    # … and actually called with the constructed ingestor.
+    assert re.search(r"run_ingestion\(\s*ingestor,", src), (
+        f"{template}: main() does not call run_ingestion(ingestor, ...)"
     )

--- a/tests/test_category_congruence.py
+++ b/tests/test_category_congruence.py
@@ -1,0 +1,141 @@
+"""Congruence tests across the per-category dispatch sites.
+
+A category accepted by the schema enum flows through four dispatch sites,
+each of which silently no-ops on a category it doesn't know:
+
+    1. ``conventions._data_format_for``        (raises — the only loud one)
+    2. ``utils.validators_mapping.map_validators``  (falls through to ``[]``)
+    3. ``ingestors.base._FILE_BEARING_CATEGORIES``  (gate: skips file transfer)
+    4. ``file_transfer.map_file_transfer``          (falls through to ``None``)
+
+instance_segmentation shipped wired into the enum and conventions but
+missing from sites 2-4: configs validated, validation "passed" with zero
+checks, rows reached MySQL and the backend API, and not a single image was
+staged to DEST_PATH — training then failed on missing files (the
+silent-half-ingest pattern from #99). It has been removed from the enum;
+these tests make the invariant structural so the next category cannot ship
+half-wired: every category the schema accepts must be fully dispatched
+everywhere, no carve-outs.
+
+The enum ↔ ``TaskCategory`` equality itself is pinned separately by
+``test_schema_validation.test_schema_category_enum_matches_engine_categories``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from tracebloc_ingestor import file_transfer
+from tracebloc_ingestor.cli.conventions import (
+    DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY,
+    IMAGE_CATEGORIES,
+    _data_format_for,
+)
+from tracebloc_ingestor.ingestors.base import _FILE_BEARING_CATEGORIES
+from tracebloc_ingestor.utils.constants import DataFormat, TaskCategory
+from tracebloc_ingestor.utils.validators_mapping import map_validators
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "tracebloc_ingestor" / "schema" / "ingest.v1.json"
+
+SCHEMA_CATEGORIES = sorted(
+    json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))["properties"]["category"]["enum"]
+)
+
+# Deliberately over-provisioned: carries every key any map_validators branch
+# constructs from (image branches index `extension`/`target_size` directly;
+# the rest use .get). Values only need to satisfy validator constructors —
+# no validation runs here, so semantic fit per category doesn't matter.
+GENEROUS_OPTIONS = {
+    "extension": ".jpg",
+    "target_size": [256, 256],
+    "schema": {"feature_a": "INT", "timestamp": "TIMESTAMP"},
+    "number_of_keypoints": 9,
+    "time_column": "time",
+    "label_column": "label",
+}
+
+
+def _file_bearing(category: str) -> bool:
+    """A category is file-bearing iff its data format implies per-row
+    sidecar files (image/text). Derived from the same production helper
+    the resolver uses, so this test can't drift from the engine — and
+    ``_data_format_for`` raises on a category missing from every
+    conventions grouping, which makes that gap loud here too."""
+    return _data_format_for(category) in (DataFormat.IMAGE, DataFormat.TEXT)
+
+
+@pytest.mark.parametrize("category", SCHEMA_CATEGORIES)
+def test_every_schema_category_resolves_validators(category: str):
+    """Site 2: ``map_validators`` falls through to ``[]`` for categories it
+    doesn't know, which makes validation trivially "pass" with zero checks.
+    Every wired branch returns at least TableName + Duplicate validators,
+    so non-empty is exactly the wired/unwired distinction."""
+    validators = map_validators(category, dict(GENEROUS_OPTIONS))
+    assert validators, (
+        f"map_validators({category!r}) returned no validators — the schema "
+        f"accepts this category but validation would trivially pass with "
+        f"zero checks. Add a branch in utils/validators_mapping.py or "
+        f"remove the category from the schema enum."
+    )
+
+
+def test_file_bearing_categories_match_file_transfer_gate():
+    """Site 3: ``_FILE_BEARING_CATEGORIES`` gates both the SRC_PATH
+    preflight and the per-record ``map_file_transfer`` call. Equality in
+    both directions: a file-bearing category missing from the set ingests
+    rows without ever staging files; a tabular category in the set would
+    fail every record on a file transfer it doesn't need."""
+    expected = {c for c in SCHEMA_CATEGORIES if _file_bearing(c)}
+    assert _FILE_BEARING_CATEGORIES == expected, (
+        "ingestors/base.py _FILE_BEARING_CATEGORIES has drifted from the "
+        "schema enum's file-bearing categories:\n"
+        f"  file-bearing but NOT gated (records ingest with zero files "
+        f"staged): {sorted(expected - _FILE_BEARING_CATEGORIES)}\n"
+        f"  gated but not file-bearing (every record would fail transfer): "
+        f"{sorted(_FILE_BEARING_CATEGORIES - expected)}"
+    )
+
+
+def test_every_file_bearing_category_has_file_transfer_branch():
+    """Site 4: ``map_file_transfer`` falls through to ``None`` for
+    categories it doesn't know; the ingest loop counts that as a
+    file-transfer failure for EVERY record. Inspect the dispatch source
+    for an explicit ``TaskCategory.X`` branch per file-bearing category.
+
+    (Source inspection because calling the real branches touches the
+    filesystem, and the unwired fall-through returns the same ``None`` as
+    a wired branch handling a missing file — behaviorally ambiguous. If
+    map_file_transfer is ever refactored away from explicit TaskCategory
+    comparisons, update this test alongside it.)
+    """
+    source = inspect.getsource(file_transfer.map_file_transfer)
+    mentioned_names = set(re.findall(r"TaskCategory\.([A-Z_][A-Z0-9_]*)", source))
+    mentioned = {getattr(TaskCategory, name) for name in mentioned_names}
+
+    missing = {c for c in SCHEMA_CATEGORIES if _file_bearing(c)} - mentioned
+    assert not missing, (
+        f"map_file_transfer has no branch for file-bearing categories "
+        f"{sorted(missing)} — every record would be dropped as a "
+        f"file-transfer failure. Add a branch in file_transfer.py or "
+        f"remove the category from the schema enum."
+    )
+
+
+def test_every_image_category_has_file_options_defaults():
+    """Companion to site 1: ``_default_file_options_for`` indexes
+    ``DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY[category]`` for image
+    categories — a missing entry is a KeyError at resolve time for every
+    config of that category."""
+    missing = set(IMAGE_CATEGORIES) - set(DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY)
+    assert not missing, (
+        f"IMAGE_CATEGORIES {sorted(missing)} have no entry in "
+        f"DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY — resolve() raises "
+        f"KeyError for every config using them."
+    )

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -119,7 +119,16 @@ def test_malformed_yaml_fails_fast(clean_env, mock_runtime, monkeypatch, capsys,
 
 def test_schema_violation_fails_fast(clean_env, mock_runtime, monkeypatch, capsys, tmp_path):
     """A config that passes YAML parsing but fails schema validation must
-    exit before any DB/network call, listing the failures."""
+    exit before any DB/network call, listing the failures.
+
+    Also pins that primitive checks ('X is a required property') keep
+    jsonschema's clear default message — they must NOT be replaced by
+    the schema's generic root description ("Declarative configuration
+    for the tracebloc data ingestor..."), which would happen if the
+    description-walker captured the root node's description (bugbot
+    #254). Schemas only attach their description when an INNER node
+    along the failing rule's path has one.
+    """
     bad = tmp_path / "bad.yaml"
     bad.write_text(
         # Missing `table`, `csv`, `images`, `label` — schema must reject.
@@ -139,8 +148,108 @@ def test_schema_violation_fails_fast(clean_env, mock_runtime, monkeypatch, capsy
     assert "validation failed" in err
     # Should mention at least one of the missing fields.
     assert "table" in err or "csv" in err or "images" in err or "label" in err
+    # The schema's GENERIC root description must NOT leak into primitive
+    # errors — bugbot #254 caught the walker capturing the root.
+    assert "Declarative configuration" not in err
+    # Primitive 'required property' messages must reach the user
+    # unmodified, NOT be replaced with a description + (rule:) line.
+    assert "is a required property" in err
     mock_runtime["Database"].assert_not_called()
     mock_runtime["APIClient"].assert_not_called()
+
+
+def test_schema_violation_surfaces_description_not_raw_mechanic(
+    clean_env, mock_runtime, monkeypatch, capsys, tmp_path
+):
+    """Setting ``label:`` for masked_language_modeling violates the
+    schema's allOf rule. The user-visible error must surface the rule
+    AUTHOR'S description (which names the self-supervised category, the
+    fix, and #213's history) — NOT just the raw JSON-schema mechanic
+    "<{full yaml dump}> should not be valid under {'required':
+    ['label']}", which is technically correct but unreadable: it dumps
+    the entire submission as a Python dict and uses JSON-schema
+    vocabulary the customer didn't write.
+
+    Verified end-to-end against v0.3.10-rc1: a user who copy-pasted
+    `label: label` from another category's yaml saw only the raw
+    mechanic and had no way to know that MLM is self-supervised.
+    """
+    bad = tmp_path / "mlm_with_label.yaml"
+    bad.write_text(
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: masked_language_modeling\n"
+        "table: ssh_test\n"
+        "intent: test\n"
+        "csv: /tmp/ignored.csv\n"
+        "sequences: /tmp/ignored/\n"
+        "label: label\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(bad))
+
+    from tracebloc_ingestor.cli.run import main
+    rc = main()
+
+    err = capsys.readouterr().err
+    assert rc == 2
+    # The schema's description is what the user needs to see — it names
+    # the actual rationale and the fix.
+    assert "Self-supervised" in err
+    assert "MUST NOT set `label`" in err
+    # Don't drop the mechanic entirely — it's still on a follow-up line
+    # for power-user debugging.
+    assert "rule:" in err
+    # Should NOT dump the entire YAML body as a Python dict in the
+    # headline (the old behavior).
+    headline = err.split("\n", 1)[0]
+    assert "{'apiVersion'" not in headline  # raw dict dump suppressed
+    mock_runtime["Database"].assert_not_called()
+    mock_runtime["APIClient"].assert_not_called()
+
+
+def test_describe_from_schema_path_skips_root_description():
+    """Unit-test for the description walker:
+
+    The schema's ROOT description ("Declarative configuration for the
+    tracebloc data ingestor...") is a generic blurb about the schema
+    as a whole, not about any specific rule. It must NOT be returned
+    for primitive errors whose path doesn't dig into an `allOf`/`oneOf`
+    branch — otherwise EVERY validation error gets blanketed with the
+    same generic text and jsonschema's clear messages get hidden
+    (bugbot #254).
+
+    A primitive error like 'required' has schema_path == ('required',),
+    which walks into the schema's `required` list — a list with no
+    `description`. The walker must return None for that case.
+
+    The MLM+label case has schema_path == ('allOf', N, 'then', 'not'),
+    which DOES walk into a dict with the rule-specific description.
+    The walker must return THAT description.
+    """
+    from tracebloc_ingestor.cli.run import _describe_from_schema_path
+
+    schema = {
+        "description": "Generic root blurb that should NEVER be returned",
+        "properties": {"x": {"type": "integer"}},
+        "required": ["x"],
+        "allOf": [
+            {
+                "description": "Rule-specific prose with rationale and fix.",
+                "if": {"properties": {"category": {"const": "abc"}}},
+                "then": {"not": {"required": ["label"]}},
+            }
+        ],
+    }
+    # Primitive 'required' error path → no inner description → None
+    assert _describe_from_schema_path(schema, ["required"]) is None
+    # Generic top-level type error path → no inner description → None
+    assert _describe_from_schema_path(schema, ["properties", "x", "type"]) is None
+    # AllOf branch path → inner description is returned
+    assert (
+        _describe_from_schema_path(schema, ["allOf", 0, "then", "not"])
+        == "Rule-specific prose with rationale and fix."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coercion_consistency.py
+++ b/tests/test_coercion_consistency.py
@@ -1,0 +1,136 @@
+"""Cross-layer coercion consistency — the validator gate and the ingest paths
+must reach the SAME verdict on the same value (#236, #237).
+
+This is the regression net for the whole bug class: the three layers
+(DataValidator gate, CSVIngestor cast, JSONIngestor per-record check) used to
+decide independently what a type permits and what counts as missing, so they
+drifted (#189/#204) and disagreed — a file passed validation and then crashed
+mid-ingest. Each case below pins one cell of the matrix
+(edge-case × layer) so a future divergence fails here instead of in a
+customer's cluster.
+"""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.ingestors.json_ingestor import _validate_value_against_dtype
+from tracebloc_ingestor.utils import coercion
+from tracebloc_ingestor.utils.constants import TaskCategory
+from tracebloc_ingestor.validators.data_validator import DataValidator
+
+BIG_INT = "99999999999999999999999999"  # 26 digits, well beyond signed int64
+
+
+def _validate(schema, csv_text, tmp_path):
+    p = tmp_path / "v.csv"
+    p.write_text(csv_text)
+    return DataValidator(schema=schema).validate(str(p))
+
+
+def _csv_ingestor(schema, category=TaskCategory.TABULAR_CLASSIFICATION):
+    return CSVIngestor(
+        database=MagicMock(),
+        api_client=MagicMock(),
+        table_name="t",
+        schema=schema,
+        category=category,
+    )
+
+
+# ── #236: out-of-int64 value in an INT column — REJECTED everywhere ─────────
+
+
+def test_236_int_overflow_unit_helpers():
+    assert coercion.int_value_overflows(BIG_INT) is True
+    assert coercion.int_value_overflows("5") is False
+    # Non-numeric and non-finite inputs are not this helper's concern (the
+    # caller's non-numeric / finite checks handle them) — it returns False.
+    assert coercion.int_value_overflows("abc") is False
+    assert coercion.int_value_overflows(None) is False
+    assert coercion.int_value_overflows(float("inf")) is False
+    err = coercion.int_range_error(pd.Series([BIG_INT, "5"]), "n", "INT")
+    assert err is not None and "64-bit" in err and "BIGINT" in err
+    # A valid FLOAT-sized value is NOT an INT overflow concern only for INT/BIGINT
+    assert coercion.int_range_error(pd.Series([BIG_INT]), "n", "FLOAT") is None
+
+
+def test_236_validator_rejects_int_overflow(tmp_path):
+    res = _validate({"id": "INT", "n": "INT"}, f"id,n\n1,{BIG_INT}\n2,5\n", tmp_path)
+    assert not res.is_valid
+    assert "64-bit" in " ".join(res.errors)
+
+
+def test_236_csv_ingest_rejects_int_overflow_cleanly(tmp_path):
+    """The cryptic numpy "ufunc 'isinf'" / pandas "Integer out of range" is
+    replaced by a clear, actionable message — and the ingest aborts rather than
+    crashing or corrupting."""
+    p = tmp_path / "x.csv"
+    p.write_text(f"id,n\n1,{BIG_INT}\n2,5\n")
+    ing = _csv_ingestor({"id": "INT", "n": "INT"})
+    with pytest.raises(ValueError, match="64-bit"):
+        list(ing.read_data(str(p)))
+
+
+def test_236_json_detects_int_overflow():
+    with pytest.raises(ValueError, match="64-bit"):
+        _validate_value_against_dtype(BIG_INT, "INT")
+    # BIGINT column: still rejected (its ceiling is int64 too), but no
+    # "declare BIGINT" hint.
+    with pytest.raises(ValueError, match="64-bit") as exc:
+        _validate_value_against_dtype(BIG_INT, "BIGINT")
+    assert "declare" not in str(exc.value).lower()
+
+
+def test_236_big_value_in_float_column_is_accepted(tmp_path):
+    """A 26-digit value is a valid FLOAT (1e26) — the gate accepts it and the
+    ingest stores it. Only INT/BIGINT columns reject it."""
+    schema = {"id": "INT", "x": "FLOAT"}
+    res = _validate(schema, f"id,x\n1,{BIG_INT}\n", tmp_path)
+    assert res.is_valid, res.errors
+
+    p = tmp_path / "x.csv"
+    p.write_text(f"id,x\n1,{BIG_INT}\n")
+    records = list(_csv_ingestor(schema).read_data(str(p)))  # must not raise
+    assert float(records[0]["x"]) > 1e25
+
+
+# ── #237: NA token in a numeric column — MISSING everywhere ─────────────────
+
+
+@pytest.mark.parametrize(
+    "category",
+    [TaskCategory.TABULAR_CLASSIFICATION, TaskCategory.IMAGE_CLASSIFICATION],
+)
+def test_237_na_in_numeric_passes_gate_and_ingests_as_missing(category, tmp_path):
+    """'NA' in a numeric column: the gate passes it (missing), and the ingest
+    yields it as missing — for tabular AND non-tabular alike. Before the fix
+    the non-tabular ingest crashed on the same file the gate had passed."""
+    schema = {"score": "INT"}
+    csv_text = "filename,score\nimg1,7\nimg2,NA\n"
+
+    res = _validate(schema, csv_text, tmp_path)
+    assert res.is_valid, res.errors
+
+    p = tmp_path / "x.csv"
+    p.write_text(csv_text)
+    records = list(_csv_ingestor(schema, category).read_data(str(p)))
+    assert pd.isna(records[1]["score"])
+
+
+def test_237_genuine_non_numeric_still_rejected_both_layers(tmp_path):
+    """The NA-tolerance must not swallow a genuinely bad token: 'abc' in an INT
+    column is rejected by the gate AND the ingest (it's data corruption, not a
+    missing marker)."""
+    schema = {"id": "INT", "n": "INT"}
+    csv_text = "id,n\n1,abc\n2,5\n"
+
+    res = _validate(schema, csv_text, tmp_path)
+    assert not res.is_valid
+
+    p = tmp_path / "x.csv"
+    p.write_text(csv_text)
+    with pytest.raises(ValueError):
+        list(_csv_ingestor(schema).read_data(str(p)))

--- a/tests/test_config_lazy.py
+++ b/tests/test_config_lazy.py
@@ -157,3 +157,20 @@ def test_api_endpoint_follows_edge_env(clean_env, monkeypatch):
 
     monkeypatch.setenv("CLIENT_ENV", "local")
     assert config.API_ENDPOINT == "http://localhost:8000"
+
+
+@pytest.mark.parametrize("env,attr", [("MYSQL_PORT", "DB_PORT"), ("BATCH_SIZE", "BATCH_SIZE")])
+def test_non_numeric_int_field_raises_clear_error(clean_env, monkeypatch, env, attr):
+    # A non-numeric MYSQL_PORT / BATCH_SIZE must surface a clear config error
+    # naming the field, not a raw "invalid literal for int()" (#238).
+    monkeypatch.setenv(env, "abc")
+    with pytest.raises(ValueError, match="must be an integer"):
+        getattr(Config(), attr)
+
+
+def test_numeric_int_field_still_coerces(clean_env, monkeypatch):
+    monkeypatch.setenv("MYSQL_PORT", "3307")
+    monkeypatch.setenv("BATCH_SIZE", "500")
+    config = Config()
+    assert config.DB_PORT == 3307
+    assert config.BATCH_SIZE == 500

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -332,7 +332,6 @@ def test_image_categories_set_matches_schema_requirements():
         TaskCategory.OBJECT_DETECTION,
         TaskCategory.KEYPOINT_DETECTION,
         TaskCategory.SEMANTIC_SEGMENTATION,
-        TaskCategory.INSTANCE_SEGMENTATION,
     }
     assert IMAGE_CATEGORIES == expected
 

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -42,6 +42,24 @@ def test_read_data_missing_file_raises():
         list(ing.read_data("/no/such/file.csv"))
 
 
+@pytest.mark.parametrize(
+    "sep,needle",
+    [(";", "semicolon"), ("\t", "tab"), ("|", "pipe")],
+)
+def test_wrong_delimiter_hints_at_delimiter(tmp_path, sep, needle):
+    # A ;/tab/pipe-delimited file read as CSV parses as a single column; the
+    # error should hint at the real delimiter instead of the misleading
+    # "every column missing" (#238).
+    p = tmp_path / "f.csv"
+    p.write_text(f"a{sep}b{sep}label\n1{sep}2{sep}x\n")
+    ing = make_csv_ingestor(
+        schema={"a": "INT", "b": "INT", "label": "VARCHAR(10)"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    with pytest.raises(ValueError, match=needle):
+        list(ing.read_data(str(p)))
+
+
 def test_read_data_strips_column_whitespace(tmp_path):
     p = tmp_path / "d.csv"
     p.write_text(" a , b \n1,2\n")

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -96,11 +96,24 @@ def test_read_data_unique_id_column_missing_raises(make_csv):
         list(ing.read_data(str(path)))
 
 
-def test_read_data_empty_file_returns_nothing(tmp_path):
+def test_read_data_empty_file_raises_with_clear_message(tmp_path):
+    """An empty (zero-byte) CSV is a hard input error, not a successful
+    '0 rows' run. The old code logged a WARNING and silently returned an
+    empty generator — the ingestor then created an empty MySQL table and
+    called `send_generate_edge_label_meta`, which 400'd with the misleading
+    'No data found for table X' message (same cascade #213 traced for
+    self-supervised + label mismatch). The user blamed the backend.
+
+    Fail fast at the read layer with a clear, source-truthful message
+    naming the path and pointing at staging as the likely cause —
+    DataValidator's existing 'No data found to validate' path catches it
+    before any backend round-trip.
+    """
     p = tmp_path / "empty.csv"
     p.write_text("")
     ing = make_csv_ingestor(schema={})
-    assert list(ing.read_data(str(p))) == []
+    with pytest.raises(ValueError, match="Empty CSV file"):
+        list(ing.read_data(str(p)))
 
 
 def test_validate_csv_type_coercion():

--- a/tests/test_csv_na_values.py
+++ b/tests/test_csv_na_values.py
@@ -1,10 +1,15 @@
-"""Per-category na_values defaults inside CSVIngestor.
+"""Shared per-column NA policy in CSVIngestor (and the DataValidator gate).
 
-Templates in ``templates/tabular_*/`` and ``templates/time_*/`` pass
-``na_values=["", "NA", "NULL", "None"]`` via csv_options. The YAML path
-can't express that key (schema restricts ``spec.csv_options`` to a small
-whitelist), so the ingestor itself widens its internal default for
-tabular-family categories. Other categories keep the narrower ``[""]``.
+Before #237 the NA set was chosen by *category*: the tabular family treated
+"NA"/"NULL"/"None" as missing, every other category kept them as literal
+strings — so a numeric column with an "NA" cell PASSED the validator (which
+read with pandas defaults) and then CRASHED the ingestor's numeric cast
+(validate-pass -> ingest-crash).
+
+The policy now lives in one place — ``coercion.build_csv_na_values`` — used by
+both the ingestor read and the validator gate, so the two can't disagree.
+Every *schema* column treats ""/NA/null/None as missing; the framework's own
+filename/mask_id columns are protected (a file named "NA.jpg" survives).
 """
 
 from unittest.mock import MagicMock, patch
@@ -13,77 +18,113 @@ import pandas as pd
 import pytest
 
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils import coercion
 from tracebloc_ingestor.utils.constants import TaskCategory
 
 
-def _make_ingestor(category):
+def _make_ingestor(category, schema=None):
     return CSVIngestor(
         database=MagicMock(),
         api_client=MagicMock(),
         table_name="t",
-        schema={"feature_a": "str", "label": "str"},
+        schema=schema or {"feature_a": "INT", "label": "VARCHAR(50)"},
         category=category,
         label_column="label",
     )
+
+
+# ── build_csv_na_values: the single source of truth ─────────────────────────
+
+
+def test_na_builder_covers_every_schema_column():
+    na = coercion.build_csv_na_values({"a": "INT", "b": "VARCHAR(10)", "t": "DATE"})
+    assert set(na) == {"a", "b", "t"}
+    # Numeric, string AND date columns alike get the full sentinel set.
+    for col in na:
+        assert na[col] == list(coercion.NA_SENTINELS)
+    assert "NA" in na["a"] and "" in na["a"] and "null" in na["a"]
+
+
+def test_na_builder_omits_non_schema_columns():
+    """filename / mask_id aren't schema columns, so they're omitted. With
+    keep_default_na=False that means no NA coercion — a file named 'NA' keeps
+    its name."""
+    na = coercion.build_csv_na_values({"feature_a": "INT"})
+    assert "filename" not in na
+    assert "mask_id" not in na
+
+
+# ── the #237 fix: identical verdict regardless of category ──────────────────
 
 
 @pytest.mark.parametrize(
     "category",
     [
         TaskCategory.TABULAR_CLASSIFICATION,
-        TaskCategory.TABULAR_REGRESSION,
-        TaskCategory.TIME_SERIES_FORECASTING,
-        TaskCategory.TIME_TO_EVENT_PREDICTION,
+        TaskCategory.IMAGE_CLASSIFICATION,
+        TaskCategory.TEXT_CLASSIFICATION,
     ],
 )
-def test_tabular_family_uses_wider_na_values(category, tmp_path):
-    """Tabular-family ingestors must call pd.read_csv with the wider
-    na_values set so 'NA'/'NULL'/'None' string cells parse as NaN."""
-    csv_path = tmp_path / "x.csv"
-    csv_path.write_text("feature_a,label\n1,a\n")
-    ing = _make_ingestor(category)
+def test_na_token_in_numeric_column_is_missing_for_every_category(category, tmp_path):
+    """An 'NA'/'null' cell in a numeric column parses as NaN (-> NULL) for
+    EVERY category, not just tabular. Before #237 the non-tabular path kept
+    'NA' as a literal string and then crashed the numeric type-cast."""
+    p = tmp_path / "x.csv"
+    p.write_text("filename,score\nimg1,1.5\nimg2,NA\nimg3,null\n")
+    ing = _make_ingestor(category, schema={"score": "FLOAT"})
 
-    with patch.object(pd, "read_csv", return_value=iter([])) as mock_read:
-        list(ing.read_data(str(csv_path)))
+    records = list(ing.read_data(str(p)))  # must not raise for ANY category
 
-    _, kwargs = mock_read.call_args
-    assert kwargs["na_values"] == ["", "NA", "NULL", "None"]
-    # keep_default_na=True for tabular so pandas' full NA set (NaN/N/A/null/...)
-    # is recognised — matching the validators' read, which closes the gate-lie
-    # where a file passes validation but crashes the ingestor's type-conversion.
-    assert kwargs["keep_default_na"] is True
+    scores = [r["score"] for r in records]
+    assert scores[0] == 1.5
+    assert pd.isna(scores[1]) and pd.isna(scores[2])
 
 
-def test_non_tabular_keeps_narrow_na_values(tmp_path):
-    """Image / text categories don't get the wider sentinel."""
-    csv_path = tmp_path / "x.csv"
-    csv_path.write_text("feature_a,label\n1,a\n")
+def test_read_uses_per_column_dict_and_keep_default_na_false(tmp_path):
+    """The read passes the per-column na_values dict + keep_default_na=False,
+    so NA detection is driven entirely by the schema (pandas' global default
+    set never reaches a protected column)."""
+    p = tmp_path / "x.csv"
+    p.write_text("feature_a,label\n1,a\n")
     ing = _make_ingestor(TaskCategory.IMAGE_CLASSIFICATION)
 
     with patch.object(pd, "read_csv", return_value=iter([])) as mock_read:
-        list(ing.read_data(str(csv_path)))
+        list(ing.read_data(str(p)))
 
     _, kwargs = mock_read.call_args
-    assert kwargs["na_values"] == [""]
     assert kwargs["keep_default_na"] is False
+    assert isinstance(kwargs["na_values"], dict)
+    assert kwargs["na_values"]["feature_a"] == list(coercion.NA_SENTINELS)
 
 
-def test_tabular_na_token_in_numeric_column_does_not_crash(tmp_path):
-    """A 'NaN'/'N/A' cell in a numeric column used to PASS the validator but then
-    crash the ingestor's numeric type-conversion (the validator read it as NaN,
-    the ingestor kept it as text). With keep_default_na=True both agree: the cell
-    parses as NaN, read_data succeeds, and the value is missing."""
-    csv_path = tmp_path / "x.csv"
-    csv_path.write_text("x,label\n1.5,a\nNaN,b\nN/A,c\n")
-    ing = CSVIngestor(
-        database=MagicMock(),
-        api_client=MagicMock(),
-        table_name="t",
-        schema={"x": "FLOAT", "label": "str"},
-        category=TaskCategory.TABULAR_CLASSIFICATION,
-        label_column="label",
+def test_filename_named_NA_survives(tmp_path):
+    """A non-schema 'filename' column holding 'NA' is NOT coerced to missing —
+    it's the framework's structural column, not a declared schema column, so a
+    file genuinely named 'NA' keeps its name."""
+    p = tmp_path / "x.csv"
+    p.write_text("filename,score\nNA,1.5\n")
+    ing = _make_ingestor(TaskCategory.IMAGE_CLASSIFICATION, schema={"score": "FLOAT"})
+
+    records = list(ing.read_data(str(p)))
+
+    assert records[0]["filename"] == "NA"
+
+
+def test_string_schema_column_treats_na_tokens_as_missing(tmp_path):
+    """A declared VARCHAR schema column still treats NA/NULL as missing — the
+    team's existing convention (a *schema* string column of "NA" is missing,
+    unlike the structural filename column). Locks the boundary so a future
+    change is conscious."""
+    p = tmp_path / "x.csv"
+    p.write_text("a,b\n1,NA\n2,NULL\n3,hello\n")
+    ing = _make_ingestor(
+        TaskCategory.TABULAR_CLASSIFICATION,
+        schema={"a": "INT", "b": "VARCHAR(10)"},
     )
-    records = list(ing.read_data(str(csv_path)))  # must not raise
-    xs = [r["x"] for r in records]
-    assert xs[0] == 1.5
-    assert pd.isna(xs[1]) and pd.isna(xs[2])
+
+    records = list(ing.read_data(str(p)))
+
+    bs = [r["b"] for r in records]
+    assert bs[0] is None  # "NA"   -> NULL (VARCHAR cast maps NaN -> None)
+    assert bs[1] is None  # "NULL" -> NULL
+    assert bs[2] == "hello"

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -131,6 +131,81 @@ def test_loads_from_json_empty_string_is_missing(tmp_path):
     assert result.is_valid, f"expected valid; errors={result.errors}"
 
 
+def test_loads_from_json_single_dict_normalised_to_one_record(tmp_path):
+    """A top-level JSON dict (one record, not wrapped in `[...]`) must validate
+    the same way `[{...}]` does — matching JSONIngestor.read_data's contract.
+
+    Regression: `JSONIngestor.read_data` is explicit:
+
+        # Handle both array and object formats
+        if isinstance(data, dict):
+            data = [data]
+        elif not isinstance(data, list):
+            raise ValueError("JSON data must be an object or array of objects")
+
+    And its docstring promises "handles both single-object and
+    array-of-objects formats". But `DataValidator._load_data`'s .json branch
+    used `pd.read_json(orient="records")`, which expects a list — a
+    top-level dict produced a DataFrame the validator then rejected with
+    "No data found to validate", before `read_data` ever ran. A user
+    submitting a single-record JSON file got the same "0 rows" treatment
+    as an empty file even though their data was perfectly well-formed.
+
+    Surfaced by adversarial testing against v0.3.9-rc1 (issue #232).
+    """
+    p = tmp_path / "single.json"
+    p.write_text('{"id": 1, "age": 30, "label": "A"}')
+    result = DataValidator(
+        schema={"id": "INT", "age": "INT", "label": "VARCHAR(8)"}
+    ).validate(str(p))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+
+
+def test_loads_from_json_non_object_top_level_still_fails(tmp_path):
+    """A top-level JSON value that's neither a dict nor a list (a bare
+    string, number, etc.) must still be rejected — the normalisation only
+    wraps dicts, not arbitrary scalars."""
+    p = tmp_path / "bare.json"
+    p.write_text('"just a string"')
+    result = DataValidator(schema={"a": "INT"}).validate(str(p))
+    assert not result.is_valid
+
+
+def test_loads_from_json_scalar_array_fails_not_silently_passes(tmp_path):
+    """A top-level JSON array of scalars (numbers/strings, no objects) must be
+    rejected, not pass validation against an unrelated schema.
+
+    Regression: after #232 switched `_load_data` from `pd.read_json` to
+    `json.load` + `pd.DataFrame(raw)`, a top-level scalar array like
+    `[1, 2, 3]` became a non-empty 1-column DataFrame, so schema validation
+    could pass even though `JSONIngestor._iter_validated_records` skips every
+    non-dict element and ingests *zero* records — a validate-pass →
+    ingest-nothing trap. `_load_data` now drops non-dict items to mirror the
+    ingestor, so an all-scalar array collapses to empty and is rejected with
+    "No data found to validate" (bugbot #233).
+    """
+    p = tmp_path / "scalars.json"
+    p.write_text("[1, 2, 3]")
+    result = DataValidator(schema={"id": "INT", "label": "VARCHAR(8)"}).validate(
+        str(p)
+    )
+    assert not result.is_valid
+    assert "No data found" in result.errors[0]
+
+
+def test_loads_from_json_mixed_array_keeps_only_objects(tmp_path):
+    """A top-level array mixing objects and scalars must validate only the
+    objects — matching `JSONIngestor`, which skips the scalars and ingests
+    the dict records (bugbot #233)."""
+    p = tmp_path / "mixed.json"
+    p.write_text('[{"id": 1, "label": "A"}, 42, {"id": 2, "label": "B"}]')
+    result = DataValidator(schema={"id": "INT", "label": "VARCHAR(8)"}).validate(
+        str(p)
+    )
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+    assert result.metadata["rows_checked"] == 2
+
+
 def test_unknown_type_fails():
     df = pd.DataFrame({"a": [1]})
     result = DataValidator(schema={"a": "WEIRDTYPE"}).validate(df)

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -206,6 +206,46 @@ def test_loads_from_json_mixed_array_keeps_only_objects(tmp_path):
     assert result.metadata["rows_checked"] == 2
 
 
+def test_loads_from_json_jsonl_surfaces_clear_error(tmp_path):
+    """A newline-delimited JSON (JSONL) file — one JSON object per
+    line, no top-level array — must surface a CLEAR error pointing at
+    the JSONL pattern and the fix (combine into an array). The opaque
+    ``json.JSONDecodeError: Extra data`` / ``Trailing data`` message
+    isn't actionable for users who didn't write json.load themselves.
+
+    Surfaced by adversarial new-user testing (N12 — common export
+    format from log / event pipelines).
+    """
+    p = tmp_path / "events.json"
+    p.write_text(
+        '{"id":1,"label":"A"}\n'
+        '{"id":2,"label":"B"}\n'
+        '{"id":3,"label":"A"}\n'
+    )
+    result = DataValidator(schema={"id": "INT", "label": "VARCHAR(8)"}).validate(
+        str(p)
+    )
+    assert not result.is_valid
+    err = result.errors[0]
+    assert "JSONL" in err or "newline-delimited" in err
+    # Should point at the fix.
+    assert "array" in err.lower()
+
+
+def test_loads_from_json_malformed_not_misidentified_as_jsonl(tmp_path):
+    """A genuinely malformed JSON file (not JSONL) must NOT be
+    misidentified — the JSONL detection requires the file's first
+    non-empty line to itself parse as JSON. ``{trailing garbage``
+    doesn't parse → fall through to the original 'Data type
+    validation error' path."""
+    p = tmp_path / "broken.json"
+    p.write_text("{this is not valid json at all")
+    result = DataValidator(schema={"a": "INT"}).validate(str(p))
+    assert not result.is_valid
+    # Must NOT claim it's JSONL.
+    assert "JSONL" not in result.errors[0]
+
+
 def test_unknown_type_fails():
     df = pd.DataFrame({"a": [1]})
     result = DataValidator(schema={"a": "WEIRDTYPE"}).validate(df)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -10,7 +10,18 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-from sqlalchemy import Integer, String, BigInteger, Column, Table
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    Integer,
+    Numeric,
+    String,
+    Table,
+)
+from sqlalchemy.dialects import mysql
 
 from tracebloc_ingestor import database as db_mod
 from tracebloc_ingestor.database import Database
@@ -424,22 +435,82 @@ def test_insert_batch_rolls_back_between_transient_retries(db, mock_engine_facto
 # get_table_schema
 # ---------------------------------------------------------------------------
 
-def test_get_table_schema(db):
+def test_get_table_schema_reflected_dialect_types(db):
+    """Regression: ``inspector.get_columns()`` against a real MySQL returns
+    DIALECT type classes (INTEGER, FLOAT, DATETIME, ...), not the generic
+    SQLAlchemy ones (Integer, Float, ...). The old mapping was keyed by the
+    generic class names, so every non-VARCHAR column fell through to the
+    VARCHAR default — the backend was told INT/FLOAT/DATETIME columns were
+    VARCHAR. (VARCHAR columns only came out right because the fallback
+    happened to be VARCHAR.)"""
+    inspector = MagicMock()
+    inspector.get_columns.return_value = [
+        {"name": "id", "type": mysql.BIGINT(display_width=20)},
+        {"name": "f_int", "type": mysql.INTEGER()},
+        {"name": "f_float", "type": mysql.FLOAT()},
+        {"name": "f_double", "type": mysql.DOUBLE()},
+        {"name": "f_dec", "type": mysql.DECIMAL(precision=10, scale=2)},
+        {"name": "f_bool", "type": mysql.TINYINT(display_width=1)},  # BOOL
+        {"name": "f_tiny", "type": mysql.TINYINT(display_width=4)},
+        {"name": "f_vc", "type": mysql.VARCHAR(length=255)},
+        {"name": "f_text", "type": mysql.TEXT()},
+        {"name": "f_date", "type": mysql.DATE()},
+        {"name": "f_dt", "type": mysql.DATETIME()},
+        {"name": "f_ts", "type": mysql.TIMESTAMP()},
+        {"name": "f_time", "type": mysql.TIME()},
+        {"name": "f_blob", "type": mysql.LONGBLOB()},
+    ]
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        schema = db.get_table_schema("tbl")
+    assert schema == {
+        "id": "BIGINT",
+        "f_int": "INT",
+        "f_float": "FLOAT",
+        "f_double": "DOUBLE",
+        "f_dec": "DECIMAL(10,2)",
+        "f_bool": "BOOLEAN",  # MySQL reflects BOOL as TINYINT(1)
+        "f_tiny": "TINYINT",
+        "f_vc": "VARCHAR(255)",
+        "f_text": "TEXT",
+        "f_date": "DATE",
+        "f_dt": "DATETIME",
+        "f_ts": "TIMESTAMP",
+        "f_time": "TIME",
+        "f_blob": "LONGBLOB",
+    }
+
+
+def test_get_table_schema_generic_types(db):
+    """Generic (in-process) SQLAlchemy types map to the same MySQL vocabulary
+    as their reflected dialect counterparts."""
     inspector = MagicMock()
     class Weird:  # unknown SQLAlchemy type, no 'length' attribute
         pass
 
     inspector.get_columns.return_value = [
         {"name": "id", "type": Integer()},
+        {"name": "big", "type": BigInteger()},
         {"name": "name", "type": String(255)},
+        {"name": "bare_str", "type": String()},  # no length declared
+        {"name": "ratio", "type": Float()},
+        {"name": "price", "type": Numeric(8, 3)},
+        {"name": "flag", "type": Boolean()},
+        {"name": "seen", "type": DateTime()},
         {"name": "weird", "type": Weird()},
     ]
     with patch.object(db_mod, "inspect", return_value=inspector):
         schema = db.get_table_schema("tbl")
     assert schema["id"] == "INT"
+    assert schema["big"] == "BIGINT"
     assert schema["name"] == "VARCHAR(255)"
-    # unknown SQLAlchemy type falls back to VARCHAR
-    assert schema["weird"] == "VARCHAR"
+    assert schema["bare_str"] == "VARCHAR"  # no "VARCHAR(None)"
+    assert schema["ratio"] == "FLOAT"
+    assert schema["price"] == "DECIMAL(8,3)"
+    assert schema["flag"] == "BOOLEAN"
+    assert schema["seen"] == "DATETIME"
+    # Unknown types pass through as their (upper-cased) class name instead of
+    # being mislabelled VARCHAR.
+    assert schema["weird"] == "WEIRD"
 
 
 def test_create_table_rejects_reserved_column():

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -97,6 +97,59 @@ def test_get_sqlalchemy_type_unsupported_raises(db):
         db._get_sqlalchemy_type("GEOMETRY")
 
 
+def test_get_sqlalchemy_type_typo_suggests_correction(db):
+    """A close-typo unknown type must surface a 'Did you mean X?' hint.
+
+    A new user typing ``BIGINTEGER`` (mixing up MySQL's ``BIGINT`` with
+    Python's ``int`` keyword) used to get a bare ``Unsupported MySQL
+    type: BIGINTEGER`` — correct but unhelpful. With the suggestion
+    layer the error guides them toward a related supported type and
+    lists the full vocabulary alongside, turning a 'wait, what's the
+    right spelling?' round-trip into a zero-thought fix. Surfaced by
+    adversarial new-user testing N3 (parent #261).
+
+    ``BIGINTEGER``'s nearest by Levenshtein distance is ``INTEGER``
+    (d=3 — drop the BIG prefix); ``BIGINT`` is d=4 (drop the EGER
+    suffix). Both are valid supported types, INTEGER wins by a single
+    edit. The full supported-types list (which the error also prints)
+    surfaces ``BIGINT`` for the user who actually wanted the 64-bit
+    range.
+    """
+    with pytest.raises(ValueError, match="Did you mean 'INTEGER'") as excinfo:
+        db._get_sqlalchemy_type("BIGINTEGER")
+    # The full supported-types listing must also be present so the user
+    # discovers BIGINT (the better fit by intent) even though the
+    # suggestion is INTEGER by edit distance.
+    assert "Supported types" in str(excinfo.value)
+    assert "BIGINT" in str(excinfo.value)
+
+
+def test_get_sqlalchemy_type_typo_no_suggestion_for_distant_input(db):
+    """A type name that's NOT close to any supported entry must NOT
+    misleadingly suggest one — ``GEOMETRY`` is a real MySQL type but
+    semantically unrelated to anything we map; suggesting ``DATETIME``
+    for it would be worse than no suggestion."""
+    with pytest.raises(ValueError, match="Unsupported MySQL type") as excinfo:
+        db._get_sqlalchemy_type("GEOMETRY")
+    assert "Did you mean" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize("typo,suggestion", [
+    ("INTGER", "INTEGER"),
+    ("NUMRIC", "NUMERIC"),
+    ("BOLEAN", "BOOLEAN"),
+    ("VARCAHR", "VARCHAR"),
+])
+def test_get_sqlalchemy_type_typo_suggestions_cover_common_mistakes(
+    db, typo, suggestion
+):
+    """Several real-world typos a new user might make. Each is within
+    edit distance 2 of the suggested correction and far enough from
+    other candidates that the suggestion is unambiguous."""
+    with pytest.raises(ValueError, match=f"Did you mean '{suggestion}'"):
+        db._get_sqlalchemy_type(typo)
+
+
 def test_get_sqlalchemy_type_decimal_precision_scale(db):
     # Regression (#190 bugbot): DECIMAL(10,2) used to fail int("10,2") and
     # fall back to a bare Numeric() — declared precision and scale silently

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -115,6 +115,35 @@ def test_get_sqlalchemy_type_numeric_precision_scale(db):
     assert result.scale == 3
 
 
+def test_get_sqlalchemy_type_char_with_length(db):
+    """Regression: CHAR(N) was absent from `type_mapping`. The DataValidator
+    accepts CHAR(N) (see `_validate_char` in data_validator.py), so a user
+    could declare e.g. `code: CHAR(1)` in their schema, pass preflight, then
+    hit `ValueError: Unsupported MySQL type: CHAR(1)` at table creation —
+    the validator and DDL layers had divergent vocabularies. CHAR is a
+    valid MySQL type (fixed-width, padded), distinct from VARCHAR but same
+    SQLAlchemy semantics; add it to the mapping so the two layers agree.
+
+    Surfaced by an adversarial 'all-types' tabular schema run against
+    v0.3.10-rc1: a CSV declaring `code: CHAR(1)` failed at table creation
+    even though every column type the schema lists is documented as
+    supported.
+    """
+    result = db._get_sqlalchemy_type("CHAR(1)")
+    assert isinstance(result, db_mod.CHAR)
+    assert result.length == 1
+
+
+def test_get_sqlalchemy_type_char_bare(db):
+    """Bare ``CHAR`` (no length) is still valid SQL — MySQL defaults to
+    CHAR(1). Don't raise; map to the SQLAlchemy class so the column gets
+    created with the dialect default."""
+    result = db._get_sqlalchemy_type("CHAR")
+    # May be the class or an instance — either is acceptable as long as
+    # the dialect picks up the right default at DDL time.
+    assert isinstance(result, db_mod.CHAR) or result is db_mod.CHAR
+
+
 # ---------------------------------------------------------------------------
 # create_table
 # ---------------------------------------------------------------------------

--- a/tests/test_file_transfer_path_traversal.py
+++ b/tests/test_file_transfer_path_traversal.py
@@ -1,0 +1,151 @@
+"""Security: path traversal via the manifest's filename / mask_id columns (#239).
+
+Those per-row values come straight from the user's CSV/JSON manifest and used
+to flow unsanitised into ``os.path.join`` on both the read (SRC_PATH) and write
+(DEST_PATH) sides. A crafted value — an absolute path or ``..`` traversal —
+escaped both sandboxes:
+
+  - read: a file outside SRC_PATH was resolved and copied INTO the dataset
+    (exfiltration of another tenant's data / a pod-mounted secret), and
+  - write: the copy destination landed outside DEST_PATH (arbitrary write,
+    e.g. ``/etc/cron.d/evil``) on the shared cluster PVC.
+
+``_safe_join`` now rejects any join that resolves outside its root. These tests
+demonstrate each primitive is blocked and that the legitimate basename path is
+unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tracebloc_ingestor import file_transfer
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+@pytest.fixture
+def dirs(tmp_path, monkeypatch):
+    """Point file_transfer's Config at tmp src + storage dirs, and plant a
+    'secret' file OUTSIDE both sandboxes."""
+    src = tmp_path / "src"
+    storage = tmp_path / "storage"
+    src.mkdir()
+    storage.mkdir()
+    monkeypatch.setenv("SRC_PATH", str(src))
+    monkeypatch.setenv("TABLE_NAME", "tbl")
+    monkeypatch.setattr(file_transfer.config, "STORAGE_PATH", str(storage))
+    secret = tmp_path / "SECRET.txt"
+    secret.write_text("top secret")
+    return src, storage / "tbl", secret
+
+
+# ── _safe_join unit ─────────────────────────────────────────────────────────
+
+
+def test_safe_join_allows_basename(tmp_path):
+    root = str(tmp_path)
+    assert file_transfer._safe_join(root, "images", "cat.jpg") == os.path.abspath(
+        os.path.join(root, "images", "cat.jpg")
+    )
+
+
+@pytest.mark.parametrize(
+    "evil",
+    ["../evil", "../../etc/passwd", "/etc/passwd", "a/../../evil", "../../../x"],
+)
+def test_safe_join_rejects_escape(tmp_path, evil):
+    with pytest.raises(ValueError, match="escapes"):
+        file_transfer._safe_join(str(tmp_path), evil)
+
+
+# ── read primitive: _find_src / _find_mask_src ──────────────────────────────
+
+
+def test_find_src_rejects_absolute_filename(dirs):
+    _, _, secret = dirs
+    with pytest.raises(ValueError, match="escapes"):
+        file_transfer._find_src("images", str(secret), ".txt")
+
+
+def test_find_src_rejects_traversal_filename(dirs):
+    with pytest.raises(ValueError, match="escapes"):
+        file_transfer._find_src("images", "../../SECRET", ".txt")
+
+
+def test_find_src_allows_legit_missing(dirs):
+    # A normal basename that simply doesn't exist -> (None, fname), a tolerated
+    # skip — NOT a raise. The traversal guard must not turn missing files into
+    # hard errors.
+    path, fname = file_transfer._find_src("images", "cat", ".jpg")
+    assert path is None and fname == "cat.jpg"
+
+
+def test_find_mask_src_rejects_absolute(dirs):
+    # An absolute mask_id (no leading '.') survives the extension-split and
+    # reaches _safe_join, which rejects it for escaping masks/.
+    with pytest.raises(ValueError, match="escapes"):
+        file_transfer._find_mask_src("/etc/hostname")
+
+
+def test_find_mask_src_traversal_does_not_escape(dirs):
+    # A dotted '..' mask_id is neutralised by the extension-split
+    # (mask_id.split(".")[0] collapses "../../SECRET" to ""), so it resolves to
+    # a missing file inside the sandbox -> (None, ...), never to a path outside
+    # masks/. Either way no file outside the sandbox is reached; _safe_join is
+    # the backstop if the split ever lets a real traversal through.
+    src_path, ext, _ = file_transfer._find_mask_src("../../SECRET")
+    assert src_path is None
+
+
+# ── write primitive: image_transfer / text_transfer DEST ────────────────────
+
+
+def test_image_transfer_rejects_traversal_dest(dirs):
+    src, dest, secret = dirs
+    # src_path provided (atomic-branch style) so we reach the DEST join with a
+    # crafted filename_with_ext; the write target must not escape DEST.
+    with pytest.raises(ValueError):
+        file_transfer.image_transfer(
+            {"filename": "x"},
+            {"extension": ".jpg"},
+            src_path=str(secret),
+            filename_with_ext="../../PWNED.jpg",
+        )
+    # Nothing was written outside the dataset directory.
+    assert not (dest.parent.parent / "PWNED.jpg").exists()
+
+
+def test_text_transfer_rejects_traversal(dirs):
+    with pytest.raises(ValueError):
+        file_transfer.text_transfer({"filename": "../../PWNED"}, {"extension": ".txt"})
+
+
+# ── end-to-end via map_file_transfer ────────────────────────────────────────
+
+
+def test_map_file_transfer_rejects_absolute_filename(dirs):
+    # image_classification -> image_transfer -> _find_src raises on the absolute
+    # path. (The base ingest loop catches this per-record as a failure, so the
+    # record is rejected + counted, not silently ingested.)
+    with pytest.raises(ValueError):
+        file_transfer.map_file_transfer(
+            TaskCategory.IMAGE_CLASSIFICATION,
+            {"filename": "/etc/hostname"},
+            {"extension": ".jpg"},
+        )
+
+
+# ── the legitimate path is unchanged ────────────────────────────────────────
+
+
+def test_legit_basename_copies_inside_dest(dirs):
+    src, dest, _ = dirs
+    (src / "images").mkdir()
+    (src / "images" / "cat.jpg").write_bytes(b"img")
+
+    rec = file_transfer.image_transfer({"filename": "cat"}, {"extension": ".jpg"})
+
+    assert rec is not None
+    assert (dest / "cat.jpg").exists()  # copied INSIDE the dataset directory

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -704,14 +704,14 @@ def test_check_src_path_only_runs_for_file_bearing_categories():
     CSV path is checked separately). This keeps tabular-only ingests
     working even when SRC_PATH isn't set."""
     from tracebloc_ingestor.utils.constants import TaskCategory
-    from tracebloc_ingestor.ingestors.base import _SRC_PATH_REQUIRED_CATEGORIES
+    from tracebloc_ingestor.ingestors.base import _FILE_BEARING_CATEGORIES
     for cat in (
         TaskCategory.TABULAR_CLASSIFICATION,
         TaskCategory.TABULAR_REGRESSION,
         TaskCategory.TIME_SERIES_FORECASTING,
         TaskCategory.TIME_TO_EVENT_PREDICTION,
     ):
-        assert cat not in _SRC_PATH_REQUIRED_CATEGORIES
+        assert cat not in _FILE_BEARING_CATEGORIES
     # Image / text / segmentation / MLM all need a staged SRC_PATH.
     for cat in (
         TaskCategory.IMAGE_CLASSIFICATION,
@@ -721,7 +721,7 @@ def test_check_src_path_only_runs_for_file_bearing_categories():
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
     ):
-        assert cat in _SRC_PATH_REQUIRED_CATEGORIES
+        assert cat in _FILE_BEARING_CATEGORIES
 
 
 def test_check_src_path_required_for_token_classification():
@@ -729,5 +729,5 @@ def test_check_src_path_required_for_token_classification():
     SRC_PATH (same layout as text_classification), so it must get the
     early staging preflight instead of N file-transfer 'not found' errors."""
     from tracebloc_ingestor.utils.constants import TaskCategory
-    from tracebloc_ingestor.ingestors.base import _SRC_PATH_REQUIRED_CATEGORIES
-    assert TaskCategory.TOKEN_CLASSIFICATION in _SRC_PATH_REQUIRED_CATEGORIES
+    from tracebloc_ingestor.ingestors.base import _FILE_BEARING_CATEGORIES
+    assert TaskCategory.TOKEN_CLASSIFICATION in _FILE_BEARING_CATEGORIES

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -64,6 +64,7 @@ def test_summary_clean_run_no_failures():
 @pytest.mark.parametrize("kwargs", [
     dict(failed_records=1),
     dict(file_transfer_failures=1),
+    dict(skipped_records=1),        # a record dropped during processing (#234)
     dict(inserted_records=9),       # < total
     dict(api_sent_records=9),       # < inserted
 ])
@@ -428,15 +429,61 @@ def test_ingest_still_calls_edge_label_for_label_carrying_categories():
     ing.api_client.send_generate_edge_label_meta.assert_called_once()
 
 
-def test_ingest_skips_records_that_fail_processing():
-    # invalid intent -> process_record returns None -> counted as skipped
+def test_ingest_fails_fast_on_invalid_intent():
+    # A bad intent is a run-wide config error, not a per-row skip: it must
+    # abort loudly before any DB work (#234), not silently skip every record
+    # and exit 0 with an empty dataset and a Job marked Succeeded.
     records = [{"a": "1", "filename": "f1"}]
     ing = make_ingestor(records=records, category=None, intent="bogus")
+    with pytest.raises(ValueError, match="intent"):
+        ing.ingest("src", batch_size=10)
+    ing.database.insert_batch.assert_not_called()
+
+
+def test_ingest_counts_dropped_record_as_failure():
+    # A record dropped during processing (here: a missing unique_id when
+    # unique_id_column is set) must be surfaced as a failed record so the run
+    # exits non-zero — not silently skipped with a clean exit 0 (#234). The
+    # dropped record never reaches the DB.
+    records = [{"a": "1", "filename": "f1"}]  # no 'uid' -> _map_unique_id drops it
+    ing = make_ingestor(
+        records=records, category=None, intent="train", unique_id_column="uid"
+    )
     with patch.object(base_mod, "Session") as Sess:
         Sess.return_value.__enter__.return_value = MagicMock()
         failed = ing.ingest("src", batch_size=10)
-    assert failed == []
+    assert len(failed) == 1
+    assert failed[0]["error"] == "record_dropped_in_processing"
     ing.database.insert_batch.assert_not_called()
+
+
+def test_ingest_keeps_good_records_and_counts_dropped():
+    # The canonical #234 scenario: a mixed run. The good record ingests; the
+    # dropped one (blank unique_id) is surfaced as a failure, the summary
+    # records the drop and trips has_failures — so a partial run can NOT be
+    # reported as a clean success (the "0 failures / most records failed"
+    # contradiction).
+    records = [{"a": "1", "uid": "x1"}, {"a": "2", "uid": "  "}]  # 2nd: blank uid
+    ing = make_ingestor(
+        records=records, category=None, intent="train", unique_id_column="uid"
+    )
+    captured = {}
+    real_log = BaseIngestor._log_summary
+
+    def spy(self, summary):
+        captured["summary"] = summary
+        return real_log(self, summary)
+
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(BaseIngestor, "_log_summary", spy):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+
+    summary = captured["summary"]
+    assert summary.skipped_records == 1
+    assert summary.has_failures is True
+    assert any(f["error"] == "record_dropped_in_processing" for f in failed)
+    ing.database.insert_batch.assert_called()  # the good record reached the DB
 
 
 def test_ingest_reraises_on_session_error():

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -532,6 +532,16 @@ def test_check_csv_encoding_skips_non_csv_sources(tmp_path):
     BaseIngestor._check_csv_encoding(str(tmp_path / "missing.csv"))   # nonexistent
 
 
+def test_check_csv_encoding_rejects_nul_byte(tmp_path):
+    # A NUL byte (0x00) is valid UTF-8 so it slips past the decode check, but
+    # pandas' C parser silently TRUNCATES the field at it ("a\x00b" -> "a").
+    # Reject it up front with a clear message (#238).
+    bad = tmp_path / "nul.csv"
+    bad.write_bytes(b"id,name\n1,a\x00b\n2,ok\n")
+    with pytest.raises(ValueError, match="NUL byte"):
+        BaseIngestor._check_csv_encoding(str(bad))
+
+
 # ---------------------------------------------------------------------------
 # Concurrent-ingest table lock — backend/#772 P2
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -86,8 +86,10 @@ def test_init_strips_label_annotation_unique_from_schema():
         label_column="lbl", annotation_column="ann", unique_id_column="uid",
         category=None,
     )
-    # The cleaned table schema passed to create_table excludes the special cols.
-    table_schema = ing.database.create_table.call_args[0][1]
+    # Table creation is deferred until validation passes (#260), so inspect
+    # the cleaned schema stashed for later create_table() instead of asserting
+    # against a call that hasn't happened yet.
+    table_schema = ing._table_schema
     assert "lbl" not in table_schema and "ann" not in table_schema and "uid" not in table_schema
     assert "a" in table_schema
 
@@ -384,6 +386,42 @@ def test_validate_data_validator_exception_raises():
 # ---------------------------------------------------------------------------
 # ingest (full flow, Session patched)
 # ---------------------------------------------------------------------------
+
+def test_init_does_not_create_table_until_validation_passes():
+    # REGRESSION GUARD (#260): create_table used to fire inside __init__, so a
+    # validator-rejected ingest left an empty orphaned table that the next run's
+    # stale-table guard tripped on, forcing the user to manually DROP. Table
+    # creation must be deferred until validation has accepted the input.
+    ing = make_ingestor(category=None)
+    ing.database.create_table.assert_not_called()
+    assert ing.table is None
+
+
+def test_validation_failure_leaves_no_table_created():
+    # REGRESSION GUARD (#260): when validate_data rejects the input, the
+    # ingestor must not have created the destination table — so a corrected
+    # re-run starts from a clean slate without manual DB intervention.
+    ing = make_ingestor(category=None)
+    bad = MagicMock()
+    bad.name = "Bad"
+    bad.validate.return_value = ValidationResult(False, ["nope"], [], {})
+    with patch.object(base_mod, "map_validators", return_value=[bad]):
+        with pytest.raises(ValueError):
+            ing.ingest("src", batch_size=10)
+    ing.database.create_table.assert_not_called()
+    assert ing.table is None
+
+
+def test_ingest_creates_table_after_validation_passes():
+    # The table is created exactly once, after validation accepts the input.
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=None)
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    ing.database.create_table.assert_called_once_with("tbl", {"a": "INT"})
+    assert ing.table is not None
+
 
 def test_ingest_happy_path():
     records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -138,6 +138,40 @@ def test_process_record_applies_bucket_label_policy():
     assert rec["label"] != "12345"
 
 
+def test_process_record_strips_whitespace_from_string_label():
+    """Issue #261: a raw label value like ``"  A  "`` must be stripped
+    before the label policy runs, so MySQL stores ``"A"`` and a CSV
+    with ``"  A  "`` mixed with ``"A"`` doesn't land as two distinct
+    classes (silent label-set corruption).
+
+    The strip mirrors what the framework does for ``data_id`` (line
+    below in process_record) and for column headers (csv_ingestor).
+    """
+    ing = make_ingestor(label_column="lbl", category=None)
+    rec = ing.process_record({"lbl": "  A  ", "filename": "f"})
+    # PASSTHROUGH policy: label lands verbatim, but stripped.
+    assert rec["label"] == "A", f"expected stripped 'A', got {rec['label']!r}"
+
+
+def test_process_record_label_strip_makes_whitespace_variants_equivalent():
+    """End-to-end check that two records with ``"  A  "`` and ``"A"``
+    produce the SAME cleaned label — the contract the corruption fix
+    establishes."""
+    ing = make_ingestor(label_column="lbl", category=None)
+    rec1 = ing.process_record({"lbl": "  A  ", "filename": "f1"})
+    rec2 = ing.process_record({"lbl": "A", "filename": "f2"})
+    assert rec1["label"] == rec2["label"] == "A"
+
+
+def test_process_record_label_strip_preserves_non_string_labels():
+    """INT class IDs and other non-string labels (which have no
+    whitespace to strip) must pass through unchanged."""
+    ing = make_ingestor(label_column="lbl", category=None)
+    rec = ing.process_record({"lbl": 42, "filename": "f"})
+    # Numeric labels pass through the policy unchanged.
+    assert rec["label"] == 42
+
+
 def test_process_record_preserves_none_for_sql_null():
     """Null-like values (Python None, NaN, pd.NA, NaT) must round-trip as
     Python None so the DB binder writes SQL NULL — not as the literal

--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -59,19 +59,25 @@ def test_read_data_invalid_top_level_type_raises(tmp_path):
         list(ing.read_data(str(p)))
 
 
-def test_read_data_skips_non_dict_items(tmp_path):
+def test_read_data_non_dict_item_raises(tmp_path):
+    # A non-object array item is malformed data: fail fast instead of silently
+    # skipping it (which exited 0 on a partial ingest — #234) and diverging
+    # from CSV/the gate, which abort on a bad record (#235).
     p = _write_json(tmp_path, [{"a": 1}, "not-a-dict", {"a": 2}])
     ing = make_json_ingestor(schema={"a": "INT"})
-    records = list(ing.read_data(str(p)))
-    assert len(records) == 2
+    with pytest.raises(ValueError, match="not an object"):
+        list(ing.read_data(str(p)))
 
 
-def test_read_data_skips_records_failing_validation(tmp_path):
-    # record missing unique_id_column -> _validate_record raises -> skipped
+def test_read_data_record_failing_validation_raises(tmp_path):
+    # A record missing the configured unique_id_column makes _validate_record
+    # raise; that now propagates (fail-fast) instead of silently skipping the
+    # record and reporting a partial ingest as success (#234), consistent with
+    # the CSV cast and the DataValidator gate (#235).
     p = _write_json(tmp_path, [{"a": 1}, {"a": 2, "uid": "x"}])
     ing = make_json_ingestor(schema={"a": "INT"}, unique_id_column="uid")
-    records = list(ing.read_data(str(p)))
-    assert records == [{"a": 2, "uid": "x"}]
+    with pytest.raises(ValueError, match="uid"):
+        list(ing.read_data(str(p)))
 
 
 def test_read_data_malformed_json_raises(tmp_path):

--- a/tests/test_label_diversity_validator.py
+++ b/tests/test_label_diversity_validator.py
@@ -269,6 +269,45 @@ def test_string_schema_label_no_numeric_collapse(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Whitespace handling — silent-corruption fix (#261)
+# ---------------------------------------------------------------------------
+
+def test_whitespace_duplicates_collapsed_and_warned():
+    """Whitespace-padded label values must collapse to the same class
+    AND surface a WARNING so the user knows the framework will strip
+    them at write time. Without this, a CSV with ``"  A  "`` and
+    ``"A"`` mixed would pass diversity (2 distinct) but train a model
+    with 3 classes after ingest — silent label-set corruption (#261).
+    """
+    df = pd.DataFrame({"label": ["  A  ", "A", "B", "  A"]})
+    result = LabelDiversityValidator().validate(df)
+    # After collapsing whitespace duplicates, distinct count == 2 (A, B).
+    assert result.is_valid
+    assert result.metadata["distinct_count"] == 2
+    # Warning must name the offending pre-strip variants so the user
+    # can fix their upstream data if they meant them to be different.
+    assert result.warnings, "expected a whitespace-duplicate warning"
+    w = result.warnings[0]
+    assert "whitespace" in w.lower()
+
+
+def test_whitespace_only_single_value_still_fails():
+    """If the dataset has ``["  A  ", "A", "  A"]`` (all collapse to ``A``),
+    after stripping it's a single-class dataset and the validator must
+    still reject — the silent-corruption fix doesn't undo the diversity
+    requirement, it just refuses to inflate distinct count via
+    whitespace differences.
+    """
+    df = pd.DataFrame({"label": ["  A  ", "A", "  A"]})
+    result = LabelDiversityValidator().validate(df)
+    assert not result.is_valid
+    assert "1 distinct" in result.errors[0]
+    # The error should mention whitespace stripping so the user knows
+    # what the validator did.
+    assert "whitespace" in result.errors[0].lower()
+
+
+# ---------------------------------------------------------------------------
 # Custom column name
 # ---------------------------------------------------------------------------
 

--- a/tests/test_label_diversity_validator.py
+++ b/tests/test_label_diversity_validator.py
@@ -1,0 +1,283 @@
+"""Tests for LabelDiversityValidator — fail-fast on single-label classification.
+
+Surfaces the cause locally (with the actual distinct label values) instead
+of letting the backend reject with the misleading "Backend failed to
+prepare the dataset; it was NOT registered" cascade once rows have already
+landed in MySQL. Issue #251.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.label_diversity_validator import (
+    LabelDiversityValidator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Positive cases — must pass
+# ---------------------------------------------------------------------------
+
+def test_two_distinct_labels_passes():
+    df = pd.DataFrame({"a": [1, 2, 3, 4], "label": ["A", "B", "A", "B"]})
+    result = LabelDiversityValidator().validate(df)
+    assert result.is_valid
+
+
+def test_many_distinct_labels_passes():
+    df = pd.DataFrame({"label": ["A", "B", "C", "D", "E"]})
+    result = LabelDiversityValidator().validate(df)
+    assert result.is_valid
+
+
+def test_distinct_labels_with_nulls_counts_only_non_null():
+    """Null cells don't count toward distinct labels; if there are still
+    ≥2 distinct non-null values the dataset is fine."""
+    df = pd.DataFrame({"label": ["A", "B", None, None]})
+    result = LabelDiversityValidator().validate(df)
+    assert result.is_valid
+    assert result.metadata["distinct_count"] == 2
+
+
+def test_label_column_case_insensitive_match():
+    """A CSV header ``Label`` should still resolve when the validator is
+    configured for ``label`` (default). Matches the case-insensitive
+    pattern BIOLabelValidator uses."""
+    df = pd.DataFrame({"a": [1, 2], "Label": ["X", "Y"]})
+    result = LabelDiversityValidator().validate(df)
+    assert result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# Failure cases — must reject with a CLEAR message
+# ---------------------------------------------------------------------------
+
+def test_single_label_fails_with_distinct_value_listed():
+    """A 10-row dataset where every row has ``label = "X"`` is not a
+    classification dataset. The error must name the offending distinct
+    value(s) and the count so the user immediately sees what's wrong."""
+    df = pd.DataFrame({"label": ["X"] * 10})
+    result = LabelDiversityValidator().validate(df)
+    assert not result.is_valid
+    err = result.errors[0]
+    # User-facing message must include the actual single value found.
+    assert "'X'" in err or "'X'" in str(result.metadata.get("value_counts", {}))
+    # And explain WHY it's rejected.
+    assert "classification" in err.lower()
+    assert "distinct" in err.lower()
+
+
+def test_single_label_only_nulls_fails():
+    """All-null label column → 0 distinct → rejected."""
+    df = pd.DataFrame({"label": [None, None, None]})
+    result = LabelDiversityValidator().validate(df)
+    assert not result.is_valid
+
+
+def test_single_label_one_value_with_some_nulls_fails():
+    """One distinct value plus nulls is still only 1 distinct value."""
+    df = pd.DataFrame({"label": ["A", "A", None, "A", None]})
+    result = LabelDiversityValidator().validate(df)
+    assert not result.is_valid
+
+
+def test_error_mentions_regression_alternative():
+    """A user who has a continuous target shouldn't be told 'add a fake
+    second label' — the error should point them at regression-family
+    categories which legitimately accept a single target column."""
+    df = pd.DataFrame({"label": ["A"] * 5})
+    result = LabelDiversityValidator().validate(df)
+    assert not result.is_valid
+    assert "regression" in result.errors[0].lower()
+
+
+# ---------------------------------------------------------------------------
+# Defensive paths — must not double-report (other validators own those)
+# ---------------------------------------------------------------------------
+
+def test_empty_dataframe_passes_silently():
+    """Empty input is the 'no rows' / empty-CSV class — handled by other
+    validators with their own clear messages. Don't double-report."""
+    result = LabelDiversityValidator().validate(pd.DataFrame())
+    assert result.is_valid
+    assert result.metadata["rows_checked"] == 0
+
+
+def test_label_column_missing_passes_with_warning():
+    """If the CSV has no label column at all, that's a schema-mismatch
+    case handled by other layers. This validator just warns and skips."""
+    df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    result = LabelDiversityValidator().validate(df)
+    assert result.is_valid
+    assert any("not found in CSV" in w for w in (result.warnings or []))
+
+
+# ---------------------------------------------------------------------------
+# CSV-path streaming check — must not load the whole wide CSV into memory
+# ---------------------------------------------------------------------------
+
+def test_csv_path_reads_only_the_label_column(tmp_path):
+    """For a wide CSV (one label + many feature columns), the validator
+    must read only the label column — counting distinct labels doesn't
+    need the features, and a multi-GB proteomics panel would otherwise
+    OOM. Mirrors the streaming-first patterns elsewhere in the codebase
+    (DataValidator's chunked path)."""
+    p = tmp_path / "wide.csv"
+    cols = ",".join([f"f{i:02d}" for i in range(50)] + ["label"])
+    rows = "\n".join(
+        [",".join(["0.5"] * 50 + [("A" if i % 2 else "B")]) for i in range(20)]
+    )
+    p.write_text(cols + "\n" + rows + "\n")
+    result = LabelDiversityValidator().validate(str(p))
+    assert result.is_valid
+    assert result.metadata["distinct_count"] == 2
+
+
+def test_csv_path_rejects_single_label(tmp_path):
+    """End-to-end CSV-path test of the failure case — mirrors the
+    adversarial test against v0.3.10-rc1 that surfaced #251."""
+    p = tmp_path / "single.csv"
+    p.write_text("id,label\n1,X\n2,X\n3,X\n")
+    result = LabelDiversityValidator().validate(str(p))
+    assert not result.is_valid
+    assert "1 distinct" in result.errors[0]
+    assert "'X'" in result.errors[0] or "'X'" in str(result.metadata.get("value_counts", {}))
+
+
+def test_csv_whitespace_header_still_checked(tmp_path):
+    """A label header with surrounding whitespace (" label ") must still be
+    found and checked, not skipped.
+
+    Regression (bugbot #252): CSVIngestor strips column-name whitespace on
+    read, so " label " is ingested as `label`. The validator resolved against
+    the raw header, treated the column as missing, skipped the diversity check
+    with a warning, and a single-class CSV sailed through preflight to fail at
+    backend prepare. _resolve_column now strips, matching the ingestor.
+    """
+    p = tmp_path / "ws_header.csv"
+    p.write_text("id, label \n1,X\n2,X\n3,X\n")
+    result = LabelDiversityValidator().validate(str(p))
+    assert not result.is_valid
+    assert "1 distinct" in result.errors[0]
+
+
+def test_csv_whitespace_header_schema_na_rules_apply(tmp_path):
+    """A whitespace label header that IS a schema column must still get the
+    schema NA rules — " label " strips to `label`, matches the schema entry,
+    so "null" reads as missing and a single-class dataset is flagged
+    (bugbot #252)."""
+    p = tmp_path / "ws_schema.csv"
+    p.write_text("id, label \n1,X\n2,null\n3,X\n")
+    result = LabelDiversityValidator(
+        label_column="label", schema={"id": "INT", "label": "VARCHAR(8)"}
+    ).validate(str(p))
+    assert not result.is_valid
+    assert "1 distinct" in result.errors[0]
+
+
+def test_csv_quoted_header_does_not_skew_multilabel(tmp_path):
+    """A quoted/comma-bearing header must not trip the column resolution.
+
+    Regression (bugbot #252, medium): the old loader resolved the label
+    column with a naive ``header_line.split(",")``, which splits inside
+    quoted headers and diverges from pandas. When it failed to find the
+    column it fell back to ``nrows=1`` and counted distinct labels on that
+    single row — rejecting a perfectly diverse dataset. Resolving against
+    pandas' own header parse (nrows=0) fixes it, so a header like
+    ``"feature,with,commas"`` alongside ``label`` reads the full column.
+    """
+    p = tmp_path / "quoted.csv"
+    # The first column's header literally contains commas (quoted).
+    p.write_text(
+        '"feature,with,commas",label\n'
+        + "\n".join(f"{i},{'A' if i % 2 else 'B'}" for i in range(20))
+        + "\n"
+    )
+    result = LabelDiversityValidator().validate(str(p))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+    assert result.metadata["distinct_count"] == 2
+
+
+def test_csv_read_error_fails_closed_not_skipped(tmp_path, monkeypatch):
+    """A read failure must FAIL the check, not silently pass.
+
+    Regression (bugbot #252, high): ``_load_data`` previously swallowed any
+    read exception and returned ``None``, which ``validate`` treats as an
+    empty/benign dataset → valid. A single-label CSV whose targeted read
+    errored could sail through preflight and hit the backend rejection this
+    validator exists to prevent. Read errors now propagate to ``validate``'s
+    handler and fail the check.
+    """
+    p = tmp_path / "boom.csv"
+    p.write_text("id,label\n1,X\n2,X\n")
+
+    real_read_csv = pd.read_csv
+
+    def _boom(path, *args, **kwargs):
+        # Let the cheap header probe (nrows=0) succeed, then blow up on the
+        # actual data read — mimics a usecols/encoding failure mid-load.
+        if kwargs.get("nrows") == 0:
+            return real_read_csv(path, *args, **kwargs)
+        raise ValueError("simulated CSV read failure")
+
+    monkeypatch.setattr(pd, "read_csv", _boom)
+    result = LabelDiversityValidator().validate(str(p))
+    assert not result.is_valid
+    assert "validation error" in result.errors[0].lower()
+
+
+def test_schema_label_sentinel_tokens_count_as_missing(tmp_path):
+    """When the label IS a schema column, NA sentinels ("null", "NA", …) must
+    be read as missing — matching CSVIngestor/DataValidator — so a CSV whose
+    only real class is "X" plus sentinel rows is correctly flagged
+    single-label (bugbot #252)."""
+    p = tmp_path / "schema_label.csv"
+    p.write_text("id,label\n1,X\n2,null\n3,NA\n4,X\n")
+    result = LabelDiversityValidator(
+        label_column="label", schema={"id": "INT", "label": "VARCHAR(8)"}
+    ).validate(str(p))
+    assert not result.is_valid
+    assert "1 distinct" in result.errors[0]
+
+
+def test_non_schema_label_keeps_sentinel_as_real_class(tmp_path):
+    """When the label is NOT a schema column (image/text classification),
+    the ingestor keeps "NA"/"null" as literal class values — so the validator
+    must too, or it would miss / mis-count classes (bugbot #252). Here "X"
+    and "NA" are two genuine classes; the dataset must pass."""
+    p = tmp_path / "non_schema_label.csv"
+    p.write_text("filename,label\na.jpg,X\nb.jpg,NA\nc.jpg,X\nd.jpg,NA\n")
+    result = LabelDiversityValidator(label_column="label").validate(str(p))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+    assert result.metadata["distinct_count"] == 2
+
+
+def test_string_schema_label_no_numeric_collapse(tmp_path):
+    """A VARCHAR label column with numeric-looking values ("1.0", "1.00",
+    "01") must keep them distinct as strings — matching the ingestor's
+    string-dtype pin — rather than collapsing to a single float class and
+    wrongly rejecting a diverse dataset (bugbot #252)."""
+    p = tmp_path / "numeric_strings.csv"
+    p.write_text("id,label\n1,01\n2,1\n3,1.0\n4,02\n")
+    result = LabelDiversityValidator(
+        label_column="label", schema={"id": "INT", "label": "VARCHAR(8)"}
+    ).validate(str(p))
+    assert result.is_valid, f"expected valid; errors={result.errors}"
+    assert result.metadata["distinct_count"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Custom column name
+# ---------------------------------------------------------------------------
+
+def test_custom_label_column_name():
+    """When the user configures a non-default label column, the
+    validator must check THAT column (mirrors BIOLabelValidator's
+    behavior with custom columns)."""
+    df = pd.DataFrame({"target": ["A", "B"], "label": ["X", "X"]})
+    # Custom column is the diverse one — should pass.
+    assert LabelDiversityValidator(label_column="target").validate(df).is_valid
+    # The default `label` column is single-value here — should fail.
+    assert not LabelDiversityValidator(label_column="label").validate(df).is_valid

--- a/tests/test_modality_failure_accounting.py
+++ b/tests/test_modality_failure_accounting.py
@@ -179,35 +179,71 @@ def test_clean_run_has_no_failures_for_every_category(category):
 _TEMPLATES = sorted(Path(__file__).parent.parent.glob("templates/*/*.py"))
 
 
-def _main_except_handlers(template: Path):
-    """Yield every ``except Exception`` handler inside the template's
-    ``main()`` function."""
+def _main_node(template: Path):
     tree = ast.parse(template.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef) and node.name == "main":
-            for sub in ast.walk(node):
-                if isinstance(sub, ast.ExceptHandler):
-                    if isinstance(sub.type, ast.Name) and sub.type.id == "Exception":
-                        yield sub
+            return node
+    raise AssertionError(f"{template}: no main() function")
+
+
+def _swallowing_handlers(func: ast.FunctionDef):
+    """Yield every exception handler inside ``func`` that could swallow an
+    Exception: ``except Exception``, a tuple containing Exception, or a
+    bare ``except:``."""
+    for sub in ast.walk(func):
+        if not isinstance(sub, ast.ExceptHandler):
+            continue
+        catches_exception = (
+            sub.type is None  # bare except
+            or (isinstance(sub.type, ast.Name) and sub.type.id == "Exception")
+            or (
+                isinstance(sub.type, ast.Tuple)
+                and any(
+                    isinstance(el, ast.Name) and el.id == "Exception"
+                    for el in sub.type.elts
+                )
+            )
+        )
+        if catches_exception:
+            yield sub
 
 
 @pytest.mark.parametrize("template", _TEMPLATES, ids=lambda p: p.parent.name)
 def test_template_except_handler_reraises(template):
-    """A template's ``except Exception`` must re-raise. Log-and-swallow
-    turned any exception escaping ``ingest()`` — validation failure, DB
-    error, the backend-registration RuntimeErrors from base.py — into
-    exit code 0 and a K8s Job marked Succeeded, the same silent-success
-    class #223 fixed for batch POST failures."""
-    handlers = list(_main_except_handlers(template))
-    assert handlers, f"{template}: no except-Exception handler in main()"
-    for handler in handlers:
+    """main() must not swallow exceptions. Log-and-swallow turned any
+    exception escaping ``ingest()`` — validation failure, DB error, the
+    backend-registration RuntimeErrors from base.py — into exit code 0
+    and a K8s Job marked Succeeded, the same silent-success class #223
+    fixed for batch POST failures (#230).
+
+    Since the duplication extraction, the templates delegate the whole
+    run/report/exit contract to ``run_ingestion`` (which logs and
+    re-raises — covered in tests/test_template_runner.py) and carry no
+    handler of their own. This guard remains so a reintroduced
+    ``except Exception`` (or bare ``except``) around the run can't bring
+    the swallow back: if a handler exists, it must re-raise, and main()
+    must still route through run_ingestion either way."""
+    main_fn = _main_node(template)
+    for handler in _swallowing_handlers(main_fn):
         has_raise = any(
             isinstance(stmt, ast.Raise) for stmt in ast.walk(handler)
         )
         assert has_raise, (
-            f"{template}: except-Exception handler in main() does not "
-            f"re-raise — a hard ingest failure would exit 0"
+            f"{template}: exception handler in main() does not re-raise "
+            f"— a hard ingest failure would exit 0"
         )
+    calls_run_ingestion = any(
+        isinstance(sub, ast.Call)
+        and isinstance(sub.func, ast.Name)
+        and sub.func.id == "run_ingestion"
+        for sub in ast.walk(main_fn)
+    )
+    assert calls_run_ingestion, (
+        f"{template}: main() does not call run_ingestion — the exit "
+        f"contract (sys.exit(1) on failed records, re-raise on hard "
+        f"errors) would not apply"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_modality_failure_accounting.py
+++ b/tests/test_modality_failure_accounting.py
@@ -1,0 +1,328 @@
+"""Per-modality guards for the batch-send failure accounting fixed in #223.
+
+#223 was verified end-to-end with a real ingest for token_classification
+only. These tests close the per-modality gap in three directions:
+
+1. The ``api_send_failed`` accounting in ``BaseIngestor._flush_batch`` is
+   exercised for EVERY template category (the #223 tests ran it with
+   ``category=None`` only, which skips the file-transfer branch the file-
+   bearing categories take).
+2. The template scripts' ``except Exception`` handler must re-raise.
+   Five templates (image_classification, tabular_classification,
+   tabular_regression, time_series_forecasting, time_to_event_prediction)
+   used to log-and-swallow, so a hard failure raised by ``ingest()`` —
+   validation error, DB error, or the fail-loud backend-registration
+   RuntimeErrors from base.py — ended with exit code 0 and a K8s Job
+   marked Succeeded. (#223's structural test only covered the
+   ``failed_records`` branch, which exits via SystemExit and bypasses the
+   handler.)
+3. After a MID-batch DB failure, ``_process_batch`` must send the API the
+   records that actually inserted. ``zip(ids, batch)`` paired positionally
+   and truncated to ``len(ids)``, sending the DB-failed record (a phantom
+   backend entry with no MySQL row) and dropping the last inserted one (a
+   committed row the platform never sees).
+
+Plus the #223 diagnostics fix (log ``HTTP <status>: <body>`` instead of a
+100-char stub) mirrored onto the remaining API-client methods.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+from typing import Any, Dict, Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.api.client import APIClient
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+# ---------------------------------------------------------------------------
+# helpers (mirror test_batch_send_failure_accounting.py)
+# ---------------------------------------------------------------------------
+
+# One entry per template directory — the 11 supported modalities.
+_TEMPLATE_CATEGORIES = [
+    TaskCategory.IMAGE_CLASSIFICATION,
+    TaskCategory.KEYPOINT_DETECTION,
+    TaskCategory.MASKED_LANGUAGE_MODELING,
+    TaskCategory.OBJECT_DETECTION,
+    TaskCategory.SEMANTIC_SEGMENTATION,
+    TaskCategory.TABULAR_CLASSIFICATION,
+    TaskCategory.TABULAR_REGRESSION,
+    TaskCategory.TEXT_CLASSIFICATION,
+    TaskCategory.TIME_SERIES_FORECASTING,
+    TaskCategory.TIME_TO_EVENT_PREDICTION,
+    TaskCategory.TOKEN_CLASSIFICATION,
+]
+
+
+def _client(**overrides):
+    defaults = dict(BACKEND_TOKEN="tok", CLIENT_USERNAME=None,
+                    CLIENT_PASSWORD=None, EDGE_ENV="prod", TITLE=None)
+    defaults.update(overrides)
+    return APIClient(Config(**defaults))
+
+
+def _resp(status=200, json_body=None, text=""):
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = json_body if json_body is not None else {}
+    r.text = text
+    return r
+
+
+class FakeIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source: Any) -> Generator[Dict[str, Any], None, None]:
+        yield from self._records
+
+
+def make_ingestor(records=None, **overrides):
+    db = MagicMock(name="Database")
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
+    db.get_table_schema.return_value = {"a": "INT"}
+    api = MagicMock(name="APIClient")
+    api.send_batch.return_value = True
+    api.send_generate_edge_label_meta.return_value = True
+    api.send_global_meta_meta.return_value = True
+    api.prepare_dataset.return_value = True
+    api.create_dataset.return_value = {"id": 1}
+
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=None,
+    )
+    kwargs.update(overrides)
+    return FakeIngestor(records or [], **kwargs)
+
+
+def _run_ingest(ing, batch_size=10):
+    """Run ingest with Session / validation / file-transfer patched out so
+    every category — including the file-bearing ones — runs without a real
+    filesystem. Captures the logged summary."""
+    captured = {}
+    real_log = BaseIngestor._log_summary
+
+    def spy(self, summary):
+        captured["summary"] = summary
+        return real_log(self, summary)
+
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(BaseIngestor, "_log_summary", spy), \
+         patch.object(ing, "validate_data", return_value=True), \
+         patch.object(base_mod, "map_file_transfer",
+                      side_effect=lambda c, r, o: r):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=batch_size)
+    return failed, captured.get("summary")
+
+
+# ---------------------------------------------------------------------------
+# 1. api_send_failed accounting holds for every template category
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("category", _TEMPLATE_CATEGORIES)
+def test_api_send_failure_counted_for_every_category(category):
+    """Every batch POST rejected -> every record comes back as a failed
+    record for EVERY modality, so the caller exits non-zero. Covers the
+    file-transfer branch in _ingest_with_lock that ``category=None``
+    (the #223 tests) skips."""
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=category)
+    ing.api_client.send_batch.return_value = False  # every batch POST rejected
+
+    failed, summary = _run_ingest(ing)
+
+    assert len(failed) == 2, f"{category}: api-send failures not surfaced"
+    assert all(f["error"] == "api_send_failed" for f in failed)
+    assert summary.inserted_records == 2
+    assert summary.api_sent_records == 0
+    assert summary.has_failures is True
+
+
+@pytest.mark.parametrize("category", _TEMPLATE_CATEGORIES)
+def test_clean_run_has_no_failures_for_every_category(category):
+    """Control: with the API accepting every batch, no category reports
+    failures (guards against the file-transfer patch masking a skip)."""
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records, category=category)
+
+    failed, summary = _run_ingest(ing)
+
+    assert failed == []
+    assert summary.api_sent_records == summary.inserted_records == 2
+    assert summary.has_failures is False
+
+
+# ---------------------------------------------------------------------------
+# 2. templates must re-raise from their except-Exception handler
+# ---------------------------------------------------------------------------
+
+_TEMPLATES = sorted(Path(__file__).parent.parent.glob("templates/*/*.py"))
+
+
+def _main_except_handlers(template: Path):
+    """Yield every ``except Exception`` handler inside the template's
+    ``main()`` function."""
+    tree = ast.parse(template.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.ExceptHandler):
+                    if isinstance(sub.type, ast.Name) and sub.type.id == "Exception":
+                        yield sub
+
+
+@pytest.mark.parametrize("template", _TEMPLATES, ids=lambda p: p.parent.name)
+def test_template_except_handler_reraises(template):
+    """A template's ``except Exception`` must re-raise. Log-and-swallow
+    turned any exception escaping ``ingest()`` — validation failure, DB
+    error, the backend-registration RuntimeErrors from base.py — into
+    exit code 0 and a K8s Job marked Succeeded, the same silent-success
+    class #223 fixed for batch POST failures."""
+    handlers = list(_main_except_handlers(template))
+    assert handlers, f"{template}: no except-Exception handler in main()"
+    for handler in handlers:
+        has_raise = any(
+            isinstance(stmt, ast.Raise) for stmt in ast.walk(handler)
+        )
+        assert has_raise, (
+            f"{template}: except-Exception handler in main() does not "
+            f"re-raise — a hard ingest failure would exit 0"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. mid-batch DB failure: only the inserted records are sent to the API
+# ---------------------------------------------------------------------------
+
+def test_mid_batch_db_failure_sends_only_inserted_records():
+    """3-record batch, middle record fails DB insert. The API send must
+    carry exactly the two records that inserted (#0 and #2) — not a
+    positional ``batch[:len(ids)]`` prefix that would send the DB-failed
+    #1 (phantom backend record with no MySQL row) and drop the inserted
+    #2 (committed row the platform never sees)."""
+    records = [{"a": str(i), "filename": f"f{i}"} for i in range(3)]
+    ing = make_ingestor(records=records, category=None)
+    seen = {}
+
+    def fake_insert(table_name, batch):
+        seen["batch"] = list(batch)
+        # Middle record fails; failure carries a COPY of the record (the
+        # real insert_batch builds processed_record = {**record, ...}).
+        failed_copy = {**batch[1], "updated_at": "now"}
+        return [10, 12], [{"record": failed_copy, "error": "dup key"}]
+
+    ing.database.insert_batch.side_effect = fake_insert
+
+    failed, summary = _run_ingest(ing)
+
+    sent = ing.api_client.send_batch.call_args[0][0]
+    sent_data_ids = {record["data_id"] for _, record in sent}
+    batch = seen["batch"]
+    assert sent_data_ids == {batch[0]["data_id"], batch[2]["data_id"]}, (
+        "API send must carry the records that actually inserted"
+    )
+    assert len(sent) == 2
+    # Accounting unchanged: the DB failure is the only failed record.
+    assert [f["error"] for f in failed] == ["dup key"]
+    assert summary.inserted_records == 2
+    assert summary.api_sent_records == 2
+    assert summary.failed_records == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. registration-step diagnostics: full backend error logged, not a stub
+#    (mirrors the #223 send_batch fix on the remaining client methods)
+# ---------------------------------------------------------------------------
+
+# Well past the old str(e)[:100] cutoff ("HTTP 400: " left ~90 visible chars).
+_DRF_400_BODY = (
+    '{"error": ["No data found for table name padding padding padding '
+    'padding padding padding padding to push the explanation well past '
+    'the first hundred characters of the message."]}'
+)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(
+            lambda c: c.send_global_meta_meta("tbl", {"a": "INT"}, {}),
+            id="send_global_meta_meta",
+        ),
+        pytest.param(
+            lambda c: c.send_generate_edge_label_meta("tbl", "ing", "train"),
+            id="send_generate_edge_label_meta",
+        ),
+        pytest.param(
+            lambda c: c.prepare_dataset(
+                TaskCategory.IMAGE_CLASSIFICATION, "ing", "image", "train"
+            ),
+            id="prepare_dataset",
+        ),
+    ],
+)
+def test_registration_call_400_logs_status_and_full_error(call, caplog):
+    client = _client()
+    with patch.object(client.session, "post",
+                      return_value=_resp(400, text=_DRF_400_BODY)), \
+         patch.object(client.session, "get",
+                      return_value=_resp(400, text=_DRF_400_BODY)):
+        with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
+            assert call(client) is False
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "HTTP 400" in joined
+    # The tail of the body — beyond the old [:100] truncation — must be
+    # visible so the operator can see WHY the backend rejected the call.
+    assert "well past the first hundred characters" in joined
+
+
+def test_create_dataset_400_logs_full_error_and_raises(caplog):
+    client = _client()
+    with patch.object(client.session, "post",
+                      return_value=_resp(400, text=_DRF_400_BODY)):
+        with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
+            with pytest.raises(requests.exceptions.HTTPError):
+                client.create_dataset(
+                    ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
+                )
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "HTTP 400" in joined
+    assert "well past the first hundred characters" in joined
+
+
+def test_create_dataset_exception_propagates_out_of_ingest():
+    """create_dataset is the one registration call whose return value
+    isn't checked in _ingest_with_lock — it signals failure by raising.
+    Guard that the raise actually escapes ingest() (with the template
+    re-raise fix, that now fails the run in every modality)."""
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=None)
+    ing.api_client.create_dataset.side_effect = requests.exceptions.HTTPError(
+        "HTTP 401: token expired"
+    )
+
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(ing, "validate_data", return_value=True):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(requests.exceptions.HTTPError):
+            ing.ingest("src", batch_size=10)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,74 @@
+"""Tests for ConsoleRenderer — the extracted ingestion-summary presentation.
+
+Pulling the summary box out of ``BaseIngestor._log_summary`` into
+``reporting.ConsoleRenderer`` (structural refactor — backend#796, P2) means
+the presentation is now testable in isolation, without a database or a full
+ingest. These lock the rendered output's contract.
+"""
+
+import contextlib
+import io
+
+import pytest
+
+from tracebloc_ingestor.ingestors.base import IngestionSummary
+from tracebloc_ingestor.reporting import ConsoleRenderer
+
+
+def _render(summary):
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ConsoleRenderer().render_summary(summary)
+    return buf.getvalue()
+
+
+def test_clean_run_renders_success_banner():
+    out = _render(IngestionSummary("ing-1", 10, 10, 10, 10, 0, 0, 0))
+    assert "📊 INGESTION SUMMARY" in out
+    assert "ing-1" in out
+    assert "100.0%" in out
+    assert "🎉 Ingestion completed successfully!" in out
+
+
+def test_dropped_records_disqualify_success_and_are_counted():
+    # 4 of 10 dropped during processing (skipped_records). Per #234 the banner
+    # must NOT claim success, and the failure count must include the drops.
+    out = _render(IngestionSummary("ing-2", 10, 6, 6, 6, 0, 4, 0))
+    assert "🎉" not in out
+    assert "with 4 failure(s)" in out
+
+
+def test_file_transfer_failures_disqualify_success():
+    out = _render(IngestionSummary("ing-3", 10, 10, 10, 10, 0, 0, 2))
+    assert "🎉" not in out
+    assert "with 2 failure(s)" in out
+
+
+def test_api_send_gap_counted_without_double_counting():
+    # 10 inserted, only 7 shipped to the API -> 3 api-only failures, and no
+    # other channel failed, so the total is exactly 3 (not double-counted
+    # against total_records).
+    out = _render(IngestionSummary("ing-4", 10, 10, 10, 7, 0, 0, 0))
+    assert "🎉" not in out
+    assert "with 3 failure(s)" in out
+
+
+@pytest.mark.parametrize(
+    "summary,needle",
+    [
+        # success_rate >= 80 -> mild banner
+        (IngestionSummary("a", 10, 9, 9, 9, 1, 0, 0), "see logs."),
+        # 60 <= rate < 80 -> "many records failed"
+        (IngestionSummary("b", 10, 7, 7, 7, 3, 0, 0), "many records failed"),
+        # rate < 60 -> "Critical"
+        (IngestionSummary("c", 10, 3, 3, 3, 7, 0, 0), "❌ Critical!"),
+    ],
+)
+def test_severity_thresholds(summary, needle):
+    assert needle in _render(summary)
+
+
+def test_zero_total_records_does_not_divide_by_zero():
+    # An empty source must render without raising (no success-rate bar).
+    out = _render(IngestionSummary("empty", 0, 0, 0, 0, 0, 0, 0))
+    assert "📊 INGESTION SUMMARY" in out

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -80,8 +80,14 @@ def test_image_classification_is_eight_lines():
 
 
 def test_all_task_categories_covered():
-    """Every value in the schema's category enum has a corresponding example,
-    except instance_segmentation which has no template/validator support yet."""
+    """Every value in the schema's category enum has a corresponding example.
+
+    No carve-outs: a category the schema accepts must be fully supported,
+    example included. instance_segmentation used to be exempted here while
+    sitting in the enum with no validators and no file transfer — configs
+    half-ingested (rows + API records, zero files staged). It was removed
+    from the enum instead; see tests/test_category_congruence.py for the
+    guard that keeps every enum value fully wired."""
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     enum_values = set(schema["properties"]["category"]["enum"])
 
@@ -91,10 +97,7 @@ def test_all_task_categories_covered():
         if name != "custom_processor.yaml"  # uses tabular_classification, already covered
     }
 
-    # instance_segmentation is in the enum but has no map_validators branch
-    # yet (no template either) — tracked separately.
-    expected = enum_values - {"instance_segmentation"}
-    missing = expected - covered
+    missing = enum_values - covered
     assert not missing, f"No example for categories: {missing}"
 
 

--- a/tests/test_table_name_validator.py
+++ b/tests/test_table_name_validator.py
@@ -35,7 +35,6 @@ def test_missing_table_name_fails(clean_env, validator):
         "my-table",       # hyphen
         "my table",       # space
         "table$",         # symbol
-        "_leading",       # underscore start (pattern requires a letter)
     ],
 )
 def test_invalid_characters_fail(clean_env, validator, bad_name):
@@ -44,6 +43,17 @@ def test_invalid_characters_fail(clean_env, validator, bad_name):
     assert not result.is_valid
     assert any("invalid characters" in e for e in result.errors)
     assert result.metadata["invalid_names"]
+
+
+@pytest.mark.parametrize("name", ["_tmp", "_leading", "_"])
+def test_leading_underscore_is_valid(clean_env, validator, name):
+    # The regex used to forbid a leading underscore while the error message +
+    # `valid_pattern` metadata both said it was allowed (#238). MySQL permits a
+    # leading underscore, so such names are now accepted — matching what the
+    # validator already advertised.
+    clean_env.setenv("TABLE_NAME", name)
+    result = validator.validate(None)
+    assert result.is_valid, result.errors
 
 
 def test_reserved_keyword_warns_but_passes(clean_env, validator):

--- a/tests/test_template_runner.py
+++ b/tests/test_template_runner.py
@@ -1,0 +1,113 @@
+"""Behavioral contract of ``run_ingestion`` — the shared run/report/exit
+wrapper the template scripts delegate to.
+
+The eleven templates used to inline this block and the copies drifted:
+five swallowed exceptions and exited 0 on hard failures (#230), and the
+failed-record log line was wrong in three different ways (wrapper-level
+``.get("filename")`` logged None; ``.get("name")`` always logged
+Unknown). The structural template tests pin that every template calls
+this helper; these tests pin what the helper actually guarantees.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from tracebloc_ingestor import run_ingestion as run_ingestion_from_root
+from tracebloc_ingestor.utils.template_runner import run_ingestion
+
+
+def _ingestor(failed_records=None, ingest_side_effect=None):
+    ing = MagicMock(name="ingestor")
+    ing.__enter__ = MagicMock(return_value=ing)
+    ing.__exit__ = MagicMock(return_value=False)
+    if ingest_side_effect is not None:
+        ing.ingest.side_effect = ingest_side_effect
+    else:
+        ing.ingest.return_value = failed_records or []
+    return ing
+
+
+_LOGGER = logging.getLogger("test_template_runner_template")
+
+
+def test_exported_from_package_root():
+    # Templates import it via `from tracebloc_ingestor import run_ingestion`.
+    assert run_ingestion_from_root is run_ingestion
+
+
+def test_clean_run_logs_success_and_returns(caplog):
+    ing = _ingestor(failed_records=[])
+    with caplog.at_level(logging.INFO, logger=_LOGGER.name):
+        assert run_ingestion(ing, "labels.csv", batch_size=7, logger=_LOGGER) is None
+    ing.ingest.assert_called_once_with("labels.csv", batch_size=7)
+    assert "All records processed successfully" in caplog.text
+
+
+def test_failed_records_exit_nonzero_and_log_each(caplog):
+    failures = [
+        {"record": {"filename": "f1", "data_id": "d1"}, "error": "api_send_failed"},
+        {"record": {"data_id": "d2"}, "error": "dup key"},  # tabular: no filename
+        {"record": {}, "error": "boom"},
+        {"error": "no record key at all"},
+    ]
+    ing = _ingestor(failed_records=failures)
+    with caplog.at_level(logging.WARNING, logger=_LOGGER.name):
+        with pytest.raises(SystemExit) as excinfo:
+            run_ingestion(ing, "labels.csv", batch_size=7, logger=_LOGGER)
+    assert excinfo.value.code == 1
+    assert "Failed to process 4 records" in caplog.text
+    # Identifier resolution: filename where present, else data_id, else Unknown.
+    assert "Failed record: f1" in caplog.text
+    assert "Failed record: d2" in caplog.text
+    assert "Failed record: Unknown" in caplog.text
+    assert "Error details: api_send_failed" in caplog.text
+    assert "Error details: dup key" in caplog.text
+    # SystemExit must pass through the except-Exception handler untouched —
+    # it must NOT be re-logged as a hard failure.
+    assert "Ingestion failed" not in caplog.text
+
+
+def test_exception_from_ingest_is_logged_and_reraised(caplog):
+    err = RuntimeError("Backend rejected edge-label metadata")
+    ing = _ingestor(ingest_side_effect=err)
+    with caplog.at_level(logging.ERROR, logger=_LOGGER.name):
+        with pytest.raises(RuntimeError) as excinfo:
+            run_ingestion(ing, "labels.csv", batch_size=7, logger=_LOGGER)
+    # Re-raised, not swallowed (the #230 silent-success class) — and it's
+    # the ORIGINAL exception, not a replacement.
+    assert excinfo.value is err
+    assert "Ingestion failed: Backend rejected edge-label metadata" in caplog.text
+
+
+def test_ingestor_used_as_context_manager():
+    ing = _ingestor(failed_records=[])
+    run_ingestion(ing, "labels.csv", batch_size=7, logger=_LOGGER)
+    ing.__enter__.assert_called_once()
+    ing.__exit__.assert_called_once()
+
+
+def test_context_manager_exited_on_failure_paths():
+    # SystemExit (failed records) and a hard error must both leave the
+    # with-block normally unwound.
+    ing = _ingestor(failed_records=[{"record": {}, "error": "x"}])
+    with pytest.raises(SystemExit):
+        run_ingestion(ing, "labels.csv", batch_size=7, logger=_LOGGER)
+    ing.__exit__.assert_called_once()
+
+    ing2 = _ingestor(ingest_side_effect=RuntimeError("db gone"))
+    with pytest.raises(RuntimeError):
+        run_ingestion(ing2, "labels.csv", batch_size=7, logger=_LOGGER)
+    ing2.__exit__.assert_called_once()
+
+
+def test_default_logger_used_when_none_passed(caplog):
+    ing = _ingestor(failed_records=[])
+    with caplog.at_level(
+        logging.INFO, logger="tracebloc_ingestor.utils.template_runner"
+    ):
+        run_ingestion(ing, "labels.csv", batch_size=7)
+    assert "All records processed successfully" in caplog.text

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -24,6 +24,9 @@ from tracebloc_ingestor.validators.keypoint_visibility_validator import (
     KeypointVisibilityValidator,
 )
 from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
+from tracebloc_ingestor.validators.label_diversity_validator import (
+    LabelDiversityValidator,
+)
 
 
 IMAGE_OPTS = {"extension": FileExtension.JPG, "target_size": [224, 224]}
@@ -38,9 +41,62 @@ def test_image_classification():
     assert _types(v) == [
         FileTypeValidator,
         ImageResolutionValidator,
+        LabelDiversityValidator,
         TableNameValidator,
         DuplicateValidator,
     ]
+
+
+def test_classification_categories_include_label_diversity():
+    """Single-label classification is caught at preflight across every
+    classification-family category — image/object/semantic/keypoint/
+    tabular/text — but NOT token_classification (its label is a per-token
+    BIO sequence, not a single class) or the regression / self-supervised
+    families (issue #251)."""
+    for cat in (
+        TaskCategory.IMAGE_CLASSIFICATION,
+        TaskCategory.OBJECT_DETECTION,
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        TaskCategory.KEYPOINT_DETECTION,
+        TaskCategory.TABULAR_CLASSIFICATION,
+        TaskCategory.TEXT_CLASSIFICATION,
+    ):
+        assert LabelDiversityValidator in _types(map_validators(cat, IMAGE_OPTS)), cat
+
+    for cat in (
+        TaskCategory.TOKEN_CLASSIFICATION,
+        TaskCategory.TABULAR_REGRESSION,
+        TaskCategory.TIME_SERIES_FORECASTING,
+        TaskCategory.TIME_TO_EVENT_PREDICTION,
+        TaskCategory.MASKED_LANGUAGE_MODELING,
+    ):
+        assert LabelDiversityValidator not in _types(
+            map_validators(cat, {"schema": {"a": "INT"}})
+        ), cat
+
+
+def test_label_diversity_uses_full_schema_for_label_type():
+    """base.py strips the label column out of file_options["schema"] (it's a
+    framework column, not a table column) but passes the UNSTRIPPED schema as
+    `full_schema`. The label-diversity validator must read the label's type
+    from `full_schema`, else it never applies the ingestor's NA/dtype rules to
+    the label column (bugbot #252)."""
+    ldv = next(
+        v
+        for v in map_validators(
+            TaskCategory.TABULAR_CLASSIFICATION,
+            {
+                # file_options["schema"] — label already stripped by base.py.
+                "schema": {"age": "INT"},
+                "label_column": "churned",
+                # full, unstripped schema base.py also passes.
+                "full_schema": {"age": "INT", "churned": "VARCHAR(8)"},
+            },
+        )
+        if isinstance(v, LabelDiversityValidator)
+    )
+    # The validator must see the label column's type via the full schema.
+    assert ldv._schema_type_for("churned") == "VARCHAR(8)"
 
 
 def test_object_detection_includes_xml_validator():

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -9,6 +9,7 @@ from .config import Config
 from .database import Database
 from .api.client import APIClient
 from .ingestors import BaseIngestor, CSVIngestor, JSONIngestor
+from .utils.template_runner import run_ingestion
 from .validators import (
     BaseValidator,
     ValidationResult,
@@ -34,4 +35,5 @@ __all__ = [
     "FileTypeValidator",
     "ImageResolutionValidator",
     "TableNameValidator",
+    "run_ingestion",
 ]

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -21,7 +21,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.9"
+__version__ = "0.3.10"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -320,10 +320,16 @@ class APIClient:
                 timeout=API_TIMEOUT,
             )
 
-            # Check status after retries are exhausted
+            # Check status after retries are exhausted. Attach the response
+            # so the handler below can log the status and the full body —
+            # a bare HTTPError has e.response = None, which routed a DRF 400
+            # into a str(e)[:100] branch that truncated the message right
+            # after "HTTP 400: ", hiding the field error (same swallow point
+            # send_batch had — fixed in #223).
             if response.status_code >= 400:
                 raise requests.exceptions.HTTPError(
-                    f"HTTP {response.status_code}: {response.text}"
+                    f"HTTP {response.status_code}: {response.text}",
+                    response=response,
                 )
             logger.info(
                 f"{GREEN}Successfully sent global metadata. "
@@ -332,11 +338,16 @@ class APIClient:
             return True
 
         except requests.exceptions.RequestException as e:
-            logger.error(
-                f"{RED}Error sending global metadata to API: {str(e)[:100]}{RESET}"
-            )
-            if hasattr(e.response, "text"):
-                logger.error(f"{RED}Error response: {e.response.text}{RESET}")
+            if e.response is not None:
+                body = (e.response.text or "")[:2000]
+                logger.error(
+                    f"{RED}Error sending global metadata to API: "
+                    f"HTTP {e.response.status_code}: {body}{RESET}"
+                )
+            else:
+                logger.error(
+                    f"{RED}Error sending global metadata to API: {str(e)[:500]}{RESET}"
+                )
             return False
 
     def send_generate_edge_label_meta(
@@ -364,10 +375,12 @@ class APIClient:
             )
             response = self._authed_request("GET", url, timeout=API_TIMEOUT)
 
-            # Check status after retries are exhausted
+            # Check status after retries are exhausted. Response attached so
+            # the handler logs the full backend error (see send_batch / #223).
             if response.status_code >= 400:
                 raise requests.exceptions.HTTPError(
-                    f"HTTP {response.status_code}: {response.text}"
+                    f"HTTP {response.status_code}: {response.text}",
+                    response=response,
                 )
             logger.info(
                 f"{GREEN}Successfully generated edge label metadata. Response{RESET}"
@@ -375,11 +388,16 @@ class APIClient:
             return True
 
         except requests.exceptions.RequestException as e:
-            logger.error(
-                f"{RED}Error generating edge label metadata: {str(e)[:100]}{RESET}"
-            )
-            if hasattr(e.response, "text"):
-                logger.error(f"{RED}Error response: {e.response.text}{RESET}")
+            if e.response is not None:
+                body = (e.response.text or "")[:2000]
+                logger.error(
+                    f"{RED}Error generating edge label metadata: "
+                    f"HTTP {e.response.status_code}: {body}{RESET}"
+                )
+            else:
+                logger.error(
+                    f"{RED}Error generating edge label metadata: {str(e)[:500]}{RESET}"
+                )
             return False
 
     def prepare_dataset(
@@ -416,10 +434,12 @@ class APIClient:
             )
             response = self._authed_request("GET", url, timeout=API_TIMEOUT)
 
-            # Check status after retries are exhausted
+            # Check status after retries are exhausted. Response attached so
+            # the handler logs the full backend error (see send_batch / #223).
             if response.status_code >= 400:
                 raise requests.exceptions.HTTPError(
-                    f"HTTP {response.status_code}: {response.text}"
+                    f"HTTP {response.status_code}: {response.text}",
+                    response=response,
                 )
             logger.info(
                 f"{GREEN}Successfully prepared data. "
@@ -428,9 +448,14 @@ class APIClient:
             return True
 
         except requests.exceptions.RequestException as e:
-            logger.error(f"{RED}Error preparing data: {str(e)[:100]}{RESET}")
-            if hasattr(e.response, "text"):
-                logger.error(f"{RED}Error response: {e.response.text}{RESET}")
+            if e.response is not None:
+                body = (e.response.text or "")[:2000]
+                logger.error(
+                    f"{RED}Error preparing data: "
+                    f"HTTP {e.response.status_code}: {body}{RESET}"
+                )
+            else:
+                logger.error(f"{RED}Error preparing data: {str(e)[:500]}{RESET}")
             return False
 
     def create_dataset(
@@ -487,10 +512,12 @@ class APIClient:
                 timeout=API_TIMEOUT,
             )
 
-            # Check status after retries are exhausted
+            # Check status after retries are exhausted. Response attached so
+            # the handler logs the full backend error (see send_batch / #223).
             if response.status_code >= 400:
                 raise requests.exceptions.HTTPError(
-                    f"HTTP {response.status_code}: {response.text}"
+                    f"HTTP {response.status_code}: {response.text}",
+                    response=response,
                 )
             dataset = self._parse_json(response, required=True)
             logger.info(
@@ -499,9 +526,14 @@ class APIClient:
             return dataset
 
         except requests.exceptions.RequestException as e:
-            logger.error(f"{RED}Error creating dataset: {str(e)[:100]}{RESET}")
-            if hasattr(e.response, "text"):
-                logger.error(f"{RED}Error response: {e.response.text}{RESET}")
+            if e.response is not None:
+                body = (e.response.text or "")[:2000]
+                logger.error(
+                    f"{RED}Error creating dataset: "
+                    f"HTTP {e.response.status_code}: {body}{RESET}"
+                )
+            else:
+                logger.error(f"{RED}Error creating dataset: {str(e)[:500]}{RESET}")
             raise
 
     def __del__(self):

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -41,6 +41,13 @@ class APIClient:
         self.config = config
         self.session = self._create_session()
 
+        # Last `prepare_dataset` HTTP-error body, retained so callers
+        # can include the actual backend reason in the user-visible
+        # RuntimeError instead of just pointing at "the logged API
+        # error above" (issue #251). Set by `prepare_dataset`'s error
+        # handler; remains None on a clean run.
+        self.last_prepare_error: Optional[str] = None
+
         # Auth resolution order:
         #   1. local mode  → mock token, no network call
         #   2. BACKEND_TOKEN set → use it directly (preferred; mirrors the
@@ -414,6 +421,13 @@ class APIClient:
         Returns:
             bool: True if successful, False otherwise
         """
+        # Clear any error stashed by a previous prepare_dataset call up front,
+        # so an early `return False` below (local mode, invalid category)
+        # can't leave a stale message that base.py then attaches to an
+        # unrelated failure (bugbot #252). Only the exception handler in THIS
+        # call should ever populate it.
+        self.last_prepare_error = None
+
         # Skip API calls in local mode
         if self.config.EDGE_ENV == "local":
             logger.info(f"Mock: Would prepare dataset {category}")
@@ -454,8 +468,18 @@ class APIClient:
                     f"{RED}Error preparing data: "
                     f"HTTP {e.response.status_code}: {body}{RESET}"
                 )
+                # Stash the backend's response so callers can surface the
+                # actual reason (e.g. "Please provide atleast 2 labels.")
+                # in the user-visible error — instead of pointing at "the
+                # logged API error above" which the user has to grep for.
+                # Issue #251: misleading "Backend failed to prepare the
+                # dataset" message that buried a clear backend reason.
+                self.last_prepare_error = (
+                    f"HTTP {e.response.status_code}: {body}"
+                )
             else:
                 logger.error(f"{RED}Error preparing data: {str(e)[:500]}{RESET}")
+                self.last_prepare_error = str(e)[:500]
             return False
 
     def create_dataset(

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -40,7 +40,6 @@ IMAGE_CATEGORIES: FrozenSet[str] = frozenset({
     TaskCategory.OBJECT_DETECTION,
     TaskCategory.KEYPOINT_DETECTION,
     TaskCategory.SEMANTIC_SEGMENTATION,
-    TaskCategory.INSTANCE_SEGMENTATION,
 })
 
 TEXT_CATEGORIES: FrozenSet[str] = frozenset({
@@ -108,9 +107,6 @@ DEFAULT_IMAGE_FILE_OPTIONS_BY_CATEGORY: Dict[str, Dict[str, Any]] = {
     # keypoint_detection: no target_size default — the customer's pose model
     # dictates input resolution, so the schema requires it top-level.
     TaskCategory.KEYPOINT_DETECTION:      {"extension": ".jpg"},
-    # No template exists yet for instance_segmentation; mirror semantic for
-    # forward-compatibility, revisit when the template lands.
-    TaskCategory.INSTANCE_SEGMENTATION:   {"target_size": [512, 512], "extension": ".jpg"},
 }
 
 DEFAULT_TEXT_FILE_OPTIONS: Dict[str, Any] = {

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -44,7 +44,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, NoReturn
+from typing import Any, Dict, Iterable, List, NoReturn, Optional
 
 import yaml
 from jsonschema import Draft7Validator, ValidationError
@@ -184,17 +184,78 @@ def _validate(raw_config: Dict[str, Any]) -> Iterable[ValidationError]:
     return sorted(validator.iter_errors(raw_config), key=lambda e: list(e.absolute_path))
 
 
-def _format_errors(errors: List[ValidationError]) -> str:
-    """Format errors as ``<json-pointer>: <message>``, one per line.
+def _describe_from_schema_path(
+    schema: Dict[str, Any], schema_path: List[Any]
+) -> Optional[str]:
+    """Walk the schema from root toward the failing rule, returning the
+    deepest ``description`` field encountered along the way.
 
-    Real line numbers (per the ticket) require a YAML loader that preserves
-    position info. v1.1 follow-up — for now, the JSON-pointer path is
-    enough to grep the customer's YAML.
+    JSON Schema ``allOf`` rules in ``schema/ingest.v1.json`` carry rich
+    ``description`` fields explaining each branch (e.g. "Self-supervised
+    categories MUST NOT set `label`. The shipped CSV has no label column,
+    and the framework registers no edge-label metadata for them…"), but
+    ``ValidationError.message`` only surfaces the mechanic
+    ("``{full yaml dump}`` should not be valid under ``{'required':
+    ['label']}``"). That raw message is correct but practically
+    unreadable: it dumps the entire submission as a Python dict and uses
+    JSON-schema vocabulary that the customer didn't write.
+
+    Walking from root captures the description nearest the failing rule,
+    so the user sees the rule author's intent (and the suggested fix)
+    instead of the mechanic. Returns ``None`` when no description applies
+    — the caller falls back to ``e.message`` so primitive checks
+    (``'label' is a required property``, ``'foo' is not one of [...]``)
+    still surface their existing clear messages.
     """
+    # Walk step-by-step, only capturing descriptions on nodes we DESCEND
+    # INTO — never the root's. The root description in ingest.v1.json is a
+    # generic blurb ("Declarative configuration for the tracebloc data
+    # ingestor…") that's correct for the schema as a whole but would
+    # blanket-attach to every primitive error, overwriting jsonschema's
+    # clear `'X' is a required property` messages with the generic prose
+    # (bugbot #254). Only INNER descriptions — the ones authored on
+    # `allOf` branches, sub-property definitions, etc. — are rule-specific
+    # enough to be worth surfacing.
+    description = None
+    node: Any = schema
+    for step in schema_path:
+        try:
+            node = node[step]
+        except (KeyError, IndexError, TypeError):
+            return description
+        if isinstance(node, dict) and isinstance(node.get("description"), str):
+            description = node["description"]
+    return description
+
+
+def _format_errors(errors: List[ValidationError]) -> str:
+    """Format errors as ``<json-pointer>: <description-or-message>``,
+    one per line. When a failing rule has a ``description`` field in the
+    schema, surface THAT (with the underlying mechanic on a follow-up
+    line) — the descriptions in ``schema/ingest.v1.json`` are
+    customer-facing prose with rationale and fix hints, and the mechanic
+    is JSON-schema vocabulary the customer didn't write.
+
+    Real line numbers (per the ticket) require a YAML loader that
+    preserves position info. v1.1 follow-up — for now, the JSON-pointer
+    path is enough to grep the customer's YAML.
+    """
+    schema = _load_schema()
     lines = []
     for e in errors:
         path = ".".join(str(p) for p in e.absolute_path) or "<root>"
-        lines.append(f"  {path}: {e.message}")
+        description = _describe_from_schema_path(
+            schema, list(e.absolute_schema_path)
+        )
+        if description:
+            lines.append(f"  {path}: {description}")
+            # Keep the mechanic on a follow-up line for power-user
+            # debugging without burying it in the headline.
+            lines.append(
+                f"      (rule: {e.validator}={e.validator_value!r})"
+            )
+        else:
+            lines.append(f"  {path}: {e.message}")
     return "\n".join(lines)
 
 

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -72,6 +72,24 @@ class Config:
             return self._overrides[name]
         return default
 
+    @staticmethod
+    def _as_int(field: str, env_name: str, raw: Any) -> int:
+        """``int(raw)`` with a clear config error (#238).
+
+        A non-numeric ``MYSQL_PORT`` / ``BATCH_SIZE`` (e.g. a typo'd
+        ``MYSQL_PORT=abc``) otherwise surfaced as a raw
+        ``ValueError: invalid literal for int() with base 10: 'abc'`` at the
+        point of property access — opaque about which setting is wrong. Name
+        the field and the env var the user should fix instead.
+        """
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"{field} must be an integer, got {raw!r}. Set the "
+                f"{env_name} environment variable to a valid integer."
+            )
+
     # ===== Database =====
     # Cluster-internal MySQL ships with these credentials baked into its
     # image; they're connection conventions, not secrets. Override via env
@@ -85,7 +103,7 @@ class Config:
     def DB_PORT(self) -> int:
         ov = self._override("DB_PORT")
         raw = ov if ov is not _MISSING else os.environ.get("MYSQL_PORT", "3306")
-        return int(raw)
+        return self._as_int("DB_PORT", "MYSQL_PORT", raw)
 
     @property
     def DB_USER(self) -> str:
@@ -106,7 +124,7 @@ class Config:
     def BATCH_SIZE(self) -> int:
         ov = self._override("BATCH_SIZE")
         raw = ov if ov is not _MISSING else os.environ.get("BATCH_SIZE", "4000")
-        return int(raw)
+        return self._as_int("BATCH_SIZE", "BATCH_SIZE", raw)
 
     # ===== API =====
     @property

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -492,34 +492,48 @@ class Database:
         # Get all columns from the table
         columns = inspector.get_columns(table_name)
 
-        # Convert SQLAlchemy types back to MySQL types
+        # Reflection against a live MySQL returns DIALECT type classes whose
+        # names already ARE the MySQL keywords (VARCHAR, INTEGER, DECIMAL,
+        # TINYINT, ...), while in-process metadata uses the GENERIC classes
+        # (String, Integer, Numeric, ...). Upper-casing the class name unifies
+        # the two; this map only covers names that differ from the platform's
+        # MySQL vocabulary (the keywords _get_sqlalchemy_type accepts).
         type_mapping = {
-            "String": "VARCHAR",
-            "Text": "TEXT",
-            "Integer": "INT",
-            "BigInteger": "BIGINT",
-            "Float": "FLOAT",
-            "Double": "DOUBLE",
-            "Boolean": "BOOLEAN",
-            "Date": "DATE",
-            "DateTime": "DATETIME",
-            "Timestamp": "TIMESTAMP",
-            "Time": "TIME",
-            "BLOB": "BLOB",
-            "LONGBLOB": "LONGBLOB",
+            "STRING": "VARCHAR",
+            "INTEGER": "INT",
+            "BIGINTEGER": "BIGINT",
+            "SMALLINTEGER": "SMALLINT",
+            "NUMERIC": "DECIMAL",
+            "DOUBLE_PRECISION": "DOUBLE",
+            "LARGEBINARY": "BLOB",
         }
 
         schema = {}
         for column in columns:
-            # Get the type name
-            type_name = column["type"].__class__.__name__
+            col_type = column["type"]
+            type_name = col_type.__class__.__name__.upper()
 
-            # Convert SQLAlchemy type to MySQL type
-            mysql_type = type_mapping.get(type_name, "VARCHAR")
+            # MySQL has no native BOOLEAN type: BOOL columns are created — and
+            # therefore reflected — as TINYINT(1).
+            if (
+                type_name == "TINYINT"
+                and getattr(col_type, "display_width", None) == 1
+            ):
+                schema[column["name"]] = "BOOLEAN"
+                continue
 
-            # Add length for VARCHAR types
-            if mysql_type == "VARCHAR" and hasattr(column["type"], "length"):
-                mysql_type = f"{mysql_type}({column['type'].length})"
+            mysql_type = type_mapping.get(type_name, type_name)
+
+            # Re-attach the parametrisation MySQL carries in the DDL string.
+            if mysql_type in ("VARCHAR", "CHAR", "BINARY", "VARBINARY"):
+                length = getattr(col_type, "length", None)
+                if length:
+                    mysql_type = f"{mysql_type}({length})"
+            elif mysql_type == "DECIMAL":
+                precision = getattr(col_type, "precision", None)
+                if precision is not None:
+                    scale = getattr(col_type, "scale", None) or 0
+                    mysql_type = f"DECIMAL({precision},{scale})"
 
             schema[column["name"]] = mysql_type
 

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -24,7 +24,7 @@ from sqlalchemy.dialects.mysql import insert, LONGBLOB, BLOB
 from sqlalchemy.exc import OperationalError, InterfaceError, DBAPIError
 import logging
 from urllib.parse import quote
-from typing import List, Dict, Any, Optional
+from typing import Iterable, List, Dict, Any, Optional
 from datetime import datetime
 from tenacity import (
     retry,
@@ -97,6 +97,58 @@ def _execute_with_retry(connection, stmt):
                 f"connection.rollback() failed between retries: {rb_exc}"
             )
         raise
+
+
+def _suggest_type(unknown: str, known: Iterable[str]) -> Optional[str]:
+    """Return the closest match from ``known`` to ``unknown`` if any
+    candidate is within edit distance 3 (Levenshtein), else None.
+
+    Used by ``_get_sqlalchemy_type`` to surface a "Did you mean BIGINT?"
+    hint when a customer types BIGINTEGER, BOOLEAN→BOOL, NUMRIC→NUMERIC,
+    etc. Distance 3 is the empirical sweet spot — close enough to catch
+    every realistic typo we've seen in the wild (single-letter swaps,
+    common prefix/suffix confusion like INT-vs-INTEGER, missing or
+    duplicated letters), wide enough to fail-silently on entries that
+    are genuinely different vocabulary (no false "Did you mean DATE?"
+    for a GEOMETRY).
+
+    Returns the FIRST best match at the minimum distance — type_mapping
+    has stable insertion order so the deterministic result is fine for
+    tests.
+    """
+    if not unknown:
+        return None
+
+    def _levenshtein(a: str, b: str) -> int:
+        if a == b:
+            return 0
+        if not a:
+            return len(b)
+        if not b:
+            return len(a)
+        # Two-row DP — O(len(a)*len(b)) time, O(min(a,b)) space.
+        prev = list(range(len(b) + 1))
+        for i, ca in enumerate(a, start=1):
+            curr = [i] + [0] * len(b)
+            for j, cb in enumerate(b, start=1):
+                cost = 0 if ca == cb else 1
+                curr[j] = min(
+                    prev[j] + 1,
+                    curr[j - 1] + 1,
+                    prev[j - 1] + cost,
+                )
+            prev = curr
+        return prev[-1]
+
+    target = unknown.upper()
+    best: Optional[str] = None
+    best_d = 99
+    for candidate in known:
+        d = _levenshtein(target, candidate)
+        if d < best_d:
+            best = candidate
+            best_d = d
+    return best if best_d <= 3 else None
 
 
 class Database:
@@ -181,7 +233,24 @@ class Database:
                     return alchemy_type(parts[0])
             return alchemy_type
 
-        raise ValueError(f"Unsupported MySQL type: {mysql_type}")
+        # Surface a "did you mean" hint when the typo is one edit away from
+        # a supported type — BIGINTEGER → BIGINT, BOOLEAN → BOOL, NUMRIC →
+        # NUMERIC, etc. A user-facing schema error that just says
+        # "Unsupported" leaves the customer guessing; a single short hint
+        # turns a 5-minute "what's the right spelling?" round trip into a
+        # zero-thought fix. Levenshtein distance ≤ 3 catches every realistic
+        # typo we've seen without false-flagging unrelated types.
+        suggestion = _suggest_type(base_type, type_mapping.keys())
+        if suggestion:
+            raise ValueError(
+                f"Unsupported MySQL type: {mysql_type}. Did you mean "
+                f"'{suggestion}'? Supported types: "
+                f"{sorted(type_mapping.keys())}"
+            )
+        raise ValueError(
+            f"Unsupported MySQL type: {mysql_type}. Supported types: "
+            f"{sorted(type_mapping.keys())}"
+        )
 
     def create_table(self, table_name: str, schema: Dict[str, str]):
         """

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -4,6 +4,7 @@ from sqlalchemy import (
     Table,
     Column,
     BigInteger,
+    CHAR,
     DateTime,
     Date,
     Time,
@@ -134,6 +135,7 @@ class Database:
         """
         type_mapping = {
             "VARCHAR": String,
+            "CHAR": CHAR,
             "TEXT": Text,
             "INT": Integer,
             "INTEGER": Integer,

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -62,6 +62,38 @@ def _copy_file_with_retry(src_path: str, dest_path: str) -> None:
     logger.debug(f"Successfully copied file from {src_path} to {dest_path}")
 
 
+def _safe_join(root: str, *parts: str) -> str:
+    """Join ``parts`` under ``root`` and guarantee the result stays inside it.
+
+    The per-row ``filename`` / ``mask_id`` come straight from the user's
+    manifest and are joined onto ``SRC_PATH`` / ``DEST_PATH`` to read and write
+    sidecar files. ``os.path.join`` makes two unsafe moves on hostile input:
+
+      - an absolute component drops everything before it
+        (``os.path.join("/data/shared", "images", "/etc/passwd")`` ->
+        ``"/etc/passwd"``), and
+      - ``..`` segments walk up out of ``root``.
+
+    On the shared cluster PVC that lets a crafted manifest read another
+    tenant's files into the dataset, or clobber files anywhere the Job can
+    write (#239). Normalise the join and reject anything that resolves outside
+    ``root``. ``os.path.abspath`` (not ``realpath``) collapses ``.`` / ``..``
+    and makes the path absolute WITHOUT resolving symlinks, so legitimately
+    symlinked PVC mounts keep working while traversal / absolute injection is
+    blocked.
+    """
+    root_abs = os.path.abspath(root)
+    candidate = os.path.abspath(os.path.join(root_abs, *parts))
+    if candidate != root_abs and not candidate.startswith(root_abs + os.sep):
+        raise ValueError(
+            f"{RED}Refusing path that escapes {root_abs!r}: the manifest value "
+            f"{os.path.join(*parts)!r} resolved to {candidate!r}. A filename / "
+            f"mask_id must stay within the dataset directory — absolute paths "
+            f"and '..' traversal are rejected (path-traversal guard, #239).{RESET}"
+        )
+    return candidate
+
+
 def _has_extension(filename: str) -> bool:
     """Check if filename has an extension, handling multiple dots correctly.
 
@@ -102,7 +134,10 @@ def _find_src(subdirectory: str, filename: str, extension: str):
     filename_with_ext = (
         filename if _has_extension(filename) else f"{filename}{extension}"
     )
-    candidate = os.path.join(config.SRC_PATH, subdirectory, filename_with_ext)
+    # _safe_join raises on a traversal/absolute filename (#239); a genuinely
+    # missing file still returns None below (skip), so a malicious manifest
+    # value is rejected loudly while an absent sidecar is tolerated.
+    candidate = _safe_join(config.SRC_PATH, subdirectory, filename_with_ext)
     if os.path.exists(candidate):
         return candidate, filename_with_ext
     return None, filename_with_ext
@@ -146,8 +181,8 @@ def image_transfer(
                 )
                 return None
 
-        # Save the resized image
-        image_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)
+        # Save the resized image (write target guarded against escaping DEST — #239)
+        image_dest_path = _safe_join(config.DEST_PATH, filename_with_ext)
         # Copy file with retry logic
         _copy_file_with_retry(src_path, image_dest_path)
 
@@ -201,8 +236,8 @@ def annotation_transfer(
                 )
                 return None
 
-        # Save the file
-        file_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)
+        # Save the file (write target guarded against escaping DEST — #239)
+        file_dest_path = _safe_join(config.DEST_PATH, filename_with_ext)
         # Copy file with retry logic
         _copy_file_with_retry(src_path, file_dest_path)
 
@@ -247,14 +282,15 @@ def text_transfer(
         else:
             filename_with_ext = filename
 
-        # Process the text file
-        text_src_path = os.path.join(config.SRC_PATH, src_subdir, filename_with_ext)
+        # Process the text file (both ends guarded against escaping the
+        # SRC/DEST sandboxes via a crafted filename — #239)
+        text_src_path = _safe_join(config.SRC_PATH, src_subdir, filename_with_ext)
         if not os.path.exists(text_src_path):
             logger.error(f"{RED}Source text file not found: {text_src_path}{RESET}")
             return None
 
         # Save the text file
-        text_dest_path = os.path.join(config.DEST_PATH, filename_with_ext)
+        text_dest_path = _safe_join(config.DEST_PATH, filename_with_ext)
         # Copy file with retry logic
         _copy_file_with_retry(text_src_path, text_dest_path)
 
@@ -276,7 +312,8 @@ def _find_mask_src(mask_id: str):
     """
     mask_name = mask_id.split(".")[0] if "." in mask_id else mask_id
     for ext in [".png", ".jpg", ".jpeg"]:
-        candidate = os.path.join(config.SRC_PATH, "masks", f"{mask_name}{ext}")
+        # _safe_join raises on a traversal/absolute mask_id (#239).
+        candidate = _safe_join(config.SRC_PATH, "masks", f"{mask_name}{ext}")
         if os.path.exists(candidate):
             return candidate, ext, mask_name
     return None, None, mask_name
@@ -297,7 +334,8 @@ def mask_transfer(
     os.makedirs(config.DEST_PATH, exist_ok=True)
 
     try:
-        mask_dest_path = os.path.join(config.DEST_PATH, f"{mask_name}{mask_ext}")
+        # Write target guarded against escaping DEST via a crafted mask_id (#239)
+        mask_dest_path = _safe_join(config.DEST_PATH, f"{mask_name}{mask_ext}")
         _copy_file_with_retry(mask_src_path, mask_dest_path)
 
         logger.info(f"{GREEN}Successfully copied mask: {mask_name}{RESET}")

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -1037,8 +1037,27 @@ class BaseIngestor(ABC):
             api_success = False
             # Send to API with ingestor_id
             if ids:  # Only send to API if we have valid IDs
+                # Send only the records that actually inserted.
+                # ``zip(ids, batch)`` pairs positionally and truncates to
+                # ``len(ids)``; after a MID-batch DB failure (insert_batch's
+                # per-record fallback appends successes in scan order) that
+                # would send the DB-failed record to the API and drop the
+                # last inserted one — a phantom backend record pointing at
+                # no MySQL row, plus a committed row the platform never
+                # sees. Match by data_id, same as _flush_batch.
+                if db_failures:
+                    db_failed_data_ids = {
+                        f.get("record", {}).get("data_id") for f in db_failures
+                    }
+                    records_to_send = [
+                        record
+                        for record in batch
+                        if record.get("data_id") not in db_failed_data_ids
+                    ]
+                else:
+                    records_to_send = batch
                 api_success = self.api_client.send_batch(
-                    [(id, record) for id, record in zip(ids, batch)],
+                    [(id, record) for id, record in zip(ids, records_to_send)],
                     self.table_name,
                     ingestor_id=self.ingestor_id,  # Include ingestor_id in API requests
                 )

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -45,20 +45,29 @@ _TABULAR_FAMILY_CATEGORIES = frozenset({
     TaskCategory.TIME_TO_EVENT_PREDICTION,
 })
 
-# File-bearing categories resolve every per-row sidecar against
-# ``config.SRC_PATH``. If that path is empty/unset/missing, every file
-# lookup silently falls through to a relative path (``"" + "images/x.jpg"``
-# -> ``"images/x.jpg"``), file_transfer skips every record, and the user
-# sees N copies of "Source image not found: images/x.jpg" — blaming the
-# data when the real cause is "SRC_PATH was never staged on the PVC".
+# File-bearing categories: every record references sidecar files (images,
+# annotations, masks, texts, sequences) that live under ``config.SRC_PATH``
+# and must be copied to DEST_PATH by ``map_file_transfer``. This single set
+# drives BOTH uses:
+#   1. the SRC_PATH preflight in ``validate_data`` — if SRC_PATH is
+#      empty/unset/missing, every file lookup silently falls through to a
+#      relative path and the user sees N copies of "Source image not
+#      found: images/x.jpg", blaming the data when the real cause is
+#      "SRC_PATH was never staged on the PVC";
+#   2. the per-record ``map_file_transfer`` gate in ``_ingest_with_lock``.
+# Keeping these two on one set is deliberate: when they were separate
+# lists, instance_segmentation sat in one but not the other and shipped
+# half-wired — rows reached MySQL and the backend API with zero files
+# staged (the silent-half-ingest pattern from #99).
+# ``tests/test_category_congruence.py`` anchors this set to the schema
+# enum's file-bearing categories.
 # Tabular / time-series have no sidecar dirs under SRC_PATH, so they're
-# excluded from the guard (the CSV path itself is checked elsewhere).
-_SRC_PATH_REQUIRED_CATEGORIES = frozenset({
+# excluded (the CSV path itself is checked elsewhere).
+_FILE_BEARING_CATEGORIES = frozenset({
     TaskCategory.IMAGE_CLASSIFICATION,
     TaskCategory.OBJECT_DETECTION,
     TaskCategory.KEYPOINT_DETECTION,
     TaskCategory.SEMANTIC_SEGMENTATION,
-    TaskCategory.INSTANCE_SEGMENTATION,
     TaskCategory.TEXT_CLASSIFICATION,
     TaskCategory.TOKEN_CLASSIFICATION,
     TaskCategory.MASKED_LANGUAGE_MODELING,
@@ -636,7 +645,7 @@ class BaseIngestor(ABC):
         # "Source image not found: images/x.jpg" — blames the data when
         # the real cause is "SRC_PATH was never staged / set" (#772 P2).
         # File-bearing categories only (tabular has nothing under SRC_PATH).
-        if self.category in _SRC_PATH_REQUIRED_CATEGORIES:
+        if self.category in _FILE_BEARING_CATEGORIES:
             self._check_src_path()
 
         # Pre-flight: a non-UTF-8 CSV otherwise surfaces as a misleading
@@ -785,15 +794,7 @@ class BaseIngestor(ABC):
                         if processed_record:
                             stats["processed_records"] += 1
 
-                            if self.category in [
-                                TaskCategory.IMAGE_CLASSIFICATION,
-                                TaskCategory.OBJECT_DETECTION,
-                                TaskCategory.TEXT_CLASSIFICATION,
-                                TaskCategory.TOKEN_CLASSIFICATION,
-                                TaskCategory.SEMANTIC_SEGMENTATION,
-                                TaskCategory.KEYPOINT_DETECTION,
-                                TaskCategory.MASKED_LANGUAGE_MODELING,
-                            ]:
+                            if self.category in _FILE_BEARING_CATEGORIES:
                                 processed_record = map_file_transfer(
                                     self.category, processed_record, self.file_options
                                 )

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -677,7 +677,21 @@ class BaseIngestor(ABC):
         # mutating file_options / metadata) so label-aware validators like
         # BIOLabelValidator check the right column when a custom name is used.
         validators = map_validators(
-            self.category, {**self.file_options, "label_column": self.label_column}
+            self.category,
+            {
+                **self.file_options,
+                "label_column": self.label_column,
+                # file_options["schema"] has the label/annotation/id columns
+                # stripped (they're framework columns, not table columns), but
+                # CSVIngestor reads the file with NA/dtype rules from the FULL
+                # schema — so the label column DOES get NA-sentinel treatment at
+                # ingest. Pass the full schema so LabelDiversityValidator counts
+                # distinct labels the same way the data is actually ingested,
+                # rather than letting "null"/"NA" inflate the distinct count and
+                # sneak an effectively single-class dataset past the gate
+                # (bugbot #252).
+                "full_schema": self.schema,
+            },
         )
         logger.info(f"Running {len(validators)} validator(s) on data source")
         all_valid = True
@@ -966,10 +980,20 @@ class BaseIngestor(ABC):
                     self.data_format,
                     self.intent,
                 ):
+                    # Surface the BACKEND'S actual reason in the user-visible
+                    # error — not just "see the logged API error above" which
+                    # forces the user to grep the log for the real cause.
+                    # Issue #251: a misleading "Backend failed to prepare the
+                    # dataset" message buried the real reason (e.g. "Please
+                    # provide atleast 2 labels.") in a preceding ERROR line.
+                    detail = (
+                        getattr(self.api_client, "last_prepare_error", None)
+                        or "see the logged API error above"
+                    )
                     raise RuntimeError(
-                        "Backend failed to prepare the dataset; it was NOT "
-                        "registered (its rows are already in the database). See "
-                        "the logged API error above."
+                        f"Backend failed to prepare the dataset; it was NOT "
+                        f"registered (its rows are already in the database). "
+                        f"Backend response: {detail}"
                     )
 
                 self.api_client.create_dataset(

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -247,8 +247,15 @@ class BaseIngestor(ABC):
             if self.category in _TABULAR_FAMILY_CATEGORIES:
                 self.file_options["number_of_columns"] = len(table_schema)
 
-        # Ensure table exists
-        self.table = self.database.create_table(table_name, table_schema)
+        # Defer table creation until after ``validate_data()`` passes so a
+        # validator-rejected ingest leaves no orphaned table behind (#260).
+        # Creating it in ``__init__`` meant a rejected ingest left a stale
+        # empty table that the next retry's stale-table guard tripped on,
+        # forcing the user to manually DROP before re-running. Stash the
+        # cleaned schema; ``_ingest_with_lock`` creates the table once
+        # validation succeeds.
+        self.table = None
+        self._table_schema = table_schema
 
     def _map_unique_id(
         self, record: Dict[str, Any], cleaned_record: Dict[str, Any]
@@ -833,6 +840,15 @@ class BaseIngestor(ABC):
             raise e
         except Exception as e:
             raise e
+
+        # Create the destination table now that validation has accepted the
+        # input (#260). Deferring to here ensures a validator-rejected ingest
+        # leaves no orphaned empty table behind that the next retry's
+        # stale-table guard would trip on.
+        if self.table is None:
+            self.table = self.database.create_table(
+                self.table_name, self._table_schema
+            )
 
         batch = []
         failed_records = []

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -20,12 +20,12 @@ from ..utils.constants import (
     GREEN,
     RED,
     YELLOW,
-    BLUE,
     CYAN,
 )
 from ..utils import label_policy as label_policy_module
 from ..utils.validators_mapping import map_validators
 from ..file_transfer import map_file_transfer
+from ..reporting import ConsoleRenderer
 
 # Logger for this module. Level is set by `setup_logging()` on the root
 # logger when the user script calls it; child loggers inherit that level.
@@ -1139,122 +1139,13 @@ class BaseIngestor(ABC):
             raise
 
     def _log_summary(self, summary: IngestionSummary):
-        """Log ingestion summary in a clear, formatted way with enhanced visual appeal.
+        """Render the ingestion summary box.
 
-        A "success" here means the record was inserted to the DB, sent to
-        the API, AND its sidecar file (image / annotation / mask / text)
-        was copied to the destination. Records whose source file was
-        missing are subtracted from the success count even if the DB
-        row landed — see issue #99 for the silent-data-loss pattern that
-        motivated this.
+        Delegates to :class:`tracebloc_ingestor.reporting.ConsoleRenderer` so the
+        presentation (ANSI colours, emoji, the box layout) lives in one place,
+        out of the ingestion logic (structural refactor — backend#796, P2).
+        Kept as a method (rather than calling the renderer at the call site) so
+        existing callers and tests that reference ``BaseIngestor._log_summary``
+        keep working unchanged; the rendered output is byte-for-byte identical.
         """
-
-        # A successful record requires DB insert AND API send AND, where
-        # applicable, a successful file transfer. File-transfer failures
-        # short-circuit before the DB write (they're skipped from the
-        # batch), so subtracting them from total_records gives the
-        # denominator's effective ceiling. Use inserted_records (the
-        # actual durable outcome) as the numerator.
-        success_rate = 0
-        if summary.total_records > 0:
-            success_rate = (summary.inserted_records / summary.total_records) * 100
-
-        # Determine overall status color
-        status_color = (
-            GREEN if success_rate >= 90 and not summary.has_failures
-            else YELLOW if success_rate >= 70
-            else RED
-        )
-
-        print(f"\n{CYAN}{'═'*60}{RESET}")
-        print(f"{BOLD}{CYAN}📊 INGESTION SUMMARY 📊{RESET}")
-        print(f"{CYAN}{'═'*60}{RESET}")
-        print(
-            f"{BOLD}Ingestor ID:{RESET}                {BLUE}{summary.ingestor_id}{RESET}"
-        )
-        # Main statistics with icons and colors
-        print(
-            f"{BOLD}📈 Total Records Found:{RESET}     {BLUE}{summary.total_records:,}{RESET}"
-        )
-        print(
-            f"{BOLD}✅ Successfully Processed:{RESET}  {GREEN}{summary.processed_records:,}{RESET}"
-        )
-        print(
-            f"{BOLD}💾 Inserted to Database:{RESET}    {GREEN}{summary.inserted_records:,}{RESET}"
-        )
-        print(
-            f"{BOLD}🚀 Sent to API:{RESET}             {GREEN}{summary.api_sent_records:,}{RESET}"
-        )
-        print(
-            f"{BOLD}⏭️  Skipped Records:{RESET}        {YELLOW}{summary.skipped_records:,}{RESET}"
-        )
-        file_transfer_color = (
-            RED if summary.file_transfer_failures > 0 else GREEN
-        )
-        print(
-            f"{BOLD}📁 File Transfer Failures:{RESET}  {file_transfer_color}{summary.file_transfer_failures:,}{RESET}"
-        )
-        print(
-            f"{BOLD}❌ Failed DB Insertion:{RESET}     {RED}{summary.failed_records:,}{RESET}"
-        )
-        # Only count records that made it to a DB insert but didn't ship
-        # to the API. Using `total_records - api_sent_records` would also
-        # include file-transfer failures and DB failures (which never had
-        # a chance to ship), giving an inflated, double-counted total.
-        api_only_failures = max(
-            0, summary.inserted_records - summary.api_sent_records
-        )
-        print(
-            f"{BOLD}❌ Failed to Send to API:{RESET}   {RED}{api_only_failures:,}{RESET}"
-        )
-        print(f"{CYAN}{'─'*60}{RESET}")
-
-        # Success rate with visual indicator
-        if summary.total_records > 0:
-            # Progress bar
-            bar_length = 30
-            filled_length = int(bar_length * success_rate / 100)
-            bar = "█" * filled_length + "░" * (bar_length - filled_length)
-            print(
-                f"{BOLD}📊 Success Rate:{RESET} [{status_color}{bar}{RESET}] {status_color}{success_rate:.1f}%{RESET}"
-            )
-
-        # Status banner. Any non-trivial failure (DB, API, file-transfer, or a
-        # record dropped during processing) disqualifies the "completed
-        # successfully" message — a customer seeing 🎉 should be able to trust
-        # that no record was silently dropped. The four failure channels are
-        # mutually exclusive per record (a dropped record never reaches
-        # file-transfer; file-transfer failures never reach DB; DB failures
-        # never reach API; api_only_failures are records that hit DB but didn't
-        # ship), so summing them gives a clean unique count instead of the
-        # double-count `total_records - api_sent_records` would produce.
-        # ``skipped_records`` MUST be included or the count contradicts the
-        # severity text — a run that drops most rows printed "0 failure(s)"
-        # while success_rate said "most records failed" (#234).
-        total_failures = (
-            summary.failed_records
-            + summary.file_transfer_failures
-            + summary.skipped_records
-            + api_only_failures
-        )
-        if not summary.has_failures:
-            status_msg = "🎉 Ingestion completed successfully!"
-        elif success_rate >= 80:
-            status_msg = (
-                f"⚠️  Ingestion completed with {total_failures:,} failure(s), "
-                "see logs."
-            )
-        elif success_rate >= 60:
-            status_msg = (
-                f"⚠️  Ingestion completed with {total_failures:,} failure(s); "
-                "many records failed to process — see logs."
-            )
-        else:
-            status_msg = (
-                f"❌ Critical! Ingestion completed with {total_failures:,} "
-                "failure(s); most records failed — see logs."
-            )
-
-        print(f"{CYAN}{'─'*60}{RESET}")
-        print(f"{BOLD}{status_color}{status_msg}{RESET}")
-        print(f"{CYAN}{'═'*60}{RESET}\n")
+        ConsoleRenderer().render_summary(summary)

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -468,21 +468,39 @@ class BaseIngestor(ABC):
 
     @staticmethod
     def _check_csv_encoding(source: Any) -> None:
-        """Fail fast with a clear message if a CSV source is not valid UTF-8.
+        """Fail fast with a clear message on a CSV that isn't valid UTF-8 or
+        that contains a NUL byte.
 
         Every validator reads CSVs as UTF-8 and swallows decode errors into a
         misleading "No data found"; a non-UTF-8 export (e.g. a Latin-1/Windows
-        CSV with umlauts) would otherwise crash or mislead. Probe once, up front.
+        CSV with umlauts) would otherwise crash or mislead. A NUL byte (0x00)
+        is sneakier: it IS valid UTF-8 (U+0000) so it slips past the decode
+        check, but pandas' C parser silently TRUNCATES the field at the NUL
+        (``"a\\x00b"`` -> ``"a"``) — silent corruption (#238). Probe once, up
+        front, and reject both.
         """
         if not isinstance(source, (str, Path)):
             return
         path = Path(source)
         if path.suffix.lower() != ".csv" or not path.exists():
             return
+        offset = 0
         try:
             with open(path, "r", encoding="utf-8") as fh:
-                while fh.read(1 << 20):  # decode in 1 MB chunks; raises on a bad byte
-                    pass
+                while True:
+                    chunk = fh.read(1 << 20)  # 1 MB; decode raises on a bad byte
+                    if not chunk:
+                        break
+                    nul = chunk.find("\x00")
+                    if nul != -1:
+                        raise ValueError(
+                            f"{RED}'{path.name}' contains a NUL byte (0x00) at "
+                            f"character {offset + nul}. This is not valid CSV text "
+                            f"— the file is likely binary or a corrupt export, and "
+                            f"pandas would silently truncate the field at the NUL. "
+                            f"Remove the NUL byte(s) and re-ingest.{RESET}"
+                        )
+                    offset += len(chunk)
         except UnicodeDecodeError as exc:
             raise ValueError(
                 f"{RED}'{path.name}' is not valid UTF-8 — a non-UTF-8 byte was found at "

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -313,6 +313,22 @@ class BaseIngestor(ABC):
                     label_val = label_val.item()
                 except (ValueError, AttributeError):
                     pass
+            # Strip surrounding whitespace from string label values before
+            # the policy runs — protects against silent label-set
+            # corruption (issue #261) where ``"  A  "`` and ``"A"`` would
+            # otherwise land as distinct classes in MySQL. A user
+            # copy-pasting from Excel / another tool routinely has
+            # whitespace they can't see; the framework's contract for
+            # the label column is "the class identifier", and class
+            # identifiers don't carry whitespace semantics. The strip
+            # mirrors what the framework already does for the
+            # ``data_id`` column (line below) and for column headers
+            # (``chunk.columns.str.strip()`` in csv_ingestor).
+            #
+            # Non-string labels (INT class IDs, BIOLabelValidator's
+            # space-separated tags, etc.) pass through unchanged.
+            if isinstance(label_val, str):
+                label_val = label_val.strip()
             cleaned_record["label"] = label_policy_module.apply(
                 label_val, self.label_policy
             )

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -119,12 +119,14 @@ class IngestionSummary(NamedTuple):
     def has_failures(self) -> bool:
         """True if any non-trivial failure occurred — DB insert short of
         total, API short of inserted, file-transfer skipped any record,
-        or processing errored. Used to gate the "completed successfully"
+        a record was dropped during processing (skipped_records), or
+        processing errored. Used to gate the "completed successfully"
         banner so customers can't mistake a partial run for a clean one.
         """
         return (
             self.failed_records > 0
             or self.file_transfer_failures > 0
+            or self.skipped_records > 0
             or self.inserted_records < self.total_records
             or self.api_sent_records < self.inserted_records
         )
@@ -719,6 +721,24 @@ class BaseIngestor(ABC):
             logger.debug(f"Unable to count records: {str(e)}")
             return None
 
+    def _check_intent(self) -> None:
+        """Fail fast on a missing/invalid ``intent`` before any lock, DB, or
+        row work (#234).
+
+        ``intent`` is a single run-wide config value, not per-row data. When
+        it was wrong (e.g. a ``"trian"`` typo), ``_map_unique_id`` returned
+        None for EVERY record, so every row was silently skipped and — before
+        #234 — the run still exited 0 with an empty dataset and a Job marked
+        Succeeded. A config error must abort loudly, not masquerade as N
+        per-row skips.
+        """
+        if not self.intent or self.intent not in Intent.get_all_intents():
+            raise ValueError(
+                f"{RED}Invalid intent {self.intent!r}. Must be one of "
+                f"{Intent.get_all_intents()}. This is a configuration error — "
+                f"set 'intent: train' or 'intent: test' in your config.{RESET}"
+            )
+
     def ingest(self, source: Any, batch_size: int = 50) -> List[Dict[str, Any]]:
         """
         Ingest data from the source with progress tracking
@@ -741,6 +761,9 @@ class BaseIngestor(ABC):
         # including ones the inner ``except Exception`` doesn't catch
         # (Session() construction failure, _count_records exceptions,
         # KeyboardInterrupt, etc.).
+        # Fail fast on a config error (bad intent) before acquiring a table
+        # lock or touching the DB — it would otherwise skip every row (#234).
+        self._check_intent()
         _lock_path = self._acquire_table_lock()
         try:
             return self._ingest_with_lock(source, batch_size)
@@ -841,7 +864,24 @@ class BaseIngestor(ABC):
                                     pbar.update(len(batch))
                                     batch = []
                         else:
+                            # process_record returned None: the record was
+                            # dropped (blank/invalid unique_id, or an error
+                            # inside process_record). Count it AND surface it
+                            # as a failed record so the run exits non-zero —
+                            # a dropped record is silent data loss, not a
+                            # clean skip. Before #234 these reached only
+                            # skipped_records, never failed_records, so
+                            # run_ingestion returned [] and the K8s Job was
+                            # marked Succeeded despite losing rows. The
+                            # specific reason was already logged by
+                            # process_record / _map_unique_id.
                             stats["skipped_records"] += 1
+                            failed_records.append(
+                                {
+                                    "record": record,
+                                    "error": "record_dropped_in_processing",
+                                }
+                            )
                             pbar.update(1)  # Update progress bar for skipped records
                     except Exception as e:
                         # Count processing errors (including missing columns) as failed records
@@ -1161,17 +1201,22 @@ class BaseIngestor(ABC):
                 f"{BOLD}📊 Success Rate:{RESET} [{status_color}{bar}{RESET}] {status_color}{success_rate:.1f}%{RESET}"
             )
 
-        # Status banner. Any non-trivial failure (DB, API, or file-transfer)
-        # disqualifies the "completed successfully" message — a customer
-        # seeing 🎉 should be able to trust that no record was silently
-        # dropped. The three failure channels are mutually exclusive per
-        # record (file-transfer failures never reach DB; DB failures never
-        # reach API; api_only_failures are records that hit DB but didn't
-        # ship), so summing them gives a clean unique count instead of
-        # the double-count `total_records - api_sent_records` would produce.
+        # Status banner. Any non-trivial failure (DB, API, file-transfer, or a
+        # record dropped during processing) disqualifies the "completed
+        # successfully" message — a customer seeing 🎉 should be able to trust
+        # that no record was silently dropped. The four failure channels are
+        # mutually exclusive per record (a dropped record never reaches
+        # file-transfer; file-transfer failures never reach DB; DB failures
+        # never reach API; api_only_failures are records that hit DB but didn't
+        # ship), so summing them gives a clean unique count instead of the
+        # double-count `total_records - api_sent_records` would produce.
+        # ``skipped_records`` MUST be included or the count contradicts the
+        # severity text — a run that drops most rows printed "0 failure(s)"
+        # while success_rate said "most records failed" (#234).
         total_failures = (
             summary.failed_records
             + summary.file_transfer_failures
+            + summary.skipped_records
             + api_only_failures
         )
         if not summary.has_failures:

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -14,8 +14,9 @@ from pathlib import Path
 from .base import BaseIngestor
 from ..database import Database
 from ..api.client import APIClient
-from ..utils.constants import RESET, RED, YELLOW, TaskCategory
+from ..utils.constants import RESET, RED, YELLOW
 from ..utils import label_policy as label_policy_module
+from ..utils import coercion
 from ..config import Config
 
 config = Config()
@@ -59,14 +60,6 @@ logger.setLevel(config.LOG_LEVEL)
 __all__ = ["Ingestor"]
 
 
-# Tabular-family categories parse CSVs with a wider null sentinel set so the
-# strings "NA" / "NULL" / "None" become NaN instead of being stored verbatim.
-# This matches what the legacy templates (templates/tabular_*/...) passed
-# explicitly via csv_options; the YAML path can't express it because
-# schema/ingest.v1.json restricts spec.csv_options to a small whitelist.
-_TABULAR_NA_VALUES = ["", "NA", "NULL", "None"]
-
-
 def _cast_datetime_strict(series: pd.Series, column: str, dtype: str) -> pd.Series:
     """Cast a CSV column to datetime with the SAME error policy as numeric
     columns: an un-parseable token raises (instead of silently coercing
@@ -107,12 +100,6 @@ def _cast_datetime_strict(series: pd.Series, column: str, dtype: str) -> pd.Seri
             f"value(s) or declare the column as VARCHAR if the content "
             f"isn't actually a date. (Underlying parser error: {exc})"
         ) from exc
-_TABULAR_FAMILY_CATEGORIES = frozenset({
-    TaskCategory.TABULAR_CLASSIFICATION,
-    TaskCategory.TABULAR_REGRESSION,
-    TaskCategory.TIME_SERIES_FORECASTING,
-    TaskCategory.TIME_TO_EVENT_PREDICTION,
-})
 
 
 class CSVIngestor(BaseIngestor):
@@ -209,6 +196,18 @@ class CSVIngestor(BaseIngestor):
             dtype = self.schema[column]
             try:
                 if "INT" in dtype.upper():
+                    # Reject out-of-int64 values FIRST with a clear message.
+                    # On a value beyond int64 pandas reads the column as object
+                    # (strings) and ``pd.to_numeric(errors="raise")`` below
+                    # throws a cryptic "Integer out of range" (or, on other
+                    # pandas versions, the old overflow guard threw numpy's
+                    # "ufunc 'isinf' not supported") — #236. The shared check
+                    # coerces-then-range-checks so it's object/string-dtype
+                    # safe, and it pre-empts the cryptic raise. Same check runs
+                    # in DataValidator so preflight and ingest agree.
+                    overflow = coercion.int_range_error(df[column], column, dtype)
+                    if overflow:
+                        raise ValueError(overflow)
                     # Nullable Int64, NOT to_numeric(downcast="integer"): under
                     # the old code any missing cell forced the column to float64,
                     # so 7 round-tripped as "7.0" — silent corruption of every
@@ -216,6 +215,8 @@ class CSVIngestor(BaseIngestor):
                     # Int64 keeps integers integral and stores missing as pd.NA
                     # (-> SQL NULL); default errors="raise" still surfaces a
                     # genuinely non-numeric value as a clear per-column error.
+                    # (Safe now: the only values that make to_numeric return an
+                    # object dtype are out-of-int64 ints, already rejected above.)
                     converted = pd.to_numeric(df[column])
                     _raise_on_overflow(column, df[column], converted, dtype)
                     df[column] = converted.astype("Int64")
@@ -223,11 +224,27 @@ class CSVIngestor(BaseIngestor):
                     # float64 — NOT downcast='float' (float32), which corrupted
                     # precision: 3.14 -> '3.140000104904175'. Also covers DOUBLE/
                     # DECIMAL/NUMERIC, which previously matched NO branch and let
-                    # non-numeric junk flow untouched to the DB; errors='raise'
-                    # (the default) now rejects junk with a clear per-column
-                    # error. MySQL still applies the column's own precision/scale
-                    # on write.
-                    converted = pd.to_numeric(df[column])
+                    # non-numeric junk flow untouched to the DB. MySQL still
+                    # applies the column's own precision/scale on write.
+                    #
+                    # Coerce-then-detect (NOT errors="raise"): a value with more
+                    # than ~15 integer digits is a perfectly valid float (1e26)
+                    # but pandas reads it as an object/string column, and
+                    # errors="raise" then threw the same cryptic "Integer out of
+                    # range" #236 hits on INT. Coercing yields the float; we
+                    # surface a genuinely non-numeric token with a clear
+                    # per-column message instead of a raw parser error.
+                    converted = pd.to_numeric(df[column], errors="coerce")
+                    non_numeric = converted.isna() & df[column].notna()
+                    if non_numeric.any():
+                        sample = df[column][non_numeric].head(5).tolist()
+                        raise ValueError(
+                            f"Column '{column}' contains {int(non_numeric.sum())} "
+                            f"non-numeric value(s). Sample: {sample}"
+                        )
+                    # inf guard (e.g. an overflow that coerced to ±inf). Safe to
+                    # call np.isinf here: `converted` is now a float series, never
+                    # the object dtype that made this throw on the raw column.
                     _raise_on_overflow(column, df[column], converted, dtype)
                     df[column] = converted
                 elif "BOOL" in dtype.upper():
@@ -304,15 +321,16 @@ class CSVIngestor(BaseIngestor):
         try:
             chunk_size = self.csv_options.pop("chunk_size", 1000)
 
-            # NA handling. Tabular-family CSVs use pandas' full default NA set
-            # (keep_default_na=True) so every common missing sentinel — ""/NaN/
-            # "N/A"/"null"/"NA"/"NULL"/"None" — parses as NaN. Crucially this
-            # MATCHES how the validators read the file (plain pd.read_csv with
-            # defaults), so a file that passes validation can't then crash the
-            # numeric type-conversion below on an unrecognised NA token. Other
-            # categories keep the conservative empty-only behaviour.
-            is_tabular = self.category in _TABULAR_FAMILY_CATEGORIES
-            na_values = _TABULAR_NA_VALUES if is_tabular else [""]
+            # NA handling — PER COLUMN, identical to the validator gate. Every
+            # schema column treats ""/NA/null/None as missing (-> NULL);
+            # non-schema columns (filename, mask_id, …) are omitted so a file
+            # named "NA.jpg" survives. The same builder feeds DataValidator's
+            # read, so a file can't pass validation and then crash the cast on a
+            # token one layer treats as missing and the other as data — the
+            # whole-category split (tabular vs other) that caused #237. Used
+            # with keep_default_na=False so pandas' global default set never
+            # reaches a non-schema column.
+            na_values = coercion.build_csv_na_values(self.schema)
 
             # Pin string-family schema columns to dtype=str so pandas can't infer
             # them numeric and silently strip meaning. An all-digit code column
@@ -371,7 +389,10 @@ class CSVIngestor(BaseIngestor):
                 # (numeric/bool/date columns are coerced explicitly in
                 # _validate_csv). None when there are no string columns.
                 "dtype": string_dtype or None,
-                "keep_default_na": is_tabular,
+                # keep_default_na=False: NA detection is driven entirely by the
+                # per-column na_values dict above, so pandas' global default set
+                # can't turn a protected column's "NA" into NULL.
+                "keep_default_na": False,
                 "na_values": na_values,
                 "encoding": "utf-8",
                 # Fail loudly on a malformed (ragged) row instead of silently

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -187,8 +187,30 @@ class CSVIngestor(BaseIngestor):
         # Log which schema columns are not in the CSV (for information only)
         missing_columns = set(self.schema.keys()) - set(df.columns)
         if missing_columns:
+            # A delimiter mismatch is the usual cause when EVERY schema column
+            # reads as "missing": a ;/tab/pipe-delimited file (European Excel
+            # export, or a TSV saved as .csv) parses as a single column whose
+            # header still contains the real delimiter. Surface that instead of
+            # the misleading "every column missing" (#238).
+            hint = ""
+            if len(df.columns) == 1:
+                only = str(df.columns[0])
+                for delim, label in (
+                    (";", "';' (semicolon)"),
+                    ("\t", "a tab"),
+                    ("|", "'|' (pipe)"),
+                ):
+                    if delim in only:
+                        hint = (
+                            f" The file parsed as a single column — it appears to "
+                            f"be delimited by {label}, not a comma. Set the "
+                            f"delimiter (csv_options 'delimiter') to match and "
+                            f"re-ingest."
+                        )
+                        break
             raise ValueError(
-                f"{RED}Schema columns not present in CSV: {', '.join(missing_columns)}{RESET}"
+                f"{RED}Schema columns not present in CSV: "
+                f"{', '.join(sorted(missing_columns))}.{hint}{RESET}"
             )
 
         # Type validation using pandas dtypes - only for columns that exist in the CSV

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -490,8 +490,24 @@ class CSVIngestor(BaseIngestor):
                     yield record
 
         except pd.errors.EmptyDataError:
-            logger.warning(f"{YELLOW}Empty CSV file: {file_path}{RESET}")
-            return
+            # An empty (zero-byte) CSV is a hard input error, not a
+            # successful "0 rows" run. Previously this branch logged a
+            # WARNING and silently returned an empty generator — the
+            # ingestor then proceeded to create an empty MySQL table and
+            # called `send_generate_edge_label_meta`, which 400'd with
+            # the misleading "No data found for table X" message that
+            # blamed the BACKEND instead of the input. (Same misleading
+            # cascade #213 traced for self-supervised + label mismatch.)
+            # Raise here so DataValidator's existing "No data found to
+            # validate" error path surfaces the empty-input cause with a
+            # clear, source-truthful message — and no backend round-trip.
+            raise ValueError(
+                f"{RED}Empty CSV file: {file_path}. The file has no "
+                f"header and no rows. Either stage a non-empty CSV at "
+                f"this path, or check the cluster-side path (the chart "
+                f"mounts your PVC at /data/shared/ — confirm staging "
+                f"completed before helm install).{RESET}"
+            )
 
         except (pd.errors.ParserError, Exception):
             raise

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -60,6 +60,7 @@ from ..database import Database
 from ..api.client import APIClient
 from ..utils.constants import RESET, RED, YELLOW
 from ..utils import label_policy as label_policy_module
+from ..utils import coercion
 
 logger = logging.getLogger(__name__)
 
@@ -143,6 +144,21 @@ def _validate_value_against_dtype(value: Any, dtype_upper: str) -> None:
             raise ValueError(
                 f"value {value!r} is non-finite (inf/NaN) and cannot be "
                 f"stored in an INT column"
+            )
+        # Reject values beyond signed 64-bit range with the same verdict the
+        # CSV cast + DataValidator give (#236) — a value no MySQL integer type
+        # can hold. The "declare BIGINT" hint is dropped when the column is
+        # already BIGINT (its ceiling is int64 too).
+        if coercion.int_value_overflows(value):
+            base = dtype_upper.split("(")[0].strip()
+            hint = (
+                ""
+                if base == "BIGINT"
+                else " (declare the column as BIGINT for larger integers)"
+            )
+            raise ValueError(
+                f"value {value!r} is outside the signed 64-bit integer range "
+                f"(max {coercion.INT64_MAX}){hint}"
             )
         if not f.is_integer():
             raise ValueError(

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -387,21 +387,26 @@ class JSONIngestor(BaseIngestor):
         single-object and array-streaming paths in ``read_data``. Factored
         out so the array path can ``yield from`` it inside the ``with
         open(...)`` block — the file handle stays open exactly as long as
-        the generator is being consumed."""
+        the generator is being consumed.
+
+        A type-invalid or malformed record RAISES (fail-fast); it is NOT
+        silently skipped. Skipping reported a partial ingest as success and
+        exited 0 (#234), and it diverged from the CSV cast and the
+        DataValidator gate, which both abort on a bad record. Raising makes
+        JSON behave consistently with CSV (#235): a bad record aborts the
+        run with a clear, non-zero exit instead of vanishing from the
+        dataset with only a log line nobody durably sees."""
         for record in records:
             if not isinstance(record, dict):
-                logger.warning(
-                    f"{YELLOW}Skipping invalid record: {record}{RESET}"
+                raise ValueError(
+                    f"{RED}JSON record is not an object: {record!r}. Every item "
+                    f"in a JSON array must be an object mapping column names to "
+                    f"values.{RESET}"
                 )
-                continue
-            try:
-                self._validate_record(record)
-                yield record  # Let base class handle the cleaning and unique ID mapping
-            except ValueError as e:
-                logger.warning(
-                    f"{YELLOW}Skipping invalid record: {str(e)}{RESET}"
-                )
-                continue
+            # _validate_record raises ValueError on a type-invalid record;
+            # let it propagate (fail-fast) rather than skip-and-continue.
+            self._validate_record(record)
+            yield record  # base handles cleaning + unique-ID mapping
 
     def _count_records(self, file_path: str) -> Optional[int]:
         """Count total records in JSON file without materialising it.

--- a/tracebloc_ingestor/reporting.py
+++ b/tracebloc_ingestor/reporting.py
@@ -1,0 +1,143 @@
+"""Console rendering for ingestion output.
+
+The single home for human-facing presentation of an ingestion run — the ANSI
+colours, the emoji, and the summary box. Business logic builds a pure
+``IngestionSummary`` (data only); this renderer turns it into the terminal
+output a customer sees.
+
+Keeping presentation here, out of ``BaseIngestor``, means the engine can run
+headless, the summary format can change without touching ingestion logic, and
+there is exactly one place that imports the ANSI constants for this path
+(structural refactor — backend#796, phase P2). Behaviour is unchanged: the
+rendered output is byte-for-byte what ``BaseIngestor._log_summary`` produced.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .utils.constants import BLUE, BOLD, CYAN, GREEN, RED, RESET, YELLOW
+
+if TYPE_CHECKING:  # import only for typing — avoids a runtime cycle, since
+    # base.py imports this module at load time.
+    from .ingestors.base import IngestionSummary
+
+
+class ConsoleRenderer:
+    """Renders ingestion results to stdout.
+
+    The only place the summary's ANSI / emoji formatting lives. Stateless for
+    now; a class (rather than a bare function) so later presentation concerns
+    — a no-colour mode, rendering validation errors — have a natural home.
+    """
+
+    def render_summary(self, summary: "IngestionSummary") -> None:
+        """Print the ingestion summary box (success rate, per-channel counts,
+        status banner). Moved verbatim from ``BaseIngestor._log_summary`` — the
+        success-rate / failure-count arithmetic stays with the rendering it
+        feeds, so the customer-facing output is identical."""
+        # A successful record requires DB insert AND API send AND, where
+        # applicable, a successful file transfer. File-transfer failures
+        # short-circuit before the DB write (they're skipped from the
+        # batch), so subtracting them from total_records gives the
+        # denominator's effective ceiling. Use inserted_records (the
+        # actual durable outcome) as the numerator.
+        success_rate = 0
+        if summary.total_records > 0:
+            success_rate = (summary.inserted_records / summary.total_records) * 100
+
+        # Determine overall status color
+        status_color = (
+            GREEN
+            if success_rate >= 90 and not summary.has_failures
+            else YELLOW if success_rate >= 70 else RED
+        )
+
+        print(f"\n{CYAN}{'═'*60}{RESET}")
+        print(f"{BOLD}{CYAN}📊 INGESTION SUMMARY 📊{RESET}")
+        print(f"{CYAN}{'═'*60}{RESET}")
+        print(
+            f"{BOLD}Ingestor ID:{RESET}                {BLUE}{summary.ingestor_id}{RESET}"
+        )
+        # Main statistics with icons and colors
+        print(
+            f"{BOLD}📈 Total Records Found:{RESET}     {BLUE}{summary.total_records:,}{RESET}"
+        )
+        print(
+            f"{BOLD}✅ Successfully Processed:{RESET}  {GREEN}{summary.processed_records:,}{RESET}"
+        )
+        print(
+            f"{BOLD}💾 Inserted to Database:{RESET}    {GREEN}{summary.inserted_records:,}{RESET}"
+        )
+        print(
+            f"{BOLD}🚀 Sent to API:{RESET}             {GREEN}{summary.api_sent_records:,}{RESET}"
+        )
+        print(
+            f"{BOLD}⏭️  Skipped Records:{RESET}        {YELLOW}{summary.skipped_records:,}{RESET}"
+        )
+        file_transfer_color = RED if summary.file_transfer_failures > 0 else GREEN
+        print(
+            f"{BOLD}📁 File Transfer Failures:{RESET}  {file_transfer_color}{summary.file_transfer_failures:,}{RESET}"
+        )
+        print(
+            f"{BOLD}❌ Failed DB Insertion:{RESET}     {RED}{summary.failed_records:,}{RESET}"
+        )
+        # Only count records that made it to a DB insert but didn't ship
+        # to the API. Using `total_records - api_sent_records` would also
+        # include file-transfer failures and DB failures (which never had
+        # a chance to ship), giving an inflated, double-counted total.
+        api_only_failures = max(0, summary.inserted_records - summary.api_sent_records)
+        print(
+            f"{BOLD}❌ Failed to Send to API:{RESET}   {RED}{api_only_failures:,}{RESET}"
+        )
+        print(f"{CYAN}{'─'*60}{RESET}")
+
+        # Success rate with visual indicator
+        if summary.total_records > 0:
+            # Progress bar
+            bar_length = 30
+            filled_length = int(bar_length * success_rate / 100)
+            bar = "█" * filled_length + "░" * (bar_length - filled_length)
+            print(
+                f"{BOLD}📊 Success Rate:{RESET} [{status_color}{bar}{RESET}] {status_color}{success_rate:.1f}%{RESET}"
+            )
+
+        # Status banner. Any non-trivial failure (DB, API, file-transfer, or a
+        # record dropped during processing) disqualifies the "completed
+        # successfully" message — a customer seeing 🎉 should be able to trust
+        # that no record was silently dropped. The four failure channels are
+        # mutually exclusive per record (a dropped record never reaches
+        # file-transfer; file-transfer failures never reach DB; DB failures
+        # never reach API; api_only_failures are records that hit DB but didn't
+        # ship), so summing them gives a clean unique count instead of the
+        # double-count `total_records - api_sent_records` would produce.
+        # ``skipped_records`` MUST be included or the count contradicts the
+        # severity text — a run that drops most rows printed "0 failure(s)"
+        # while success_rate said "most records failed" (#234).
+        total_failures = (
+            summary.failed_records
+            + summary.file_transfer_failures
+            + summary.skipped_records
+            + api_only_failures
+        )
+        if not summary.has_failures:
+            status_msg = "🎉 Ingestion completed successfully!"
+        elif success_rate >= 80:
+            status_msg = (
+                f"⚠️  Ingestion completed with {total_failures:,} failure(s), "
+                "see logs."
+            )
+        elif success_rate >= 60:
+            status_msg = (
+                f"⚠️  Ingestion completed with {total_failures:,} failure(s); "
+                "many records failed to process — see logs."
+            )
+        else:
+            status_msg = (
+                f"❌ Critical! Ingestion completed with {total_failures:,} "
+                "failure(s); most records failed — see logs."
+            )
+
+        print(f"{CYAN}{'─'*60}{RESET}")
+        print(f"{BOLD}{status_color}{status_msg}{RESET}")
+        print(f"{CYAN}{'═'*60}{RESET}\n")

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -30,7 +30,6 @@
         "object_detection",
         "keypoint_detection",
         "semantic_segmentation",
-        "instance_segmentation",
         "text_classification",
         "token_classification",
         "tabular_classification",
@@ -289,8 +288,7 @@
               "image_classification",
               "object_detection",
               "keypoint_detection",
-              "semantic_segmentation",
-              "instance_segmentation"
+              "semantic_segmentation"
             ]
           }
         },
@@ -397,7 +395,6 @@
               "object_detection",
               "keypoint_detection",
               "semantic_segmentation",
-              "instance_segmentation",
               "text_classification",
               "token_classification",
               "tabular_classification"

--- a/tracebloc_ingestor/utils/coercion.py
+++ b/tracebloc_ingestor/utils/coercion.py
@@ -1,0 +1,155 @@
+"""Single source of truth for numeric coercion + the missing-value policy.
+
+Three layers used to each decide *independently* what a declared MySQL type
+permits and what tokens count as missing:
+
+  - the ``DataValidator`` gate (validators/data_validator.py),
+  - the CSV type-cast (``CSVIngestor._validate_csv``),
+  - the JSON per-record check (``JSONIngestor._validate_value_against_dtype``).
+
+Because the rules were duplicated, the layers drifted (#189, #204) and
+disagreed: a file passed the validator gate and then crashed mid-ingest
+(#236 out-of-int64 values, #237 ``NA``/``null`` sentinels in non-tabular
+CSVs). Centralising both decisions here means the gate and the ingest read
+the file the same way and reach the same verdict on the same value — by
+construction, not by a "keep this in lockstep" comment.
+
+Robustness note (#236): pandas reads an out-of-int64 column as ``object``
+dtype holding *strings*, and ``pd.to_numeric(..., errors="raise")`` on that
+raises a cryptic ``Integer out of range``; ``np.isinf`` / ``>`` on the raw
+object series throw outright. Every check here therefore coerces with
+``errors="coerce"`` first and inspects the resulting float — it never
+compares or ``isinf``-checks a raw object series.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+__all__ = [
+    "INT64_MIN",
+    "INT64_MAX",
+    "NA_SENTINELS",
+    "build_csv_na_values",
+    "int_range_error",
+    "int_value_overflows",
+]
+
+# Signed 64-bit integer bounds — the widest MySQL integer (BIGINT) and the
+# pandas ``Int64`` the INT cast targets. Values beyond this are what made
+# the old overflow guard throw a numpy error instead of a clean message.
+INT64_MIN = -9223372036854775808
+INT64_MAX = 9223372036854775807
+
+# Tokens treated as MISSING (-> SQL NULL) in declared *schema* columns.
+# Spelled out explicitly (rather than relying on pandas' ``keep_default_na``
+# set, which has shifted across versions) so the validator and the ingestor
+# apply byte-identical rules. Applied only to schema columns by
+# ``build_csv_na_values`` — never to the framework's own ``filename`` /
+# ``mask_id`` columns — so a file legitimately named ``NA.jpg`` survives.
+NA_SENTINELS: List[str] = [
+    "",
+    "NA",
+    "N/A",
+    "n/a",
+    "NULL",
+    "null",
+    "None",
+    "none",
+    "NaN",
+    "nan",
+    "<NA>",
+    "#N/A",
+]
+
+# Integer base types — used to decide whether the int64-range check applies
+# (a 1e26 value is a valid FLOAT but an out-of-range INT/BIGINT).
+_INT_TYPES = frozenset(
+    {
+        "INT",
+        "INTEGER",
+        "TINYINT",
+        "SMALLINT",
+        "MEDIUMINT",
+        "BIGINT",
+    }
+)
+
+
+def _base_type(mysql_type: str) -> str:
+    """First word, sans parenthesised args — ``DECIMAL(10,2)`` -> ``DECIMAL``,
+    ``INT UNSIGNED`` -> ``INT``."""
+    return str(mysql_type).strip().upper().split("(")[0].split()[0]
+
+
+def build_csv_na_values(schema: Dict[str, str]) -> Dict[str, List[str]]:
+    """Per-column ``na_values`` for ``pd.read_csv``, shared by the validator
+    gate and ``CSVIngestor`` so the two read a file identically (#237).
+
+    Every *schema* column — numeric, date AND string alike — gets the full
+    :data:`NA_SENTINELS` set, so ``""``/``NA``/``null``/``None`` parse as
+    missing (-> SQL NULL) consistently across *every* category. The
+    per-category split (tabular treated these as missing, other categories
+    kept them as literals and then crashed the numeric cast) was the #237
+    bug.
+
+    Use with ``keep_default_na=False`` so pandas' global default NA set never
+    reaches a non-schema column. Columns absent from the schema — the
+    framework's own ``filename`` / ``mask_id`` / unique-id columns — are
+    intentionally omitted: they get no NA coercion at read time, so a file
+    named ``"NA.jpg"`` keeps its name (an empty cell there is normalised to
+    ``None`` later by ``BaseIngestor.process_record``).
+    """
+    return {col: list(NA_SENTINELS) for col in schema}
+
+
+def int_range_error(original: pd.Series, column: str, mysql_type: str) -> Optional[str]:
+    """Return a clear error if an INT/BIGINT column holds values outside the
+    signed 64-bit range, else ``None`` (#236).
+
+    Object/string-dtype safe: coerces with ``errors="coerce"`` (which yields
+    a float — lossy but sufficient to flag magnitude) and range-checks the
+    float, so it never does the ``np.isinf`` / ``>`` on a raw object series
+    that threw the cryptic ``ufunc 'isinf' not supported`` /
+    ``'>' not supported between str and int`` errors.
+
+    No-op for non-integer types (a ``1e26`` value is a valid FLOAT).
+    """
+    if _base_type(mysql_type) not in _INT_TYPES:
+        return None
+    coerced = pd.to_numeric(original, errors="coerce")
+    # Present values that coerced to a finite number outside the int64 range.
+    finite = coerced.notna() & np.isfinite(coerced)
+    mask = finite & ((coerced > INT64_MAX) | (coerced < INT64_MIN))
+    count = int(mask.sum())
+    if count == 0:
+        return None
+    sample = original[mask].head(5).tolist()
+    base = _base_type(mysql_type)
+    hint = (
+        ""
+        if base == "BIGINT"
+        else " Declare the column as BIGINT if you need integers this large."
+    )
+    return (
+        f"Column '{column}' has {count} value(s) outside the signed 64-bit "
+        f"integer range (max {INT64_MAX}): {sample}.{hint}"
+    )
+
+
+def int_value_overflows(value: Any) -> bool:
+    """Scalar form of the int64-range check, for the JSON per-record path.
+
+    ``float(value)`` is enough to flag magnitude: a 26-digit string becomes
+    ``1e26`` which compares above :data:`INT64_MAX`. Non-numeric input is not
+    our concern here (the caller's non-numeric check handles it), so it
+    returns ``False``.
+    """
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return False
+    if not np.isfinite(f):
+        return False
+    return f > INT64_MAX or f < INT64_MIN

--- a/tracebloc_ingestor/utils/constants.py
+++ b/tracebloc_ingestor/utils/constants.py
@@ -45,8 +45,13 @@ class TaskCategory:
     TIME_SERIES_FORECASTING = "time_series_forecasting"
     TIME_TO_EVENT_PREDICTION = "time_to_event_prediction"
     SEMANTIC_SEGMENTATION = "semantic_segmentation"
-    INSTANCE_SEGMENTATION = "instance_segmentation"
     MASKED_LANGUAGE_MODELING = "masked_language_modeling"
+
+    # instance_segmentation is deliberately absent: it briefly shipped here
+    # and in the schema enum with no validators and no file transfer, so
+    # configs half-ingested (DB rows + API records, zero files staged).
+    # Re-adding a category requires wiring every dispatch site — enforced
+    # by tests/test_category_congruence.py.
 
     @classmethod
     def get_all_categories(cls) -> list[str]:
@@ -67,7 +72,6 @@ class TaskCategory:
             cls.TIME_SERIES_FORECASTING,
             cls.TIME_TO_EVENT_PREDICTION,
             cls.SEMANTIC_SEGMENTATION,
-            cls.INSTANCE_SEGMENTATION,
             cls.MASKED_LANGUAGE_MODELING,
         ]
 

--- a/tracebloc_ingestor/utils/template_runner.py
+++ b/tracebloc_ingestor/utils/template_runner.py
@@ -1,0 +1,83 @@
+"""Shared run-and-report wrapper for the template scripts.
+
+Every ``templates/<category>/`` script used to inline the same ~20-line
+block: run ``ingest()``, log each failed record, ``sys.exit(1)`` on
+failures, re-raise hard errors. Eleven hand-maintained copies drifted —
+five templates swallowed exceptions and exited 0 on hard failures until
+#230 — so the contract now lives here once and the templates just call
+:func:`run_ingestion`.
+"""
+
+import logging
+import sys
+from typing import Any, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard, typing only
+    from ..ingestors.base import BaseIngestor
+
+# Underscored to stay distinct from run_ingestion's `logger` parameter.
+_logger = logging.getLogger(__name__)
+
+__all__ = ["run_ingestion"]
+
+
+def run_ingestion(
+    ingestor: "BaseIngestor",
+    source: Any,
+    batch_size: int,
+    logger: Optional[logging.Logger] = None,
+) -> None:
+    """Run ``ingestor.ingest(source)`` and enforce the template exit
+    contract:
+
+    - failed records -> log each one, then ``sys.exit(1)`` so the K8s Job
+      is marked failed instead of reporting silent success
+    - an exception escaping ``ingest()`` (validation error, DB error,
+      backend registration rejection) -> log and re-raise, so the process
+      exits non-zero. Swallowing here is what let five templates end a
+      hard failure with exit code 0 and a Job marked Succeeded (#230).
+    - clean run -> success log, normal return
+
+    Args:
+        ingestor: The constructed ingestor; used as a context manager,
+            mirroring the templates' previous ``with ingestor:`` usage.
+        source: Passed through to ``ingest()`` (the labels CSV / JSON path).
+        batch_size: Passed through to ``ingest()``.
+        logger: The template's logger, so log lines keep the template's
+            logger name. Falls back to this module's logger.
+    """
+    log = logger if logger is not None else _logger
+    try:
+        with ingestor:
+            failed_records = ingestor.ingest(source, batch_size=batch_size)
+            if failed_records:
+                log.warning(f"Failed to process {len(failed_records)} records")
+                for failure in failed_records:
+                    # ingest() returns {"record": <processed record>,
+                    # "error": <reason>} entries. Identify the record by
+                    # filename where the category has one (file-bearing
+                    # categories), else by data_id (tabular family) — the
+                    # old per-template copies got this wrong in three
+                    # different ways (wrapper-level .get("filename") logged
+                    # None; .get("name") always logged Unknown).
+                    record = failure.get("record") or {}
+                    identifier = (
+                        record.get("filename") or record.get("data_id") or "Unknown"
+                    )
+                    log.warning(f"Failed record: {identifier}")
+                    log.warning(
+                        f"Error details: {failure.get('error', 'Unknown error')}"
+                    )
+                # Failed records (file transfer, DB insert, API send, or
+                # processing) must fail the run — exit non-zero so the K8s
+                # Job is marked failed instead of reporting silent success
+                # (SystemExit bypasses the except Exception below).
+                sys.exit(1)
+            log.info("All records processed successfully")
+    except Exception as e:
+        # Re-raise so the process exits non-zero — swallowing here let a
+        # hard failure (validation error, DB error, backend registration
+        # rejection raised by ingest()) end with exit code 0 and a K8s
+        # Job marked Succeeded (#230).
+        log.error(f"Ingestion failed: {str(e)}")
+        raise

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -24,7 +24,36 @@ from tracebloc_ingestor.validators.keypoint_visibility_validator import (
 from tracebloc_ingestor.validators.tokenizer_validator import TokenizerValidator
 from tracebloc_ingestor.validators.file_pairing_validator import FilePairingValidator
 from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
+from tracebloc_ingestor.validators.label_diversity_validator import (
+    LabelDiversityValidator,
+)
 from tracebloc_ingestor.utils.constants import TaskCategory, FileExtension
+
+
+def _label_diversity_validator(options: Dict[str, Any]) -> LabelDiversityValidator:
+    """Construct a LabelDiversityValidator using the user-configured
+    label column name (or the framework default ``label``). Centralised
+    so every classification-family branch wires the same instance shape.
+
+    Issue #251: a classification dataset with one distinct label value
+    is unlearnable and the backend rejects it at ``/global_meta/prepare/``
+    with ``HTTP 400: "Please provide atleast 2 labels."``. Catching it
+    at preflight surfaces the actual cause (and lists the offending
+    label value(s)) instead of cascading to a misleading
+    "Backend failed to prepare the dataset" message after the rows
+    have already landed in MySQL.
+    """
+    return LabelDiversityValidator(
+        label_column=options.get("label_column") or "label",
+        # Read the label column with the SAME NA / dtype rules CSVIngestor
+        # uses, or the distinct-label count disagrees with what's actually
+        # ingested (bugbot #252). Prefer ``full_schema`` (base.py passes the
+        # UNSTRIPPED schema here): ``schema``/``file_options["schema"]`` has
+        # the label column removed, so it can't carry the label's type — the
+        # very column this validator reads. Fall back to ``schema`` for
+        # direct callers / tests that pass an unstripped map.
+        schema=options.get("full_schema") or options.get("schema"),
+    )
 
 
 def map_validators(
@@ -34,6 +63,7 @@ def map_validators(
         return [
             FileTypeValidator(allowed_extension=options["extension"], path="images"),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
+            _label_diversity_validator(options),
             TableNameValidator(),
             DuplicateValidator(),
         ]
@@ -48,6 +78,7 @@ def map_validators(
                 sidecar_label="annotation",
             ),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
+            _label_diversity_validator(options),
             TableNameValidator(),
             DuplicateValidator(),
         ]
@@ -57,6 +88,7 @@ def map_validators(
         # Add data validator if schema is provided
         if options.get("schema"):
             validators.append(DataValidator(schema=options["schema"]))
+        validators.append(_label_diversity_validator(options))
         validators.append(TableNameValidator())
         validators.append(DuplicateValidator())
 
@@ -80,6 +112,7 @@ def map_validators(
         if options.get("schema"):
             validators.append(DataValidator(schema=options["schema"]))
 
+        validators.append(_label_diversity_validator(options))
         validators.append(TableNameValidator())
         validators.append(DuplicateValidator())
 
@@ -189,6 +222,7 @@ def map_validators(
                 sidecar_suffix="_mask",
             ),
             ImageResolutionValidator(expected_resolution=options["target_size"]),
+            _label_diversity_validator(options),
             TableNameValidator(),
             DuplicateValidator(),
         ]
@@ -206,6 +240,7 @@ def map_validators(
                 num_keypoints=options.get("number_of_keypoints")
             ),
             KeypointVisibilityValidator(),
+            _label_diversity_validator(options),
             TableNameValidator(),
             DuplicateValidator(),
         ]

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -18,6 +18,7 @@ import pandas as pd
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
+from ..utils import coercion
 from ..utils.logging import setup_logging
 
 config = Config()
@@ -182,7 +183,18 @@ class DataValidator(BaseValidator):
 
         try:
             reader = pd.read_csv(
-                path, chunksize=chunk_size, encoding="utf-8", on_bad_lines="error"
+                path,
+                chunksize=chunk_size,
+                encoding="utf-8",
+                on_bad_lines="error",
+                # Read NA exactly as CSVIngestor will (per-column: typed
+                # columns treat NA/null/None as missing, string/structural
+                # columns only ""). Without this the gate read with pandas'
+                # global default set and a non-tabular numeric column with an
+                # "NA" token passed validation, then crashed the ingestor's
+                # cast — the validate-pass -> ingest-crash of #237.
+                na_values=coercion.build_csv_na_values(self.schema),
+                keep_default_na=False,
             )
         except pd.errors.EmptyDataError:
             return self._create_result(
@@ -233,7 +245,15 @@ class DataValidator(BaseValidator):
                 suffix = path.suffix.lower()
                 if suffix == ".csv":
                     df = pd.read_csv(
-                        path, nrows=sample_size, encoding="utf-8", on_bad_lines="warn"
+                        path,
+                        nrows=sample_size,
+                        encoding="utf-8",
+                        on_bad_lines="warn",
+                        # Same per-column NA policy as the streaming path and
+                        # CSVIngestor, so a sampled validation agrees with the
+                        # full ingest read (#237).
+                        na_values=coercion.build_csv_na_values(self.schema),
+                        keep_default_na=False,
                     )
                     return df
                 elif suffix == ".json":
@@ -558,6 +578,15 @@ class DataValidator(BaseValidator):
         non_finite = self._non_finite_error(series, numeric_series, column_name)
         if non_finite:
             errors.append(non_finite)
+
+        # Reject values beyond signed 64-bit range with the SAME check the
+        # ingestor runs, so preflight and ingest agree (#236). Without it a
+        # 26-digit value coerced to a finite, integer-valued float here and
+        # passed validation, then crashed the cast with a cryptic numpy /
+        # "Integer out of range" error.
+        overflow = coercion.int_range_error(series, column_name, expected_type)
+        if overflow:
+            errors.append(overflow)
 
         # Check for integer values among the parsed, finite, non-null numbers only
         # (NaN/inf would otherwise be miscounted as "non-integer" via NaN % 1).

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -27,6 +27,34 @@ logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
 
+def _looks_like_jsonl(path: Path, decode_exc: json.JSONDecodeError) -> bool:
+    """Heuristic: is this file newline-delimited JSON (JSONL) rather
+    than malformed JSON?
+
+    Triggers on the specific ``json.load`` error class that JSONL
+    produces ("Extra data" / "Trailing data" — there's a valid JSON
+    value followed by more content) AND requires the file's first
+    non-empty line to itself parse as JSON. The second check rules
+    out genuinely malformed input that happens to share the error
+    string.
+
+    Issue #261 secondary finding (N12).
+    """
+    if "Extra data" not in str(decode_exc) and "Trailing data" not in str(decode_exc):
+        return False
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                json.loads(line)
+                return True
+            return False
+    except (json.JSONDecodeError, OSError):
+        return False
+
+
 class DataValidator(BaseValidator):
     """Validator for ensuring data type compliance with schema.
 
@@ -267,7 +295,28 @@ class DataValidator(BaseValidator):
                     # "No data found to validate" while the ingestor itself
                     # would have happily processed it — surfaced by #232.
                     with open(path, "r", encoding="utf-8") as f:
-                        raw = json.load(f)
+                        try:
+                            raw = json.load(f)
+                        except json.JSONDecodeError as exc:
+                            # JSONL (newline-delimited JSON) is a common
+                            # export format from log / event pipelines
+                            # and trips ``json.load`` with "Extra data" /
+                            # "Trailing data" — opaque to users who
+                            # didn't write json.load themselves. Detect
+                            # the JSONL shape and surface a clear fix
+                            # message. Issue #261 secondary finding (N12).
+                            if _looks_like_jsonl(path, exc):
+                                raise ValueError(
+                                    f"{path} looks like newline-delimited "
+                                    f"JSON (JSONL) — one JSON object per "
+                                    f"line. JSONL isn't supported as an "
+                                    f"input format; the ingestor expects "
+                                    f"a top-level JSON array of records or "
+                                    f"a single object. Combine the records "
+                                    f"into an array (wrap with ``[...]`` "
+                                    f"and join with ``,``) and re-ingest."
+                                ) from exc
+                            raise
                     if isinstance(raw, dict):
                         raw = [raw]
                     # Mirror JSONIngestor._iter_validated_records, which skips
@@ -299,6 +348,14 @@ class DataValidator(BaseValidator):
                 logger.warning(f"Unsupported data type: {type(data)}")
                 return None
 
+        except ValueError:
+            # Surfaceable user-facing error (e.g. the JSONL detection
+            # raises ValueError with a clear fix message). Let it
+            # propagate to validate()'s except-Exception handler, which
+            # threads ``str(e)`` into the user-visible
+            # ``"Data type validation error: ..."`` result — don't
+            # swallow it into a "No data found to validate" generic.
+            raise
         except Exception as e:
             logger.error(f"Error loading data: {str(e)}")
             return None

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -6,6 +6,7 @@ in the schema and provides clear errors when mismatches are found.
 """
 
 import csv as _csv
+import json
 import logging
 import re
 from pathlib import Path
@@ -236,14 +237,32 @@ class DataValidator(BaseValidator):
                     )
                     return df
                 elif suffix == ".json":
-                    # Mirror JSONIngestor.read_data: file is a top-level JSON
-                    # array of records. Without this branch DataValidator
-                    # returned None for every JSON input, the caller raised
-                    # "No data found to validate", and JSON ingestion was
-                    # impossible end-to-end — the recent per-record
-                    # null-tolerance fix (#170) lived behind an unreachable
-                    # gate.
-                    df = pd.read_json(path, orient="records").head(sample_size)
+                    # Mirror JSONIngestor.read_data, which accepts BOTH a
+                    # top-level array of records AND a top-level single dict
+                    # (one record). Its docstring is explicit: "handles both
+                    # single-object and array-of-objects formats", and the
+                    # implementation wraps a dict as `[data]` before iterating.
+                    # Read raw + normalise here so a single-dict JSON file
+                    # doesn't get rejected at the preflight gate with
+                    # "No data found to validate" while the ingestor itself
+                    # would have happily processed it — surfaced by #232.
+                    with open(path, "r", encoding="utf-8") as f:
+                        raw = json.load(f)
+                    if isinstance(raw, dict):
+                        raw = [raw]
+                    # Mirror JSONIngestor._iter_validated_records, which skips
+                    # every non-dict element (`if not isinstance(record, dict)`).
+                    # A top-level scalar array like [1, 2, 3] or ["a", "b"]
+                    # would otherwise become a non-empty 1-column DataFrame via
+                    # pd.DataFrame(raw), so schema validation could pass while
+                    # the ingestor skips all rows and ingests nothing
+                    # (validate-pass → ingest-nothing). Drop non-dict items here
+                    # so the resulting frame matches what actually gets ingested;
+                    # an all-scalar array collapses to empty → "No data found to
+                    # validate" at the gate (bugbot #233).
+                    if isinstance(raw, list):
+                        raw = [item for item in raw if isinstance(item, dict)]
+                    df = pd.DataFrame(raw).head(sample_size)
                     # pd.read_json (unlike pd.read_csv with keep_default_na=True)
                     # preserves "" as the literal empty string. Normalise to NaN
                     # so per-type validators below treat "" identically to JSON

--- a/tracebloc_ingestor/validators/label_diversity_validator.py
+++ b/tracebloc_ingestor/validators/label_diversity_validator.py
@@ -1,0 +1,249 @@
+"""Label Diversity Validator Module.
+
+Classification categories need at least 2 distinct label values to be
+learnable — a single-class dataset is not a classification problem (and
+the backend's ``/global_meta/prepare/`` endpoint correctly rejects it
+with ``HTTP 400: "Please provide atleast 2 labels."``).
+
+Without a preflight check, a degenerate single-label CSV:
+  1. passes per-record validation (every cell is fine in isolation),
+  2. inserts every row into MySQL,
+  3. dies at backend ``prepare_dataset`` with the message above, and
+  4. surfaces to the user as the generic "Backend failed to prepare the
+     dataset; it was NOT registered" — the actual cause is buried in a
+     preceding log line.
+
+This validator catches the degenerate case at the gate, before any DB
+or backend round-trip, and names the actual distinct label(s) found in
+the message so the user immediately knows what's wrong with the input.
+
+Skipped for regression-family categories (tabular_regression,
+time_series_forecasting, time_to_event_prediction) — those have
+continuous targets where uniqueness is meaningless — and for
+self-supervised categories (masked_language_modeling) which have no
+label column at all.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+from .base import BaseValidator, ValidationResult
+from ..config import Config
+from ..utils import coercion
+from ..utils.logging import setup_logging
+
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+
+class LabelDiversityValidator(BaseValidator):
+    """Reject classification datasets with fewer than 2 distinct label values.
+
+    Attributes:
+        label_column: CSV column holding the class label. Resolved
+            case-insensitively against the actual header.
+        min_distinct: Minimum required distinct non-null label values
+            (default 2). The backend's contract is exactly 2; the
+            parameter is exposed only for future stricter use cases.
+        schema: Optional column→SQL-type map. When the label column is a
+            schema column, it's read with the same NA / dtype rules
+            CSVIngestor and DataValidator apply, so the distinct-label
+            count matches what's actually ingested (bugbot #252).
+    """
+
+    def __init__(
+        self,
+        label_column: str = "label",
+        min_distinct: int = 2,
+        schema: Optional[Dict[str, str]] = None,
+        name: str = "Label Diversity Validator",
+    ):
+        super().__init__(name)
+        self.label_column = label_column
+        self.min_distinct = min_distinct
+        self.schema = schema or {}
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            df = self._load_data(data)
+            if df is None or df.empty:
+                # An empty input is the empty-CSV / no-data class —
+                # other validators surface that with their own clear
+                # messages (CSV ingestor raises at read; DataValidator
+                # returns "No data found to validate"). Don't double-
+                # report here.
+                return self._create_result(
+                    is_valid=True,
+                    metadata={"rows_checked": 0, "label_column": self.label_column},
+                )
+
+            col = self._resolve_column(df, self.label_column)
+            if col is None:
+                # The label column isn't in the CSV — caller's
+                # responsibility to surface (DataValidator or the
+                # ingestor will reject). Don't double-report.
+                return self._create_result(
+                    is_valid=True,
+                    warnings=[
+                        f"label column '{self.label_column}' not found in CSV; "
+                        f"skipping label-diversity check"
+                    ],
+                    metadata={"label_column": self.label_column},
+                )
+
+            distinct = df[col].dropna().unique()
+            n = len(distinct)
+            if n < self.min_distinct:
+                # Show the actual values found, capped — a user with a
+                # 50k-row degenerate dataset doesn't need the full list,
+                # but the first few values plus the count tell them
+                # exactly what's wrong with the input.
+                sample = list(distinct[:5])
+                # Surface counts per distinct value to make "all one
+                # class" stand out clearly: "{'X': 10}" vs "{'X': 10000}"
+                # both clearly read as single-class but the latter gives
+                # the user the full row count for free.
+                value_counts = df[col].value_counts(dropna=True).head(5).to_dict()
+                return self._create_result(
+                    is_valid=False,
+                    errors=[
+                        f"Classification category requires at least "
+                        f"{self.min_distinct} distinct label values in column "
+                        f"'{col}'; this dataset has {n} distinct value(s): "
+                        f"{sample}. Value counts: {value_counts}. If this is "
+                        f"intentional (e.g. you have a continuous target), "
+                        f"pick a regression-family category like "
+                        f"tabular_regression or time_series_forecasting "
+                        f"instead."
+                    ],
+                    metadata={
+                        "label_column": col,
+                        "distinct_count": n,
+                        "value_counts": value_counts,
+                    },
+                )
+
+            return self._create_result(
+                is_valid=True,
+                metadata={
+                    "label_column": col,
+                    "distinct_count": n,
+                },
+            )
+
+        except Exception as e:  # noqa: BLE001 — mirror sibling validators
+            logger.error(f"Error during label-diversity validation: {str(e)}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Label-diversity validation error: {str(e)}"],
+            )
+
+    def _load_data(self, data: Any) -> Optional[pd.DataFrame]:
+        """Load just the label column from CSV (memory-efficient) or pass
+        through a DataFrame as-is. Mirrors DataValidator's loader shape but
+        only reads the one column it needs.
+
+        Read errors are deliberately NOT swallowed — they propagate to
+        ``validate``'s handler, which fails the check. A CSV that can't be
+        read must not silently skip the single-label gate this validator
+        exists to enforce (bugbot #252, high severity). Only the genuinely
+        not-applicable cases — missing file, unsupported suffix, label
+        column absent — return ``None``, which ``validate`` treats as a
+        benign skip that sibling validators surface.
+        """
+        if isinstance(data, pd.DataFrame):
+            return data
+        if isinstance(data, (str, Path)):
+            path = Path(data)
+            if not path.exists():
+                return None
+            if path.suffix.lower() == ".csv":
+                # Resolve the label column against pandas' OWN header
+                # parsing (nrows=0 reads only the header row, cheaply),
+                # not a naive ``split(",")``. The old hand-rolled split
+                # diverged from pandas on quoted headers / alternate
+                # delimiters: it could (a) miss a column pandas does
+                # expose, then fall back to a 1-row read and miscount
+                # distinct labels — rejecting a diverse dataset (bugbot
+                # #252, medium) — or (b) build a ``usecols`` spelling
+                # pandas then rejected, erroring the read.
+                header_df = pd.read_csv(path, nrows=0, encoding="utf-8")
+                actual = self._resolve_column(header_df, self.label_column)
+                if actual is None:
+                    # Label column genuinely absent — benign skip; the
+                    # ingestor / DataValidator report the missing column.
+                    return None
+                # Load only the label column — for a 50-feature wide CSV
+                # (or a multi-GB proteomics panel) we don't need the rest
+                # to count distinct labels. Read it with the SAME NA / dtype
+                # rules CSVIngestor + DataValidator use so the distinct count
+                # agrees with what's ingested (bugbot #252).
+                return pd.read_csv(
+                    path,
+                    usecols=[actual],
+                    encoding="utf-8",
+                    **self._label_read_kwargs(actual),
+                )
+            if path.suffix.lower() == ".json":
+                return pd.read_json(path, orient="records")
+        return None
+
+    def _label_read_kwargs(self, actual: str) -> Dict[str, Any]:
+        """``pd.read_csv`` kwargs for the label column that mirror how
+        CSVIngestor / DataValidator read it, so the distinct-label count
+        matches what's actually ingested (bugbot #252).
+
+        - ``keep_default_na=False`` always: pandas' shifting global NA set
+          must not silently turn a literal ``"NA"``/``"null"`` label into a
+          missing value here when the ingestor keeps it as a real class.
+        - ``na_values``: the full :data:`coercion.NA_SENTINELS` set, but only
+          when the label is a *schema* column — the ingestor coerces only
+          schema columns; a non-schema classification label keeps
+          ``"NA"``/``"null"`` as a genuine class.
+        - ``dtype=str``: when the label is a string-family schema column,
+          matching the ingestor's string pin so numeric-looking labels
+          (``"007"``, ``"1.0"``) aren't collapsed by numeric inference and
+          under-counted.
+        """
+        kwargs: Dict[str, Any] = {"keep_default_na": False}
+        schema_type = self._schema_type_for(actual)
+        if schema_type is not None:
+            kwargs["na_values"] = {actual: list(coercion.NA_SENTINELS)}
+            base = str(schema_type).upper().split("(")[0].strip()
+            if base in ("VARCHAR", "CHAR", "TEXT", "STRING"):
+                kwargs["dtype"] = {actual: str}
+        return kwargs
+
+    def _schema_type_for(self, actual: str) -> Optional[str]:
+        """Look up the label column's declared SQL type, or ``None`` when the
+        label isn't a schema column. Matched case- AND whitespace-insensitively
+        so a CSV header like ``" label "`` (which CSVIngestor strips to
+        ``label`` on read) still finds its schema entry (bugbot #252)."""
+        if actual in self.schema:
+            return self.schema[actual]
+        target = str(actual).strip().lower()
+        normalised = {str(k).strip().lower(): v for k, v in self.schema.items()}
+        return normalised.get(target)
+
+    @staticmethod
+    def _resolve_column(df: pd.DataFrame, name: str) -> Optional[str]:
+        """Return the actual column name matching ``name`` case- AND
+        whitespace-insensitively.
+
+        CSVIngestor strips column-name whitespace on read
+        (``chunk.columns.str.strip()``), so a header like ``" label "`` is
+        ingested as ``label``. Resolving against the raw header without the
+        same strip treated the column as missing, skipped the diversity check
+        with a warning, and let a single-class CSV pass preflight (bugbot
+        #252). Match the strip here so the gate sees the same column the
+        ingestor does."""
+        if name in df.columns:
+            return name
+        target = str(name).strip().lower()
+        normalised = {str(c).strip().lower(): c for c in df.columns}
+        return normalised.get(target)

--- a/tracebloc_ingestor/validators/label_diversity_validator.py
+++ b/tracebloc_ingestor/validators/label_diversity_validator.py
@@ -96,40 +96,87 @@ class LabelDiversityValidator(BaseValidator):
                     metadata={"label_column": self.label_column},
                 )
 
-            distinct = df[col].dropna().unique()
+            # Surface whitespace-collapsable duplicates before counting
+            # distinct values (issue #261). A user CSV with values like
+            # ``"  A  "`` mixed with ``"A"`` looks fine in a notebook
+            # (pandas treats them as distinct, and so do we), inserts
+            # into MySQL with both stored verbatim, and trains a model
+            # with one extra class the user never intended — silent
+            # label-set corruption. Spot the pattern here so the warning
+            # reaches the user at preflight, and ingestion strips at the
+            # write side (BaseIngestor.process_record) so MySQL only
+            # sees the trimmed value.
+            warnings: list = []
+            raw_distinct = df[col].dropna().unique()
+            # Build the strip-collapsed set on string-typed values only
+            # (label columns are VARCHAR/CHAR/TEXT in our schema; INT or
+            # FLOAT labels — if anyone ever has them — have no whitespace
+            # to collapse).
+            collapsed: dict = {}
+            for v in raw_distinct:
+                if isinstance(v, str):
+                    stripped = v.strip()
+                    collapsed.setdefault(stripped, []).append(v)
+                else:
+                    collapsed.setdefault(v, []).append(v)
+            whitespace_dupes = {
+                stripped: variants
+                for stripped, variants in collapsed.items()
+                if len(variants) > 1
+            }
+            if whitespace_dupes:
+                # Cap the message length — a wholly-messy dataset shouldn't
+                # produce a 10kB warning.
+                sample = dict(list(whitespace_dupes.items())[:3])
+                warnings.append(
+                    f"label column '{col}' contains values that differ only "
+                    f"in surrounding whitespace and will be stored as "
+                    f"separate classes unless cleaned upstream: {sample}. "
+                    f"Ingestion strips whitespace from the label column at "
+                    f"write time, so MySQL stores the trimmed value — but "
+                    f"if you intended these to be DIFFERENT classes, fix "
+                    f"the CSV before re-running (see issue #261)."
+                )
+
+            # Count distinct AFTER collapsing whitespace duplicates — those
+            # land as ONE class in MySQL after the write-side strip, so the
+            # validator must use the same number when deciding whether the
+            # dataset crosses the min_distinct gate.
+            distinct = list(collapsed.keys())
             n = len(distinct)
             if n < self.min_distinct:
                 # Show the actual values found, capped — a user with a
                 # 50k-row degenerate dataset doesn't need the full list,
                 # but the first few values plus the count tell them
                 # exactly what's wrong with the input.
-                sample = list(distinct[:5])
+                sample = distinct[:5]
                 # Surface counts per distinct value to make "all one
                 # class" stand out clearly: "{'X': 10}" vs "{'X': 10000}"
                 # both clearly read as single-class but the latter gives
                 # the user the full row count for free.
-                value_counts = df[col].value_counts(dropna=True).head(5).to_dict()
+                raw_counts = df[col].value_counts(dropna=True).head(5).to_dict()
                 return self._create_result(
                     is_valid=False,
                     errors=[
                         f"Classification category requires at least "
                         f"{self.min_distinct} distinct label values in column "
-                        f"'{col}'; this dataset has {n} distinct value(s): "
-                        f"{sample}. Value counts: {value_counts}. If this is "
-                        f"intentional (e.g. you have a continuous target), "
-                        f"pick a regression-family category like "
-                        f"tabular_regression or time_series_forecasting "
-                        f"instead."
+                        f"'{col}' (after whitespace stripping); this dataset "
+                        f"has {n} distinct value(s): {sample}. Raw value "
+                        f"counts: {raw_counts}. If this is intentional "
+                        f"(e.g. you have a continuous target), pick a "
+                        f"regression-family category like tabular_regression "
+                        f"or time_series_forecasting instead."
                     ],
                     metadata={
                         "label_column": col,
                         "distinct_count": n,
-                        "value_counts": value_counts,
+                        "value_counts": raw_counts,
                     },
                 )
 
             return self._create_result(
                 is_valid=True,
+                warnings=warnings or None,
                 metadata={
                     "label_column": col,
                     "distinct_count": n,

--- a/tracebloc_ingestor/validators/table_name_validator.py
+++ b/tracebloc_ingestor/validators/table_name_validator.py
@@ -37,9 +37,14 @@ class TableNameValidator(BaseValidator):
             name: Human-readable name of the validator
         """
         super().__init__(name)
-        # Pattern: only alphanumeric characters and underscores
-        # Must start with a letter
-        self.pattern = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
+        # Pattern: only alphanumeric characters and underscores; must start
+        # with a letter or underscore. The compiled regex used to forbid a
+        # leading underscore while the error message AND the advertised
+        # `valid_pattern` metadata both said it was allowed — so a name like
+        # `_tmp` was rejected with a message claiming it was valid (#238).
+        # MySQL identifiers may begin with an underscore, so the regex is
+        # relaxed to agree with the (already-correct) message/metadata.
+        self.pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         """Validate table names from config.


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Wide changes to core ingest paths, authentication-adjacent API error handling, and path-traversal security on shared storage, plus many behavior changes that alter exit codes and validation outcomes for customer jobs.
> 
> **Overview**
> **Release 0.3.10** bundles a large round of ingestion reliability, security, and operator-facing error improvements, plus structural cleanup ahead of a refactor.
> 
> **Packaging & CI:** Runtime deps stay in `requirements.txt` (explicit `numpy`, dev tools moved out); **`requirements-dev.txt`** pulls runtime + pytest/lint/mypy for local/CI. **`setup.py`** filters comments and `-r` lines from `install_requires`. E2e and unit workflows install **`requirements-dev.txt`**.
> 
> **Templates & exit contract:** All template scripts delegate to shared **`run_ingestion`** (exported from the package root), replacing duplicated ingest/exit logic that could swallow errors and exit 0 on hard failures.
> 
> **Ingestion behavior:** Table creation is **deferred until validation passes** (#260). Dropped/skipped records and invalid intent are **fail-fast / counted as failures** (#234). JSON ingest **raises** on bad records instead of silent skips; empty CSV and several CSV edge cases (NUL, wrong delimiter, int overflow, shared NA policy via **`coercion`**) are tightened. **Label values are stripped** before policies (#261). **`LabelDiversityValidator`** catches single-class classification at preflight (#251); **`prepare_dataset`** stashes backend error text on **`last_prepare_error`**. API client registration paths log **full HTTP error bodies** (not 100-char stubs). CLI schema validation surfaces **rule descriptions** from `ingest.v1.json` instead of raw jsonschema mechanics (#254).
> 
> **Security:** **`_safe_join`** blocks path traversal on manifest `filename` / `mask_id` for SRC/DEST file ops (#239).
> 
> **Data & schema:** **`get_table_schema`** maps reflected MySQL dialect types correctly for backend payloads; **`CHAR(N)`** and typo hints on unknown DDL types. **`instance_segmentation`** removed from schema/conventions; **`test_category_congruence`** guards enum ↔ validators ↔ file transfer wiring.
> 
> **Tests:** New **e2e characterization** harness over bundled modalities (MySQL rows, DEST files, API payloads). Broad new/updated unit tests; **`ConsoleRenderer`** extracted for summary output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2c916cb1b817b07ab347373b060b53de84f5001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->