### PR TITLE
feat(identifiers): canonical column-identifier grammar — source of truth (#382)

### DIFF
--- a/tests/test_column_identifier_contract.py
+++ b/tests/test_column_identifier_contract.py
@@ -1,0 +1,81 @@
+"""Cross-repo column-identifier contract (ISSUE #382).
+
+This pins the canonical column-name grammar that BOTH the ingestor (here) and
+the trainer (``tracebloc-client`` core/utils/database.py) must agree on. The
+trainer mirrors ``tracebloc_ingestor.identifiers`` verbatim and has its own copy
+of this table plus a pin test; together they keep the two repos from drifting.
+
+The reconciliation is **quote-and-allow**: a column name is valid iff it can be
+safely backtick-quoted for MySQL (non-empty, ≤64 chars, no NUL). Digit-leading,
+hyphenated, spaced, dotted and unicode names are all accepted and quoted — only
+over-length / empty / NUL names are rejected.
+
+The exact parametrisation called out in the issue is included below. On the
+trainer's ``main`` today, the names marked ``accepted`` are REJECTED by its
+over-strict ``^[a-zA-Z_][a-zA-Z0-9_]{0,63}$`` regex — that mismatch is the bug
+this contract exists to prevent.
+"""
+
+import pytest
+
+from tracebloc_ingestor.identifiers import (
+    MAX_COLUMN_IDENTIFIER_LENGTH,
+    InvalidColumnIdentifierError,
+    is_valid_column_identifier,
+    quote_column_identifier,
+    validate_column_identifier,
+)
+
+# The issue's parametrisation, plus the accept/reject verdict under the
+# reconciled grammar. (name, should_be_valid)
+CONTRACT_CASES = [
+    ("123_gene", True),                       # digit-leading — quotable
+    ("_ok", True),                            # leading underscore
+    ("feature-1", True),                      # hyphen — quotable
+    ("col name", True),                       # space — quotable
+    ("P08254|MMP3", True),                    # proteomics pipe header (#184/#185)
+    ("Körpergröße", True),                    # clinical unicode header (#739)
+    ("feature.1", True),                      # dot
+    ("a" * MAX_COLUMN_IDENTIFIER_LENGTH, True),       # exactly 64 — boundary OK
+    ("a" * (MAX_COLUMN_IDENTIFIER_LENGTH + 1), False),  # 65 chars — too long
+    ("", False),                              # empty
+    ("bad\x00col", False),                    # NUL — illegal in identifier
+]
+
+
+@pytest.mark.parametrize("name,valid", CONTRACT_CASES)
+def test_is_valid_column_identifier_matches_contract(name, valid):
+    assert is_valid_column_identifier(name) is valid
+
+
+@pytest.mark.parametrize("name,valid", CONTRACT_CASES)
+def test_validate_column_identifier_matches_contract(name, valid):
+    if valid:
+        assert validate_column_identifier(name) == name
+    else:
+        with pytest.raises(InvalidColumnIdentifierError):
+            validate_column_identifier(name)
+
+
+@pytest.mark.parametrize("name", [n for n, ok in CONTRACT_CASES if ok])
+def test_valid_names_quote_safely(name):
+    """Every accepted name renders to a single backtick-quoted token, with any
+    embedded backtick doubled — so quoting alone makes it injection-safe."""
+    quoted = quote_column_identifier(name)
+    assert quoted.startswith("`") and quoted.endswith("`")
+    # Interior backticks are doubled; no lone backtick can break out of the quote.
+    assert quoted[1:-1] == name.replace("`", "``")
+
+
+def test_backtick_header_is_escaped_not_rejected():
+    """A header containing a backtick is allowed (quote-and-allow) and escaped
+    by doubling — it is never rejected and never breaks out of the identifier."""
+    assert is_valid_column_identifier("a`b")
+    assert quote_column_identifier("a`b") == "`a``b`"
+
+
+def test_injection_shaped_header_is_neutralised_by_quoting():
+    """A SQL-injection-shaped header is one inert backtick-quoted token, not a
+    rejection and not executable SQL — matching the ingestor DDL harness."""
+    evil = "x`; DROP TABLE y; --"
+    assert quote_column_identifier(evil) == "`x``; DROP TABLE y; --`"

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -7,6 +7,13 @@ ingestors, along with built-in support for common data formats.
 
 from .config import Config
 from .database import Database
+from .identifiers import (
+    MAX_COLUMN_IDENTIFIER_LENGTH,
+    InvalidColumnIdentifierError,
+    is_valid_column_identifier,
+    quote_column_identifier,
+    validate_column_identifier,
+)
 from .api.client import APIClient
 from .ingestors import BaseIngestor, CSVIngestor, JSONIngestor
 from .utils.template_runner import run_ingestion
@@ -36,4 +43,9 @@ __all__ = [
     "ImageResolutionValidator",
     "TableNameValidator",
     "run_ingestion",
+    "MAX_COLUMN_IDENTIFIER_LENGTH",
+    "InvalidColumnIdentifierError",
+    "is_valid_column_identifier",
+    "quote_column_identifier",
+    "validate_column_identifier",
 ]

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -34,6 +34,7 @@ from tenacity import (
     before_sleep_log,
 )
 from .config import Config
+from .identifiers import MAX_COLUMN_IDENTIFIER_LENGTH
 
 # Configure unified logging with config
 config = Config()
@@ -287,7 +288,13 @@ class Database:
         # before CREATE TABLE turns it into a raw MySQL 1059 error. CSV headers are
         # used verbatim as column names, so long proteomics/genomics headers (e.g. a
         # semicolon-joined isoform list) blow the limit; name the offenders clearly.
-        _MAX_IDENTIFIER = 64
+        # The 64-char cap is the only column-name restriction enforced at ingest:
+        # every other shape (digit-leading, '|'/'.'/'-', spaces, unicode, even
+        # backticks) is deliberately accepted and backtick-quoted downstream
+        # (see identifiers.py — the canonical grammar shared with the trainer,
+        # ISSUE #382). MySQL's identifier limit is the one thing quoting can't
+        # rescue, so it stays a hard, actionable failure here.
+        _MAX_IDENTIFIER = MAX_COLUMN_IDENTIFIER_LENGTH
         _too_long = sorted(c for c in schema if len(str(c)) > _MAX_IDENTIFIER)
         if _too_long:
             preview = "; ".join(f"'{c[:40]}…' ({len(c)} chars)" for c in _too_long[:5])

--- a/tracebloc_ingestor/identifiers.py
+++ b/tracebloc_ingestor/identifiers.py
@@ -1,0 +1,82 @@
+"""Canonical column-identifier grammar — the single source of truth.
+
+This module is the authoritative definition of what counts as a valid *column*
+identifier across the tracebloc platform. It is deliberately dependency-light
+(stdlib only) so the trainer (``tracebloc-client``) can mirror it verbatim
+without taking a dependency on the rest of this package.
+
+The reconciliation (ISSUE #382)
+-------------------------------
+Two repos used to disagree on column-name legality, and the disagreement was
+silent until training: the ingestor accepts and backtick-quotes arbitrary
+headers (proteomics ``P08254|MMP3``, clinical ``Körpergröße``, spaces, dots —
+see ``tests/test_i18n_adversarial_csv.py`` / #739 and #184/#185), while the
+trainer rejected anything outside ``^[a-zA-Z_][a-zA-Z0-9_]{0,63}$`` — raising
+*uncaught*, after an experiment was already running.
+
+We reconciled toward **quote-and-allow**: the ingestor's accepting behaviour is
+correct and is the source of truth. A column name is valid iff it can be safely
+backtick-quoted for MySQL:
+
+  * it is a non-empty string,
+  * at most 64 characters (MySQL's identifier limit — the one constraint
+    quoting cannot rescue), and
+  * contains no NUL (``\\x00``), which is illegal in a MySQL identifier.
+
+Every other character is permitted and made safe by quoting; backticks are
+escaped by doubling (``quote_column_identifier``). This mirrors exactly what
+SQLAlchemy emits in the ingestor's ``CREATE TABLE`` DDL.
+
+Note on *table* names: those are stricter and validated separately
+(``TableNameValidator`` here, ``_validate_sql_identifier`` in the trainer) —
+table names are platform-controlled, columns come from raw user data.
+"""
+
+# MySQL's maximum identifier length. The one column-name constraint that
+# backtick-quoting cannot work around, so both repos hard-fail above it.
+MAX_COLUMN_IDENTIFIER_LENGTH = 64
+
+
+class InvalidColumnIdentifierError(ValueError):
+    """Raised when a column name cannot be safely used as a MySQL identifier."""
+
+
+def is_valid_column_identifier(name: object) -> bool:
+    """Return True if ``name`` is a valid (safely quotable) column identifier."""
+    return (
+        isinstance(name, str)
+        and name != ""
+        and len(name) <= MAX_COLUMN_IDENTIFIER_LENGTH
+        and "\x00" not in name
+    )
+
+
+def validate_column_identifier(name: str) -> str:
+    """Validate a single column name, returning it unchanged when valid.
+
+    Raises ``InvalidColumnIdentifierError`` with an actionable message otherwise.
+    """
+    if not isinstance(name, str) or name == "":
+        raise InvalidColumnIdentifierError(
+            f"Invalid column name {name!r}: must be a non-empty string."
+        )
+    if "\x00" in name:
+        raise InvalidColumnIdentifierError(
+            f"Invalid column name {name!r}: must not contain a NUL character."
+        )
+    if len(name) > MAX_COLUMN_IDENTIFIER_LENGTH:
+        raise InvalidColumnIdentifierError(
+            f"Column name {name!r} is {len(name)} characters, exceeding the "
+            f"{MAX_COLUMN_IDENTIFIER_LENGTH}-character database limit — shorten it."
+        )
+    return name
+
+
+def quote_column_identifier(name: str) -> str:
+    """Return a MySQL backtick-quoted column identifier after validation.
+
+    Backticks in the name are escaped by doubling, matching MySQL's identifier
+    quoting rules — so any valid name is rendered injection-safe.
+    """
+    validate_column_identifier(name)
+    return "`" + name.replace("`", "``") + "`"


### PR DESCRIPTION
## Why
The ingestor and the trainer (`tracebloc-client`) disagreed on which column names are legal, and the disagreement was silent until training: the ingestor accepts and backtick-quotes arbitrary headers (pipe/dot/space/unicode), while the trainer rejected anything outside `^[a-zA-Z_][a-zA-Z0-9_]{0,63}$` — raising *uncaught*, after an experiment was already running. Tracked in tracebloc/tracebloc-client#382.

## What
Establish a single, dependency-light **source of truth** for the column-identifier grammar and reconcile toward **quote-and-allow**:

- **`tracebloc_ingestor/identifiers.py`** (new) — a column name is valid iff it can be safely backtick-quoted for MySQL: **non-empty, ≤64 chars, no NUL**. Every other character is accepted and quoted; backticks are escaped by doubling (`quote_column_identifier`). This is exactly what the engine already emits in `CREATE TABLE` DDL.
- **`database.py`** — `create_table`'s 64-char length check now sources the shared `MAX_COLUMN_IDENTIFIER_LENGTH` constant; **no behaviour change**, existing special-character / unicode header support is untouched.
- **`tests/test_column_identifier_contract.py`** (new) — contract test pinning the grammar against the parametrised set from the issue. The trainer mirrors this rule with its own pin test (kept lean — it does not import this package), so the two repos can't drift.

## Notes
- Table-name validation (`TableNameValidator`) stays strict and is unchanged — table names are platform-controlled; only column names come from raw user data.
- All test data is synthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly new shared validation helpers, tests, and a constant import; no change to ingest DDL/upsert quoting behavior beyond documenting the existing 64-char rule.
> 
> **Overview**
> Adds a **quote-and-allow** column-name contract so ingest and trainer can agree on legality: valid names are non-empty, ≤64 chars, and NUL-free; everything else (pipes, spaces, unicode, hyphens, backticks) is accepted and made safe via MySQL backtick quoting with doubled interior backticks.
> 
> **`tracebloc_ingestor/identifiers.py`** defines `is_valid_column_identifier`, `validate_column_identifier`, `quote_column_identifier`, and `MAX_COLUMN_IDENTIFIER_LENGTH` as the shared source of truth (mirrored in `tracebloc-client`). **`database.py`** only swaps the inline `64` for that constant in `create_table`'s length guard—ingest behavior for special headers is unchanged. **`tests/test_column_identifier_contract.py`** pins the issue's parametrized cases plus quoting/injection-neutralization checks so the two repos can't drift silently again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b28fdb7d709d1e31fb92019141be6a35feac044. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->