### PR TITLE
ci: add concurrency cancellation + job timeouts to data-ingestors CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   e2e:
     name: e2e (real MySQL)

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -6,8 +6,13 @@ on:
       - develop
       - ingestor-v2
 
+concurrency:
+  group: publish-dev-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   publish:
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -5,8 +5,13 @@ on:
     branches:
       - master
 
+concurrency:
+  group: publish-master-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   publish:
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -39,8 +39,13 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: tracebloc/ingestor
 
+concurrency:
+  group: release-image-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   release:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

Mechanical CI-hygiene change. Adds a per-ref `concurrency` group and `timeout-minutes` to the four non-automation workflows under `.github/workflows/`:

- `e2e.yml` — added `concurrency` only (the `e2e` job already had `timeout-minutes: 15`)
- `publish-dev.yml` — `concurrency` + `timeout-minutes: 20` on `publish`
- `publish-master.yml` — `concurrency` + `timeout-minutes: 20` on `publish`
- `release-image.yml` — `concurrency` + `timeout-minutes: 30` on `release` (multi-arch docker build + cosign)

The concurrency group is keyed on `github.ref` with `cancel-in-progress` gated to `pull_request` events only, so push/tag/schedule runs are never cancelled — only superseded PR pushes are. Hung steps now hit the job timeout instead of the 6h runner default.

`tests.yml` was left untouched (it already has both). No kanban/org-automation caller workflows were modified.

Type: CI hygiene / cost reduction

## Test plan

- All four touched workflows parse as valid YAML (`yaml.safe_load`).
- Concurrency + timeouts only — no change to any job's steps, triggers, or behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
