### PR TITLE
refactor(P6): consolidate the BOOL vocabulary into coercion (single source)

### DIFF
--- a/tests/test_coercion_consistency.py
+++ b/tests/test_coercion_consistency.py
@@ -134,3 +134,64 @@ def test_237_genuine_non_numeric_still_rejected_both_layers(tmp_path):
     p.write_text(csv_text)
     with pytest.raises(ValueError):
         list(_csv_ingestor(schema).read_data(str(p)))
+
+
+# ── #204: BOOL vocabulary is ONE shared set, honoured by all three layers ────
+#
+# The accepted boolean tokens used to live in three hand-synced copies (csv
+# cast ``_truthy``/``_falsy``, json ``_VALID_BOOL_STRINGS``, validator
+# ``valid_boolean_strings``) carrying "keep in lockstep" comments. P6 folded
+# them into a single source — ``coercion.BOOL_STRINGS`` — that all three read.
+# These cases pin that the set is well-formed AND that every layer agrees on
+# it, so a future private copy that drifts fails here instead of mid-ingest.
+
+
+def test_204_bool_vocabulary_is_well_formed():
+    assert (
+        coercion.BOOL_STRINGS
+        == coercion.BOOL_TRUE_STRINGS | coercion.BOOL_FALSE_STRINGS
+    )
+    # truthy and falsy must be disjoint — a token can't mean both.
+    assert not (coercion.BOOL_TRUE_STRINGS & coercion.BOOL_FALSE_STRINGS)
+    # Every token is already stripped + lower-case, so each layer's
+    # ``.strip().lower()`` normalisation matches by plain membership.
+    for tok in coercion.BOOL_STRINGS:
+        assert tok and tok == tok.strip().lower()
+
+
+def test_204_no_private_bool_vocab_copies():
+    """Single-source guarantee: the json layer no longer carries its own word
+    list (it reads ``coercion.BOOL_STRINGS``). If a private copy is
+    reintroduced this fails, flagging the drift risk P6 removed."""
+    import tracebloc_ingestor.ingestors.json_ingestor as j
+
+    assert not hasattr(j, "_VALID_BOOL_STRINGS")
+
+
+@pytest.mark.parametrize("token", sorted(coercion.BOOL_STRINGS))
+def test_204_shared_bool_token_accepted_by_all_layers(token, tmp_path):
+    """Every token in the shared set is blessed by the gate, the JSON
+    per-record check, AND cast to a real boolean (never NULL) by the CSV
+    ingest — the three layers agree by construction."""
+    schema = {"id": "INT", "flag": "BOOL"}
+    # 1) DataValidator gate
+    res = _validate(schema, f"id,flag\n1,{token}\n", tmp_path)
+    assert res.is_valid, (token, res.errors)
+    # 2) JSON per-record check — must not raise
+    _validate_value_against_dtype(token, "BOOL")
+    # 3) CSV cast — stores True/False, not NULL
+    p = tmp_path / "c.csv"
+    p.write_text(f"id,flag\n1,{token}\n")
+    rec = list(_csv_ingestor(schema).read_data(str(p)))[0]
+    assert rec["flag"] in (True, False), (token, rec["flag"])
+
+
+@pytest.mark.parametrize("token", ["banana", "maybe", "2", "yesno"])
+def test_204_non_bool_token_rejected_by_both_gates(token, tmp_path):
+    """A token outside the shared vocabulary (and not numeric-0/1) is rejected
+    by the gate and the JSON check alike — neither silently passes it."""
+    schema = {"id": "INT", "flag": "BOOL"}
+    res = _validate(schema, f"id,flag\n1,{token}\n", tmp_path)
+    assert not res.is_valid
+    with pytest.raises(ValueError):
+        _validate_value_against_dtype(token, "BOOL")

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -276,8 +276,12 @@ class CSVIngestor(BaseIngestor):
                     # bool-like values" on those strings — a direct contradiction
                     # with the validator, which blesses them, so a CSV with a
                     # yes/no column passed validation then crashed the ingestor.
-                    _truthy = {"true", "t", "yes", "y", "1", "1.0"}
-                    _falsy = {"false", "f", "no", "n", "0", "0.0"}
+                    # Vocabulary lives in coercion (the single source the
+                    # validator gate + JSON check read too) so the layers
+                    # can't drift. No numeric fallback here by design — only
+                    # these exact tokens map to a bool; see coercion.BOOL_*.
+                    _truthy = coercion.BOOL_TRUE_STRINGS
+                    _falsy = coercion.BOOL_FALSE_STRINGS
                     _norm = df[column].astype("string").str.strip().str.lower()
                     df[column] = _norm.map(
                         lambda x: True if x in _truthy

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -67,14 +67,6 @@ logger = logging.getLogger(__name__)
 __all__ = ["JSONIngestor"]
 
 
-# Boolean string forms DataValidator._validate_boolean accepts. Keep this list
-# in lockstep with that validator so the JSON per-record check and the CSV
-# preflight agree.
-_VALID_BOOL_STRINGS = {
-    "true", "false", "yes", "no", "y", "n", "t", "f", "1", "0", "1.0", "0.0"
-}
-
-
 def _validate_value_against_dtype(value: Any, dtype_upper: str) -> None:
     """Raise ValueError if ``value`` doesn't fit the declared MySQL dtype.
 
@@ -110,7 +102,7 @@ def _validate_value_against_dtype(value: Any, dtype_upper: str) -> None:
             return
         if isinstance(value, str):
             s = value.strip().lower()
-            if s in _VALID_BOOL_STRINGS:
+            if s in coercion.BOOL_STRINGS:
                 return
             # Numeric-coercible strings ("00", "01", "1.0", "0.0", "1e0", …)
             # that resolve to 0 or 1 are accepted by DataValidator; mirror that.

--- a/tracebloc_ingestor/utils/coercion.py
+++ b/tracebloc_ingestor/utils/coercion.py
@@ -22,7 +22,7 @@ object series throw outright. Every check here therefore coerces with
 compares or ``isinf``-checks a raw object series.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, FrozenSet, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -31,6 +31,9 @@ __all__ = [
     "INT64_MIN",
     "INT64_MAX",
     "NA_SENTINELS",
+    "BOOL_TRUE_STRINGS",
+    "BOOL_FALSE_STRINGS",
+    "BOOL_STRINGS",
     "build_csv_na_values",
     "int_range_error",
     "int_value_overflows",
@@ -62,6 +65,21 @@ NA_SENTINELS: List[str] = [
     "<NA>",
     "#N/A",
 ]
+
+# Boolean string vocabulary — the textual/numeric tokens that map to a BOOL
+# value. The three layers (CSV cast, JSON per-record check, DataValidator
+# gate) each carried their own copy and drifted on the digit forms (#204);
+# this is the one definition they all read now.
+#
+# Behaviour the layers must keep (NOT changed by centralising the vocabulary):
+#   - the CSV cast maps a token to True/False *only* by membership in these
+#     sets — it has no numeric fallback, so "00" / "1e0" cast to NULL;
+#   - the gate + JSON check additionally accept any string ``pd.to_numeric``
+#     resolves to 0 or 1, a wider set kept at those call sites unchanged.
+# The sets below are the exact-token core all three share.
+BOOL_TRUE_STRINGS: FrozenSet[str] = frozenset({"true", "t", "yes", "y", "1", "1.0"})
+BOOL_FALSE_STRINGS: FrozenSet[str] = frozenset({"false", "f", "no", "n", "0", "0.0"})
+BOOL_STRINGS: FrozenSet[str] = BOOL_TRUE_STRINGS | BOOL_FALSE_STRINGS
 
 # Integer base types — used to decide whether the int64-range check applies
 # (a 1e26 value is a valid FLOAT but an out-of-range INT/BIGINT).

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -801,13 +801,14 @@ class DataValidator(BaseValidator):
                 # Check which values are valid numeric booleans (0, 1, 0.0, 1.0)
                 numeric_valid = numeric_series.isin([0, 1, 0.0, 1.0])
                 
-                # For non-numeric values, check against valid boolean strings
-                valid_boolean_strings = {
-                    "true", "false", "yes", "no", "y", "n", 
-                    "t", "f", "TRUE", "FALSE", "YES", "NO"
-                }
+                # For non-numeric values, check against the shared boolean
+                # vocabulary (coercion.BOOL_STRINGS) — the same set the CSV
+                # cast and JSON check read, so the layers can't drift. The
+                # digit forms it adds ("1"/"0"/"1.0"/"0.0") are already
+                # covered by numeric_valid above, so membership here is inert
+                # for them; this only supplies the letter forms (true/yes/…).
                 string_lower = string_series.str.lower()
-                string_valid = string_lower.isin(valid_boolean_strings)
+                string_valid = string_lower.isin(coercion.BOOL_STRINGS)
                 
                 # A value is valid if it's either a valid numeric boolean OR a valid boolean string
                 # (NaN from to_numeric means it wasn't numeric, so check string_valid for those)


### PR DESCRIPTION
## Summary

**P6 — coercion consolidation**, the last *core* phase of the `BaseIngestor` refactor (RFC backend#796 §6). Folds the boolean-token vocabulary — which lived in **three hand-synced copies** — into the single source `coercion.py` started by #242.

Before, the accepted bool tokens were duplicated across:
- the CSV cast `_truthy` / `_falsy` (`csv_ingestor.py`)
- `JSONIngestor._VALID_BOOL_STRINGS` (`json_ingestor.py`)
- `DataValidator`'s inline `valid_boolean_strings` (`data_validator.py`)

…each with a *"keep this in lockstep"* comment. They had **already drifted** on the digit forms (#204). Now all three read `coercion.BOOL_TRUE_STRINGS` / `BOOL_FALSE_STRINGS` / `BOOL_STRINGS`. This matches the module's stated mission ("the gate and the ingest reach the same verdict by construction, not by a lockstep comment") — the bool vocabulary was the last un-centralized piece after NA policy + int64 range.

## Behaviour-preserving (the refactor contract)

- The CSV cast's sets are **byte-identical** to the old literals (still no numeric fallback — that quirk is preserved, not "fixed").
- The digit forms (`"1"/"0"/"1.0"/"0.0"`) added to `DataValidator`'s string-match set are **already covered by its numeric path**, so membership there is provably inert — no verdict changes.

## Type

Tech-debt / refactor (behavior-preserving).

## Test plan

- ✅ `1098` unit passed, `1` xfailed (known leading-zeros INT gap); coverage **97%** total, `coercion.py` + `csv_ingestor.py` **100%**.
- ✅ e2e characterization **goldens byte-identical** (`18 passed, 1 xpassed`) against real MySQL — bool columns flow through unchanged.
- ✅ New cross-layer congruence test in `test_coercion_consistency.py`: the shared set is well-formed, **every token is accepted by all three layers**, **no private copy remains** (`hasattr` guard), and non-bool tokens are rejected by both gates — so a future drift fails in CI, not in a customer's cluster.

## Notes for the reviewer

- Branches off `develop`, **independent of the open P5 stack** (#275 → #280). The one-region `csv_ingestor.py` edit (the bool cast, ~line 280) doesn't overlap #283's lint/`max_retries` edits, so no merge conflict when both land.
- Completes the coercion source-of-truth begun in #242 (NA sentinels + int64 range). The remaining per-type divergence (datetime parse: gate `coerce` vs cast `raise`) is **intentional policy**, not drift, so it's deliberately left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
