### PR TITLE
fix: register self-supervised datasets (generate edge-label metadata for all categories)

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -534,12 +534,20 @@ def test_ingest_fails_loud_when_backend_registration_step_fails(failing_step):
     ing.api_client.create_dataset.assert_not_called()
 
 
-def test_ingest_skips_edge_label_call_for_self_supervised_categories():
-    """Issue #213: self-supervised categories (MLM, …) have no `label` column,
-    so the backend's edge-label endpoint returns a misleading HTTP 400
-    ('No data found') even though the table has rows. Gate the call so it
-    only runs for label-carrying categories. The remaining registration
-    steps (send_global_meta_meta, prepare_dataset, create_dataset) still run."""
+def test_ingest_calls_edge_label_for_self_supervised_categories():
+    """Self-supervised categories (MLM, …) MUST call the edge-label endpoint
+    like every other category.
+
+    Originally (#213) the call was SKIPPED for self-supervised categories
+    because they carry no `label` and the old backend rejected blank labels,
+    returning a misleading HTTP 400. Backend PR #683 ('allow blank label for
+    self-supervised categories') fixed that: GenerateEdgeLabelsMeta now buckets
+    the single '' label into ``edge_labels_meta = {"": N}`` (HTTP 200). The
+    skip was the only thing left blocking self-supervised registration —
+    without an ``edge_labels_meta`` document the backend's get_edges finds no
+    candidate edges and ``prepare`` returns 'No edges found', so the dataset
+    never registers and stays invisible in the app. The call must now run for
+    self-supervised too; the remaining registration steps still run."""
     from tracebloc_ingestor.utils.constants import TaskCategory
 
     records = [{"a": "1", "filename": "f1"}]
@@ -549,7 +557,7 @@ def test_ingest_skips_edge_label_call_for_self_supervised_categories():
         label_column=None,
     )
     # Patch validate_data + map_file_transfer to skip real-filesystem checks;
-    # the gate we're testing lives at the registration block AFTER ingest.
+    # the behaviour we're testing lives at the registration block AFTER ingest.
     with patch.object(base_mod, "Session") as Sess, patch.object(
         ing, "validate_data", return_value=True
     ), patch.object(
@@ -559,10 +567,39 @@ def test_ingest_skips_edge_label_call_for_self_supervised_categories():
     ):
         Sess.return_value.__enter__.return_value = MagicMock()
         ing.ingest("src", batch_size=10)
-    ing.api_client.send_generate_edge_label_meta.assert_not_called()
+    ing.api_client.send_generate_edge_label_meta.assert_called_once()
     ing.api_client.send_global_meta_meta.assert_called_once()
     ing.api_client.prepare_dataset.assert_called_once()
     ing.api_client.create_dataset.assert_called_once()
+
+
+def test_ingest_fails_loud_when_edge_label_fails_for_self_supervised():
+    """A False return from the edge-label call for a self-supervised category
+    must RAISE (it is no longer skipped — see the test above), leaving the
+    dataset unregistered rather than silently exiting 0. Mirrors the
+    label-carrying fail-loud guard for the self-supervised path."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(
+        records=records,
+        category=TaskCategory.MASKED_LANGUAGE_MODELING,
+        label_column=None,
+    )
+    ing.api_client.send_generate_edge_label_meta.return_value = False
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError, match="NOT registered"):
+            ing.ingest("src", batch_size=10)
+    ing.api_client.send_generate_edge_label_meta.assert_called_once()
+    # The chain must stop — create_dataset is never reached on a failed step.
+    ing.api_client.create_dataset.assert_not_called()
 
 
 def test_ingest_still_calls_edge_label_for_label_carrying_categories():

--- a/tests/test_modality_registry.py
+++ b/tests/test_modality_registry.py
@@ -96,7 +96,10 @@ def test_base_py_imports_the_registry_derived_sets():
 
     assert base._FILE_BEARING_CATEGORIES is registry.FILE_BEARING_CATEGORIES
     assert base._TABULAR_FAMILY_CATEGORIES is registry.TABULAR_FAMILY_CATEGORIES
-    assert base._SELF_SUPERVISED_CATEGORIES is registry.SELF_SUPERVISED_CATEGORIES
+    # base.py no longer imports SELF_SUPERVISED_CATEGORIES: edge-label metadata
+    # is now generated for every category (the #213 self-supervised skip was
+    # removed once backend PR #683 allowed blank labels), so the set is unused
+    # here. The registry remains its single source for other consumers.
 
 
 def test_data_format_valid_and_matches_conventions():

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -33,7 +33,6 @@ from .table_lock import TableLock
 from ..modalities.registry import (
     FILE_BEARING_CATEGORIES as _FILE_BEARING_CATEGORIES,
     NLP_CATEGORIES as _NLP_CATEGORIES,
-    SELF_SUPERVISED_CATEGORIES as _SELF_SUPERVISED_CATEGORIES,
     TABULAR_FAMILY_CATEGORIES as _TABULAR_FAMILY_CATEGORIES,
 )
 
@@ -44,11 +43,11 @@ logger = logging.getLogger(__name__)
 __all__ = ["BaseIngestor", "IngestionSummary"]
 
 
-# NOTE: _TABULAR_FAMILY_CATEGORIES, _FILE_BEARING_CATEGORIES and
-# _SELF_SUPERVISED_CATEGORIES are imported above from modalities.registry
-# (derived from the per-category ModalitySpec flags — backend#796 P3a). The
-# ``self.category in <set>`` checks throughout this module use them unchanged;
-# the rationale for each set now lives on ModalitySpec's field docstrings.
+# NOTE: _TABULAR_FAMILY_CATEGORIES and _FILE_BEARING_CATEGORIES are imported
+# above from modalities.registry (derived from the per-category ModalitySpec
+# flags — backend#796 P3a). The ``self.category in <set>`` checks throughout
+# this module use them unchanged; the rationale for each set now lives on
+# ModalitySpec's field docstrings.
 
 
 class IngestionSummary(NamedTuple):
@@ -545,26 +544,36 @@ class BaseIngestor(ABC):
                 # the failure surfaces (the CLI streams these logs live and marks
                 # the Job failed). The api_client has already logged the
                 # underlying HTTP detail before returning False.
-                # Skip the edge-label backend call for self-supervised
-                # categories (#213). They have no `label` column on the rows;
-                # the backend's edge-label endpoint then returns a misleading
-                # HTTP 400 ("No data found for table X" — wrong, the table HAS
-                # rows, it just has no edge labels). Combined with PR #187's
-                # fail-loud behaviour, the user saw a registration crash that
-                # had nothing to do with the actual misconfiguration. The
-                # schema now rejects `label:` on these categories at
-                # submission, but this gate is the defensive in-ingestor half
-                # so script-driven / older-schema runs don't trip the same
-                # trap.
-                if self.category not in _SELF_SUPERVISED_CATEGORIES:
-                    if not self.api_client.send_generate_edge_label_meta(
-                        self.table_name, self.ingestor_id, self.intent
-                    ):
-                        raise RuntimeError(
-                            "Backend rejected edge-label metadata; the dataset was "
-                            "NOT registered (its rows are already in the database). "
-                            "See the logged API error above."
-                        )
+                # Generate edge-label metadata for EVERY category, including
+                # self-supervised ones (MLM / text / token). The backend's
+                # get_edges discovers candidate edges only via the
+                # `edge_labels_meta` collection, so a dataset with no
+                # edge_labels_meta document can never be prepared/registered —
+                # it stays invisible in the app even though its rows are in
+                # MySQL.
+                #
+                # History: this call used to be skipped for self-supervised
+                # categories (#213) because those rows carry no `label` and the
+                # old backend rejected blank labels — the edge-label endpoint
+                # returned a misleading HTTP 400 ("No data found for table X"),
+                # which combined with PR #187's fail-loud behaviour to surface a
+                # registration crash unrelated to the real cause. Backend
+                # PR #683 ("allow blank label for self-supervised categories")
+                # fixed that: blank `label` is accepted, GenerateEdgeLabelsMeta
+                # buckets the single "" label into `edge_labels_meta = {"": N}`
+                # (truthy → inserted → HTTP 200), and PrepareDatasetMeta uses
+                # min_labels=0 for these categories. So the skip is now the only
+                # thing blocking self-supervised registration — remove it and
+                # let generate run for all categories, still failing loud (the
+                # RuntimeError below) on a False return.
+                if not self.api_client.send_generate_edge_label_meta(
+                    self.table_name, self.ingestor_id, self.intent
+                ):
+                    raise RuntimeError(
+                        "Backend rejected edge-label metadata; the dataset was "
+                        "NOT registered (its rows are already in the database). "
+                        "See the logged API error above."
+                    )
 
                 # Register the contributor tokenizer fingerprint for NLP
                 # datasets (#805 Task 2). When a tokenizer.json was shipped


### PR DESCRIPTION
## Problem
Self-supervised datasets (e.g. `masked_language_modeling`) fail to register and never become visible in the app. They ingest fine (rows land in MySQL, tokenizer fingerprint stored) but fail at `prepare` with HTTP 400 **"No edges found for the requested configuration"**, so `create_dataset` never runs.

## Root cause
In `tracebloc_ingestor/ingestors/base.py` the ingestor **skipped** `send_generate_edge_label_meta` for self-supervised categories:

```python
if self.category not in _SELF_SUPERVISED_CATEGORIES:
    if not self.api_client.send_generate_edge_label_meta(...):
        raise RuntimeError(...)
```

This was a stale guard from #213/#187 — back when the backend rejected blank labels and the edge-label endpoint returned a misleading 400 for label-less datasets. Because generate was never called, **no `edge_labels_meta` document was ever created** for self-supervised tables. The backend's `get_edges` discovers candidate edges only via the `edge_labels_meta` collection → finds nothing → `prepare` returns "No edges found" → the dataset stays invisible despite its rows being in MySQL.

The backend was since fixed in **PR #683** ("allow blank label for self-supervised categories"): blank `label` is accepted, `GenerateEdgeLabelsMeta` buckets the single `""` label into `edge_labels_meta = {"": N}` (truthy → inserted → HTTP 200), and `PrepareDatasetMeta` uses `min_labels=0`. So the ingestor skip was the only remaining blocker.

## Fix (ingestor-only)
- Remove the `if self.category not in _SELF_SUPERVISED_CATEGORIES:` guard so `send_generate_edge_label_meta` runs for **every** category, still failing loud via the existing `RuntimeError` on a `False` return.
- Update the comment block to cite #683 and explain the `edge_labels_meta` → `get_edges` → `prepare` chain.
- Drop the now-unused `_SELF_SUPERVISED_CATEGORIES` import (only consumer was the deleted guard) and update the module NOTE.

## Tests
- **Added** a fail-loud test: a `False` edge-label return for an MLM category now raises and never reaches `create_dataset`.
- **Updated** the test that pinned the old skip — renamed to `test_ingest_calls_edge_label_for_self_supervised_categories`, asserts generate **is** now called for MLM (docstring cites #683). This test directly asserted the bug being fixed, so flipping it was unavoidable; net coverage is +2 tests and both contracts (self-supervised calls + fails loud, label-carrying calls) remain covered.
- **Removed** the obsolete `base._SELF_SUPERVISED_CATEGORIES is registry...` import-identity assertion (constant no longer imported in base.py); other registry-identity asserts untouched.

Full suite (`di-venv`): **1176 passed, 1 xfailed**.

## Proof on dev
On dev cluster `tb-client-dev-templates` (ns `tracebloc-templates`), MLM dataset `t2_mlm_verify_train` ingested but failed `prepare` with "No edges found". Manually running the skipped sequence — `send_generate_edge_label_meta` → `prepare_dataset` → `create_dataset` — succeeded: generate 200, prepare 200, **dataset id 1236 registered, status `available`**, `dataset_meta.count.label = {'': 5}`. Confirms the backend fully supports self-supervised; the only gap was the ingestor skip.

## Scope
Ingestor-only. No backend changes (backend already correct via #683). Does not touch the #805 tokenizer work or backend-hardening items H1–H3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the post-ingest registration path for self-supervised categories; incorrect backend behavior could still block registration, but existing fail-loud handling limits silent partial success.
> 
> **Overview**
> **Self-supervised datasets (e.g. MLM) can register again** because the ingestor no longer skips `send_generate_edge_label_meta` for those categories. Registration now always runs edge-label generation, then global metadata, prepare, and create—same fail-loud `RuntimeError` if generate returns false.
> 
> The old **#213** skip avoided a misleading backend 400 when blank labels were rejected; with **backend #683** accepting blank labels into `edge_labels_meta`, skipping was the remaining reason `prepare` saw “No edges found” and datasets stayed invisible despite rows in MySQL.
> 
> `base.py` drops the unused `_SELF_SUPERVISED_CATEGORIES` import; the registry set remains for other consumers. Tests now expect generate **is** called for MLM, add a fail-loud MLM edge-label test, and drop the obsolete base↔registry identity assert for that constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b059e1caffbce234f2bfeb144b2eb8bdb0d3045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->