### PR TITLE
fix(ingestors): defer table creation until validation passes (#260)

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -86,8 +86,10 @@ def test_init_strips_label_annotation_unique_from_schema():
         label_column="lbl", annotation_column="ann", unique_id_column="uid",
         category=None,
     )
-    # The cleaned table schema passed to create_table excludes the special cols.
-    table_schema = ing.database.create_table.call_args[0][1]
+    # Table creation is deferred until validation passes (#260), so inspect
+    # the cleaned schema stashed for later create_table() instead of asserting
+    # against a call that hasn't happened yet.
+    table_schema = ing._table_schema
     assert "lbl" not in table_schema and "ann" not in table_schema and "uid" not in table_schema
     assert "a" in table_schema
 
@@ -350,6 +352,42 @@ def test_validate_data_validator_exception_raises():
 # ---------------------------------------------------------------------------
 # ingest (full flow, Session patched)
 # ---------------------------------------------------------------------------
+
+def test_init_does_not_create_table_until_validation_passes():
+    # REGRESSION GUARD (#260): create_table used to fire inside __init__, so a
+    # validator-rejected ingest left an empty orphaned table that the next run's
+    # stale-table guard tripped on, forcing the user to manually DROP. Table
+    # creation must be deferred until validation has accepted the input.
+    ing = make_ingestor(category=None)
+    ing.database.create_table.assert_not_called()
+    assert ing.table is None
+
+
+def test_validation_failure_leaves_no_table_created():
+    # REGRESSION GUARD (#260): when validate_data rejects the input, the
+    # ingestor must not have created the destination table — so a corrected
+    # re-run starts from a clean slate without manual DB intervention.
+    ing = make_ingestor(category=None)
+    bad = MagicMock()
+    bad.name = "Bad"
+    bad.validate.return_value = ValidationResult(False, ["nope"], [], {})
+    with patch.object(base_mod, "map_validators", return_value=[bad]):
+        with pytest.raises(ValueError):
+            ing.ingest("src", batch_size=10)
+    ing.database.create_table.assert_not_called()
+    assert ing.table is None
+
+
+def test_ingest_creates_table_after_validation_passes():
+    # The table is created exactly once, after validation accepts the input.
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=None)
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    ing.database.create_table.assert_called_once_with("tbl", {"a": "INT"})
+    assert ing.table is not None
+
 
 def test_ingest_happy_path():
     records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -247,8 +247,15 @@ class BaseIngestor(ABC):
             if self.category in _TABULAR_FAMILY_CATEGORIES:
                 self.file_options["number_of_columns"] = len(table_schema)
 
-        # Ensure table exists
-        self.table = self.database.create_table(table_name, table_schema)
+        # Defer table creation until after ``validate_data()`` passes so a
+        # validator-rejected ingest leaves no orphaned table behind (#260).
+        # Creating it in ``__init__`` meant a rejected ingest left a stale
+        # empty table that the next retry's stale-table guard tripped on,
+        # forcing the user to manually DROP before re-running. Stash the
+        # cleaned schema; ``_ingest_with_lock`` creates the table once
+        # validation succeeds.
+        self.table = None
+        self._table_schema = table_schema
 
     def _map_unique_id(
         self, record: Dict[str, Any], cleaned_record: Dict[str, Any]
@@ -817,6 +824,15 @@ class BaseIngestor(ABC):
             raise e
         except Exception as e:
             raise e
+
+        # Create the destination table now that validation has accepted the
+        # input (#260). Deferring to here ensures a validator-rejected ingest
+        # leaves no orphaned empty table behind that the next retry's
+        # stale-table guard would trip on.
+        if self.table is None:
+            self.table = self.database.create_table(
+                self.table_name, self._table_schema
+            )
 
         batch = []
         failed_records = []


### PR DESCRIPTION
## Summary
Closes #260.

A validator-rejected ingest used to leave an empty orphaned table behind — `create_table` fired inside `__init__` BEFORE `validate_data()` ran. The next retry's stale-table guard then tripped and the user had to manually `DROP TABLE` before re-running.

This moves `create_table` out of `__init__` and into `_ingest_with_lock`, after `validate_data()` accepts the input. The cleaned schema is stashed on the ingestor at construction time and consumed on first ingest. `self.table` starts as `None` and only becomes a real SQLAlchemy `Table` once the table actually exists.

## Why option (a) over option (b)
The issue suggests either (a) defer `create_table`, or (b) drop the table on validation failure. Option (a) is the cleaner invariant — a rejected ingest leaves *no trace* in the DB, no DROP to race or fail. Option (b) leaves a small window where the table exists then disappears, and a crash between `create_table` and the cleanup still orphans the table. `self.table` is only ever assigned (never read elsewhere in the codebase), so deferring is a safe surface-area change.

## Test plan
- [x] New: `test_init_does_not_create_table_until_validation_passes` — construction alone makes no `create_table` call.
- [x] New: `test_validation_failure_leaves_no_table_created` — validator-rejected ingest never reaches `create_table`.
- [x] New: `test_ingest_creates_table_after_validation_passes` — happy path still creates the table exactly once with the cleaned schema.
- [x] Updated: `test_init_strips_label_annotation_unique_from_schema` now inspects the stashed `_table_schema` instead of asserting an `__init__`-time `create_table` call that no longer happens.
- [x] Full suite: 1058 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves table creation in the core ingest path (after validation, before inserts), which affects DB lifecycle on failure/retry; scope is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes **#260** by changing when the destination MySQL table is created during ingest.
> 
> **`BaseIngestor`** no longer calls `database.create_table` in `__init__`. Construction now sets `self.table = None` and stores the cleaned schema on **`_table_schema`**. **`_ingest_with_lock`** creates the table **once**, immediately **after** `validate_data()` succeeds, using `table_name` and `_table_schema`.
> 
> A failed validation therefore leaves **no empty table** in the database, so a retry is not blocked by the stale-table / schema-mismatch guard that previously forced a manual `DROP TABLE`.
> 
> Tests add regression coverage for init-without-create, validation-failure-without-create, and happy-path create-after-validation; the schema-stripping test now asserts against `_table_schema` instead of an `__init__`-time `create_table` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62310bf6413ceee3caa2d6aac9afe2f1acb4359e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->