### PR TITLE
chore(release): v0.3.12

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.11"
+__version__ = "0.3.12"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
Version bump 0.3.11 → 0.3.12.

Ships the self-supervised edge-label metadata fix ([#297](https://github.com/tracebloc/data-ingestors/pull/297)): MLM/text/token datasets now generate `edge_labels_meta` and register correctly (previously failed `prepare` with "No edges found" and stayed invisible in the app).

The `v0.3.12` tag is already pushed and the signed multi-arch image build (`release-image.yml`) is running. This PR lands the same release commit on `develop` so the branch version stays consistent. Merge with **rebase** to keep the tag on develop's history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version-only change with no runtime or behavioral code in the diff.
> 
> **Overview**
> Bumps the package **single source of truth** version in `tracebloc_ingestor/__init__.py` from `0.3.11` to `0.3.12`, which `setup.py` picks up via `_read_version()` so install metadata stays aligned with the release.
> 
> This PR’s diff is only that version literal; it lands the release commit on `develop` so the branch matches the already-tagged `v0.3.12` release (which includes the self-supervised `edge_labels_meta` fix from [#297](https://github.com/tracebloc/data-ingestors/pull/297)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1796edbea35d70654e5f33975764433a20bb45d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->