### PR TITLE
feat(ingest): ship data-derived text profile for NLP datasets (#805)

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -1004,3 +1004,87 @@ def test_check_src_path_required_for_token_classification():
     from tracebloc_ingestor.ingestors.base import _FILE_BEARING_CATEGORIES
 
     assert TaskCategory.TOKEN_CLASSIFICATION in _FILE_BEARING_CATEGORIES
+
+
+# ---------------------------------------------------------------------------
+# #805: data-derived text profile on the global-metadata channel
+# ---------------------------------------------------------------------------
+
+_TEXT_PROFILE = {
+    "schema_version": 1,
+    "docs_sampled": 3,
+    "scripts": {"Latin": 1.0},
+}
+
+
+@pytest.mark.parametrize(
+    "category",
+    ["MASKED_LANGUAGE_MODELING", "TEXT_CLASSIFICATION", "TOKEN_CLASSIFICATION"],
+)
+def test_ingest_attaches_text_profile_for_nlp(category):
+    """For every NLP category, the data-derived text profile is attached to
+    file_options so it rides the existing global-metadata channel."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    cat = getattr(TaskCategory, category)
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(records=records, category=cat, label_column=None)
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod, "map_file_transfer", side_effect=lambda c, r, o, cfg=None: r
+    ), patch.object(
+        base_mod, "compute_text_profile", return_value=_TEXT_PROFILE
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    args, _ = ing.api_client.send_global_meta_meta.call_args
+    assert args[2].get("text_profile") == _TEXT_PROFILE
+
+
+def test_ingest_omits_text_profile_when_none_for_nlp():
+    """No readable staged text -> profiler returns None -> field omitted; the
+    ingest still registers cleanly."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(
+        records=records,
+        category=TaskCategory.TEXT_CLASSIFICATION,
+        label_column="a",
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod, "map_file_transfer", side_effect=lambda c, r, o, cfg=None: r
+    ), patch.object(
+        base_mod, "compute_text_profile", return_value=None
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    args, _ = ing.api_client.send_global_meta_meta.call_args
+    assert "text_profile" not in args[2]
+
+
+def test_ingest_does_not_profile_non_nlp():
+    """Non-NLP categories never touch the text-profile path."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(
+        records=records,
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod, "map_file_transfer", side_effect=lambda c, r, o, cfg=None: r
+    ), patch.object(
+        base_mod, "compute_text_profile"
+    ) as profile:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    profile.assert_not_called()
+    args, _ = ing.api_client.send_global_meta_meta.call_args
+    assert "text_profile" not in args[2]

--- a/tests/test_text_profile.py
+++ b/tests/test_text_profile.py
@@ -1,0 +1,72 @@
+"""Tests for the data-derived NLP text profile (#805).
+
+The profile is computed from the staged text with NO tokenizer; only aggregate
+statistics (Unicode-script mix + length distribution) are produced.
+"""
+
+from types import SimpleNamespace
+
+from tracebloc_ingestor.text_profile import (
+    TEXT_PROFILE_SCHEMA_VERSION,
+    _script_of,
+    compute_text_profile,
+)
+
+
+def _cfg(dest):
+    return SimpleNamespace(DEST_PATH=str(dest))
+
+
+def _write(dest, name, text):
+    (dest / name).write_text(text, encoding="utf-8")
+
+
+def test_script_of_common_scripts():
+    assert _script_of("a") == "Latin"
+    assert _script_of("Z") == "Latin"
+    assert _script_of("я") == "Cyrillic"
+    assert _script_of("猫") == "CJK"
+    assert _script_of("あ") == "Hiragana"
+    assert _script_of("ا") == "Arabic"
+    # whitespace / unnamed control chars are not letters -> Other
+    assert _script_of(" ") == "Other"
+
+
+def test_profile_latin_english(tmp_path):
+    _write(tmp_path, "a.txt", "hello world")
+    _write(tmp_path, "b.txt", "the quick brown fox")
+    p = compute_text_profile(_cfg(tmp_path))
+    assert p["schema_version"] == TEXT_PROFILE_SCHEMA_VERSION
+    assert p["docs_sampled"] == 2
+    assert p["scripts"] == {"Latin": 1.0}
+    assert p["doc_length_words"]["max"] == 4
+    assert p["doc_length_chars"]["max"] == len("the quick brown fox")
+
+
+def test_profile_detects_cjk(tmp_path):
+    _write(tmp_path, "a.txt", "猫が好き")  # Japanese: CJK + Hiragana letters
+    p = compute_text_profile(_cfg(tmp_path))
+    assert "CJK" in p["scripts"]
+    assert abs(sum(p["scripts"].values()) - 1.0) < 1e-6
+
+
+def test_profile_mixed_scripts_proportions(tmp_path):
+    _write(tmp_path, "a.txt", "aя")  # one Latin letter, one Cyrillic letter
+    p = compute_text_profile(_cfg(tmp_path))
+    assert p["scripts"]["Latin"] == 0.5
+    assert p["scripts"]["Cyrillic"] == 0.5
+
+
+def test_profile_none_when_empty_dir(tmp_path):
+    assert compute_text_profile(_cfg(tmp_path)) is None
+
+
+def test_profile_none_when_dir_missing(tmp_path):
+    assert compute_text_profile(_cfg(tmp_path / "nope")) is None
+
+
+def test_profile_sampling_cap(tmp_path):
+    for i in range(10):
+        _write(tmp_path, f"f{i}.txt", "word")
+    p = compute_text_profile(_cfg(tmp_path), max_files=4)
+    assert p["docs_sampled"] == 4

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -19,6 +19,7 @@ from ..utils.constants import (
 from ..utils import label_policy as label_policy_module
 from ..utils.validators_mapping import map_validators
 from ..file_transfer import map_file_transfer
+from ..text_profile import compute_text_profile
 from ..reporting import ConsoleRenderer
 from . import preflight
 from .batch_writer import BatchWriter
@@ -32,6 +33,7 @@ from .table_lock import TableLock
 # (and their None/unknown -> False semantics are preserved).
 from ..modalities.registry import (
     FILE_BEARING_CATEGORIES as _FILE_BEARING_CATEGORIES,
+    NLP_CATEGORIES as _NLP_CATEGORIES,
     TABULAR_FAMILY_CATEGORIES as _TABULAR_FAMILY_CATEGORIES,
 )
 
@@ -573,6 +575,16 @@ class BaseIngestor(ABC):
                         "NOT registered (its rows are already in the database). "
                         "See the logged API error above."
                     )
+
+                # Ship a data-derived text profile for NLP datasets (#805):
+                # Unicode-script mix + length distribution, computed from the
+                # staged text with NO tokenizer. The backend uses it for a
+                # warn-only tokenizer-fit check at linking. Only aggregate
+                # statistics cross the boundary — never raw text or vocabulary.
+                if self.category in _NLP_CATEGORIES:
+                    text_profile = compute_text_profile(self.database.config)
+                    if text_profile:
+                        self.file_options["text_profile"] = text_profile
 
                 schema_dict = self.database.get_table_schema(self.table_name)
                 if not self.api_client.send_global_meta_meta(

--- a/tracebloc_ingestor/text_profile.py
+++ b/tracebloc_ingestor/text_profile.py
@@ -1,0 +1,150 @@
+"""Data-derived text profile for NLP datasets (#805).
+
+Computed at ingest from the staged text — **no tokenizer involved** — and
+shipped on the global-metadata channel so the backend can run a warn-only
+tokenizer-fit check at dataset linking (does the contributor tokenizer cover
+the data's scripts?). Only aggregate statistics cross the cluster boundary:
+the Unicode-script mix and the document-length distribution. Never raw text,
+never a vocabulary, never a hash (the FL guardrail).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import unicodedata
+from collections import Counter
+from typing import Any, Dict, List, Optional
+
+from tracebloc_ingestor import Config
+
+config = Config()
+logger = logging.getLogger(__name__)
+
+TEXT_PROFILE_SCHEMA_VERSION = 1
+
+# Cap on files read per dataset — a profile is a summary, so a deterministic
+# strided sample is enough and keeps the post-ingest pass bounded on large
+# datasets.
+_MAX_FILES = 2000
+
+# Unicode script families named explicitly; anything else buckets to "Other".
+# Derived from the ``unicodedata.name()`` prefix (stdlib — no script-table
+# dependency). ``CJK`` stays upper-case; the rest are title-cased.
+_SCRIPT_PREFIXES = (
+    "LATIN",
+    "CJK",
+    "CYRILLIC",
+    "GREEK",
+    "ARABIC",
+    "HEBREW",
+    "HANGUL",
+    "HIRAGANA",
+    "KATAKANA",
+    "DEVANAGARI",
+    "THAI",
+    "ARMENIAN",
+    "GEORGIAN",
+    "BENGALI",
+    "TAMIL",
+    "TELUGU",
+    "GUJARATI",
+    "KANNADA",
+    "MALAYALAM",
+    "ORIYA",
+    "GURMUKHI",
+    "SINHALA",
+    "MYANMAR",
+    "KHMER",
+    "LAO",
+    "TIBETAN",
+    "ETHIOPIC",
+    "CHEROKEE",
+)
+
+
+def _script_of(ch: str) -> str:
+    """Best-effort Unicode script of a single letter character, via its name."""
+    try:
+        name = unicodedata.name(ch)
+    except ValueError:
+        return "Other"
+    for prefix in _SCRIPT_PREFIXES:
+        if name.startswith(prefix):
+            return prefix if prefix == "CJK" else prefix.title()
+    return "Other"
+
+
+def _sample(paths: List[str], max_files: int) -> List[str]:
+    """Deterministic strided sample of at most ``max_files`` paths."""
+    if len(paths) <= max_files:
+        return paths
+    step = len(paths) / max_files
+    return [paths[int(i * step)] for i in range(max_files)]
+
+
+def compute_text_profile(
+    cfg: Optional[Config] = None, max_files: int = _MAX_FILES
+) -> Optional[Dict[str, Any]]:
+    """Profile the staged text files under ``DEST_PATH`` (data-derived only).
+
+    Returns the profile dict, or ``None`` when no readable text is staged (so
+    the caller simply omits the field). ``cfg`` is the run's resolved Config;
+    ``None`` falls back to the module-global ``config``.
+    """
+    cfg = cfg or config
+    dest = cfg.DEST_PATH
+    if not os.path.isdir(dest):
+        return None
+    paths = sorted(
+        os.path.join(dest, name)
+        for name in os.listdir(dest)
+        if os.path.isfile(os.path.join(dest, name))
+    )
+    if not paths:
+        return None
+
+    script_counts: Counter = Counter()
+    letters = 0
+    char_total = 0
+    word_total = 0
+    docs = 0
+    max_chars = 0
+    max_words = 0
+
+    for path in _sample(paths, max_files):
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        docs += 1
+        n_chars = len(text)
+        n_words = len(text.split())
+        char_total += n_chars
+        word_total += n_words
+        max_chars = max(max_chars, n_chars)
+        max_words = max(max_words, n_words)
+        for ch in text:
+            if unicodedata.category(ch).startswith("L"):
+                script_counts[_script_of(ch)] += 1
+                letters += 1
+
+    if docs == 0:
+        return None
+
+    scripts = (
+        {s: round(c / letters, 4) for s, c in script_counts.most_common()}
+        if letters
+        else {}
+    )
+    profile = {
+        "schema_version": TEXT_PROFILE_SCHEMA_VERSION,
+        "docs_sampled": docs,
+        "char_count": char_total,
+        "scripts": scripts,
+        "doc_length_chars": {"mean": round(char_total / docs, 2), "max": max_chars},
+        "doc_length_words": {"mean": round(word_total / docs, 2), "max": max_words},
+    }
+    logger.info(f"Computed text profile for NLP dataset: {profile}")
+    return profile


### PR DESCRIPTION
## Summary
Ships a data-derived `text_profile` for NLP datasets at ingest (epic #805, P2). Builds on the merged P1 removal (#299).

## Changes
- New `tracebloc_ingestor/text_profile.py`: a tokenizer-free profile (Unicode-script mix + document-length distribution) computed from the staged text, sampled and bounded.
- `ingestors/base.py`: attach `text_profile` to `file_options` for NLP categories so it rides the existing global-metadata channel (`send_global_meta_meta`). No tokenizer involved; only aggregate stats cross the boundary — never raw text or vocabulary (FL guardrail).
- Unit tests (`test_text_profile.py`) + ingest tests.

## Test plan
- `pytest tests/` → 1151 passed, 1 xfailed.

The backend reads this profile for a warn-only tokenizer-fit check at linking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
