### PR TITLE
ci(security): add public-repo PII gate caller

### DIFF
--- a/.github/workflows/public-pii-gate-caller.yml
+++ b/.github/workflows/public-pii-gate-caller.yml
@@ -1,0 +1,14 @@
+name: Public PII gate
+
+# Per-repo caller for the public-repo PII gate. Blocks PRs whose title/body/
+# commits contain a denylisted customer/partner name or known secret.
+# Logic lives in tracebloc/.github/.github/workflows/public-pii-gate.yml.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  pii-gate:
+    uses: tracebloc/.github/.github/workflows/public-pii-gate.yml@main
+    secrets: inherit


### PR DESCRIPTION
Adds the per-repo caller for the org-wide public-repo PII gate (tracebloc/.github#60). Blocks PRs whose title/body/commits contain a denylisted customer name or secret. Inactive (warn-only) until the `PII_DENYLIST` org secret is set, so this won't block existing PRs on merge.

Part of the public-repo PII cleanup (customer names were found leaked in public PR bodies).