### PR TITLE
fix(data_validator): surface "Did you mean ...?" on typo'd schema types (#266)

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -253,6 +253,29 @@ def test_unknown_type_fails():
     assert "Unknown data type" in result.errors[0]
 
 
+def test_unknown_type_suggests_closest_match():
+    """Issue #266: when the user types a typo'd type (INTERGER), the
+    DataValidator rejects FIRST — before ``Database._get_sqlalchemy_type``'s
+    suggestion (#264) ever runs. Surface the same hint at this layer."""
+    df = pd.DataFrame({"a": [1]})
+    result = DataValidator(schema={"a": "INTERGER"}).validate(df)
+    assert not result.is_valid
+    err = result.errors[0]
+    assert "Did you mean 'INTEGER'" in err
+    assert "Supported types" in err
+
+
+def test_unknown_type_no_suggestion_for_distant_input():
+    """A genuinely off-vocabulary type (no close match) gets the supported-types
+    list but no "Did you mean" hint — otherwise we'd surface noisy guesses."""
+    df = pd.DataFrame({"a": [1]})
+    result = DataValidator(schema={"a": "QUATERNION"}).validate(df)
+    assert not result.is_valid
+    err = result.errors[0]
+    assert "Did you mean" not in err
+    assert "Supported types" in err
+
+
 def test_csv_schema_column_not_in_header_now_fails(make_csv):
     """Issue #289: a schema column absent from a CSV header used to pass the
     DataValidator silently — the read-time check in CSVIngestor caught it

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -276,6 +276,43 @@ def test_unknown_type_no_suggestion_for_distant_input():
     assert "Supported types" in err
 
 
+@pytest.mark.parametrize("dbtype", ["TINYINT", "SMALLINT", "MEDIUMINT", "BIGINT"])
+def test_integer_variants_pass_preflight(dbtype):
+    """Bugbot #293: TINYINT/SMALLINT/MEDIUMINT are accepted by
+    ``Database._get_sqlalchemy_type`` (all map to Integer) but were missing
+    from the validator's ``type_validators`` — preflight rejected them as
+    "Unknown data type" before ingestion even ran. BIGINT was already
+    covered; the rest now share the same per-value INT check."""
+    df = pd.DataFrame({"n": [1, 2, 3]})
+    result = DataValidator(schema={"n": dbtype}).validate(df)
+    assert result.is_valid, f"{dbtype} should pass; errors={result.errors}"
+
+
+@pytest.mark.parametrize("dbtype", ["BLOB", "LONGBLOB"])
+def test_blob_types_pass_preflight(dbtype):
+    """Bugbot #293: BLOB and LONGBLOB are valid MySQL types accepted by
+    Database._get_sqlalchemy_type, but the validator rejected them as
+    "Unknown data type". Worse, the new Levenshtein hint suggested BOOL
+    (distance 2 from BLOB), framing a correctly-spelled type as a typo.
+    Add a passthrough validator so the preflight gate matches the DB
+    layer's vocabulary."""
+    df = pd.DataFrame({"payload": [b"x", b"y", b"z"]})
+    result = DataValidator(schema={"payload": dbtype}).validate(df)
+    assert result.is_valid, f"{dbtype} should pass; errors={result.errors}"
+
+
+def test_typo_suggest_does_not_mislabel_blob_as_bool():
+    """Bugbot #293 (regression guard): for a CORRECTLY spelled BLOB schema
+    the user must NEVER see "Did you mean 'BOOL'?". The fix above makes
+    BLOB a known type; this test pins the contract so future deletions of
+    BLOB from ``type_validators`` reproduce the bugbot finding immediately."""
+    df = pd.DataFrame({"payload": [b"x"]})
+    result = DataValidator(schema={"payload": "BLOB"}).validate(df)
+    assert result.is_valid
+    # And the suggestion machinery never runs because the type is known.
+    assert not any("Did you mean" in e for e in (result.errors or []))
+
+
 def test_csv_schema_column_not_in_header_now_fails(make_csv):
     """Issue #289: a schema column absent from a CSV header used to pass the
     DataValidator silently — the read-time check in CSVIngestor caught it

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -24,7 +24,7 @@ from sqlalchemy.dialects.mysql import insert, LONGBLOB, BLOB
 from sqlalchemy.exc import OperationalError, InterfaceError, DBAPIError
 import logging
 from urllib.parse import quote
-from typing import Iterable, List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional
 from datetime import datetime
 from tenacity import (
     retry,
@@ -35,6 +35,7 @@ from tenacity import (
 )
 from .config import Config
 from .identifiers import MAX_COLUMN_IDENTIFIER_LENGTH
+from .utils.typo_suggest import suggest_type as _suggest_type
 
 # Configure unified logging with config
 config = Config()
@@ -96,58 +97,6 @@ def _execute_with_retry(connection, stmt):
                 f"connection.rollback() failed between retries: {rb_exc}"
             )
         raise
-
-
-def _suggest_type(unknown: str, known: Iterable[str]) -> Optional[str]:
-    """Return the closest match from ``known`` to ``unknown`` if any
-    candidate is within edit distance 3 (Levenshtein), else None.
-
-    Used by ``_get_sqlalchemy_type`` to surface a "Did you mean BIGINT?"
-    hint when a customer types BIGINTEGER, BOOLEAN→BOOL, NUMRIC→NUMERIC,
-    etc. Distance 3 is the empirical sweet spot — close enough to catch
-    every realistic typo we've seen in the wild (single-letter swaps,
-    common prefix/suffix confusion like INT-vs-INTEGER, missing or
-    duplicated letters), wide enough to fail-silently on entries that
-    are genuinely different vocabulary (no false "Did you mean DATE?"
-    for a GEOMETRY).
-
-    Returns the FIRST best match at the minimum distance — type_mapping
-    has stable insertion order so the deterministic result is fine for
-    tests.
-    """
-    if not unknown:
-        return None
-
-    def _levenshtein(a: str, b: str) -> int:
-        if a == b:
-            return 0
-        if not a:
-            return len(b)
-        if not b:
-            return len(a)
-        # Two-row DP — O(len(a)*len(b)) time, O(min(a,b)) space.
-        prev = list(range(len(b) + 1))
-        for i, ca in enumerate(a, start=1):
-            curr = [i] + [0] * len(b)
-            for j, cb in enumerate(b, start=1):
-                cost = 0 if ca == cb else 1
-                curr[j] = min(
-                    prev[j] + 1,
-                    curr[j - 1] + 1,
-                    prev[j - 1] + cost,
-                )
-            prev = curr
-        return prev[-1]
-
-    target = unknown.upper()
-    best: Optional[str] = None
-    best_d = 99
-    for candidate in known:
-        d = _levenshtein(target, candidate)
-        if d < best_d:
-            best = candidate
-            best_d = d
-    return best if best_d <= 3 else None
 
 
 class Database:

--- a/tracebloc_ingestor/utils/typo_suggest.py
+++ b/tracebloc_ingestor/utils/typo_suggest.py
@@ -1,0 +1,64 @@
+"""Single source of truth for "Did you mean …?" suggestions on schema types.
+
+Both the row-read layer (``Database._get_sqlalchemy_type``) and the preflight
+``DataValidator`` reject unknown MySQL/SQLAlchemy types. Both should offer the
+same suggestion when the user has clearly typo'd a real entry (``INTERGER`` →
+``INTEGER``, ``BIGINTEGER`` → ``BIGINT``/``INTEGER``, ``NUMRIC`` → ``NUMERIC``).
+
+Originally lived in :mod:`tracebloc_ingestor.database` as a private helper, but
+the preflight validator rejects unknowns first (#266) — so the suggestion has
+to be reachable from both call sites without circular imports. Extracted here
+so each layer can wire its own error message identically.
+"""
+
+from typing import Iterable, Optional
+
+
+def suggest_type(unknown: str, known: Iterable[str]) -> Optional[str]:
+    """Return the closest match from ``known`` to ``unknown`` if any candidate
+    is within edit distance 3 (Levenshtein), else ``None``.
+
+    Distance 3 is the empirical sweet spot — close enough to catch every
+    realistic typo seen in the wild (single-letter swaps, common
+    prefix/suffix confusion like ``INT``↔``INTEGER``, missing or duplicated
+    letters), wide enough to fail-silently on entries that are genuinely
+    different vocabulary (no false "Did you mean DATE?" for ``GEOMETRY``).
+
+    Returns the FIRST best match at the minimum distance — callers pass an
+    ordered iterable (the type map keys) so the deterministic result is fine
+    for tests.
+    """
+    if not unknown:
+        return None
+
+    target = unknown.upper()
+    best: Optional[str] = None
+    best_d = 99
+    for candidate in known:
+        d = _levenshtein(target, candidate)
+        if d < best_d:
+            best = candidate
+            best_d = d
+    return best if best_d <= 3 else None
+
+
+def _levenshtein(a: str, b: str) -> int:
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    # Two-row DP — O(len(a)*len(b)) time, O(min(a,b)) space.
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        curr = [i] + [0] * len(b)
+        for j, cb in enumerate(b, start=1):
+            cost = 0 if ca == cb else 1
+            curr[j] = min(
+                prev[j] + 1,
+                curr[j - 1] + 1,
+                prev[j - 1] + cost,
+            )
+        prev = curr
+    return prev[-1]

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -19,6 +19,7 @@ import pandas as pd
 from .base import BaseValidator, ValidationResult
 from ..config import Config
 from ..utils import coercion
+from ..utils.typo_suggest import suggest_type as _suggest_type
 
 config = Config()
 logger = logging.getLogger(__name__)
@@ -471,9 +472,29 @@ class DataValidator(BaseValidator):
         if base_type in self.type_validators:
             return self.type_validators[base_type](series, column_name, expected_type)
         else:
+            # Surface a "Did you mean …?" hint when the customer has typed a
+            # close variant of a real type (INTERGER → INTEGER, BIGINTEGER →
+            # INTEGER, NUMRIC → NUMERIC). Without this the preflight error was
+            # just "Unknown data type: INTERGER" — the suggestion machinery
+            # existed in ``Database._get_sqlalchemy_type`` (#264) but the
+            # validator rejects unknown types FIRST, so that code path never
+            # ran for a typo'd schema (#266). Share the helper so both layers
+            # offer the same fix.
+            suggestion = _suggest_type(base_type, self.type_validators.keys())
+            if suggestion:
+                msg = (
+                    f"Unknown data type: {expected_type}. Did you mean "
+                    f"'{suggestion}'? Supported types: "
+                    f"{sorted(self.type_validators.keys())}"
+                )
+            else:
+                msg = (
+                    f"Unknown data type: {expected_type}. Supported types: "
+                    f"{sorted(self.type_validators.keys())}"
+                )
             return {
                 "is_valid": False,
-                "errors": [f"Unknown data type: {expected_type}"],
+                "errors": [msg],
                 "warnings": [],
             }
 

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -77,13 +77,28 @@ class DataValidator(BaseValidator):
         super().__init__(name)
         self.schema = schema or {}
 
-        # Map database types to validation functions
+        # Map database types to validation functions. This vocabulary MUST
+        # match ``Database._get_sqlalchemy_type``'s ``type_mapping`` — if a
+        # type is accepted by the DB layer but missing here, the user gets
+        # a misleading "Unknown data type" preflight rejection AND the
+        # Levenshtein hint can suggest a wrong-but-close-spelled validator
+        # entry (e.g. BLOB → "Did you mean BOOL?", flagged by bugbot on
+        # PR #293).
         self.type_validators = {
             "VARCHAR": self._validate_varchar,
             "CHAR": self._validate_char,
             "TEXT": self._validate_text,
             "INT": self._validate_int,
             "INTEGER": self._validate_int,
+            # MySQL integer variants share the same per-value contract — any
+            # value pandas can coerce to int passes; range-check is handled at
+            # the DDL layer by SQLAlchemy. Without these entries a schema with
+            # TINYINT/SMALLINT/MEDIUMINT hit "Unknown data type" at preflight
+            # even though Database._get_sqlalchemy_type accepts them as
+            # Integer (bugbot #293).
+            "TINYINT": self._validate_int,
+            "SMALLINT": self._validate_int,
+            "MEDIUMINT": self._validate_int,
             "BIGINT": self._validate_bigint,
             "FLOAT": self._validate_float,
             "DOUBLE": self._validate_double,
@@ -101,6 +116,15 @@ class DataValidator(BaseValidator):
             "DATETIME": self._validate_datetime,
             "TIMESTAMP": self._validate_timestamp,
             "TIME": self._validate_time,
+            # Binary blob types — Database accepts them (BLOB / LONGBLOB map
+            # to SQLAlchemy BLOB/LONGBLOB). At the validator layer there's no
+            # meaningful per-value type check to do (any Python object can
+            # bind to a BLOB column), so accept-and-pass is the right
+            # behaviour. Bugbot #293 caught the prior gap: a valid BLOB
+            # schema was rejected as "Unknown data type" and the Levenshtein
+            # hint suggested BOOL (distance 2).
+            "BLOB": self._validate_passthrough,
+            "LONGBLOB": self._validate_passthrough,
         }
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
@@ -597,6 +621,17 @@ class DataValidator(BaseValidator):
                 )
 
         return {"is_valid": len(errors) == 0, "errors": errors, "warnings": warnings}
+
+    def _validate_passthrough(
+        self, series: pd.Series, column_name: str, expected_type: str
+    ) -> Dict[str, Any]:
+        """No-op per-value check for types where the validator has no
+        meaningful constraint to enforce (BLOB, LONGBLOB). The Database layer
+        binds whatever Python value is supplied as bytes; the user has
+        opted in to that contract by declaring the column blob-typed.
+        Returns ``is_valid=True`` so the type passes preflight (bugbot #293).
+        """
+        return {"is_valid": True, "errors": [], "warnings": []}
 
     def _validate_text(
         self, series: pd.Series, column_name: str, expected_type: str


### PR DESCRIPTION
## Summary
Closes #266.

PR #264 added a Levenshtein "Did you mean …?" suggestion to `Database._get_sqlalchemy_type` so a typo'd MySQL type like `INTERGER` would surface `"Did you mean 'INTEGER'?"`. The catch: the `DataValidator` rejects unknown types *first*, with its own `Unknown data type: INTERGER` message — so the suggestion machinery never ran for a typo'd schema, and the user just saw a bare rejection.

This factors the Levenshtein helper out of `database.py` into a shared `utils.typo_suggest` and wires the hint into the DataValidator's "Unknown data type" branch as well. Both layers now share one source of truth, and the user sees the same suggestion regardless of which layer rejects first.

Reproduced and verified on `v0.3.10-rc4` dev cluster: prior to fix, ingesting with `schema: { age: INTERGER }` surfaced only `Unknown data type: INTERGER`. With the fix the user sees `Unknown data type: INTERGER. Did you mean 'INTEGER'? Supported types: [...]`.

## Test plan
- [x] New: `test_unknown_type_suggests_closest_match` — a close-typo type now gets a "Did you mean" hint at the validator layer.
- [x] New: `test_unknown_type_no_suggestion_for_distant_input` — a genuinely off-vocabulary type still gets the supported-types list but no noisy "Did you mean" guess.
- [x] Existing `test_get_sqlalchemy_type_typo_*` tests in `test_database.py` still pass — that layer's behavior is unchanged, only its helper source moved.
- [x] Full suite: 1177 passed, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to preflight validation and error messaging; no auth, persistence, or ingest execution paths are altered beyond accepting types the DB layer already supported.
> 
> **Overview**
> Preflight **DataValidator** now shows the same Levenshtein **"Did you mean …?"** hints as the database layer when a schema type is unknown but close to a supported name (e.g. `INTERGER` → `INTEGER`), fixing #266 where validation failed first with a bare message and never reached `Database._get_sqlalchemy_type`.
> 
> The suggestion logic is **extracted** from `database.py` into shared `utils.typo_suggest.suggest_type`; both call sites import it so messages stay consistent.
> 
> **Validator vocabulary** is aligned with `Database._get_sqlalchemy_type`: `TINYINT` / `SMALLINT` / `MEDIUMINT` use the int checker; `BLOB` / `LONGBLOB` use a new passthrough validator so valid blob schemas are not rejected or mis-hinted as `BOOL` (#293).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9781d9276ffa7e05718dc0f653ac9b0adbe9204f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->