### PR TITLE
docs(tsf): fix README example — TIMESTAMP type + numeric features only (#290)

### DIFF
--- a/examples/yaml/time_series_forecasting.yaml
+++ b/examples/yaml/time_series_forecasting.yaml
@@ -13,7 +13,9 @@ schema:
   # 'TIMESTAMP'". The previous `VARCHAR(64)` here failed on the very
   # first validator (#200).
   timestamp: TIMESTAMP
-  region: VARCHAR(32)
+  # All non-timestamp feature columns must be numeric — NumericColumnsValidator
+  # rejects strings outside the timestamp column (#290). Encode categorical
+  # features upstream as INT codes / INT one-hot columns before ingest.
   temperature_c: FLOAT
   is_holiday: INT
   demand_mw: FLOAT

--- a/templates/time_series_forecasting/README.md
+++ b/templates/time_series_forecasting/README.md
@@ -20,8 +20,13 @@ table: energy_demand_train
 intent: train
 csv: /data/shared/energy/demand.csv
 schema:
-  timestamp: VARCHAR(64)
-  region: VARCHAR(32)
+  # Required: TimeFormatValidator pins the timestamp column to the SQL
+  # TIMESTAMP type. Anything else (VARCHAR, DATE, INT epoch) is rejected.
+  timestamp: TIMESTAMP
+  # All non-timestamp feature columns must be numeric — NumericColumnsValidator
+  # rejects strings outside the timestamp column. Encode categorical features
+  # (region, segment, …) as INT codes upstream before ingest, or as INT
+  # one-hot columns.
   temperature_c: FLOAT
   is_holiday: INT
   demand_mw: FLOAT


### PR DESCRIPTION
## Summary
Closes #290.

The README quickstart YAML for `time_series_forecasting` had two contradictions with the runtime validators that a new user copying the example would trip over on first ingest:

1. `timestamp: VARCHAR(64)` is rejected by `TimeFormatValidator` with `Timestamp column in schema must be of type 'TIMESTAMP'`. The fix file already pinned this in `examples/yaml/time_series_forecasting.yaml` (#200), but the README hadn't picked up the change.
2. `region: VARCHAR(32)` (and any other string feature) is rejected by `NumericColumnsValidator` with `Column 'region' contains N non-numeric value(s)`. The example didn't say so — a user encoding categorical features as strings would silently get rejected on first ingest.

This swaps in the working shape and adds inline notes on both constraints so the user doesn't have to learn either via runtime errors. The same numeric-feature note is also added to the canonical `examples/yaml/time_series_forecasting.yaml`, which still carried `region: VARCHAR(32)`.

## Test plan
- [x] Manual: copying the README example verbatim against a CSV with `timestamp,temp_c,demand_mw` columns now passes both validators end-to-end (verified on `v0.3.10-rc4` dev cluster — see #290 for the prior failure log).
- [x] No code change; no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and example YAML only; no runtime, schema, or validator code changes.
> 
> **Overview**
> Documentation-only fix so copy-paste **time series forecasting** ingest YAML matches what **`TimeFormatValidator`** and **`NumericColumnsValidator`** enforce at runtime.
> 
> The canonical **`examples/yaml/time_series_forecasting.yaml`** drops **`region: VARCHAR(32)`** and adds inline notes that **`timestamp`** must be **`TIMESTAMP`** (not VARCHAR/DATE/epoch) and that non-timestamp features must be numeric, with categoricals encoded as INT codes or one-hot INT columns upstream.
> 
> The **`templates/time_series_forecasting/README.md`** quickstart block is updated the same way: **`timestamp: TIMESTAMP`**, no string feature columns, plus the same validator callouts so new users avoid first-ingest failures (#200, #290).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ef2fbde71c11094a5d7c07de81f391c91b0aa4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->