### PR TITLE
test(e2e): drop stale semantic_segmentation xfail — mask sidecar is wired (#136)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,12 +23,19 @@ The suite **auto-skips when no MySQL is reachable**, so the default `pytest`
 (unit) run is unaffected. CI runs it with a MySQL service in
 `.github/workflows/e2e.yml`.
 
-## Known gaps (currently `xfail`)
+## Known gaps
 
-| Modality | Why | Ticket |
+None — every bundled template currently ingests end-to-end, so the suite has no
+`xfail` cases. The three modalities that were once gaps have all been fixed and
+folded back into the suite as normal cases:
+
+| Modality | Was | Fixed by |
 |---|---|---|
-| object_detection | bundled VisDrone XML uses `difficult=2`; validator only accepts `0/1` | #135 |
-| semantic_segmentation | mask sidecar column not wired through the declarative path | #136 |
+| object_detection | bundled VisDrone XML uses `difficult=2`; validator only accepted `0/1` | #135 |
 | masked_language_modeling | template missing the required `tokenizer.json` | #137 |
+| semantic_segmentation | mask sidecar not wired through the declarative path | #136 |
 
-When a fix lands, the corresponding test XPASSes — drop the `xfail` mark.
+**Convention for future gaps:** add the case with
+`marks=pytest.mark.xfail(reason="…", strict=False)` against its tracking ticket.
+When the fix lands the test XPASSes; that signals the mark can be dropped (turn
+it back into a normal case).

--- a/e2e/test_ingest_e2e.py
+++ b/e2e/test_ingest_e2e.py
@@ -101,14 +101,17 @@ CASES = [
         sequences=str(T / "masked_language_modeling/data/sequences"),
     ), id="masked_language_modeling"),
 
-    # ── known gap (xfail → tracking ticket; XPASS signals the fix landed) ──
+    # semantic_segmentation: now ingests through the declarative path after the
+    # mask sidecar was wired (#136). mask_id is preserved through process_record
+    # (#212) and staged by the semantic_segmentation transfer factory, so the
+    # per-row mask lands in DEST_PATH alongside its image — verified end-to-end
+    # by this case (3 images + 3 masks staged, 3 rows inserted).
     pytest.param(_cfg(
         table="e2e_seg", category="semantic_segmentation",
         csv=str(T / "semantic_segmentation/semantic_data/labels_file_sample.csv"),
         images=str(T / "semantic_segmentation/semantic_data/images"),
         masks=str(T / "semantic_segmentation/semantic_data/masks"), label="image_label",
-    ), id="semantic_segmentation",
-        marks=pytest.mark.xfail(reason="mask sidecar not wired in declarative path (#136)", strict=False)),
+    ), id="semantic_segmentation"),
 ]
 
 


### PR DESCRIPTION
## What

Removes the last `xfail` marker in the e2e ingestion suite — the
`semantic_segmentation` case (#136) — turning it into a normal passing case,
and refreshes `e2e/README.md`'s now-stale "known gaps" section.

## Why

The e2e harness marks each known gap `xfail(strict=False)` against its tracking
ticket; the file's own convention is that **when the fix lands the test XPASSes
and the mark can be dropped**. The semseg case has been XPASSing — the
declarative mask-sidecar wiring shipped a while ago (`mask_id` preserved through
`process_record`, #212, plus the P3c transfer registry), and **#136 is already
closed**. This PR just removes the leftover scaffolding.

## Verification (real MySQL, declarative `cli/run` path)

- **Full e2e suite green: 24 passed.** `semantic_segmentation` now reports
  `PASSED` (not xfail/xpass).
- Controlled end-to-end check of the declarative path
  (`cli/run` → `map_file_transfer` → `semantic_segmentation` transfer factory →
  `mask_transfer`):
  - **3 images + 3 masks** staged into `DEST_PATH`; the masks are
    **byte-identical** (md5) to source — i.e. `mask_transfer` genuinely copied
    them (it is the only writer of `DEST_PATH/*_mask.png`).
  - **3 rows** inserted with correct `label` / `filename` / `extension`;
    `mask_id` correctly **absent** as a DB column (popped before insert in
    `_process_batch`).
  - **Negative control:** with `masks/` emptied, the run fails (rc=1, 0 rows, no
    masks staged) — proving mask staging is load-bearing, not coincidental.

## Notes

- `e2e/README.md`'s "Known gaps (currently `xfail`)" table was stale for **all
  three** listed modalities: `object_detection` (#135) and
  `masked_language_modeling` (#137) were un-xfailed in earlier PRs without the
  README being updated. Rewrote it to reflect that the suite now has zero xfail
  cases, and kept the convention note for future gaps.
- Re **#136**: already closed (2026-06-11; fix shipped via #212 + the P3c
  transfer registry), so no auto-close keyword here — this is the test-cleanup
  follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
