### PR TITLE
refactor(P5b): extract the cross-ingest table lock into TableLock

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -670,13 +670,13 @@ def test_acquire_table_lock_creates_lock_file(tmp_path):
 
     with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
         ing = make_ingestor(table_name="dataset_a", category=None)
-        lock_path = ing._acquire_table_lock()
+        lock_path = ing._table_lock.acquire()
         assert lock_path is not None
         assert lock_path.endswith(".tracebloc-ingest-dataset_a.lock")
         meta = json.loads(open(lock_path).read())
         assert meta["table_name"] == "dataset_a"
         assert meta["ingestor_id"] == ing.ingestor_id
-        ing._release_table_lock(lock_path)
+        ing._table_lock.release(lock_path)
         assert not __import__("os").path.exists(lock_path)
 
 
@@ -688,13 +688,13 @@ def test_acquire_table_lock_rejects_concurrent_ingest(tmp_path):
 
     with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
         ing_a = make_ingestor(table_name="dataset_a", category=None)
-        path_a = ing_a._acquire_table_lock()
+        path_a = ing_a._table_lock.acquire()
         try:
             ing_b = make_ingestor(table_name="dataset_a", category=None)
             with pytest.raises(RuntimeError, match="already running"):
-                ing_b._acquire_table_lock()
+                ing_b._table_lock.acquire()
         finally:
-            ing_a._release_table_lock(path_a)
+            ing_a._table_lock.release(path_a)
 
 
 def test_acquire_table_lock_different_tables_dont_conflict(tmp_path):
@@ -705,11 +705,11 @@ def test_acquire_table_lock_different_tables_dont_conflict(tmp_path):
     with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
         ing_a = make_ingestor(table_name="dataset_a", category=None)
         ing_b = make_ingestor(table_name="dataset_b", category=None)
-        path_a = ing_a._acquire_table_lock()
-        path_b = ing_b._acquire_table_lock()
+        path_a = ing_a._table_lock.acquire()
+        path_b = ing_b._table_lock.acquire()
         assert path_a != path_b
-        ing_a._release_table_lock(path_a)
-        ing_b._release_table_lock(path_b)
+        ing_a._table_lock.release(path_a)
+        ing_b._table_lock.release(path_b)
 
 
 def test_acquire_table_lock_reclaims_stale_lock(tmp_path):
@@ -722,16 +722,16 @@ def test_acquire_table_lock_reclaims_stale_lock(tmp_path):
 
     with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
         ing = make_ingestor(table_name="dataset_stale", category=None)
-        lock_path = ing._table_lock_path()
+        lock_path = ing._table_lock.path()
         old = (datetime.utcnow() - timedelta(days=2)).isoformat() + "Z"
         with open(lock_path, "w") as f:
             json.dump({"ingestor_id": "crashed-ingest", "started_at": old}, f)
         # Stale lock detected -> removed -> reacquired with the new holder.
-        path = ing._acquire_table_lock()
+        path = ing._table_lock.acquire()
         assert path == lock_path
         meta = json.loads(open(lock_path).read())
         assert meta["ingestor_id"] == ing.ingestor_id
-        ing._release_table_lock(lock_path)
+        ing._table_lock.release(lock_path)
 
 
 def test_acquire_table_lock_noop_when_storage_path_missing(tmp_path):
@@ -742,8 +742,8 @@ def test_acquire_table_lock_noop_when_storage_path_missing(tmp_path):
     missing = str(tmp_path / "never_exists")
     with patch.object(CfgCls, "STORAGE_PATH", missing):
         ing = make_ingestor(table_name="dataset_a", category=None)
-        assert ing._acquire_table_lock() is None
-        ing._release_table_lock(None)  # must not raise
+        assert ing._table_lock.acquire() is None
+        ing._table_lock.release(None)  # must not raise
 
 
 def test_release_table_lock_idempotent(tmp_path):
@@ -753,9 +753,9 @@ def test_release_table_lock_idempotent(tmp_path):
 
     with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
         ing = make_ingestor(table_name="dataset_a", category=None)
-        path = ing._acquire_table_lock()
-        ing._release_table_lock(path)
-        ing._release_table_lock(path)  # idempotent, no raise
+        path = ing._table_lock.acquire()
+        ing._table_lock.release(path)
+        ing._table_lock.release(path)  # idempotent, no raise
 
 
 # ---------------------------------------------------------------------------
@@ -776,7 +776,7 @@ def test_lock_released_when_validate_data_raises(tmp_path):
         with patch.object(ing, "validate_data", side_effect=RuntimeError("boom")):
             with pytest.raises(RuntimeError):
                 ing.ingest("src")
-        lock_path = ing._table_lock_path()
+        lock_path = ing._table_lock.path()
         assert lock_path is not None
         import os as _os
 
@@ -801,7 +801,7 @@ def test_lock_released_when_count_records_raises(tmp_path):
                 ing.ingest("src")
         import os as _os
 
-        assert not _os.path.exists(ing._table_lock_path()), "lock leaked"
+        assert not _os.path.exists(ing._table_lock.path()), "lock leaked"
 
 
 def test_acquire_table_lock_recovers_from_corrupt_lock_via_mtime(tmp_path):
@@ -815,16 +815,16 @@ def test_acquire_table_lock_recovers_from_corrupt_lock_via_mtime(tmp_path):
 
     with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
         ing = make_ingestor(table_name="dataset_corrupt", category=None)
-        lock_path = ing._table_lock_path()
+        lock_path = ing._table_lock.path()
         with open(lock_path, "w"):
             pass  # empty file -> JSON parse fails
         old = _os.path.getmtime(lock_path) - (13 * 3600)  # 13h ago
         _os.utime(lock_path, (old, old))
-        path = ing._acquire_table_lock()
+        path = ing._table_lock.acquire()
         assert path == lock_path
         meta = json.loads(open(lock_path).read())
         assert meta["ingestor_id"] == ing.ingestor_id
-        ing._release_table_lock(lock_path)
+        ing._table_lock.release(lock_path)
 
 
 def test_acquire_table_lock_corrupt_but_fresh_blocks(tmp_path):
@@ -835,11 +835,11 @@ def test_acquire_table_lock_corrupt_but_fresh_blocks(tmp_path):
 
     with patch.object(CfgCls, "STORAGE_PATH", str(tmp_path)):
         ing = make_ingestor(table_name="dataset_corrupt", category=None)
-        lock_path = ing._table_lock_path()
+        lock_path = ing._table_lock.path()
         with open(lock_path, "w"):
             pass  # empty, JSON parse fails, mtime is now (fresh)
         with pytest.raises(RuntimeError, match="already running"):
-            ing._acquire_table_lock()
+            ing._table_lock.acquire()
 
 
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -3,14 +3,12 @@ from typing import Dict, Any, Generator, List, Optional, NamedTuple
 from sqlalchemy.orm import Session
 from sqlalchemy.engine import Engine
 import logging
-import os
 import pandas as pd
 from tqdm import tqdm
 import uuid
 
 from ..database import Database
 from ..api.client import APIClient
-from ..config import Config
 from ..utils.constants import (
     Intent,
     TaskCategory,
@@ -26,6 +24,7 @@ from ..utils.validators_mapping import map_validators
 from ..file_transfer import map_file_transfer
 from ..reporting import ConsoleRenderer
 from . import preflight
+from .table_lock import TableLock
 
 # Per-category behavior flags now live in the ModalityRegistry (the single
 # source of truth — backend#796, P3a), derived from one ModalitySpec per
@@ -409,145 +408,14 @@ class BaseIngestor(ABC):
             logger.error(f"Error processing record: {str(e)}")
             return None
 
-    # Stale-lock cutoff (seconds). A crashed ingest leaves the lock file
-    # behind; if the lock is older than this we log + remove + reacquire
-    # so a customer isn't blocked indefinitely waiting for the writer
-    # whose pod has long since been garbage-collected. 12h covers any
-    # reasonable ingest (including multi-GB proteomics).
-    _TABLE_LOCK_STALE_SECONDS = 12 * 3600
-
-    def _table_lock_path(self) -> Optional[str]:
-        """Where the lock file lives — at the top of STORAGE_PATH (the
-        parent of every per-table DEST_PATH), so it's durable across pod
-        restarts on the cluster PVC. Returns None when STORAGE_PATH is
-        unset or not a directory (test configs / local runs without a
-        staging dir) — caller treats that as "no lock available, skip".
-        """
-        # Late import: keep this module free of a Config singleton at
-        # import time so unit tests can monkeypatch the env per test.
-        from ..config import Config
-
-        storage = Config().STORAGE_PATH
-        if not storage or not os.path.isdir(storage):
-            return None
-        return os.path.join(storage, f".tracebloc-ingest-{self.table_name}.lock")
-
-    def _acquire_table_lock(self) -> Optional[str]:
-        """Acquire an exclusive lock for ``self.table_name`` (#772 P2).
-
-        Two ingests targeting the same table used to race
-        ``create_table`` / interleave upserts. Atomic ``O_EXCL`` create
-        either succeeds (lock acquired) or fails with ``FileExistsError``
-        (another ingest is in flight). On conflict, read the existing
-        lock's metadata and surface it in the error so ops can find the
-        other run; if the lock is older than the stale-cutoff, remove
-        and reacquire.
-
-        Returns the lock path (or None if no STORAGE_PATH is configured)
-        so ``_release_table_lock`` can remove the right file.
-        """
-        import json as _json
-        import socket as _socket
-        from datetime import datetime as _datetime
-
-        lock_path = self._table_lock_path()
-        if lock_path is None:
-            return None
-
-        lock_info = {
-            "ingestor_id": self.ingestor_id,
-            "table_name": self.table_name,
-            "pid": os.getpid(),
-            "hostname": _socket.gethostname(),
-            "started_at": _datetime.utcnow().isoformat() + "Z",
-        }
-        try:
-            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
-        except FileExistsError:
-            # Read the existing lock so the error names the holder. Also
-            # check staleness and self-recover if so.
-            existing_info: Dict[str, Any] = {}
-            try:
-                with open(lock_path, "r") as f:
-                    existing_info = _json.load(f)
-            except Exception:
-                pass
-            age = None
-            try:
-                started = _datetime.fromisoformat(
-                    existing_info.get("started_at", "").rstrip("Z")
-                )
-                age = (_datetime.utcnow() - started).total_seconds()
-            except Exception:
-                # Lock metadata is corrupt (truncated file, malformed
-                # JSON, missing/un-parseable started_at). Fall back to
-                # the file's mtime as the age signal (#221 bugbot: a
-                # corrupt lock used to never auto-expire because age
-                # stayed None). Use time.time() rather than
-                # _datetime.utcnow().timestamp() — the latter is
-                # timezone-broken (naive datetime treated as local) so
-                # the cutoff would shift by the local UTC offset on
-                # non-UTC systems.
-                import time as _time
-
-                try:
-                    mtime = os.path.getmtime(lock_path)
-                    age = _time.time() - mtime
-                except OSError:
-                    pass
-            if age is not None and age > self._TABLE_LOCK_STALE_SECONDS:
-                logger.warning(
-                    f"{YELLOW}Stale lock at {lock_path} (age={age:.0f}s, "
-                    f"holder={existing_info!r}) — removing and reacquiring. "
-                    f"The holder's pod likely crashed before its finally "
-                    f"could run.{RESET}"
-                )
-                try:
-                    os.remove(lock_path)
-                except FileNotFoundError:
-                    pass
-                return self._acquire_table_lock()
-            raise RuntimeError(
-                f"{RED}Another ingest is already running for table "
-                f"'{self.table_name}' (lock at {lock_path}). "
-                f"Holder: {existing_info!r}. Wait for it to finish, or — "
-                f"if its pod crashed — remove the lock file manually. "
-                f"(The lock auto-clears after "
-                f"{self._TABLE_LOCK_STALE_SECONDS}s.){RESET}"
-            )
-        try:
-            with os.fdopen(fd, "w") as f:
-                _json.dump(lock_info, f)
-        except Exception:
-            # Couldn't write the metadata — drop the lock so we don't
-            # block ourselves on a malformed file.
-            try:
-                os.remove(lock_path)
-            except FileNotFoundError:
-                pass
-            raise
-        logger.info(f"Acquired table lock for '{self.table_name}' at {lock_path}")
-        return lock_path
-
-    def _release_table_lock(self, lock_path: Optional[str]) -> None:
-        """Remove the lock file. No-op when ``_acquire_table_lock``
-        returned None (no STORAGE_PATH configured). Idempotent — a
-        double-release (e.g. exception path + finally path both call
-        it) silently swallows ``FileNotFoundError``.
-        """
-        if not lock_path:
-            return
-        try:
-            os.remove(lock_path)
-            logger.info(f"Released table lock for '{self.table_name}'")
-        except FileNotFoundError:
-            pass
-        except Exception as exc:
-            logger.warning(
-                f"Failed to remove table lock {lock_path}: {exc}. "
-                f"It will auto-clear after "
-                f"{self._TABLE_LOCK_STALE_SECONDS}s."
-            )
+    @property
+    def _table_lock(self) -> TableLock:
+        """The run's table lock (P5b). ``TableLock`` owns the file-lock
+        lifecycle — compute path, atomic acquire with stale-reclaim, release —
+        and the ingestor just composes it. A fresh instance per access is fine:
+        the lock state lives in the on-disk file, not the object (``acquire``
+        returns the path, ``release`` takes it back)."""
+        return TableLock(self.table_name, self.ingestor_id)
 
     def validate_data(self, source: Any) -> bool:
         """Validate data before ingestion using configured validators.
@@ -683,11 +551,12 @@ class BaseIngestor(ABC):
         # Fail fast on a config error (bad intent) before acquiring a table
         # lock or touching the DB — it would otherwise skip every row (#234).
         preflight.check_intent(self.intent)
-        _lock_path = self._acquire_table_lock()
+        lock = self._table_lock
+        _lock_path = lock.acquire()
         try:
             return self._ingest_with_lock(source, batch_size)
         finally:
-            self._release_table_lock(_lock_path)
+            lock.release(_lock_path)
 
     def _ingest_with_lock(
         self, source: Any, batch_size: int = 50

--- a/tracebloc_ingestor/ingestors/table_lock.py
+++ b/tracebloc_ingestor/ingestors/table_lock.py
@@ -1,0 +1,172 @@
+"""Cross-ingest table lock (structural refactor — backend#796, P5b).
+
+A file-based mutex that serialises ingests targeting the same table (#772 P2):
+two runs against one table used to race ``create_table`` / interleave upserts.
+Extracted verbatim from ``BaseIngestor`` — the lock lifecycle (compute path,
+atomic O_EXCL acquire with stale-reclaim, release) is a cohesive, stateful
+responsibility, so it lives as its own class that ``BaseIngestor`` composes.
+
+The lock file lives at the top of ``STORAGE_PATH`` (the parent of every
+per-table DEST_PATH) so it's durable across pod restarts on the cluster PVC.
+``STORAGE_PATH`` is a class constant on :class:`Config` (not env/override
+driven), so it's read from a plain ``Config()`` — every instance sees the same
+value. Behaviour (and every error message) is unchanged from the former
+``BaseIngestor._acquire_table_lock`` / ``_release_table_lock``.
+"""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from ..utils.constants import RED, RESET, YELLOW
+
+logger = logging.getLogger(__name__)
+
+
+class TableLock:
+    """Exclusive, file-based lock for one ``table_name`` ingest.
+
+    Stateless across calls: ``acquire`` returns the lock path and ``release``
+    takes it back, so the only durable state is the on-disk lock file itself.
+    """
+
+    # Stale-lock cutoff (seconds). A crashed ingest leaves the lock file
+    # behind; if the lock is older than this we log + remove + reacquire so a
+    # customer isn't blocked indefinitely waiting for the writer whose pod has
+    # long since been garbage-collected. 12h covers any reasonable ingest
+    # (including multi-GB proteomics).
+    STALE_SECONDS = 12 * 3600
+
+    def __init__(self, table_name: str, ingestor_id: str):
+        self.table_name = table_name
+        self.ingestor_id = ingestor_id
+
+    def path(self) -> Optional[str]:
+        """Where the lock file lives — at the top of STORAGE_PATH (the parent
+        of every per-table DEST_PATH), so it's durable across pod restarts on
+        the cluster PVC. Returns None when STORAGE_PATH is unset or not a
+        directory (test configs / local runs without a staging dir) — caller
+        treats that as "no lock available, skip".
+        """
+        # Late import: keep this module free of a Config singleton at import
+        # time so unit tests can monkeypatch the env per test.
+        from ..config import Config
+
+        storage = Config().STORAGE_PATH
+        if not storage or not os.path.isdir(storage):
+            return None
+        return os.path.join(storage, f".tracebloc-ingest-{self.table_name}.lock")
+
+    def acquire(self) -> Optional[str]:
+        """Acquire an exclusive lock for ``self.table_name`` (#772 P2).
+
+        Two ingests targeting the same table used to race ``create_table`` /
+        interleave upserts. Atomic ``O_EXCL`` create either succeeds (lock
+        acquired) or fails with ``FileExistsError`` (another ingest is in
+        flight). On conflict, read the existing lock's metadata and surface it
+        in the error so ops can find the other run; if the lock is older than
+        the stale-cutoff, remove and reacquire.
+
+        Returns the lock path (or None if no STORAGE_PATH is configured) so
+        ``release`` can remove the right file.
+        """
+        import json as _json
+        import socket as _socket
+        from datetime import datetime as _datetime
+
+        lock_path = self.path()
+        if lock_path is None:
+            return None
+
+        lock_info = {
+            "ingestor_id": self.ingestor_id,
+            "table_name": self.table_name,
+            "pid": os.getpid(),
+            "hostname": _socket.gethostname(),
+            "started_at": _datetime.utcnow().isoformat() + "Z",
+        }
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            # Read the existing lock so the error names the holder. Also
+            # check staleness and self-recover if so.
+            existing_info: Dict[str, Any] = {}
+            try:
+                with open(lock_path, "r") as f:
+                    existing_info = _json.load(f)
+            except Exception:
+                pass
+            age = None
+            try:
+                started = _datetime.fromisoformat(
+                    existing_info.get("started_at", "").rstrip("Z")
+                )
+                age = (_datetime.utcnow() - started).total_seconds()
+            except Exception:
+                # Lock metadata is corrupt (truncated file, malformed JSON,
+                # missing/un-parseable started_at). Fall back to the file's
+                # mtime as the age signal (#221 bugbot: a corrupt lock used to
+                # never auto-expire because age stayed None). Use time.time()
+                # rather than _datetime.utcnow().timestamp() — the latter is
+                # timezone-broken (naive datetime treated as local) so the
+                # cutoff would shift by the local UTC offset on non-UTC systems.
+                import time as _time
+
+                try:
+                    mtime = os.path.getmtime(lock_path)
+                    age = _time.time() - mtime
+                except OSError:
+                    pass
+            if age is not None and age > self.STALE_SECONDS:
+                logger.warning(
+                    f"{YELLOW}Stale lock at {lock_path} (age={age:.0f}s, "
+                    f"holder={existing_info!r}) — removing and reacquiring. "
+                    f"The holder's pod likely crashed before its finally "
+                    f"could run.{RESET}"
+                )
+                try:
+                    os.remove(lock_path)
+                except FileNotFoundError:
+                    pass
+                return self.acquire()
+            raise RuntimeError(
+                f"{RED}Another ingest is already running for table "
+                f"'{self.table_name}' (lock at {lock_path}). "
+                f"Holder: {existing_info!r}. Wait for it to finish, or — "
+                f"if its pod crashed — remove the lock file manually. "
+                f"(The lock auto-clears after "
+                f"{self.STALE_SECONDS}s.){RESET}"
+            )
+        try:
+            with os.fdopen(fd, "w") as f:
+                _json.dump(lock_info, f)
+        except Exception:
+            # Couldn't write the metadata — drop the lock so we don't block
+            # ourselves on a malformed file.
+            try:
+                os.remove(lock_path)
+            except FileNotFoundError:
+                pass
+            raise
+        logger.info(f"Acquired table lock for '{self.table_name}' at {lock_path}")
+        return lock_path
+
+    def release(self, lock_path: Optional[str]) -> None:
+        """Remove the lock file. No-op when ``acquire`` returned None (no
+        STORAGE_PATH configured). Idempotent — a double-release (e.g. exception
+        path + finally path both call it) silently swallows
+        ``FileNotFoundError``.
+        """
+        if not lock_path:
+            return
+        try:
+            os.remove(lock_path)
+            logger.info(f"Released table lock for '{self.table_name}'")
+        except FileNotFoundError:
+            pass
+        except Exception as exc:
+            logger.warning(
+                f"Failed to remove table lock {lock_path}: {exc}. "
+                f"It will auto-clear after "
+                f"{self.STALE_SECONDS}s."
+            )


### PR DESCRIPTION
## Summary

**Structural refactor — phase P5 (decompose the `BaseIngestor` god-class), slice 2.** P5a (#274) is merged, so this targets `develop` directly.

Extracts the **cross-ingest table lock** (#772 P2). The lock lifecycle (compute path under `STORAGE_PATH`, atomic `O_EXCL` acquire with stale-reclaim + corrupt-lock mtime fallback, release) was three methods + a constant on `BaseIngestor`. It's a stateful, self-contained responsibility, so it moves **verbatim** (every error message unchanged) into a `TableLock` class (`ingestors/table_lock.py`) that `BaseIngestor` composes via a `_table_lock` property.

`_ingest_with_lock` now reads:
```python
lock = self._table_lock
_lock_path = lock.acquire()
try:
    return self._ingest_with_lock(source, batch_size)
finally:
    lock.release(_lock_path)
```

## Behaviour preservation

- `STORAGE_PATH` is a `Config` class constant (not env/override driven), so `TableLock` reads it from a plain `Config()` exactly as the old code did — the ~10 lock tests that `patch.object(Config, "STORAGE_PATH", …)` keep working unchanged. They now exercise the lock via `ing._table_lock.acquire()` / `.release()` / `.path()` (a clean rename).
- Removed the now-unused `os` and `..config.Config` imports from base.py (their last users moved out in P5a/P5b).

Verification:
- Full unit suite: **1080 passed**, coverage **96.8%**.
- **e2e (real MySQL): 23 passed, 1 xpassed** — #247 characterization goldens unchanged.

**base.py: 1180 → 939 lines** across P5a+P5b.

## What's next in P5

- **P5c** — `RecordProcessor` (`process_record` / `_map_unique_id`).
- **P5d** — the batch/DB/API write path (`_flush_batch` / `_process_batch`).

Each behaviour-preserving. The deferred bug fixes (`mask_id` cross-layer leak, per-row tolerance #235, atomicity #227/#260) ride later focused slices on top of the clean structure — keeping a god-class teardown out of the same diff as subtle correctness changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
