### PR TITLE
Test/drop semseg xfail 136

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,12 +23,19 @@ The suite **auto-skips when no MySQL is reachable**, so the default `pytest`
 (unit) run is unaffected. CI runs it with a MySQL service in
 `.github/workflows/e2e.yml`.
 
-## Known gaps (currently `xfail`)
+## Known gaps
 
-| Modality | Why | Ticket |
+None — every bundled template currently ingests end-to-end, so the suite has no
+`xfail` cases. The three modalities that were once gaps have all been fixed and
+folded back into the suite as normal cases:
+
+| Modality | Was | Fixed by |
 |---|---|---|
-| object_detection | bundled VisDrone XML uses `difficult=2`; validator only accepts `0/1` | #135 |
-| semantic_segmentation | mask sidecar column not wired through the declarative path | #136 |
+| object_detection | bundled VisDrone XML uses `difficult=2`; validator only accepted `0/1` | #135 |
 | masked_language_modeling | template missing the required `tokenizer.json` | #137 |
+| semantic_segmentation | mask sidecar not wired through the declarative path | #136 |
 
-When a fix lands, the corresponding test XPASSes — drop the `xfail` mark.
+**Convention for future gaps:** add the case with
+`marks=pytest.mark.xfail(reason="…", strict=False)` against its tracking ticket.
+When the fix lands the test XPASSes; that signals the mark can be dropped (turn
+it back into a normal case).

--- a/e2e/test_ingest_e2e.py
+++ b/e2e/test_ingest_e2e.py
@@ -101,14 +101,17 @@ CASES = [
         sequences=str(T / "masked_language_modeling/data/sequences"),
     ), id="masked_language_modeling"),
 
-    # ── known gap (xfail → tracking ticket; XPASS signals the fix landed) ──
+    # semantic_segmentation: now ingests through the declarative path after the
+    # mask sidecar was wired (#136). mask_id is preserved through process_record
+    # (#212) and staged by the semantic_segmentation transfer factory, so the
+    # per-row mask lands in DEST_PATH alongside its image — verified end-to-end
+    # by this case (3 images + 3 masks staged, 3 rows inserted).
     pytest.param(_cfg(
         table="e2e_seg", category="semantic_segmentation",
         csv=str(T / "semantic_segmentation/semantic_data/labels_file_sample.csv"),
         images=str(T / "semantic_segmentation/semantic_data/images"),
         masks=str(T / "semantic_segmentation/semantic_data/masks"), label="image_label",
-    ), id="semantic_segmentation",
-        marks=pytest.mark.xfail(reason="mask sidecar not wired in declarative path (#136)", strict=False)),
+    ), id="semantic_segmentation"),
 ]
 
 


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation only; no runtime or ingestion logic changes.
> 
> **Overview**
> **Semantic segmentation** is now a normal passing e2e case: the `pytest.mark.xfail` on the bundled-template ingest test is removed now that mask sidecars work on the declarative path (#136, with mask staging verified per the updated test comment).
> 
> The **e2e README** no longer lists active gaps or an xfail table for open tickets. It states all bundled modalities ingest end-to-end, summarizes the three historically flaky modalities (object detection, MLM, semantic segmentation) in a “was / fixed by” table, and documents how to add future gaps with `xfail(strict=False)` until fixes land.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682324837673f283fb41bf33fcb3178fa7f703f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->