### PR TITLE
fix(json): detect JSONL input and surface a clear fix message

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -206,6 +206,46 @@ def test_loads_from_json_mixed_array_keeps_only_objects(tmp_path):
     assert result.metadata["rows_checked"] == 2
 
 
+def test_loads_from_json_jsonl_surfaces_clear_error(tmp_path):
+    """A newline-delimited JSON (JSONL) file — one JSON object per
+    line, no top-level array — must surface a CLEAR error pointing at
+    the JSONL pattern and the fix (combine into an array). The opaque
+    ``json.JSONDecodeError: Extra data`` / ``Trailing data`` message
+    isn't actionable for users who didn't write json.load themselves.
+
+    Surfaced by adversarial new-user testing (N12 — common export
+    format from log / event pipelines).
+    """
+    p = tmp_path / "events.json"
+    p.write_text(
+        '{"id":1,"label":"A"}\n'
+        '{"id":2,"label":"B"}\n'
+        '{"id":3,"label":"A"}\n'
+    )
+    result = DataValidator(schema={"id": "INT", "label": "VARCHAR(8)"}).validate(
+        str(p)
+    )
+    assert not result.is_valid
+    err = result.errors[0]
+    assert "JSONL" in err or "newline-delimited" in err
+    # Should point at the fix.
+    assert "array" in err.lower()
+
+
+def test_loads_from_json_malformed_not_misidentified_as_jsonl(tmp_path):
+    """A genuinely malformed JSON file (not JSONL) must NOT be
+    misidentified — the JSONL detection requires the file's first
+    non-empty line to itself parse as JSON. ``{trailing garbage``
+    doesn't parse → fall through to the original 'Data type
+    validation error' path."""
+    p = tmp_path / "broken.json"
+    p.write_text("{this is not valid json at all")
+    result = DataValidator(schema={"a": "INT"}).validate(str(p))
+    assert not result.is_valid
+    # Must NOT claim it's JSONL.
+    assert "JSONL" not in result.errors[0]
+
+
 def test_unknown_type_fails():
     df = pd.DataFrame({"a": [1]})
     result = DataValidator(schema={"a": "WEIRDTYPE"}).validate(df)

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -27,6 +27,34 @@ logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
 
+def _looks_like_jsonl(path: Path, decode_exc: json.JSONDecodeError) -> bool:
+    """Heuristic: is this file newline-delimited JSON (JSONL) rather
+    than malformed JSON?
+
+    Triggers on the specific ``json.load`` error class that JSONL
+    produces ("Extra data" / "Trailing data" — there's a valid JSON
+    value followed by more content) AND requires the file's first
+    non-empty line to itself parse as JSON. The second check rules
+    out genuinely malformed input that happens to share the error
+    string.
+
+    Issue #261 secondary finding (N12).
+    """
+    if "Extra data" not in str(decode_exc) and "Trailing data" not in str(decode_exc):
+        return False
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                json.loads(line)
+                return True
+            return False
+    except (json.JSONDecodeError, OSError):
+        return False
+
+
 class DataValidator(BaseValidator):
     """Validator for ensuring data type compliance with schema.
 
@@ -267,7 +295,28 @@ class DataValidator(BaseValidator):
                     # "No data found to validate" while the ingestor itself
                     # would have happily processed it — surfaced by #232.
                     with open(path, "r", encoding="utf-8") as f:
-                        raw = json.load(f)
+                        try:
+                            raw = json.load(f)
+                        except json.JSONDecodeError as exc:
+                            # JSONL (newline-delimited JSON) is a common
+                            # export format from log / event pipelines
+                            # and trips ``json.load`` with "Extra data" /
+                            # "Trailing data" — opaque to users who
+                            # didn't write json.load themselves. Detect
+                            # the JSONL shape and surface a clear fix
+                            # message. Issue #261 secondary finding (N12).
+                            if _looks_like_jsonl(path, exc):
+                                raise ValueError(
+                                    f"{path} looks like newline-delimited "
+                                    f"JSON (JSONL) — one JSON object per "
+                                    f"line. JSONL isn't supported as an "
+                                    f"input format; the ingestor expects "
+                                    f"a top-level JSON array of records or "
+                                    f"a single object. Combine the records "
+                                    f"into an array (wrap with ``[...]`` "
+                                    f"and join with ``,``) and re-ingest."
+                                ) from exc
+                            raise
                     if isinstance(raw, dict):
                         raw = [raw]
                     # Mirror JSONIngestor._iter_validated_records, which skips
@@ -299,6 +348,14 @@ class DataValidator(BaseValidator):
                 logger.warning(f"Unsupported data type: {type(data)}")
                 return None
 
+        except ValueError:
+            # Surfaceable user-facing error (e.g. the JSONL detection
+            # raises ValueError with a clear fix message). Let it
+            # propagate to validate()'s except-Exception handler, which
+            # threads ``str(e)`` into the user-visible
+            # ``"Data type validation error: ..."`` result — don't
+            # swallow it into a "No data found to validate" generic.
+            raise
         except Exception as e:
             logger.error(f"Error loading data: {str(e)}")
             return None


### PR DESCRIPTION
Newline-delimited JSON (JSONL) trips json.load with an opaque `Extra data` / `Trailing data` error that surfaced verbatim to users:

```
Label-diversity validation error: Trailing data
```

Detect the JSONL shape (both the trip-string AND a first-line-parses probe) and raise a clear message naming the format and the fix (combine into a top-level JSON array). Conservative — genuinely malformed JSON still falls through to the generic error path.

Surfaced by adversarial new-user testing (N12, parent issue #261).

Tests:
- JSONL input → error mentions JSONL + fix hint
- Malformed JSON → falls through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect JSON load error handling and user-visible validation messages in the data validator; no ingestion, auth, or schema logic changes.
> 
> **Overview**
> **JSONL files** no longer fail preflight with opaque `Extra data` / `Trailing data` messages from `json.load`. `DataValidator` now catches those decode errors, uses `_looks_like_jsonl` (error text plus “first non-empty line parses as JSON”), and raises a **user-facing** message that names JSONL and tells users to combine lines into a top-level JSON array.
> 
> Genuinely broken JSON still follows the generic validation error path. **`ValueError`** from that detection is re-raised in `_load_data` so it surfaces as `Data type validation error: ...` instead of being turned into “No data found to validate.”
> 
> Tests cover JSONL → actionable error and malformed JSON → not labeled JSONL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a015000b3adf20edddff9dcd12c903acd1efd7b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->