### PR TITLE
fix(file_validator): include allowed extension in invalid-extension error (#291)

### DIFF
--- a/tests/test_file_validator.py
+++ b/tests/test_file_validator.py
@@ -45,6 +45,13 @@ def test_invalid_extension_in_strict_mode_fails(clean_env, tmp_path):
     result = FileTypeValidator(allowed_extension=".jpg").validate(None)
     assert not result.is_valid
     assert any("invalid extensions" in e for e in result.errors)
+    # #291: the message must name the expected extension and point the user
+    # at how to override it — without it, the user only saw the rejected
+    # paths and had to guess what was allowed.
+    err = result.errors[0]
+    assert "Allowed extensions" in err
+    assert ".jpg" in err
+    assert "spec.file_options.extension" in err
 
 
 def test_no_files_fails(clean_env, tmp_path):

--- a/tracebloc_ingestor/validators/file_validator.py
+++ b/tracebloc_ingestor/validators/file_validator.py
@@ -205,9 +205,20 @@ class FileTypeValidator(BaseValidator):
 
         # Check for invalid extensions in strict mode
         if invalid_files:
+            # Include the allowed extension(s) inline so the user knows what
+            # to switch to (#291). Without this the user only saw the list of
+            # rejected file paths and had to guess at the expected extension
+            # — the sibling Image Resolution Validator already does this
+            # right by embedding "(expected: [256, 256])" in its message.
             return self._create_result(
                 is_valid=False,
-                errors=[f"Files with invalid extensions found: {invalid_files}"],
+                errors=[
+                    f"Files with invalid extensions found: {invalid_files}. "
+                    f"Allowed extensions: {sorted(self.allowed_extension)}. "
+                    f"Set `spec.file_options.extension` in your ingest.yaml "
+                    f"to override the default (e.g. `.jpg` for image "
+                    f"categories, `.txt` for text_classification)."
+                ],
                 metadata={
                     "files_checked": len(files),
                     "extensions_found": sorted(extensions),


### PR DESCRIPTION
## Summary
Closes #291.

`FileTypeValidator`'s invalid-extension error listed the rejected file paths but never said what extension WAS expected. A user staging `.jpg` files for `image_classification` (default expected: `.jpeg`) saw `Files with invalid extensions found: [...long list of .jpg paths...]` and had to guess. The allowed extension was already in the result `metadata`, but never reached the user.

Embed the allowed extensions inline and point the user at the `spec.file_options.extension` override. Mirrors the pattern the sibling `Image Resolution Validator` uses (`(expected: [256, 256])`).

## Test plan
- [x] Existing `test_invalid_extension_in_strict_mode_fails` extended: the rejection message must include the allowed extension AND the override hint.
- [x] Full suite: 1175 passed, 1 xfailed (no regressions; the count differs from sibling PRs because each is branched off `develop` independently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error text and metadata only; validation rules and pass/fail behavior are unchanged.
> 
> **Overview**
> **Invalid-extension failures now tell users what was expected and how to fix it** (#291). When strict mode rejects files, the error no longer stops at a long list of bad paths—it also lists **allowed extensions** and points to **`spec.file_options.extension`** in `ingest.yaml` (aligned with how the image resolution validator surfaces expected values).
> 
> The failure **metadata** now includes `allowed_extension` on this path. **`test_invalid_extension_in_strict_mode_fails`** asserts the message contains the allowed extension and the override hint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b822e25a524cda8d47aaacb074150e0f8392b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->