### PR TITLE
chore(audit minors): drop dead max_retries, csv lint, send_batch payload test

### DIFF
--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -424,3 +424,39 @@ def test_refresh_token_false_when_reauth_raises():
     client.token = "old_token"
     with patch.object(client, "authenticate", side_effect=RuntimeError("auth down")):
         assert client._refresh_token() is False
+
+
+# ---------------------------------------------------------------------------
+# send_batch payload contract — the per-record body the backend depends on,
+# including defaults and the misspelled-but-load-bearing `injestor_id` key. A
+# typo/default drift here would silently break registration with green tests.
+# ---------------------------------------------------------------------------
+
+
+def test_send_batch_payload_shape():
+    import json as _json
+
+    client = _client()
+    records = [
+        (1, {"data_id": "a", "data_intent": "test", "label": "cat"}),
+        (2, {"data_id": "b"}),  # exercises the data_intent / label defaults
+    ]
+    with patch.object(client.session, "post", return_value=_resp(200)) as post:
+        assert client.send_batch(records, "tbl", ingestor_id="ing-42") is True
+
+    sent = _json.loads(post.call_args.kwargs["data"])
+    assert sent[0] == {
+        "data_id": "a",
+        "data_intent": "test",
+        "label": "cat",
+        "is_sample": False,
+        "injestor_id": "ing-42",
+    }
+    # Defaults: data_intent -> "train", label -> "".
+    assert sent[1] == {
+        "data_id": "b",
+        "data_intent": "train",
+        "label": "",
+        "is_sample": False,
+        "injestor_id": "ing-42",
+    }

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -107,7 +107,6 @@ class BaseIngestor(ABC):
         api_client: API client for sending data
         table_name: Name of the target database table
         schema: Database schema definition
-        max_retries: Maximum number of retry attempts
         unique_id_column: Column name for unique identifiers
         label_column: Column name for labels
         intent: Data intent (training/testing)
@@ -121,7 +120,6 @@ class BaseIngestor(ABC):
         api_client: APIClient,
         table_name: str,
         schema: Dict[str, str] = {},
-        max_retries: int = 3,
         unique_id_column: Optional[str] = None,
         label_column: Optional[str] = None,
         intent: Optional[str] = None,
@@ -138,7 +136,6 @@ class BaseIngestor(ABC):
             api_client: API client instance for data transmission
             table_name: Name of the target table
             schema: Database schema definition
-            max_retries: Maximum number of retry attempts
             unique_id_column: Name of the column to use as unique identifier
             label_column: Name of the column to use as label
             intent: Is the data for training or testing
@@ -162,7 +159,6 @@ class BaseIngestor(ABC):
         self.api_client = api_client
         self.table_name = table_name
         self.schema = schema
-        self.max_retries = max_retries
         self.unique_id_column = unique_id_column
         self.label_column = label_column
         self.intent = intent

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -57,7 +57,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
 
-__all__ = ["Ingestor"]
+__all__ = ["CSVIngestor"]
 
 
 def _cast_datetime_strict(series: pd.Series, column: str, dtype: str) -> pd.Series:
@@ -119,7 +119,6 @@ class CSVIngestor(BaseIngestor):
         api_client: APIClient,
         table_name: str,
         schema: Dict[str, str] = {},
-        max_retries: int = 3,
         csv_options: Optional[Dict[str, Any]] = None,
         file_options: Optional[Dict[str, Any]] = None,
         unique_id_column: Optional[str] = None,
@@ -137,7 +136,6 @@ class CSVIngestor(BaseIngestor):
             api_client: API client instance for data transmission
             table_name: Name of the target table
             schema: Database schema definition
-            max_retries: Maximum number of retry attempts
             csv_options: Additional options for pandas read_csv
             file_options: Additional options for file processing
             unique_id_column: Name of the column to use as unique identifier
@@ -156,7 +154,6 @@ class CSVIngestor(BaseIngestor):
             api_client,
             table_name,
             schema,
-            max_retries,
             unique_id_column,
             label_column,
             intent,
@@ -543,7 +540,7 @@ class CSVIngestor(BaseIngestor):
 
             return failed_records
 
-        except Exception as e:
+        except Exception:
             raise
 
     def _count_records(self, file_path: str) -> Optional[int]:

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -206,7 +206,6 @@ class JSONIngestor(BaseIngestor):
         api_client: APIClient,
         table_name: str,
         schema: Dict[str, str],
-        max_retries: int = 3,
         json_options: Optional[Dict[str, Any]] = None,
         unique_id_column: Optional[str] = None,
         label_column: Optional[str] = None,
@@ -225,7 +224,6 @@ class JSONIngestor(BaseIngestor):
             api_client: API client instance for data transmission
             table_name: Name of the target table
             schema: Database schema definition
-            max_retries: Maximum number of retry attempts
             json_options: Additional options for JSON processing
             unique_id_column: Name of the column to use as unique identifier
             label_column: Name of the column to use as label
@@ -247,7 +245,6 @@ class JSONIngestor(BaseIngestor):
             api_client,
             table_name,
             schema,
-            max_retries,
             unique_id_column,
             label_column,
             intent,

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -71,7 +71,12 @@ class ImageResolutionValidator(BaseValidator):
         """Validate image resolution uniformity.
 
         Args:
-            data: Image file path, directory path, or list of image file paths to validate
+            path: Accepted for the ``BaseValidator.validate`` interface but
+                IGNORED — the images directory is always resolved from the run's
+                Config as ``<SRC_PATH>/images`` (see the first line of the body).
+                Callers pass the source through ``validate_data``; it has no
+                effect here. (Audit foot-gun note: do not "fix" this to honour
+                ``path`` without checking every call site.)
             **kwargs: Additional validation parameters
                 - recursive: Whether to search directories recursively (default: True)
                 - ignore_hidden: Whether to ignore hidden files (default: True)


### PR DESCRIPTION
Sweeps the low-priority audit findings. Stacked on #282.

- **Dead `max_retries` param removed** from BaseIngestor / CSVIngestor / JSONIngestor — it was stored but never read (the real retries live in api/client's `HTTPAdapter` + the DB-layer tenacity). No caller passed it; the full suite (which constructs all three ingestors) stays green, confirming the positional `super()` alignment held. A minor trim of a no-op public param.
- **csv_ingestor lint**: `__all__` fixed (`Ingestor` → `CSVIngestor`, F822) + an unused `except … as e` binding dropped (F841).
- **`test_send_batch_payload_shape`** (M2): pins the per-record backend payload — the defaults (`data_intent="train"`, `label=""`) and the misspelled-but-load-bearing `injestor_id` key — so a typo/default drift can't slip through green.
- **`image_validator.validate`** (M4): docstring note that its `path` arg is accepted for the `BaseValidator` interface but IGNORED (resolves `<SRC_PATH>/images`).

Full suite **1086 passed, 97.1%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
