### PR TITLE
fix(#805): harden tokenizer fingerprint extraction against malformed input

### DIFF
--- a/tests/test_tokenizer_fingerprint.py
+++ b/tests/test_tokenizer_fingerprint.py
@@ -120,6 +120,59 @@ def test_extract_handles_empty_or_unknown_structure():
 
 
 # ---------------------------------------------------------------------------
+# Hardening — adversarial / malformed tokenizer.json (found by fuzzing).
+# Every input must yield the 4 scalar keys and never raise (FL guardrail).
+# ---------------------------------------------------------------------------
+
+_EMPTY = {
+    "vocab_size": 0,
+    "mask_token_id": None,
+    "pad_token_id": None,
+    "tokenizer_type": None,
+}
+
+
+@pytest.mark.parametrize("bad", [[], "x", 42, None, True, [1, 2, 3]])
+def test_extract_non_dict_top_level_is_safe(bad):
+    """A tokenizer.json that is valid JSON but not an object must not crash."""
+    assert extract_tokenizer_metadata(bad) == _EMPTY
+
+
+@pytest.mark.parametrize("model", [None, "wordpiece", 123, [], {"type": {"x": 1}}])
+def test_extract_malformed_model_is_safe(model):
+    """A null / non-dict ``model`` (or a non-string ``model.type``) must not
+    crash and must not leak a non-scalar ``tokenizer_type``."""
+    meta = extract_tokenizer_metadata({"model": model})
+    assert set(meta) == set(_EMPTY)
+    assert meta["tokenizer_type"] is None or isinstance(meta["tokenizer_type"], str)
+
+
+def test_extract_non_int_added_token_id_is_dropped():
+    """A non-int ``id`` (e.g. a nested object) must not become the token id —
+    the FL guardrail allows only scalar integers across the boundary."""
+    data = {
+        "model": {"vocab": {"[PAD]": 0}},
+        "added_tokens": [{"content": "[MASK]", "id": {"x": 1}}],
+    }
+    meta = extract_tokenizer_metadata(data)
+    assert meta["mask_token_id"] is None  # the {"x": 1} id was rejected
+    assert meta["pad_token_id"] == 0  # vocab fallback still works
+
+
+def test_extract_dict_model_type_coerced_to_none():
+    meta = extract_tokenizer_metadata({"model": {"type": {"nested": 1}, "vocab": {}}})
+    assert meta["tokenizer_type"] is None
+
+
+def test_load_valid_json_non_object_returns_none(tmp_path):
+    """A tokenizer.json holding a JSON array/string/number is parseable but
+    not a tokenizer — load must return None, not crash."""
+    p = tmp_path / "tokenizer.json"
+    p.write_text("[1, 2, 3]")
+    assert load_tokenizer_metadata(str(p)) is None
+
+
+# ---------------------------------------------------------------------------
 # _special_token_id
 # ---------------------------------------------------------------------------
 

--- a/tracebloc_ingestor/validators/tokenizer_validator.py
+++ b/tracebloc_ingestor/validators/tokenizer_validator.py
@@ -27,17 +27,23 @@ def _special_token_id(tokenizer_data: dict, token: str) -> Optional[int]:
     id), then falls back to the ``model.vocab`` mapping. Returns ``None`` when
     the token isn't present — e.g. classification tokenizers have no ``[MASK]``.
     """
-    for entry in tokenizer_data.get("added_tokens", []) or []:
-        if isinstance(entry, dict) and entry.get("content") == token:
-            token_id = entry.get("id")
-            # Only trust an added_tokens entry that actually carries an id;
-            # a malformed entry without one must not shadow the model.vocab
-            # mapping below (which may still hold the id).
-            if token_id is not None:
-                return token_id
-    vocab = (tokenizer_data.get("model") or {}).get("vocab")
+    added = tokenizer_data.get("added_tokens", [])
+    if isinstance(added, list):
+        for entry in added:
+            if isinstance(entry, dict) and entry.get("content") == token:
+                token_id = entry.get("id")
+                # Only trust an added_tokens entry that carries a real integer
+                # id (bool excluded — JSON true/false is not a token id). A
+                # missing or non-int id must not shadow the model.vocab mapping
+                # below, nor let a non-scalar value reach the backend.
+                if isinstance(token_id, int) and not isinstance(token_id, bool):
+                    return token_id
+    model = tokenizer_data.get("model")
+    vocab = model.get("vocab") if isinstance(model, dict) else None
     if isinstance(vocab, dict):
-        return vocab.get(token)
+        vid = vocab.get(token)
+        if isinstance(vid, int) and not isinstance(vid, bool):
+            return vid
     return None
 
 
@@ -61,13 +67,23 @@ def extract_tokenizer_metadata(tokenizer_data: dict) -> Dict[str, Any]:
       - ``tokenizer_type``: ``model.type`` (``WordLevel`` / ``WordPiece`` /
                             ``BPE`` / ``Unigram``), or ``None``.
     """
+    # Totality: a tokenizer.json that is valid JSON but not an object (e.g.
+    # ``[]`` / ``"x"`` / ``null``) must not crash the post-ingest registration —
+    # treat it as empty. The TokenizerValidator gate already rejects such files
+    # upstream; this keeps the public helper safe for any caller.
+    if not isinstance(tokenizer_data, dict):
+        tokenizer_data = {}
     vocab = TokenizerValidator._extract_vocab(tokenizer_data) or set()
-    model = tokenizer_data.get("model") or {}
+    model = tokenizer_data.get("model")
+    tok_type = model.get("type") if isinstance(model, dict) else None
+    # FL guardrail at the source: only scalar values ever leave the cluster.
+    # Coerce a malformed non-int id / non-string type to None so a hand-crafted
+    # tokenizer.json can't smuggle a nested object into the backend metadata.
     return {
         "vocab_size": len(vocab),
         "mask_token_id": _special_token_id(tokenizer_data, "[MASK]"),
         "pad_token_id": _special_token_id(tokenizer_data, "[PAD]"),
-        "tokenizer_type": model.get("type"),
+        "tokenizer_type": tok_type if isinstance(tok_type, str) else None,
     }
 
 
@@ -86,6 +102,12 @@ def load_tokenizer_metadata(tokenizer_path: str) -> Optional[Dict[str, Any]]:
             tokenizer_data = json.load(f)
     except (OSError, ValueError) as e:
         logger.warning(f"Could not read tokenizer.json at {tokenizer_path}: {e}")
+        return None
+    if not isinstance(tokenizer_data, dict):
+        logger.warning(
+            f"tokenizer.json at {tokenizer_path} is not a JSON object "
+            f"({type(tokenizer_data).__name__}); no fingerprint registered."
+        )
         return None
     return extract_tokenizer_metadata(tokenizer_data)
 
@@ -222,13 +244,16 @@ class TokenizerValidator(BaseValidator):
         Returns:
             Set of token strings, or None if the structure is unrecognised.
         """
+        if not isinstance(tokenizer_data, dict):
+            return None
+
         tokens = set()
 
         # model.vocab — the main vocabulary mapping
         # WordLevel/WordPiece/BPE store vocab as {token: id} dict.
         # Unigram stores vocab as [[token, score], ...] list.
-        model = tokenizer_data.get("model", {})
-        vocab = model.get("vocab")
+        model = tokenizer_data.get("model")
+        vocab = model.get("vocab") if isinstance(model, dict) else None
         if isinstance(vocab, dict):
             tokens.update(vocab.keys())
         elif isinstance(vocab, list):
@@ -236,12 +261,14 @@ class TokenizerValidator(BaseValidator):
                 if isinstance(entry, (list, tuple)) and len(entry) >= 1:
                     tokens.add(str(entry[0]))
 
-        # added_tokens — special tokens registered separately
+        # added_tokens — special tokens registered separately. Only count a
+        # string ``content`` — a malformed non-string would be unhashable
+        # (dict/list) or pollute the vocab count.
         added_tokens = tokenizer_data.get("added_tokens", [])
         if isinstance(added_tokens, list):
             for entry in added_tokens:
-                if isinstance(entry, dict) and "content" in entry:
-                    tokens.update([entry["content"]])
+                if isinstance(entry, dict) and isinstance(entry.get("content"), str):
+                    tokens.add(entry["content"])
                 elif isinstance(entry, str):
                     tokens.add(entry)
 


### PR DESCRIPTION
## Follow-up hardening for #805 Task 2 (data-ingestors#281)

I fuzz-tested the merged Task 2 tokenizer-fingerprint logic (50k+ adversarial `tokenizer.json` variants — structural + byte-level) to try to break it. It found **three** ways a hand-crafted / malformed `tokenizer.json` could break it:

| # | Input | Before |
|---|---|---|
| 1 | `{"model": null}` or a non-object top-level JSON (`[]`, `"x"`, `42`) | `extract`/`load` raised `AttributeError` (`None.get(...)`); `load_tokenizer_metadata` only caught `OSError/ValueError`, so it propagated |
| 2 | non-string `model.type` (e.g. a dict) | registered **verbatim** → a non-scalar value crosses to the backend |
| 3 | `added_tokens` `id` that's a dict/list | returned as the token id → non-scalar `mask/pad_token_id` |

#2 and #3 **breach the FL guardrail** (only 4 scalar integers may ever reach the backend) and would poison the Task 3/4 comparison. The crash cases (#1) are rejected by the `TokenizerValidator` gate in the integrated flow, but the guardrail breaches can **pass validation** (it doesn't inspect `model.type` or token ids), and the public helpers should be total regardless of the caller.

### Hardening
- **`extract_tokenizer_metadata`** — treat a non-dict as empty; coerce `tokenizer_type` to `str`-or-`None`.
- **`_special_token_id`** — only return a real `int` id (`bool` excluded); guard that `added_tokens` is a list and `model` is a dict before the vocab fallback.
- **`_extract_vocab`** — guard non-dict input / non-dict `model`; only count a **string** `content` (a dict content was unhashable → would crash).
- **`load_tokenizer_metadata`** — return `None` for a valid-JSON-but-non-object file.

After hardening, `extract`/`load` **never raise** and only ever emit the 4 scalar keys — verified by re-running the fuzz harness (50k iterations: *"no crashes, no invariant violations"*).

### Tests
Adds deterministic regression tests for each fuzz-found case (non-dict top-level, malformed/`null` model, non-string `model.type`, non-int `id`, non-object file). Full suite: **1143 passed, 1 xfailed**.

The fuzz harness itself lives outside the repo (`~/work/claude/805-task2-fuzz/`); happy to add a seeded version to the suite if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FL metadata boundary validation and post-ingest fingerprint registration; malformed inputs are now coerced instead of crashing or leaking nested values, which could alter registered fingerprints for edge-case files that still pass upstream validation.
> 
> **Overview**
> Hardens **#805** tokenizer fingerprint extraction so malformed `tokenizer.json` cannot crash post-ingest registration or send non-scalar values on the global-metadata channel.
> 
> **`extract_tokenizer_metadata`** now treats non-dict input as empty and only emits a string-or-`None` **`tokenizer_type`**. **`_special_token_id`** requires real integer token ids (excluding JSON booleans), validates **`added_tokens`** / **`model`** shape before vocab fallback, and applies the same int checks to vocab ids. **`TokenizerValidator._extract_vocab`** guards non-dict roots and only counts string **`content`** in **`added_tokens`**. **`load_tokenizer_metadata`** returns **`None`** (with a warning) when JSON parses but is not an object.
> 
> Adds regression tests for fuzz-found cases: non-object top-level JSON, null/malformed **`model`**, non-string **`model.type`**, non-int **`added_tokens`** ids, and array **`tokenizer.json`** files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f9881a31bb981eb15c8ddcefa7121e4a6ef652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->