### PR TITLE
chore(release): v0.3.11

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -21,7 +21,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.10"
+__version__ = "0.3.11"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
Bump `__version__` `0.3.10` → `0.3.11` to cut a release.

Once merged, tag **`v0.3.11`** on `develop` HEAD → `release-image.yml` builds `ghcr.io/tracebloc/ingestor:0.3.11` / `:0.3` / `:3`, and the dev cluster's `image-refresh` cron rolls the new `:0.3` onto `tracebloc-templates`.

This release ships, onto the dev ingestor image:
- **#805 Task 2** — NLP tokenizer fingerprint at ingest (#281)
- **fuzz-hardening** of that logic (#286)
- (plus everything else merged to `develop` since `v0.3.10`: the P3–P6 structural refactor train, token_classification, etc.)

Single-sourced version (`tracebloc_ingestor/__init__.py`; `setup.py` reads it) — `test_version_single_source` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version constant change with no runtime logic modified.
> 
> **Overview**
> **Release bump only:** `__version__` in `tracebloc_ingestor/__init__.py` goes from `0.3.10` to `0.3.11`. `setup.py` still reads that literal via `_read_version()`, so packaging stays in sync without a second edit.
> 
> This tag is meant to ship whatever is already on `develop` (e.g. NLP tokenizer fingerprint at ingest, related hardening, and other merged work since `0.3.10`) through the usual GHCR image build and dev cluster refresh—not to introduce new code in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0efe6db1614529d68c761cc1f04e313b00acdc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->