### PR TITLE
feat(#805): register NLP tokenizer fingerprint at ingest (Task 2)

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -918,3 +918,88 @@ def test_check_src_path_required_for_token_classification():
     from tracebloc_ingestor.ingestors.base import _FILE_BEARING_CATEGORIES
 
     assert TaskCategory.TOKEN_CLASSIFICATION in _FILE_BEARING_CATEGORIES
+
+
+# ---------------------------------------------------------------------------
+# #805 Task 2: tokenizer fingerprint registration on the global-metadata channel
+# ---------------------------------------------------------------------------
+
+_FINGERPRINT = {
+    "vocab_size": 15,
+    "mask_token_id": 4,
+    "pad_token_id": 0,
+    "tokenizer_type": "WordLevel",
+}
+
+
+@pytest.mark.parametrize(
+    "category",
+    ["MASKED_LANGUAGE_MODELING", "TEXT_CLASSIFICATION", "TOKEN_CLASSIFICATION"],
+)
+def test_ingest_registers_tokenizer_fingerprint_for_nlp(category):
+    """For every NLP category, a shipped tokenizer's 4-integer fingerprint is
+    attached to file_options so it rides the existing global-metadata channel."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    cat = getattr(TaskCategory, category)
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=cat, label_column=None)
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod, "map_file_transfer", side_effect=lambda c, r, o, cfg=None: r
+    ), patch.object(
+        base_mod, "get_shipped_tokenizer_metadata", return_value=_FINGERPRINT
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    args, _ = ing.api_client.send_global_meta_meta.call_args
+    assert args[2].get("tokenizer") == _FINGERPRINT
+
+
+def test_ingest_warns_and_skips_tokenizer_when_absent_for_nlp():
+    """A site that ships no tokenizer.json still registers cleanly — the
+    fingerprint is simply omitted (the epic's legacy/skipped path)."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(
+        records=records,
+        category=TaskCategory.TEXT_CLASSIFICATION,
+        label_column="a",
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod, "map_file_transfer", side_effect=lambda c, r, o, cfg=None: r
+    ), patch.object(
+        base_mod, "get_shipped_tokenizer_metadata", return_value=None
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    args, _ = ing.api_client.send_global_meta_meta.call_args
+    assert "tokenizer" not in args[2]
+    # Registration still completes — absence is non-fatal.
+    ing.api_client.create_dataset.assert_called_once()
+
+
+def test_ingest_does_not_register_tokenizer_for_non_nlp():
+    """Non-NLP categories never touch the tokenizer path."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(
+        records=records,
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod, "map_file_transfer", side_effect=lambda c, r, o, cfg=None: r
+    ), patch.object(base_mod, "get_shipped_tokenizer_metadata") as get_meta:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    get_meta.assert_not_called()
+    args, _ = ing.api_client.send_global_meta_meta.call_args
+    assert "tokenizer" not in args[2]

--- a/tests/test_modality_registry.py
+++ b/tests/test_modality_registry.py
@@ -15,6 +15,7 @@ import pytest
 
 from tracebloc_ingestor.modalities import (
     FILE_BEARING_CATEGORIES,
+    NLP_CATEGORIES,
     REGISTRY,
     SELF_SUPERVISED_CATEGORIES,
     TABULAR_FAMILY_CATEGORIES,
@@ -53,6 +54,17 @@ def test_derived_sets_match_spec_flags():
     }
     assert SELF_SUPERVISED_CATEGORIES == {
         c for c, s in REGISTRY.items() if s.is_self_supervised
+    }
+    assert NLP_CATEGORIES == {c for c, s in REGISTRY.items() if s.is_nlp}
+
+
+def test_nlp_categories_are_the_three_text_categories():
+    """#805 Task 2: the tokenizer-fingerprint set is exactly the NLP text
+    categories (text/token classification + MLM) — never image/tabular."""
+    assert NLP_CATEGORIES == {
+        TaskCategory.TEXT_CLASSIFICATION,
+        TaskCategory.TOKEN_CLASSIFICATION,
+        TaskCategory.MASKED_LANGUAGE_MODELING,
     }
 
 

--- a/tests/test_tokenizer_fingerprint.py
+++ b/tests/test_tokenizer_fingerprint.py
@@ -1,0 +1,212 @@
+"""Tests for the NLP tokenizer fingerprint extracted + registered at ingest.
+
+Covers issue #805 Task 2: the 4 structural integers (vocab_size /
+mask_token_id / pad_token_id / tokenizer_type) extracted from a shipped
+``tokenizer.json`` and shipped on the global-metadata channel. The FL
+guardrail is that ONLY these integers leave the cluster — never vocabulary
+content and never a hash.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tracebloc_ingestor import file_transfer
+from tracebloc_ingestor.validators.tokenizer_validator import (
+    _special_token_id,
+    extract_tokenizer_metadata,
+    load_tokenizer_metadata,
+)
+
+# A BERT/WordPiece-style tokenizer.json with the full classification +
+# MLM special-token set, special tokens declared in added_tokens.
+_BERT_STYLE = {
+    "version": "1.0",
+    "model": {
+        "type": "WordPiece",
+        "vocab": {
+            "[PAD]": 0,
+            "[UNK]": 1,
+            "[CLS]": 2,
+            "[SEP]": 3,
+            "[MASK]": 4,
+            "hello": 5,
+            "world": 6,
+        },
+    },
+    "added_tokens": [
+        {"id": 0, "content": "[PAD]", "special": True},
+        {"id": 1, "content": "[UNK]", "special": True},
+        {"id": 2, "content": "[CLS]", "special": True},
+        {"id": 3, "content": "[SEP]", "special": True},
+        {"id": 4, "content": "[MASK]", "special": True},
+    ],
+}
+
+# A classification tokenizer that has [PAD] but no [MASK] (no masking task).
+_NO_MASK = {
+    "model": {"type": "WordPiece", "vocab": {"[PAD]": 0, "[UNK]": 1, "a": 2}},
+    "added_tokens": [{"id": 0, "content": "[PAD]", "special": True}],
+}
+
+# A Unigram tokenizer stores its vocab as a [token, score] list.
+_UNIGRAM = {
+    "model": {
+        "type": "Unigram",
+        "vocab": [["[PAD]", 0.0], ["[MASK]", 0.0], ["x", -1.0], ["y", -2.0]],
+    },
+    "added_tokens": [
+        {"id": 0, "content": "[PAD]", "special": True},
+        {"id": 1, "content": "[MASK]", "special": True},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# extract_tokenizer_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_extract_full_fingerprint_bert_style():
+    meta = extract_tokenizer_metadata(_BERT_STYLE)
+    assert meta == {
+        "vocab_size": 7,
+        "mask_token_id": 4,
+        "pad_token_id": 0,
+        "tokenizer_type": "WordPiece",
+    }
+
+
+def test_extract_classification_without_mask_yields_none_mask_id():
+    meta = extract_tokenizer_metadata(_NO_MASK)
+    assert meta["mask_token_id"] is None
+    assert meta["pad_token_id"] == 0
+    assert meta["vocab_size"] == 3
+    assert meta["tokenizer_type"] == "WordPiece"
+
+
+def test_extract_unigram_list_vocab():
+    meta = extract_tokenizer_metadata(_UNIGRAM)
+    assert meta["vocab_size"] == 4
+    assert meta["mask_token_id"] == 1
+    assert meta["pad_token_id"] == 0
+    assert meta["tokenizer_type"] == "Unigram"
+
+
+def test_fl_guardrail_only_four_scalar_keys():
+    """No vocabulary content or hash may cross to the backend — only the 4
+    scalar integers (one may be a type string / None)."""
+    meta = extract_tokenizer_metadata(_BERT_STYLE)
+    assert set(meta) == {
+        "vocab_size",
+        "mask_token_id",
+        "pad_token_id",
+        "tokenizer_type",
+    }
+    for value in meta.values():
+        assert not isinstance(value, (dict, list))
+
+
+def test_extract_handles_empty_or_unknown_structure():
+    meta = extract_tokenizer_metadata({})
+    assert meta == {
+        "vocab_size": 0,
+        "mask_token_id": None,
+        "pad_token_id": None,
+        "tokenizer_type": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _special_token_id
+# ---------------------------------------------------------------------------
+
+
+def test_special_token_id_prefers_added_tokens():
+    data = {
+        "model": {"vocab": {"[PAD]": 99}},
+        "added_tokens": [{"id": 7, "content": "[PAD]"}],
+    }
+    assert _special_token_id(data, "[PAD]") == 7
+
+
+def test_special_token_id_falls_back_to_vocab():
+    data = {"model": {"vocab": {"[PAD]": 3}}, "added_tokens": []}
+    assert _special_token_id(data, "[PAD]") == 3
+
+
+def test_special_token_id_absent_returns_none():
+    assert _special_token_id(_NO_MASK, "[MASK]") is None
+
+
+# ---------------------------------------------------------------------------
+# load_tokenizer_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_load_reads_file(tmp_path):
+    p = tmp_path / "tokenizer.json"
+    p.write_text(json.dumps(_BERT_STYLE))
+    meta = load_tokenizer_metadata(str(p))
+    assert meta["vocab_size"] == 7
+    assert meta["mask_token_id"] == 4
+
+
+def test_load_missing_file_returns_none(tmp_path):
+    assert load_tokenizer_metadata(str(tmp_path / "nope.json")) is None
+
+
+def test_load_malformed_json_returns_none(tmp_path):
+    p = tmp_path / "tokenizer.json"
+    p.write_text("{ not valid json ")
+    assert load_tokenizer_metadata(str(p)) is None
+
+
+# ---------------------------------------------------------------------------
+# file_transfer helpers (SRC_PATH / DEST_PATH backed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dirs(tmp_path, monkeypatch):
+    """Point file_transfer's Config at tmp src + storage dirs (mirrors the
+    fixture in test_file_transfer_transfers.py)."""
+    src = tmp_path / "src"
+    storage = tmp_path / "storage"
+    src.mkdir()
+    storage.mkdir()
+    monkeypatch.setenv("SRC_PATH", str(src))
+    monkeypatch.setenv("TABLE_NAME", "tbl")
+    monkeypatch.setattr(file_transfer.config, "STORAGE_PATH", str(storage))
+    return src, storage / "tbl"
+
+
+def test_get_shipped_tokenizer_metadata_reads_src(dirs):
+    src, _ = dirs
+    (src / "tokenizer.json").write_text(json.dumps(_BERT_STYLE))
+    meta = file_transfer.get_shipped_tokenizer_metadata()
+    assert meta["vocab_size"] == 7
+    assert meta["pad_token_id"] == 0
+
+
+def test_get_shipped_tokenizer_metadata_none_when_absent(dirs):
+    assert file_transfer.get_shipped_tokenizer_metadata() is None
+
+
+def test_copy_tokenizer_returns_fingerprint_on_copy(dirs):
+    src, dest = dirs
+    # In production text_transfer creates DEST_PATH before the tokenizer copy;
+    # mirror that here since we call the helper in isolation.
+    dest.mkdir(parents=True, exist_ok=True)
+    (src / "tokenizer.json").write_text(json.dumps(_BERT_STYLE))
+    meta = file_transfer._copy_tokenizer_if_present()
+    assert (dest / "tokenizer.json").exists()
+    assert meta["vocab_size"] == 7
+    # Already copied: a second call is a no-op and returns None.
+    assert file_transfer._copy_tokenizer_if_present() is None
+
+
+def test_copy_tokenizer_none_when_absent(dirs):
+    assert file_transfer._copy_tokenizer_if_present() is None

--- a/tests/test_tokenizer_fingerprint.py
+++ b/tests/test_tokenizer_fingerprint.py
@@ -137,6 +137,16 @@ def test_special_token_id_falls_back_to_vocab():
     assert _special_token_id(data, "[PAD]") == 3
 
 
+def test_special_token_id_idless_added_token_falls_back_to_vocab():
+    """A malformed added_tokens entry with no ``id`` must not shadow the
+    model.vocab mapping that does hold the id (bugbot)."""
+    data = {
+        "model": {"vocab": {"[PAD]": 5}},
+        "added_tokens": [{"content": "[PAD]"}],  # no "id"
+    }
+    assert _special_token_id(data, "[PAD]") == 5
+
+
 def test_special_token_id_absent_returns_none():
     assert _special_token_id(_NO_MASK, "[MASK]") is None
 

--- a/tests/test_tokenizer_fingerprint.py
+++ b/tests/test_tokenizer_fingerprint.py
@@ -193,9 +193,11 @@ def dirs(tmp_path, monkeypatch):
     return src, storage / "tbl"
 
 
-def test_get_shipped_tokenizer_metadata_reads_src(dirs):
-    src, _ = dirs
-    (src / "tokenizer.json").write_text(json.dumps(_BERT_STYLE))
+def test_get_shipped_tokenizer_metadata_reads_dest(dirs):
+    """Fingerprints the STAGED tokenizer (DEST) — the file the client uses."""
+    _, dest = dirs
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "tokenizer.json").write_text(json.dumps(_BERT_STYLE))
     meta = file_transfer.get_shipped_tokenizer_metadata()
     assert meta["vocab_size"] == 7
     assert meta["pad_token_id"] == 0
@@ -203,6 +205,19 @@ def test_get_shipped_tokenizer_metadata_reads_src(dirs):
 
 def test_get_shipped_tokenizer_metadata_none_when_absent(dirs):
     assert file_transfer.get_shipped_tokenizer_metadata() is None
+
+
+def test_get_shipped_fingerprints_dest_not_src(dirs):
+    """On a re-ingest the copy is skipped (DEST already exists), so the client
+    trains on DEST; the registered fingerprint must describe DEST, not a
+    changed SRC (bugbot)."""
+    src, dest = dirs
+    dest.mkdir(parents=True, exist_ok=True)
+    # SRC has a 3-token tokenizer; DEST (already staged) has the 7-token one.
+    (src / "tokenizer.json").write_text(json.dumps(_NO_MASK))
+    (dest / "tokenizer.json").write_text(json.dumps(_BERT_STYLE))
+    meta = file_transfer.get_shipped_tokenizer_metadata()
+    assert meta["vocab_size"] == 7  # DEST, not SRC's 3
 
 
 def test_copy_tokenizer_returns_fingerprint_on_copy(dirs):

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -402,18 +402,23 @@ def _copy_tokenizer_if_present(cfg: Optional[Config] = None) -> Optional[Dict[st
 def get_shipped_tokenizer_metadata(
     cfg: Optional[Config] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Return the structural fingerprint of the ingested ``tokenizer.json``.
+    """Return the structural fingerprint of the staged ``tokenizer.json``.
 
-    Reads the user-shipped ``SRC_PATH/tokenizer.json`` (the file
-    :class:`TokenizerValidator` checked) and returns the 4 structural integers,
-    or ``None`` when no tokenizer was shipped. Called once after ingestion to
+    Reads ``DEST_PATH/tokenizer.json`` — the file the training client actually
+    loads — NOT ``SRC_PATH``. ``_copy_tokenizer_if_present`` copies the source
+    only once (it skips when a DEST copy already exists), so on a re-ingest
+    that ships a changed source the client keeps training on the existing DEST
+    file; fingerprinting DEST keeps the registered metadata matched to what is
+    trained on (else the contributor cross-check at linking would compare
+    against a tokenizer the site never used). Returns the 4 structural integers,
+    or ``None`` when no tokenizer was staged. Called once after ingestion to
     register the fingerprint on the existing global-metadata channel (#805
     Task 2); only these integers cross the cluster boundary. ``cfg`` is the
     run's resolved Config (threaded from the ingestor); ``None`` falls back to
     the module-global ``config``.
     """
     cfg = cfg or config
-    return load_tokenizer_metadata(os.path.join(cfg.SRC_PATH, "tokenizer.json"))
+    return load_tokenizer_metadata(os.path.join(cfg.DEST_PATH, "tokenizer.json"))
 
 
 def map_file_transfer(

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -30,6 +30,7 @@ from tracebloc_ingestor.utils.constants import (
     FileExtension,
     TaskCategory,
 )
+from tracebloc_ingestor.validators.tokenizer_validator import load_tokenizer_metadata
 
 # Initialize config and configure logging
 config = Config()
@@ -366,20 +367,53 @@ def mask_transfer(
         raise ValueError(f"{RED}Error processing mask file: {str(e)}{RESET}")
 
 
-def _copy_tokenizer_if_present(cfg: Optional[Config] = None) -> None:
-    """Copy a user-shipped ``tokenizer.json`` from SRC_PATH to DEST_PATH (once).
+def _copy_tokenizer_if_present(cfg: Optional[Config] = None) -> Optional[Dict[str, Any]]:
+    """Copy a user-shipped ``tokenizer.json`` from SRC_PATH to DEST_PATH (once)
+    and return its structural fingerprint.
 
     Optional for NLP datasets: the training client looks for
     ``DEST_PATH/tokenizer.json`` and uses it as a custom tokenizer; if it's
     absent the client falls back to the HuggingFace tokenizer_id / default.
-    No-op when no tokenizer.json was shipped, or when it was already copied.
+    After the copy, the 4-integer fingerprint — ``vocab_size`` /
+    ``mask_token_id`` / ``pad_token_id`` / ``tokenizer_type`` — is extracted
+    and logged so it can be registered on the global-metadata channel for the
+    contributor-tokenizer cross-check at dataset linking (#805 Task 2). Only
+    those integers ever leave the cluster — never vocabulary content or a hash.
+
+    Returns the fingerprint dict on the call that performs the copy, and
+    ``None`` thereafter (already copied this run) or when no tokenizer.json was
+    shipped. The authoritative fingerprint for registration is read once,
+    post-ingest, via :func:`get_shipped_tokenizer_metadata`.
     """
     cfg = cfg or config
     tokenizer_src = os.path.join(cfg.SRC_PATH, "tokenizer.json")
     tokenizer_dest = os.path.join(cfg.DEST_PATH, "tokenizer.json")
-    if os.path.isfile(tokenizer_src) and not os.path.exists(tokenizer_dest):
-        _copy_file_with_retry(tokenizer_src, tokenizer_dest)
-        logger.info(f"{GREEN}Copied tokenizer.json to {cfg.DEST_PATH}{RESET}")
+    if not os.path.isfile(tokenizer_src) or os.path.exists(tokenizer_dest):
+        return None
+    _copy_file_with_retry(tokenizer_src, tokenizer_dest)
+    metadata = load_tokenizer_metadata(tokenizer_dest)
+    logger.info(
+        f"{GREEN}Copied tokenizer.json to {cfg.DEST_PATH} "
+        f"(fingerprint: {metadata}){RESET}"
+    )
+    return metadata
+
+
+def get_shipped_tokenizer_metadata(
+    cfg: Optional[Config] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return the structural fingerprint of the ingested ``tokenizer.json``.
+
+    Reads the user-shipped ``SRC_PATH/tokenizer.json`` (the file
+    :class:`TokenizerValidator` checked) and returns the 4 structural integers,
+    or ``None`` when no tokenizer was shipped. Called once after ingestion to
+    register the fingerprint on the existing global-metadata channel (#805
+    Task 2); only these integers cross the cluster boundary. ``cfg`` is the
+    run's resolved Config (threaded from the ingestor); ``None`` falls back to
+    the module-global ``config``.
+    """
+    cfg = cfg or config
+    return load_tokenizer_metadata(os.path.join(cfg.SRC_PATH, "tokenizer.json"))
 
 
 def map_file_transfer(

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -23,7 +23,7 @@ from ..utils.constants import (
 )
 from ..utils import label_policy as label_policy_module
 from ..utils.validators_mapping import map_validators
-from ..file_transfer import map_file_transfer
+from ..file_transfer import map_file_transfer, get_shipped_tokenizer_metadata
 from ..reporting import ConsoleRenderer
 from . import preflight
 
@@ -34,6 +34,7 @@ from . import preflight
 # (and their None/unknown -> False semantics are preserved).
 from ..modalities.registry import (
     FILE_BEARING_CATEGORIES as _FILE_BEARING_CATEGORIES,
+    NLP_CATEGORIES as _NLP_CATEGORIES,
     SELF_SUPERVISED_CATEGORIES as _SELF_SUPERVISED_CATEGORIES,
     TABULAR_FAMILY_CATEGORIES as _TABULAR_FAMILY_CATEGORIES,
 )
@@ -859,6 +860,30 @@ class BaseIngestor(ABC):
                             "Backend rejected edge-label metadata; the dataset was "
                             "NOT registered (its rows are already in the database). "
                             "See the logged API error above."
+                        )
+
+                # Register the contributor tokenizer fingerprint for NLP
+                # datasets (#805 Task 2). When a tokenizer.json was shipped
+                # (mandatory for MLM, optional for text/token classification),
+                # attach its 4 structural integers (vocab_size / mask_token_id /
+                # pad_token_id / tokenizer_type) to file_options so they ride
+                # the existing global-metadata channel below and the backend can
+                # cross-check a contributor tokenizer at dataset linking. Only
+                # these integers cross the cluster boundary — never vocabulary
+                # content or a hash (the FL guardrail). A site that ships none
+                # simply skips the cross-check (the epic's legacy/skipped path).
+                if self.category in _NLP_CATEGORIES:
+                    tokenizer_meta = get_shipped_tokenizer_metadata(
+                        self.database.config
+                    )
+                    if tokenizer_meta:
+                        self.file_options["tokenizer"] = tokenizer_meta
+                    else:
+                        logger.warning(
+                            f"{YELLOW}No tokenizer.json shipped for NLP dataset "
+                            f"'{self.table_name}'; no tokenizer fingerprint will "
+                            f"be registered, so the contributor-tokenizer "
+                            f"cross-check is skipped for this site.{RESET}"
                         )
 
                 schema_dict = self.database.get_table_schema(self.table_name)

--- a/tracebloc_ingestor/modalities/__init__.py
+++ b/tracebloc_ingestor/modalities/__init__.py
@@ -3,6 +3,7 @@ task category's ingestion behavior (structural refactor — backend#796, P3)."""
 
 from .registry import (
     FILE_BEARING_CATEGORIES,
+    NLP_CATEGORIES,
     REGISTRY,
     SELF_SUPERVISED_CATEGORIES,
     TABULAR_FAMILY_CATEGORIES,
@@ -17,4 +18,5 @@ __all__ = [
     "FILE_BEARING_CATEGORIES",
     "TABULAR_FAMILY_CATEGORIES",
     "SELF_SUPERVISED_CATEGORIES",
+    "NLP_CATEGORIES",
 ]

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -68,6 +68,7 @@ _SPECS = (
         data_format=DataFormat.TEXT,
         build_validators=v.text_classification,
         transfer=t.text_classification,
+        is_nlp=True,
     ),
     ModalitySpec(
         TaskCategory.TOKEN_CLASSIFICATION,
@@ -77,6 +78,7 @@ _SPECS = (
         data_format=DataFormat.TEXT,
         build_validators=v.token_classification,
         transfer=t.token_classification,
+        is_nlp=True,
     ),
     # masked_language_modeling is file-bearing AND self-supervised (no label).
     ModalitySpec(
@@ -87,6 +89,7 @@ _SPECS = (
         data_format=DataFormat.TEXT,
         build_validators=v.masked_language_modeling,
         transfer=t.masked_language_modeling,
+        is_nlp=True,
     ),
     # Tabular family (structured feature tables; no sidecar files -> no transfer).
     ModalitySpec(
@@ -157,3 +160,6 @@ TABULAR_FAMILY_CATEGORIES = frozenset(
 SELF_SUPERVISED_CATEGORIES = frozenset(
     c for c, s in REGISTRY.items() if s.is_self_supervised
 )
+# NLP text categories that ship a tokenizer.json; their tokenizer fingerprint
+# is registered on the global-metadata channel at ingest (#805 Task 2).
+NLP_CATEGORIES = frozenset(c for c, s in REGISTRY.items() if s.is_nlp)

--- a/tracebloc_ingestor/modalities/spec.py
+++ b/tracebloc_ingestor/modalities/spec.py
@@ -61,6 +61,12 @@ class ModalitySpec:
             targets at train time (e.g. masked language modeling). The backend
             stores no edge-label metadata, so the edge-label call is skipped
             (#213).
+        is_nlp: an NLP text category (text / token classification, MLM) that
+            ships a ``tokenizer.json``. When one is present, its 4-integer
+            fingerprint (vocab_size / mask_token_id / pad_token_id /
+            tokenizer_type) is registered on the global-metadata channel at
+            ingest for the contributor-tokenizer cross-check at dataset linking
+            (#805 Task 2). Image / tabular / time-series are False.
     """
 
     category: str
@@ -72,3 +78,4 @@ class ModalitySpec:
     transfer: Optional[
         Callable[[Dict[str, Any], Dict[str, Any], Any], Optional[Dict[str, Any]]]
     ] = None
+    is_nlp: bool = False

--- a/tracebloc_ingestor/validators/tokenizer_validator.py
+++ b/tracebloc_ingestor/validators/tokenizer_validator.py
@@ -8,8 +8,9 @@ out-of-bounds IndexError.
 
 import json
 import logging
+import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Optional
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
@@ -17,6 +18,71 @@ from ..config import Config
 config = Config()
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
+
+
+def _special_token_id(tokenizer_data: dict, token: str) -> Optional[int]:
+    """Resolve a special token's id from a HuggingFace tokenizer JSON.
+
+    Prefers the ``added_tokens`` list (where special tokens carry an explicit
+    id), then falls back to the ``model.vocab`` mapping. Returns ``None`` when
+    the token isn't present — e.g. classification tokenizers have no ``[MASK]``.
+    """
+    for entry in tokenizer_data.get("added_tokens", []) or []:
+        if isinstance(entry, dict) and entry.get("content") == token:
+            return entry.get("id")
+    vocab = (tokenizer_data.get("model") or {}).get("vocab")
+    if isinstance(vocab, dict):
+        return vocab.get(token)
+    return None
+
+
+def extract_tokenizer_metadata(tokenizer_data: dict) -> Dict[str, Any]:
+    """Extract the 4 structural integers that fingerprint a tokenizer (#805).
+
+    These — and only these — cross to the backend on the global-metadata
+    channel so a contributor tokenizer can be cross-checked at dataset
+    linking without ever shipping vocabulary content or a hash (the FL
+    guardrail): the vocabulary of a custom (e.g. clinical / knowledge-graph)
+    tokenizer is data-derived and must not be centrally fingerprinted.
+
+    Returns a dict with:
+      - ``vocab_size``:     number of distinct tokens (``model.vocab`` ∪
+                            ``added_tokens``) — the bound the model's embedding
+                            table must cover; matches ``len(tokenizer)`` and the
+                            SDK's upload-time vocab-fit check.
+      - ``mask_token_id``:  id of ``[MASK]``, or ``None`` (classification has
+                            no ``[MASK]``).
+      - ``pad_token_id``:   id of ``[PAD]``, or ``None``.
+      - ``tokenizer_type``: ``model.type`` (``WordLevel`` / ``WordPiece`` /
+                            ``BPE`` / ``Unigram``), or ``None``.
+    """
+    vocab = TokenizerValidator._extract_vocab(tokenizer_data) or set()
+    model = tokenizer_data.get("model") or {}
+    return {
+        "vocab_size": len(vocab),
+        "mask_token_id": _special_token_id(tokenizer_data, "[MASK]"),
+        "pad_token_id": _special_token_id(tokenizer_data, "[PAD]"),
+        "tokenizer_type": model.get("type"),
+    }
+
+
+def load_tokenizer_metadata(tokenizer_path: str) -> Optional[Dict[str, Any]]:
+    """Read ``tokenizer_path`` and return its structural fingerprint, or ``None``.
+
+    Returns ``None`` (with a warning) when the file is absent or unparseable so
+    callers on the post-ingest registration path never crash an already-committed
+    dataset over a tokenizer read — presence and validity are enforced upstream
+    by :class:`TokenizerValidator` at validation time.
+    """
+    if not os.path.isfile(tokenizer_path):
+        return None
+    try:
+        with open(tokenizer_path, "r", encoding="utf-8") as f:
+            tokenizer_data = json.load(f)
+    except (OSError, ValueError) as e:
+        logger.warning(f"Could not read tokenizer.json at {tokenizer_path}: {e}")
+        return None
+    return extract_tokenizer_metadata(tokenizer_data)
 
 
 class TokenizerValidator(BaseValidator):

--- a/tracebloc_ingestor/validators/tokenizer_validator.py
+++ b/tracebloc_ingestor/validators/tokenizer_validator.py
@@ -29,7 +29,12 @@ def _special_token_id(tokenizer_data: dict, token: str) -> Optional[int]:
     """
     for entry in tokenizer_data.get("added_tokens", []) or []:
         if isinstance(entry, dict) and entry.get("content") == token:
-            return entry.get("id")
+            token_id = entry.get("id")
+            # Only trust an added_tokens entry that actually carries an id;
+            # a malformed entry without one must not shadow the model.vocab
+            # mapping below (which may still hold the id).
+            if token_id is not None:
+                return token_id
     vocab = (tokenizer_data.get("model") or {}).get("vocab")
     if isinstance(vocab, dict):
         return vocab.get(token)


### PR DESCRIPTION
## Task 2 of tracebloc/backend#805 — Ship tokenizer validation metadata at ingest

Part of the epic **federated NLP tokenizer alignment** (parent tracebloc/backend#748). This is the **data-ingestors** half of Task 2; the **backend** half (a storage contract test) is tracebloc/backend#813.

### What & why
At ingest, extract a shipped `tokenizer.json`'s **4 structural integers** and ship them on the **existing** global-metadata channel (`send_global_meta_meta`) so the backend can later cross-check a contributor tokenizer at dataset linking (Task 4):

| field | meaning |
|---|---|
| `vocab_size` | distinct tokens (`model.vocab` ∪ `added_tokens`) — the bound the model embedding must cover |
| `mask_token_id` | id of `[MASK]` (`None` for classification) |
| `pad_token_id` | id of `[PAD]` |
| `tokenizer_type` | `model.type` (WordLevel / WordPiece / BPE / Unigram) |

**FL guardrail:** only these 4 integers ever cross the cluster boundary — never vocabulary content and never a hash. A custom clinical/knowledge-graph tokenizer's vocabulary is data-derived and must not be centrally fingerprinted.

### Changes
- **`modalities/spec.py` + `registry.py`** — new `is_nlp` `ModalitySpec` flag (mirrors `is_self_supervised`); `NLP_CATEGORIES` derived from it (registry single-source, can't drift). Exported from `modalities/__init__.py`.
- **`validators/tokenizer_validator.py`** — `extract_tokenizer_metadata` / `load_tokenizer_metadata` / `_special_token_id`. Pure-JSON parse (no `tokenizers`/`transformers` dependency added), reusing the existing `_extract_vocab` so `vocab_size` matches the SDK's upload-time vocab-fit basis.
- **`file_transfer.py`** — `_copy_tokenizer_if_present(cfg)` returns the fingerprint; new `get_shipped_tokenizer_metadata(cfg)` reads `SRC_PATH/tokenizer.json` (Config threaded per the P4 refactor).
- **`ingestors/base.py`** — for NLP datasets, attach `file_options["tokenizer"]` before `send_global_meta_meta`, using the run's resolved Config (`self.database.config`).

### Behaviour (non-breaking)
- **MLM** — tokenizer remains mandatory (unchanged).
- **Text / token classification** — tokenizer stays **optional**: the fingerprint is registered when a `tokenizer.json` is present; when absent, a warning is logged and the contributor-tokenizer cross-check is simply skipped for that site (the epic's "legacy/skipped" path).
- No backend migration — `GlobalMetaData.meta_data` is a JSONField that stores the key as-is.

### Tests
- `tests/test_tokenizer_fingerprint.py` — extraction (BERT/WordPiece, no-mask classification, Unigram), FL guardrail (exactly 4 scalar keys), `load_tokenizer_metadata` (missing/malformed → None), and the `file_transfer` helpers.
- `tests/test_ingestor_base.py` — 3 ingest-flow tests (fingerprint registered for each NLP category; absent → warn + still register; non-NLP untouched).
- `tests/test_modality_registry.py` — `NLP_CATEGORIES` derives from `is_nlp` and equals the three text categories.

**Full suite: 1101 passed, 1 xfailed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dataset registration metadata and federated privacy boundaries (only scalars should leave the cluster); behavior is additive and optional for classification, but wrong DEST fingerprinting could misalign backend cross-checks at linking.
> 
> **Overview**
> Adds **#805 Task 2**: NLP ingests can ship a **4-field tokenizer fingerprint** on the existing global-metadata path (`send_global_meta_meta` via `file_options["tokenizer"]`), so the backend can cross-check contributor tokenizers at dataset linking without sending vocab text or hashes.
> 
> **Modality registry** gains `is_nlp` on the three text categories and a derived `NLP_CATEGORIES` set (exported like the other flag-derived frozensets).
> 
> **`tokenizer_validator`** adds `extract_tokenizer_metadata`, `load_tokenizer_metadata`, and `_special_token_id` to pull `vocab_size`, `mask_token_id`, `pad_token_id`, and `tokenizer_type` from HuggingFace-style `tokenizer.json`.
> 
> **`file_transfer`** updates `_copy_tokenizer_if_present` to return the fingerprint on first copy; **`get_shipped_tokenizer_metadata`** reads **`DEST_PATH/tokenizer.json`** (staged file used for training), including re-ingest cases where SRC changed but DEST was not recopied.
> 
> **`BaseIngestor`** for NLP categories attaches the fingerprint before global metadata when present; missing tokenizer logs a warning and registration still completes (optional path for text/token classification).
> 
> Tests cover extraction variants, DEST-vs-SRC fingerprinting, ingest wiring for NLP vs non-NLP, and registry `NLP_CATEGORIES` invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35aab7eb5d291990917f0979805a426ecf8137ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->