### PR TITLE
refactor(P5a): extract run-level preflight checks into ingestors/preflight

### DIFF
--- a/tests/test_coverage_gaps2.py
+++ b/tests/test_coverage_gaps2.py
@@ -116,7 +116,7 @@ def test_ingest_image_category_batches_in_loop():
     with patch.object(base_mod, "Session") as Sess, patch.object(
         base_mod, "map_file_transfer", side_effect=lambda c, r, o, cfg=None: r
     ), patch.object(base_mod, "map_validators", return_value=[]), patch.object(
-        base_mod.BaseIngestor, "_check_src_path", return_value=None
+        base_mod.preflight, "check_src_path", return_value=None
     ):
         Sess.return_value.__enter__.return_value = MagicMock()
         failed = ing.ingest("src", batch_size=1)

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pytest
 
 from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors import preflight
 from tracebloc_ingestor.ingestors.base import BaseIngestor, IngestionSummary
 from tracebloc_ingestor.validators.base import ValidationResult
 
@@ -629,20 +630,20 @@ def test_check_csv_encoding_rejects_non_utf8(tmp_path):
     bad = tmp_path / "umlaut.csv"
     bad.write_bytes("Größe,label\n1,a\n".encode("latin-1"))
     with pytest.raises(ValueError, match="UTF-8"):
-        BaseIngestor._check_csv_encoding(str(bad))
+        preflight.check_csv_encoding(str(bad))
 
 
 def test_check_csv_encoding_accepts_utf8(tmp_path):
     good = tmp_path / "ok.csv"
     good.write_text("Größe,label\n1,a\n", encoding="utf-8")
-    BaseIngestor._check_csv_encoding(str(good))  # must not raise
+    preflight.check_csv_encoding(str(good))  # must not raise
 
 
 def test_check_csv_encoding_skips_non_csv_sources(tmp_path):
     # Non-CSV / non-path / missing sources are left to the validators.
-    BaseIngestor._check_csv_encoding(str(tmp_path))  # a directory
-    BaseIngestor._check_csv_encoding(None)  # not a path
-    BaseIngestor._check_csv_encoding(str(tmp_path / "missing.csv"))  # nonexistent
+    preflight.check_csv_encoding(str(tmp_path))  # a directory
+    preflight.check_csv_encoding(None)  # not a path
+    preflight.check_csv_encoding(str(tmp_path / "missing.csv"))  # nonexistent
 
 
 def test_check_csv_encoding_rejects_nul_byte(tmp_path):
@@ -652,7 +653,7 @@ def test_check_csv_encoding_rejects_nul_byte(tmp_path):
     bad = tmp_path / "nul.csv"
     bad.write_bytes(b"id,name\n1,a\x00b\n2,ok\n")
     with pytest.raises(ValueError, match="NUL byte"):
-        BaseIngestor._check_csv_encoding(str(bad))
+        preflight.check_csv_encoding(str(bad))
 
 
 # ---------------------------------------------------------------------------
@@ -851,14 +852,14 @@ def test_check_src_path_empty_raises(clean_env):
     # actionable cause. Fail fast with the real reason.
     clean_env.setenv("SRC_PATH", "")
     with pytest.raises(RuntimeError, match="SRC_PATH is empty"):
-        BaseIngestor._check_src_path()
+        preflight.check_src_path()
 
 
 def test_check_src_path_unset_raises(clean_env):
     # SRC_PATH not in env at all -> same outcome.
     clean_env.delenv("SRC_PATH", raising=False)
     with pytest.raises(RuntimeError, match="SRC_PATH is empty"):
-        BaseIngestor._check_src_path()
+        preflight.check_src_path()
 
 
 def test_check_src_path_relative_raises(clean_env):
@@ -866,20 +867,20 @@ def test_check_src_path_relative_raises(clean_env):
     # time; the validator surfaces the misconfiguration before that point.
     clean_env.setenv("SRC_PATH", "data/shared")  # not absolute
     with pytest.raises(RuntimeError, match="not an absolute path"):
-        BaseIngestor._check_src_path()
+        preflight.check_src_path()
 
 
 def test_check_src_path_nonexistent_raises(clean_env, tmp_path):
     missing = tmp_path / "never_staged"
     clean_env.setenv("SRC_PATH", str(missing))
     with pytest.raises(RuntimeError, match="does not exist"):
-        BaseIngestor._check_src_path()
+        preflight.check_src_path()
 
 
 def test_check_src_path_accepts_real_directory(clean_env, tmp_path):
     # A properly-staged absolute directory passes — no raise.
     clean_env.setenv("SRC_PATH", str(tmp_path))
-    BaseIngestor._check_src_path()  # must not raise
+    preflight.check_src_path()  # must not raise
 
 
 def test_check_src_path_only_runs_for_file_bearing_categories():

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -7,7 +7,6 @@ import os
 import pandas as pd
 from tqdm import tqdm
 import uuid
-from pathlib import Path
 
 from ..database import Database
 from ..api.client import APIClient
@@ -26,6 +25,7 @@ from ..utils import label_policy as label_policy_module
 from ..utils.validators_mapping import map_validators
 from ..file_transfer import map_file_transfer
 from ..reporting import ConsoleRenderer
+from . import preflight
 
 # Per-category behavior flags now live in the ModalityRegistry (the single
 # source of truth — backend#796, P3a), derived from one ModalitySpec per
@@ -409,98 +409,6 @@ class BaseIngestor(ABC):
             logger.error(f"Error processing record: {str(e)}")
             return None
 
-    @staticmethod
-    def _check_src_path(config=None) -> None:
-        """Fail fast with a clear message when ``config.SRC_PATH`` isn't set
-        or doesn't exist (#772 P2).
-
-        ``config`` is the run's resolved Config — ``validate_data`` threads
-        ``self.database.config`` so SRC_PATH comes from the resolved
-        ingest.yaml, not ``os.environ`` (P4c). A ``None`` default keeps the
-        env-reading path for direct callers / tests that monkeypatch env.
-
-        Every file-bearing category resolves its per-row sidecars against
-        ``config.SRC_PATH`` (file_transfer.py:105 etc.). If the env var
-        / ConfigMap key is empty, ``os.path.join("", "images", "x.jpg")``
-        returns the relative path ``"images/x.jpg"`` — every file lookup
-        fails and the user sees N copies of
-        ``Source image not found: images/x.jpg`` blaming the data, when
-        the real cause is "SRC_PATH was never set / the PVC wasn't
-        staged before the Job ran". One clear error at preflight beats
-        one cryptic error per row.
-        """
-        # Late import: keep this module free of a Config singleton at
-        # import time so unit tests can monkeypatch the env per test.
-        from ..config import Config
-
-        src = (config if config is not None else Config()).SRC_PATH
-        if not src or not str(src).strip():
-            raise RuntimeError(
-                f"{RED}SRC_PATH is empty. Set it to the cluster-PVC path where "
-                f"your data is staged (e.g. /data/shared/<dataset>/). The "
-                f"chart's data-staging recipe (kubectl cp or init-container "
-                f"sync) must run before the ingest Job — see "
-                f"tracebloc/client/ingestor/README.md.{RESET}"
-            )
-        if not os.path.isabs(src):
-            raise RuntimeError(
-                f"{RED}SRC_PATH={src!r} is not an absolute path. The ingestor "
-                f"resolves every sidecar file against it via os.path.join, "
-                f"and a relative SRC_PATH silently falls through to the "
-                f"working directory — every file lookup then fails with a "
-                f"misleading 'Source image not found'. Use an absolute path "
-                f"(e.g. /data/shared/<dataset>/).{RESET}"
-            )
-        if not os.path.isdir(src):
-            raise RuntimeError(
-                f"{RED}SRC_PATH={src!r} does not exist or is not a directory. "
-                f"Did the data-staging step (kubectl cp / init-container sync) "
-                f"run before the ingest Job? Verify with "
-                f"`kubectl exec <pod> -- ls {src}`.{RESET}"
-            )
-
-    @staticmethod
-    def _check_csv_encoding(source: Any) -> None:
-        """Fail fast with a clear message on a CSV that isn't valid UTF-8 or
-        that contains a NUL byte.
-
-        Every validator reads CSVs as UTF-8 and swallows decode errors into a
-        misleading "No data found"; a non-UTF-8 export (e.g. a Latin-1/Windows
-        CSV with umlauts) would otherwise crash or mislead. A NUL byte (0x00)
-        is sneakier: it IS valid UTF-8 (U+0000) so it slips past the decode
-        check, but pandas' C parser silently TRUNCATES the field at the NUL
-        (``"a\\x00b"`` -> ``"a"``) — silent corruption (#238). Probe once, up
-        front, and reject both.
-        """
-        if not isinstance(source, (str, Path)):
-            return
-        path = Path(source)
-        if path.suffix.lower() != ".csv" or not path.exists():
-            return
-        offset = 0
-        try:
-            with open(path, "r", encoding="utf-8") as fh:
-                while True:
-                    chunk = fh.read(1 << 20)  # 1 MB; decode raises on a bad byte
-                    if not chunk:
-                        break
-                    nul = chunk.find("\x00")
-                    if nul != -1:
-                        raise ValueError(
-                            f"{RED}'{path.name}' contains a NUL byte (0x00) at "
-                            f"character {offset + nul}. This is not valid CSV text "
-                            f"— the file is likely binary or a corrupt export, and "
-                            f"pandas would silently truncate the field at the NUL. "
-                            f"Remove the NUL byte(s) and re-ingest.{RESET}"
-                        )
-                    offset += len(chunk)
-        except UnicodeDecodeError as exc:
-            raise ValueError(
-                f"{RED}'{path.name}' is not valid UTF-8 — a non-UTF-8 byte was found at "
-                f"byte {exc.start}. Re-save the file as UTF-8 (in Excel: Save As → "
-                f"'CSV UTF-8 (Comma delimited)'), then re-ingest.{RESET}"
-            ) from exc
-
     # Stale-lock cutoff (seconds). A crashed ingest leaves the lock file
     # behind; if the lock is older than this we log + remove + reacquire
     # so a customer isn't blocked indefinitely waiting for the writer
@@ -659,12 +567,12 @@ class BaseIngestor(ABC):
         # the real cause is "SRC_PATH was never staged / set" (#772 P2).
         # File-bearing categories only (tabular has nothing under SRC_PATH).
         if self.category in _FILE_BEARING_CATEGORIES:
-            self._check_src_path(self.database.config)
+            preflight.check_src_path(self.database.config)
 
         # Pre-flight: a non-UTF-8 CSV otherwise surfaces as a misleading
         # "No data found" (validators read UTF-8 and swallow decode errors).
         # Catch it once here with a clear, actionable message.
-        self._check_csv_encoding(source)
+        preflight.check_csv_encoding(source)
 
         # Pass the configured label_column through (without permanently
         # mutating file_options / metadata) so label-aware validators like
@@ -750,24 +658,6 @@ class BaseIngestor(ABC):
             logger.debug(f"Unable to count records: {str(e)}")
             return None
 
-    def _check_intent(self) -> None:
-        """Fail fast on a missing/invalid ``intent`` before any lock, DB, or
-        row work (#234).
-
-        ``intent`` is a single run-wide config value, not per-row data. When
-        it was wrong (e.g. a ``"trian"`` typo), ``_map_unique_id`` returned
-        None for EVERY record, so every row was silently skipped and — before
-        #234 — the run still exited 0 with an empty dataset and a Job marked
-        Succeeded. A config error must abort loudly, not masquerade as N
-        per-row skips.
-        """
-        if not self.intent or self.intent not in Intent.get_all_intents():
-            raise ValueError(
-                f"{RED}Invalid intent {self.intent!r}. Must be one of "
-                f"{Intent.get_all_intents()}. This is a configuration error — "
-                f"set 'intent: train' or 'intent: test' in your config.{RESET}"
-            )
-
     def ingest(self, source: Any, batch_size: int = 50) -> List[Dict[str, Any]]:
         """
         Ingest data from the source with progress tracking
@@ -792,7 +682,7 @@ class BaseIngestor(ABC):
         # KeyboardInterrupt, etc.).
         # Fail fast on a config error (bad intent) before acquiring a table
         # lock or touching the DB — it would otherwise skip every row (#234).
-        self._check_intent()
+        preflight.check_intent(self.intent)
         _lock_path = self._acquire_table_lock()
         try:
             return self._ingest_with_lock(source, batch_size)

--- a/tracebloc_ingestor/ingestors/preflight.py
+++ b/tracebloc_ingestor/ingestors/preflight.py
@@ -1,0 +1,121 @@
+"""Run-level preflight checks (structural refactor — backend#796, P5a).
+
+Fail-fast guards that run once per ingest, BEFORE any lock / DB / row work,
+so a misconfiguration aborts loudly with an actionable message instead of
+masquerading as N silent per-row skips or a misleading "No data found".
+
+Extracted verbatim from ``BaseIngestor`` (the god-class decomposition, P5):
+these are stateless validations of a single input each, so they live as
+module functions rather than methods — ``BaseIngestor`` calls them directly.
+The error messages are unchanged (they're pinned by tests).
+"""
+
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+from ..config import Config
+from ..utils.constants import Intent, RED, RESET
+
+
+def check_src_path(config: Optional[Config] = None) -> None:
+    """Fail fast with a clear message when ``config.SRC_PATH`` isn't set
+    or doesn't exist (#772 P2).
+
+    ``config`` is the run's resolved Config — ``validate_data`` threads
+    ``self.database.config`` so SRC_PATH comes from the resolved ingest.yaml,
+    not ``os.environ`` (P4c). A ``None`` default keeps the env-reading path for
+    direct callers / tests that monkeypatch env.
+
+    Every file-bearing category resolves its per-row sidecars against
+    ``config.SRC_PATH`` (file_transfer.py:105 etc.). If the env var / ConfigMap
+    key is empty, ``os.path.join("", "images", "x.jpg")`` returns the relative
+    path ``"images/x.jpg"`` — every file lookup fails and the user sees N
+    copies of ``Source image not found: images/x.jpg`` blaming the data, when
+    the real cause is "SRC_PATH was never set / the PVC wasn't staged".
+    """
+    src = (config if config is not None else Config()).SRC_PATH
+    if not src or not str(src).strip():
+        raise RuntimeError(
+            f"{RED}SRC_PATH is empty. Set it to the cluster-PVC path where "
+            f"your data is staged (e.g. /data/shared/<dataset>/). The "
+            f"chart's data-staging recipe (kubectl cp or init-container "
+            f"sync) must run before the ingest Job — see "
+            f"tracebloc/client/ingestor/README.md.{RESET}"
+        )
+    if not os.path.isabs(src):
+        raise RuntimeError(
+            f"{RED}SRC_PATH={src!r} is not an absolute path. The ingestor "
+            f"resolves every sidecar file against it via os.path.join, "
+            f"and a relative SRC_PATH silently falls through to the "
+            f"working directory — every file lookup then fails with a "
+            f"misleading 'Source image not found'. Use an absolute path "
+            f"(e.g. /data/shared/<dataset>/).{RESET}"
+        )
+    if not os.path.isdir(src):
+        raise RuntimeError(
+            f"{RED}SRC_PATH={src!r} does not exist or is not a directory. "
+            f"Did the data-staging step (kubectl cp / init-container sync) "
+            f"run before the ingest Job? Verify with "
+            f"`kubectl exec <pod> -- ls {src}`.{RESET}"
+        )
+
+
+def check_csv_encoding(source: Any) -> None:
+    """Fail fast with a clear message on a CSV that isn't valid UTF-8 or
+    that contains a NUL byte.
+
+    Every validator reads CSVs as UTF-8 and swallows decode errors into a
+    misleading "No data found"; a non-UTF-8 export (e.g. a Latin-1/Windows
+    CSV with umlauts) would otherwise crash or mislead. A NUL byte (0x00)
+    is sneakier: it IS valid UTF-8 (U+0000) so it slips past the decode
+    check, but pandas' C parser silently TRUNCATES the field at the NUL
+    (``"a\\x00b"`` -> ``"a"``) — silent corruption (#238). Probe once, up
+    front, and reject both.
+    """
+    if not isinstance(source, (str, Path)):
+        return
+    path = Path(source)
+    if path.suffix.lower() != ".csv" or not path.exists():
+        return
+    offset = 0
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            while True:
+                chunk = fh.read(1 << 20)  # 1 MB; decode raises on a bad byte
+                if not chunk:
+                    break
+                nul = chunk.find("\x00")
+                if nul != -1:
+                    raise ValueError(
+                        f"{RED}'{path.name}' contains a NUL byte (0x00) at "
+                        f"character {offset + nul}. This is not valid CSV text "
+                        f"— the file is likely binary or a corrupt export, and "
+                        f"pandas would silently truncate the field at the NUL. "
+                        f"Remove the NUL byte(s) and re-ingest.{RESET}"
+                    )
+                offset += len(chunk)
+    except UnicodeDecodeError as exc:
+        raise ValueError(
+            f"{RED}'{path.name}' is not valid UTF-8 — a non-UTF-8 byte was found at "
+            f"byte {exc.start}. Re-save the file as UTF-8 (in Excel: Save As → "
+            f"'CSV UTF-8 (Comma delimited)'), then re-ingest.{RESET}"
+        ) from exc
+
+
+def check_intent(intent: Any) -> None:
+    """Fail fast on a missing/invalid ``intent`` before any lock, DB, or
+    row work (#234).
+
+    ``intent`` is a single run-wide config value, not per-row data. When it
+    was wrong (e.g. a ``"trian"`` typo), ``_map_unique_id`` returned None for
+    EVERY record, so every row was silently skipped and — before #234 — the
+    run still exited 0 with an empty dataset and a Job marked Succeeded. A
+    config error must abort loudly, not masquerade as N per-row skips.
+    """
+    if not intent or intent not in Intent.get_all_intents():
+        raise ValueError(
+            f"{RED}Invalid intent {intent!r}. Must be one of "
+            f"{Intent.get_all_intents()}. This is a configuration error — "
+            f"set 'intent: train' or 'intent: test' in your config.{RESET}"
+        )


### PR DESCRIPTION
## Summary

**Structural refactor — phase P5 (decompose the `BaseIngestor` god-class), slice 1.** Stacked on #273 (P4c).

`BaseIngestor` is ~1180 lines doing everything (preflight, locking, record processing, batch/DB/API writes, orchestration). P5 breaks it into focused collaborators, one safe slice at a time under the e2e gate. This first slice extracts the cheapest, most self-contained cluster: the **run-level preflight checks**.

Three fail-fast guards run once per ingest, *before* any lock/DB/row work:

| check | guards against |
|---|---|
| `check_src_path` | unset / relative / missing `SRC_PATH` (#772 P2) |
| `check_csv_encoding` | non-UTF-8 + NUL-byte CSVs (#238) |
| `check_intent` | missing/invalid `intent` that silently skips every row (#234) |

They were methods on `BaseIngestor` but are **stateless validations of a single input each** — so they move to a focused `ingestors/preflight.py` module of functions (not a stateful class). `BaseIngestor` calls them directly (`preflight.check_src_path(...)` etc.); **no delegate stubs left behind**. base.py drops **1180 → 1070 lines**.

## Behaviour preservation

Moved verbatim — the error-message strings (asserted by tests) are unchanged.

- Full unit suite: **1080 passed**, coverage **96.8%**.
- **e2e (real MySQL): 23 passed, 1 xpassed** — #247 characterization goldens unchanged.

Tests that exercised the checks now call the `preflight` functions (the bypass patch in `test_coverage_gaps2` retargets `base_mod.preflight`). Removed the now-unused `pathlib.Path` import from base.py.

## What's next in P5

This was the safe pattern-establishing slice. Remaining collaborators, each its own e2e-gated slice:
- **TableLock** — `_table_lock_path` / `_acquire` / `_release` lock lifecycle.
- **RecordProcessor** — `process_record` / `_map_unique_id`.
- **Batch/DB/API write path** — `_flush_batch` / `_process_batch`.

The deferred bug fixes (the `mask_id` cross-layer leak, per-row tolerance #235, atomicity #227/#260) ride the slice that owns the relevant code, rather than landing standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
