### PR TITLE
Release v0.3.10 (ingestion hardening + path-traversal fix + single-label preflight)

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -21,7 +21,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.9"
+__version__ = "0.3.10"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
## Summary

Release v0.3.10. Bumps `__version__` 0.3.9 → 0.3.10. Bundles the fixes merged to `develop` since v0.3.9.

**Security**
- Block path traversal via manifest `filename`/`mask_id` (#239 → #244)

**Ingestion correctness & accounting**
- Dropped records now fail the run; JSON read-layer fails fast (#230, #234, #235 → #243)
- Single source of truth for NA policy + int64 range handling (#236, #237 → #242)
- Real MySQL column types from `get_table_schema` (#241)
- `CHAR(N)` maps to a SQLAlchemy type (#249)
- Empty CSV fails fast with a clear input error (#250)
- DataValidator: accept single-dict JSON / filter non-dict items (#232, #233)

**Single-label classification preflight (#251 → #252)**
- New `LabelDiversityValidator` catches unlearnable single-class datasets at preflight and surfaces the backend reason — instead of a misleading "Backend failed to prepare the dataset" after rows land in MySQL.
- Hardened through six Cursor Bugbot rounds so the validator reads the label column **identically to CSVIngestor**: fail-closed on read errors, pandas-native header parse, `build_csv_na_values` NA sentinels, string-dtype pin, full (unstripped) schema, and whitespace-insensitive column resolution.

**UX / CLI / packaging**
- Four ingestion validation/UX papercuts: delimiter hint, NUL truncation, table-name message, Config numeric coercion (#238 → #245)
- Schema descriptions surfaced in validation errors instead of raw JSON-schema mechanics (#254)
- `ConsoleRenderer` extraction (#248); runtime vs dev requirements split, numpy declared (#246)
- Remove `instance_segmentation` from the schema enum + category congruence guard (#240)

## Test plan

- [ ] `pytest` green on `release/v0.3.10` (local: 1043 passed, 1 xfailed)
- [ ] CI green
- [ ] `python setup.py sdist bdist_wheel` builds cleanly
- [ ] `pip install dist/tracebloc_ingestor-0.3.10-*.whl` then `python -c "import tracebloc_ingestor; print(tracebloc_ingestor.__version__)"` → `0.3.10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch security-sensitive path joining, core ingest/validate/DB/API paths, and packaging/CI install graphs across many modalities—high blast radius despite strong test coverage.
> 
> **Overview**
> **v0.3.10** bumps the package version and bundles correctness, security, and UX fixes with a large expansion of tests and CI wiring.
> 
> **Security & file handling:** Manifest `filename`/`mask_id` values are joined via `_safe_join` so reads/writes cannot escape `SRC_PATH`/`DEST_PATH` (#239).
> 
> **Ingestion behavior:** Dropped or invalid records and empty CSVs fail the run instead of silent success; JSON read/validate paths align with CSV (fail-fast, single-dict JSON, filter non-objects). Shared **NA coercion** and **int64 overflow** checks keep validator and ingest layers in agreement. **`get_table_schema`** maps reflected MySQL dialect types correctly; **`CHAR(N)`** is supported in DDL. Mid-batch DB failures send only inserted rows to the API; **`skipped_records`** count toward **`has_failures`**.
> 
> **Preflight:** New **`LabelDiversityValidator`** rejects single-class classification datasets locally; **`prepare_dataset`** stashes **`last_prepare_error`** for clearer errors (#251). **`instance_segmentation`** is removed from the schema; **`test_category_congruence`** guards full dispatch wiring.
> 
> **Templates & packaging:** All template scripts delegate to exported **`run_ingestion`**; summary UI moves to **`ConsoleRenderer`**. Runtime deps stay in **`requirements.txt`** (adds explicit **numpy**); test/lint tools move to **`requirements-dev.txt`** with **`setup.py`** filtering comment lines. CI installs **`requirements-dev.txt`**.
> 
> **Tests:** New **e2e characterization** harness over bundled modalities; expanded unit/e2e coverage for the above; CLI schema errors prefer rule **descriptions** over raw JSON Schema mechanics (#254).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aabfa207414e870cbedee8ca098b324c1702dd61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->