### PR TITLE
docs(releasing): correct ingestor rollout — floating tag + imagePullPolicy=Always, not INGESTOR_IMAGE_DIGEST rewrite

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -148,17 +148,41 @@ docker run --rm --entrypoint python ${IMAGE}@${DIGEST} \
   -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
 ```
 
-## 7. (Optional) Bump the greenfield baseline in `tracebloc/client`
+## 7. Confirm the rollout (existing installs roll themselves forward)
 
-**Live clusters roll themselves forward — this step is not required for rollout.** Since [`tracebloc/client#159`](https://github.com/tracebloc/client/pull/159) (the [#158](https://github.com/tracebloc/client/issues/158) auto-refresh feature), the chart ships `images.ingestor.autoRefresh: true` with a floating tag (`images.ingestor.tag: "0.3"`). An image-refresh CronJob polls `ghcr.io/tracebloc/ingestor:0.3` and rewrites the live deployment's `INGESTOR_IMAGE_DIGEST` within ~15 min of a new image push — no chart change, no `helm upgrade`. Every existing install converges on its own, as long as the new image matches the chart's floating tag. (Authoritative explanation: the comment block around `images.ingestor` in [`client/values.yaml`](https://github.com/tracebloc/client/blob/develop/client/values.yaml).)
+**Existing installs pick up the new image with no chart change and no `helm upgrade` — this step only *confirms* that from the registry.** jobs-manager spawns each ingestion run as a short-lived Job from the floating tag `images.ingestor.tag` (`"0.3"`) with `imagePullPolicy: Always`, exactly the way training pods are spawned. The kubelet re-resolves the tag's current digest at **every job spawn** (a cheap registry manifest check — already-present layers are reused), so once the step-5 release moves `:0.3` to the new digest, the next ingestion run on any install runs it. Nothing rewrites a Deployment env, and there is no convergence window to wait on. (Authoritative sources: the `images.ingestor` comment block in [`client/values.yaml`](https://github.com/tracebloc/client/blob/develop/client/values.yaml), the `INGESTOR_IMAGE_*` env wiring in `client/templates/jobs-manager-deployment.yaml`, and `submit_ingestion_run._build_image_reference` in client-runtime — the mechanism landed in `client-runtime#40` / `client#125`.)
 
-The pinned `images.ingestor.digest` in the chart only sets the **greenfield baseline** — the digest a brand-new install lands on before its first refresh tick. Bumping it is a deliberate, optional chart release, not a release step. Do it when you want fresh installs to start on the version you just shipped:
+> **Corrects an earlier version of this doc.** Older text here described an image-refresh CronJob that polled `:0.3` and rewrote an `INGESTOR_IMAGE_DIGEST` env on the `*-jobs-manager` Deployment (via `kubectl set env`) within ~15 min. That "class-2" pass was **retired**: a `helm upgrade` that reset the env could revert the ingestor to a stale baseline — a regression a customer hit (a newer ingestor's fix disappeared on upgrade and resurfaced as a "non-numeric" validation error on data the new image handled correctly). The `INGESTOR_IMAGE_DIGEST` env on the jobs-manager Deployment is now **empty/unused by default**; spawning by floating tag is revert-proof and needs no env reconcile. `INGESTOR_IMAGE_DIGEST` survives only as an *opt-in* cluster-wide pin (see step 8).
+
+Because the rollout signal now lives entirely in the registry, you can verify it **without cluster access** — confirm the floating `:0.3` tag resolves to the digest you just released:
+
+```bash
+IMAGE=ghcr.io/tracebloc/ingestor
+
+# The digest the release published (the same sha256 surfaced in step 6).
+RELEASE_DIGEST=$(gh release view v${VERSION} --repo tracebloc/data-ingestors \
+  --json body --jq '.body' | grep -oE 'sha256:[a-f0-9]{64}' | head -1)
+
+# What :0.3 currently points at — the multi-arch index digest.
+TAG_DIGEST=$(docker buildx imagetools inspect ${IMAGE}:0.3 --format '{{ .Manifest.Digest }}')
+# (equivalent one-liner if you have crane:  crane digest ${IMAGE}:0.3 )
+
+[ "$TAG_DIGEST" = "$RELEASE_DIGEST" ] \
+  && echo "OK        :0.3 -> ${RELEASE_DIGEST}; every new ingestion Job runs v${VERSION}" \
+  || echo "MISMATCH  :0.3 is ${TAG_DIGEST}, release is ${RELEASE_DIGEST} (floating tag did not move)"
+```
+
+`release-image.yml` pushes `:X.Y.Z`, `:X.Y`, and `:X` to the same index digest, so a `v0.3.z` release moves `:0.3` (and `:0`) on its own — a match here means the whole fleet lands on the new image at its next ingestion-Job spawn. (Air-gapped installs that mirror `:0.3` into a private registry roll forward when *their* mirror syncs the tag; the check above confirms the upstream ghcr source that the release controls.)
+
+## 8. (Optional) Bump the greenfield baseline in `tracebloc/client`
+
+The pinned `images.ingestor.digest` in the chart only sets the **greenfield baseline** — the digest a brand-new install lands on for its first ingestion run, before it would otherwise resolve the floating `:0.3` tag. It does **not** drive rollout to existing installs (step 7 covers those). Bumping it is a deliberate, optional chart release, not a release step. Do it when you want fresh installs to start on the version you just shipped:
 
 - Bump `images.ingestor.digest` to the new digest **and** `client/Chart.yaml`'s `version` + `appVersion` in lockstep (the chart's own SemVer, independent of the ingestor's).
 - Open the PR against **`develop`**, like any other client change — this is not a `master`-targeting release PR.
 - Precedent: [`client#161`](https://github.com/tracebloc/client/pull/161) (baseline v0.3.0 → v0.3.1) and [`client#185`](https://github.com/tracebloc/client/pull/185) (v0.3.1 → v0.3.2, tracking [#184](https://github.com/tracebloc/client/issues/184)).
 
-(When you do pin, pull by digest, not tag — that's the whole point of signing.)
+(When you do pin, pull by digest, not tag — that's the whole point of signing — and the digest must be the multi-arch index, not a per-arch one, or arm64 nodes `ImagePullBackOff`.)
 
 ## Manual fallback (workflow_dispatch)
 


### PR DESCRIPTION
## What

`RELEASING.md` step 7 documented a **retired** prod-rollout mechanism — an image-refresh CronJob that polled `:0.3` and rewrote `INGESTOR_IMAGE_DIGEST` on the `*-jobs-manager` Deployment "within ~15 min". This corrects it to the floating-tag + `imagePullPolicy=Always` reality.

## Why the old text was wrong

The "class-2" image-refresh pass that kept `INGESTOR_IMAGE_DIGEST` current via `kubectl set env` was **retired**: a `helm upgrade` that reset the env could revert the ingestor to a stale baseline — a regression a customer hit (a newer ingestor's fix vanished on upgrade, surfacing as a "non-numeric" validation error on data the new image handled correctly).

## Current reality

jobs-manager spawns each ingestion run as a short-lived Job from the floating tag `images.ingestor.tag` (`:0.3`) with `imagePullPolicy=Always`, so the kubelet re-resolves the current digest at **every job spawn** — revert-proof, no env reconcile, no convergence wait. `INGESTOR_IMAGE_DIGEST` on the jobs-manager Deployment is **empty/unused by default** (opt-in cluster-wide pin only). The pinned `images.ingestor.digest` still only sets the **greenfield baseline** for brand-new installs.

## Changes

- **Step 7** rewritten → floating-tag rollout + a **registry-only prod-verify recipe**: resolve the ghcr `:0.3` digest (`docker buildx imagetools inspect … --format '{{ .Manifest.Digest }}'`) and match it to the digest in `gh release view vX.Y.Z`. Cluster access is no longer the rollout signal.
- **Step 8** (split out) → the optional greenfield-baseline `images.ingestor.digest` bump: kept, clarified as new-installs-only, and the stale "first refresh tick" phrasing fixed.
- No other repo references to the retired mechanism (only hit was `RELEASING.md:153`).

## Verified against (all on `develop`)

- `tracebloc/client` → `client/values.yaml` (`images.ingestor` comment block) and `client/templates/jobs-manager-deployment.yaml` (`INGESTOR_IMAGE_*` env wiring)
- `tracebloc/client-runtime` → `submit_ingestion_run._build_image_reference`
- Live prod cluster `tracebloc-clients-prod` / ns `tracebloc-templates-prod`, `<release>-image-refresh` ConfigMap (2026-06-15)

## Note

`release-image.yml` already pushes `:X.Y.Z`, `:X.Y`, `:X` to the same multi-arch index digest, so a `v0.3.z` release moves `:0.3` on its own — the verify recipe leans on that.

Closes #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to maintainer release steps; no runtime, auth, or packaging behavior is modified.
> 
> **Overview**
> **`RELEASING.md` step 7** is rewritten so prod rollout matches how ingestor jobs actually run: short-lived Jobs use the floating `images.ingestor.tag` (`:0.3`) with `imagePullPolicy: Always`, so each spawn re-resolves the registry digest—no `helm upgrade`, no Deployment env rewrite, and no ~15 min “convergence” window.
> 
> The doc **retires** the old image-refresh CronJob / `INGESTOR_IMAGE_DIGEST` `kubectl set env` story (including why it was removed: `helm upgrade` could pin a stale digest). Step 7 now adds a **registry-only verify** recipe: compare the release digest from `gh release view` to `docker buildx imagetools inspect` on `:0.3`.
> 
> Former optional greenfield baseline content moves to **step 8**, with clearer wording that `images.ingestor.digest` is for new installs only, plus a note to pin the **multi-arch index** digest when bumping the baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eddb9c21f90251b076eaf569d497248ed2bf9b51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->