### PR TITLE
refactor(P4a): stop reconfiguring root logging at import in 20 modules

### DIFF
--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -34,11 +34,9 @@ from tenacity import (
     before_sleep_log,
 )
 from .config import Config
-from .utils.logging import setup_logging
 
 # Configure unified logging with config
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 
 

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -30,11 +30,9 @@ from tracebloc_ingestor.utils.constants import (
     FileExtension,
     TaskCategory,
 )
-from tracebloc_ingestor.utils.logging import setup_logging
 
 # Initialize config and configure logging
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/base.py
+++ b/tracebloc_ingestor/validators/base.py
@@ -14,10 +14,8 @@ import logging
 from tqdm import tqdm
 
 from tracebloc_ingestor.config import Config
-from tracebloc_ingestor.utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/bio_label_validator.py
+++ b/tracebloc_ingestor/validators/bio_label_validator.py
@@ -24,10 +24,8 @@ import pandas as pd
 from .base import BaseValidator, ValidationResult
 from ..config import Config
 from ..utils.constants import FileExtension
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -19,10 +19,8 @@ import pandas as pd
 from .base import BaseValidator, ValidationResult
 from ..config import Config
 from ..utils import coercion
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/duplicate_validator.py
+++ b/tracebloc_ingestor/validators/duplicate_validator.py
@@ -11,10 +11,8 @@ import logging
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/file_pairing_validator.py
+++ b/tracebloc_ingestor/validators/file_pairing_validator.py
@@ -16,10 +16,8 @@ from typing import Any, Set
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/file_validator.py
+++ b/tracebloc_ingestor/validators/file_validator.py
@@ -11,10 +11,8 @@ import logging
 from .base import BaseValidator, ValidationResult
 from ..utils.constants import FileExtension, RED, RESET
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -9,7 +9,6 @@ from typing import Any, List, Optional, Tuple
 import logging
 
 from tracebloc_ingestor.config import Config
-from tracebloc_ingestor.utils.logging import setup_logging
 
 try:
     from PIL import Image, UnidentifiedImageError
@@ -25,7 +24,6 @@ from .base import BaseValidator, ValidationResult
 
 # Configure unified logging with config
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/keypoint_annotation_validator.py
+++ b/tracebloc_ingestor/validators/keypoint_annotation_validator.py
@@ -12,10 +12,8 @@ import pandas as pd
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/keypoint_visibility_validator.py
+++ b/tracebloc_ingestor/validators/keypoint_visibility_validator.py
@@ -12,10 +12,8 @@ import pandas as pd
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/label_diversity_validator.py
+++ b/tracebloc_ingestor/validators/label_diversity_validator.py
@@ -33,10 +33,8 @@ import pandas as pd
 from .base import BaseValidator, ValidationResult
 from ..config import Config
 from ..utils import coercion
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/numeric_columns_validator.py
+++ b/tracebloc_ingestor/validators/numeric_columns_validator.py
@@ -12,10 +12,8 @@ import pandas as pd
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/table_name_validator.py
+++ b/tracebloc_ingestor/validators/table_name_validator.py
@@ -11,10 +11,8 @@ import logging
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/time_before_today_validator.py
+++ b/tracebloc_ingestor/validators/time_before_today_validator.py
@@ -11,10 +11,8 @@ import pandas as pd
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/time_format_validator.py
+++ b/tracebloc_ingestor/validators/time_format_validator.py
@@ -11,10 +11,8 @@ import pandas as pd
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/time_ordered_validator.py
+++ b/tracebloc_ingestor/validators/time_ordered_validator.py
@@ -11,10 +11,8 @@ import pandas as pd
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/time_to_event_validator.py
+++ b/tracebloc_ingestor/validators/time_to_event_validator.py
@@ -21,10 +21,8 @@ except ImportError:
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/tokenizer_validator.py
+++ b/tracebloc_ingestor/validators/tokenizer_validator.py
@@ -13,10 +13,8 @@ from typing import Any
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 

--- a/tracebloc_ingestor/validators/xml_validator.py
+++ b/tracebloc_ingestor/validators/xml_validator.py
@@ -11,10 +11,8 @@ import logging
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
-from ..utils.logging import setup_logging
 
 config = Config()
-setup_logging(config)
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 


### PR DESCRIPTION
## Summary

**Structural refactor — phase P4 (config injection), first slice.** Twenty modules (every validator + `database` + `file_transfer`) called `setup_logging(config)` at **import time** — reconfiguring the root logger's handlers globally, 20× on every import. That's an import-time side effect a library shouldn't have. The entrypoints (`cli/run.main` and the template scripts) already call `setup_logging()` at startup, so the per-module calls were redundant.

This removes the import-time `setup_logging(config)` call + its now-unused import from all 20 modules. Each module keeps `config = Config()` and `logger.setLevel(config.LOG_LEVEL)` — the **full config-by-construction + env-var-bridge removal are the next P4 slices** (below). Logging is now configured once, at the app entrypoint.

## Behaviour preservation

Root logging is still configured by the entrypoint; child loggers inherit. Diff is exactly the 20 files (just the 2-line removal each).

- Full unit suite: **1078 passed, 1 xfailed**, coverage **96.9%**.
- **e2e (real MySQL): 23 passed, 1 xpassed** — the #247 characterization goldens are unchanged.

## What's next in P4

This was the safe, e2e-independent slice. The config-by-construction core follows:
- **P4b** — inject `Config` into the file validators (via the registry's `build_validators`) instead of the module-level global.
- **P4c** — `file_transfer` takes resolved paths as parameters; delete `cli/run._set_legacy_env_vars` (the `os.environ` bridge). The e2e-sensitive part — now gateable with the local harness (Docker confirmed working).

(Pre-existing flake8 noise in some touched files — unused `List`/`Optional`/`pd` etc. — is unrelated and left out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
