### PR TITLE
fix(label_diversity): swallow JSON parse errors so JSONL clean msg isn't duplicated (#267)

### DIFF
--- a/tests/test_label_diversity_validator.py
+++ b/tests/test_label_diversity_validator.py
@@ -360,3 +360,72 @@ def test_malformed_json_input_also_skipped(tmp_path):
     p.write_text('{"id": 1, "label":  ')  # truncated, unparseable
     result = LabelDiversityValidator().validate(str(p))
     assert result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# Bugbot regression guards (PR #294)
+# ---------------------------------------------------------------------------
+
+def test_single_dict_json_runs_diversity_check_not_skipped(tmp_path):
+    """Bugbot #294 (HIGH): the previous swallow-all ``pd.read_json`` catch
+    turned a top-level single-dict JSON file (the format
+    ``JSONIngestor.read_data`` and ``DataValidator`` both accept, #232) into
+    a silent benign-skip. A single-label single-dict JSON would then pass the
+    diversity gate at preflight, re-opening the #251 hole the validator
+    exists to close.
+
+    The loader must accept the single-dict shape (wrap as one record) so the
+    diversity check actually runs against the labels found.
+    """
+    p = tmp_path / "single.json"
+    # Valid single-dict JSON — DataValidator + ingestor both accept this,
+    # the diversity gate must too.
+    p.write_text('{"id": 1, "label": "X"}')
+    result = LabelDiversityValidator().validate(str(p))
+    # Single record → one distinct label → must FAIL the diversity gate, NOT
+    # silently pass. (Before the fix, this returned is_valid=True because
+    # pd.read_json raised ValueError on the dict and the catch swallowed it.)
+    assert not result.is_valid
+    assert any("distinct" in e for e in result.errors)
+
+
+def test_array_of_records_json_diversity_still_runs(tmp_path):
+    """Sanity: the standard top-level-array case must still load and run the
+    diversity check. Pairs with the single-dict test to pin both supported
+    JSON shapes against the diversity gate."""
+    p = tmp_path / "arr.json"
+    # Single-label array of 3 records — must FAIL diversity.
+    p.write_text(
+        '[{"id": 1, "label": "X"}, {"id": 2, "label": "X"}, {"id": 3, "label": "X"}]'
+    )
+    result = LabelDiversityValidator().validate(str(p))
+    assert not result.is_valid
+    assert any("distinct" in e for e in result.errors)
+
+
+def test_two_class_json_array_passes(tmp_path):
+    """Two distinct labels in a JSON array → diversity gate must pass."""
+    p = tmp_path / "ok.json"
+    p.write_text(
+        '[{"id": 1, "label": "X"}, {"id": 2, "label": "Y"}, {"id": 3, "label": "X"}]'
+    )
+    result = LabelDiversityValidator().validate(str(p))
+    assert result.is_valid
+
+
+def test_top_level_scalar_json_benign_skipped(tmp_path):
+    """A non-records-shape JSON (a bare string, number, scalar array)
+    benign-skips here — DataValidator surfaces the appropriate rejection."""
+    p = tmp_path / "bare.json"
+    p.write_text('"just a string"')
+    result = LabelDiversityValidator().validate(str(p))
+    assert result.is_valid  # benign skip
+
+
+def test_scalar_array_json_benign_skipped(tmp_path):
+    """A top-level array of scalars (no dicts) has no labels to check —
+    benign-skip; DataValidator catches the misshape elsewhere."""
+    p = tmp_path / "scalars.json"
+    p.write_text('[1, 2, 3]')
+    result = LabelDiversityValidator().validate(str(p))
+    assert result.is_valid  # benign skip

--- a/tests/test_label_diversity_validator.py
+++ b/tests/test_label_diversity_validator.py
@@ -320,3 +320,43 @@ def test_custom_label_column_name():
     assert LabelDiversityValidator(label_column="target").validate(df).is_valid
     # The default `label` column is single-value here — should fail.
     assert not LabelDiversityValidator(label_column="label").validate(df).is_valid
+
+
+# ---------------------------------------------------------------------------
+# .json input — JSONL must be a benign skip, not a duplicate error
+# ---------------------------------------------------------------------------
+
+def test_jsonl_input_is_benign_skip_not_noisy_error(tmp_path):
+    """Issue #267: a .json file containing JSONL content (one JSON object per
+    line, no enclosing ``[...]``) used to crash ``pd.read_json`` here with a
+    raw "Trailing data" exception. That bubbled to the user alongside the
+    DataValidator's clean JSONL-detection message (#263), producing a
+    duplicated/noisy error block.
+
+    The clean JSONL fix message belongs to DataValidator — this validator
+    should fail silently to a None DataFrame so only the upstream actionable
+    message reaches the user.
+    """
+    p = tmp_path / "data.json"
+    p.write_text(
+        '{"id": 1, "label": "A"}\n'
+        '{"id": 2, "label": "B"}\n'
+        '{"id": 3, "label": "A"}\n'
+    )
+    # The validator should treat this as a benign skip (no rows to check),
+    # not surface a raw pandas exception in errors.
+    result = LabelDiversityValidator().validate(str(p))
+    assert result.is_valid
+    assert not any(
+        "Trailing data" in e or "Extra data" in e for e in (result.errors or [])
+    )
+
+
+def test_malformed_json_input_also_skipped(tmp_path):
+    """A genuinely malformed .json file (not JSONL — just broken) also gets
+    the benign-skip treatment. DataValidator surfaces the appropriate parse
+    error; this validator must not duplicate it."""
+    p = tmp_path / "broken.json"
+    p.write_text('{"id": 1, "label":  ')  # truncated, unparseable
+    result = LabelDiversityValidator().validate(str(p))
+    assert result.is_valid

--- a/tracebloc_ingestor/validators/label_diversity_validator.py
+++ b/tracebloc_ingestor/validators/label_diversity_validator.py
@@ -24,6 +24,7 @@ self-supervised categories (masked_language_modeling) which have no
 label column at all.
 """
 
+import json
 import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -235,7 +236,17 @@ class LabelDiversityValidator(BaseValidator):
                     **self._label_read_kwargs(actual),
                 )
             if path.suffix.lower() == ".json":
-                return pd.read_json(path, orient="records")
+                # Parse failures on a .json input (malformed JSON, a JSONL file
+                # mis-extensioned as .json, etc.) belong to ``DataValidator`` —
+                # it surfaces the clean JSONL detection + fix message (#263).
+                # If this validator ALSO bubbles the raw pandas error
+                # ("Trailing data" or similar) the user sees the noise
+                # alongside the actionable message (#267). Swallow into a
+                # benign skip so only the upstream clean message surfaces.
+                try:
+                    return pd.read_json(path, orient="records")
+                except (ValueError, json.JSONDecodeError):
+                    return None
         return None
 
     def _label_read_kwargs(self, actual: str) -> Dict[str, Any]:

--- a/tracebloc_ingestor/validators/label_diversity_validator.py
+++ b/tracebloc_ingestor/validators/label_diversity_validator.py
@@ -236,17 +236,42 @@ class LabelDiversityValidator(BaseValidator):
                     **self._label_read_kwargs(actual),
                 )
             if path.suffix.lower() == ".json":
-                # Parse failures on a .json input (malformed JSON, a JSONL file
-                # mis-extensioned as .json, etc.) belong to ``DataValidator`` —
-                # it surfaces the clean JSONL detection + fix message (#263).
-                # If this validator ALSO bubbles the raw pandas error
-                # ("Trailing data" or similar) the user sees the noise
-                # alongside the actionable message (#267). Swallow into a
-                # benign skip so only the upstream clean message surfaces.
+                # Mirror ``DataValidator._load_data``'s JSON branch (and
+                # ``JSONIngestor.read_data``'s contract): both a top-level
+                # array of records AND a top-level single dict are accepted —
+                # ``pd.read_json(orient="records")`` rejects the single-dict
+                # case and would otherwise turn a perfectly valid input into
+                # a silent benign-skip that lets a single-label dataset
+                # bypass the diversity gate (bugbot, PR #294 — re-opens #251).
+                #
+                # Use ``json.load`` directly so the loader accepts the same
+                # shapes the ingestor and DataValidator do. Genuinely broken
+                # JSON / JSONL (mis-extensioned as ``.json``) still benign-
+                # skips here: the actionable error belongs to DataValidator's
+                # JSONL detection (#263), and surfacing the raw pandas
+                # ``Trailing data`` here would just duplicate the noise
+                # (#267).
                 try:
-                    return pd.read_json(path, orient="records")
-                except (ValueError, json.JSONDecodeError):
+                    with open(path, "r", encoding="utf-8") as fh:
+                        raw = json.load(fh)
+                except (ValueError, json.JSONDecodeError, OSError):
                     return None
+                # Mirror JSONIngestor.read_data: a bare dict is one record;
+                # a top-level array stays as-is.
+                if isinstance(raw, dict):
+                    raw = [raw]
+                elif not isinstance(raw, list):
+                    # Top-level scalar / non-object / non-array — not a
+                    # records shape. DataValidator surfaces a clear rejection;
+                    # benign-skip here.
+                    return None
+                # Mirror JSONIngestor._iter_validated_records, which drops
+                # non-dict elements (so a top-level scalar array doesn't
+                # become a 1-column DataFrame that fools the diversity check).
+                records = [item for item in raw if isinstance(item, dict)]
+                if not records:
+                    return None
+                return pd.DataFrame(records)
         return None
 
     def _label_read_kwargs(self, actual: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
Closes #267.

PR #263 added a clean JSONL-detection message to `DataValidator`, but the user still sees noise alongside it because `LabelDiversityValidator` has its own `pd.read_json` path that raises a raw `ValueError("Trailing data")` on the same input. That bubbles to the user as:

```
Label Diversity Validator Validator failed:
Label-diversity validation error: Trailing data
```

right next to the actionable message #263 was meant to deliver alone.

Swallow JSON parse errors in this validator's loader and treat them as a benign skip. The clean message in DataValidator already tells the user exactly what to do — this validator has nothing to add and shouldn't compete.

Verified on `v0.3.10-rc4` dev cluster against the JSONL-content `.json` reproducer.

## Test plan
- [x] New: `test_jsonl_input_is_benign_skip_not_noisy_error` — a JSONL `.json` no longer surfaces `"Trailing data"`/`"Extra data"` from this validator.
- [x] New: `test_malformed_json_input_also_skipped` — a genuinely broken JSON file also benign-skips here (DataValidator surfaces the parse error).
- [x] Full suite: 1177 passed, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preflight label-diversity behavior for JSON inputs—a gate that blocks single-class datasets before backend prepare—so incorrect skipping or loading could let bad data through or miss real failures.
> 
> **Overview**
> **Fixes duplicate/noisy errors when `.json` files are JSONL or unparseable (#267)** by replacing `pd.read_json(orient="records")` in `LabelDiversityValidator._load_data` with `json.load` plus the same record-shape rules as `DataValidator` / `JSONIngestor`. Parse failures (JSONL mislabeled as `.json`, truncated JSON) return `None` for a benign skip so only `DataValidator`'s actionable message is shown—not a second `"Trailing data"` block from this validator.
> 
> **Fixes a regression where valid single-object JSON silently bypassed the diversity gate (#294 / #251)**. A top-level dict is wrapped as one record and diversity still runs; scalar or non-dict-array shapes still benign-skip. Dict-only elements are kept when building the DataFrame, matching the ingestor.
> 
> New tests cover JSONL/malformed benign skip, single-dict and array diversity enforcement, two-class pass, and scalar JSON skips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533b085bb91857c27df5943a01a5702a4bf07bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->