### PR TITLE
fix(validators): fail fast on 0-record manifests + validate NLP text content

### DIFF
--- a/tests/test_duplicate_validator_extra.py
+++ b/tests/test_duplicate_validator_extra.py
@@ -50,3 +50,54 @@ def test_create_directory_if_needed_existing(tmp_path):
     dest = tmp_path / "already"
     dest.mkdir()
     assert DuplicateValidator(dest_path=str(dest))._create_directory_if_needed() is True
+
+
+# --- Within-CSV duplicate filename detection (warning, not a hard failure) ---
+
+
+def test_within_csv_duplicate_filenames_warn(tmp_path, make_csv):
+    dest = tmp_path / "new_table"  # does not exist -> no dest collision
+    path = make_csv(
+        [
+            {"filename": "a", "label": "x"},
+            {"filename": "b", "label": "y"},
+            {"filename": "a", "label": "z"},  # duplicate of row 1
+        ]
+    )
+    result = DuplicateValidator(dest_path=str(dest)).validate(str(path))
+    assert result.is_valid  # warning only — does NOT fail
+    assert any("appear more than once" in w for w in result.warnings)
+    assert result.metadata["within_csv_duplicate_filenames"] is True
+
+
+def test_within_csv_no_duplicates_no_warning(tmp_path, make_csv):
+    dest = tmp_path / "new_table"
+    path = make_csv([{"filename": "a"}, {"filename": "b"}])
+    result = DuplicateValidator(dest_path=str(dest)).validate(str(path))
+    assert result.is_valid
+    assert not any("appear more than once" in w for w in result.warnings)
+    assert result.metadata["within_csv_duplicate_filenames"] is False
+
+
+def test_within_csv_duplicate_case_insensitive_column(tmp_path, make_csv):
+    import pandas as pd
+
+    dest = tmp_path / "new_table"
+    path = make_csv(pd.DataFrame({"FileName": ["a", "a"]}))
+    result = DuplicateValidator(dest_path=str(dest)).validate(str(path))
+    assert any("appear more than once" in w for w in result.warnings)
+
+
+def test_within_csv_no_filename_column_is_noop(tmp_path, make_csv):
+    dest = tmp_path / "new_table"
+    path = make_csv([{"feature_a": "1"}, {"feature_a": "1"}])
+    result = DuplicateValidator(dest_path=str(dest)).validate(str(path))
+    assert not any("appear more than once" in w for w in result.warnings)
+
+
+def test_within_csv_none_input_is_noop(tmp_path):
+    # The table-only callers pass None; must not error or warn.
+    dest = tmp_path / "new_table"
+    result = DuplicateValidator(dest_path=str(dest)).validate(None)
+    assert result.is_valid
+    assert result.metadata["within_csv_duplicate_filenames"] is False

--- a/tests/test_ingestable_records_validator.py
+++ b/tests/test_ingestable_records_validator.py
@@ -122,3 +122,23 @@ def test_file_bearing_but_no_filename_column_is_noop(clean_env, tmp_path, make_c
     result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
     assert result.is_valid
     assert result.metadata["reason"] == "no_filename_column"
+
+
+def test_absolute_or_traversal_path_is_not_counted_as_found(
+    clean_env, tmp_path, make_csv
+):
+    # A manifest value that escapes SRC_PATH/<subdir> (absolute path or ``..``)
+    # is rejected by the transfer's _safe_join (#239); even though the file
+    # exists on disk it is NOT an ingestable file, so it must not mask the
+    # zero-record case. (Bugbot: unsafe manifest path resolution.)
+    src = tmp_path / "src"
+    (src / "sequences").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    outside = tmp_path / "outside.txt"  # exists, but outside the dataset dir
+    outside.write_text("secret", encoding="utf-8")
+    path = make_csv(
+        [{"filename": str(outside)}, {"filename": "../../outside.txt"}]
+    )
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert not result.is_valid
+    assert "No referenced data files" in result.errors[0]

--- a/tests/test_ingestable_records_validator.py
+++ b/tests/test_ingestable_records_validator.py
@@ -1,0 +1,124 @@
+"""Tests for IngestableRecordsValidator — the zero-record fail-fast guard.
+
+Covers the two "0 ingestable records" inputs the adversarial MLM run surfaced:
+a header-only / empty CSV, and a CSV whose every referenced file is missing.
+Both must be rejected at preflight (before the table is created), not fail late
+with a misleading "rows already in the database" message.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from tracebloc_ingestor.validators.ingestable_records_validator import (
+    IngestableRecordsValidator,
+)
+
+
+def _write(path, text):
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_header_only_csv_is_rejected(make_csv):
+    # A CSV with a header row but no data rows.
+    path = make_csv(pd.DataFrame(columns=["filename", "label"]))
+    result = IngestableRecordsValidator().validate(str(path))
+    assert not result.is_valid
+    assert "No data rows found" in result.errors[0]
+    assert result.metadata["data_rows"] == 0
+
+
+def test_empty_zero_byte_csv_is_rejected(tmp_path):
+    path = _write(tmp_path / "empty.csv", "")
+    result = IngestableRecordsValidator().validate(str(path))
+    assert not result.is_valid
+    assert "No data rows found" in result.errors[0]
+
+
+def test_non_csv_input_is_a_noop():
+    # JSON / non-path inputs are handled by their own validators.
+    result = IngestableRecordsValidator().validate("data.json")
+    assert result.is_valid
+    assert result.metadata["checked"] is False
+    assert IngestableRecordsValidator().validate(None).is_valid
+
+
+def test_all_referenced_files_missing_is_rejected(clean_env, tmp_path, make_csv):
+    src = tmp_path / "src"
+    (src / "sequences").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    # CSV references two files that were never staged.
+    path = make_csv([{"filename": "doc1"}, {"filename": "doc2"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert not result.is_valid
+    assert "No referenced data files could be found" in result.errors[0]
+    assert result.metadata["found_at_least_one"] is False
+
+
+def test_passes_when_at_least_one_referenced_file_exists(clean_env, tmp_path, make_csv):
+    src = tmp_path / "src"
+    seq = src / "sequences"
+    seq.mkdir(parents=True)
+    _write(seq / "doc2.txt", "hello world")  # only the second file is staged
+    clean_env.setenv("SRC_PATH", str(src))
+    path = make_csv([{"filename": "doc1"}, {"filename": "doc2"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert result.is_valid, result.errors
+    assert result.metadata["found_at_least_one"] is True
+
+
+def test_filename_with_extension_resolves_without_double_suffix(
+    clean_env, tmp_path, make_csv
+):
+    src = tmp_path / "src"
+    seq = src / "sequences"
+    seq.mkdir(parents=True)
+    _write(seq / "doc1.txt", "x")
+    clean_env.setenv("SRC_PATH", str(src))
+    # filename already carries the extension -> must not become doc1.txt.txt
+    path = make_csv([{"filename": "doc1.txt"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert result.is_valid, result.errors
+
+
+def test_filename_column_is_case_insensitive(clean_env, tmp_path, make_csv):
+    src = tmp_path / "src"
+    (src / "sequences").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    path = make_csv([{"FileName": "doc1"}])  # header cased differently
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    # column resolves, file is missing -> rejected (not a no-op)
+    assert not result.is_valid
+    assert "No referenced data files" in result.errors[0]
+
+
+def test_tabular_style_no_subdir_only_checks_rows(make_csv):
+    # With no file_subdir, a populated CSV passes (no file cross-check).
+    path = make_csv([{"a": "1"}, {"a": "2"}])
+    result = IngestableRecordsValidator(file_subdir=None).validate(str(path))
+    assert result.is_valid
+
+
+def test_valid_dataset_with_files_passes(clean_env, tmp_path, make_csv):
+    src = tmp_path / "src"
+    seq = src / "sequences"
+    seq.mkdir(parents=True)
+    for name in ("a", "b", "c"):
+        _write(seq / f"{name}.txt", "content")
+    clean_env.setenv("SRC_PATH", str(src))
+    path = make_csv([{"filename": n} for n in ("a", "b", "c")])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert result.is_valid, result.errors
+
+
+def test_file_bearing_but_no_filename_column_is_noop(clean_env, tmp_path, make_csv):
+    # Rows present, file_subdir set, but the CSV has no filename column to
+    # cross-check -> not this validator's error to raise (pass through).
+    src = tmp_path / "src"
+    (src / "sequences").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    path = make_csv([{"text_col": "hi"}, {"text_col": "yo"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert result.is_valid
+    assert result.metadata["reason"] == "no_filename_column"

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -1088,3 +1088,94 @@ def test_ingest_does_not_profile_non_nlp():
     profile.assert_not_called()
     args, _ = ing.api_client.send_global_meta_meta.call_args
     assert "text_profile" not in args[2]
+
+
+# --- Truthful registration-failure message about row state (0-record case) ---
+
+
+def test_rows_state_clause_phrasing():
+    """The parenthetical must never claim phantom rows: zero ingested -> says so;
+    nonzero -> warns the rows are persisted."""
+    assert (
+        base_mod._rows_state_clause(0)
+        == "no rows were ingested, so nothing was left in the database"
+    )
+    assert "3 already-ingested row(s)" in base_mod._rows_state_clause(3)
+
+
+def test_zero_inserted_registration_failure_message_is_truthful():
+    """A registration failure with 0 inserted rows must NOT say rows are already
+    in the database (the misleading message the adversarial run surfaced)."""
+    # insert_batch reports 0 inserted ids -> inserted_records stays 0.
+    ing = make_ingestor(records=[{"a": "1", "filename": "f1"}], category=None)
+    ing.database.insert_batch.return_value = ([], [])  # no ids inserted
+    ing.api_client.send_generate_edge_label_meta.return_value = False
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError) as exc:
+            ing.ingest("src", batch_size=10)
+    msg = str(exc.value)
+    assert "NOT registered" in msg
+    assert "already in the database" not in msg
+    assert "no rows were ingested" in msg
+
+
+def test_mlm_header_only_csv_fails_before_table_creation(clean_env, tmp_path):
+    """End-to-end fail-fast: a header-only MLM manifest is rejected during
+    validation, BEFORE the destination table is created — so no orphan empty
+    table is left behind (the #260 failure mode at the zero-records gate)."""
+    from tracebloc_ingestor.config import Config
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    src = tmp_path / "src"
+    (src / "sequences").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    clean_env.setenv("TABLE_NAME", "mlm_train")
+    clean_env.setenv("DEST_PATH", str(tmp_path / "dest" / "mlm_train"))
+
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame(columns=["filename"]).to_csv(csv, index=False)  # header only
+
+    ing = make_ingestor(
+        records=[],
+        category=TaskCategory.MASKED_LANGUAGE_MODELING,
+        label_column=None,
+    )
+    ing.database.config = Config()  # real config so path-reading validators work
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No data rows found"):
+            ing.ingest(str(csv), batch_size=10)
+
+    ing.database.create_table.assert_not_called()
+
+
+def test_mlm_all_files_missing_fails_before_table_creation(clean_env, tmp_path):
+    """The other zero-record path: a populated CSV whose every referenced file
+    is missing is rejected before table creation."""
+    from tracebloc_ingestor.config import Config
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    src = tmp_path / "src"
+    (src / "sequences").mkdir(parents=True)  # empty -> referenced files missing
+    clean_env.setenv("SRC_PATH", str(src))
+    clean_env.setenv("TABLE_NAME", "mlm_train")
+    clean_env.setenv("DEST_PATH", str(tmp_path / "dest" / "mlm_train"))
+
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["doc1", "doc2"]}).to_csv(csv, index=False)
+
+    ing = make_ingestor(
+        records=[],
+        category=TaskCategory.MASKED_LANGUAGE_MODELING,
+        label_column=None,
+    )
+    ing.database.config = Config()
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No referenced data files"):
+            ing.ingest(str(csv), batch_size=10)
+
+    ing.database.create_table.assert_not_called()

--- a/tests/test_text_content_validator.py
+++ b/tests/test_text_content_validator.py
@@ -149,3 +149,16 @@ def test_traversal_path_is_skipped_not_inspected(staged):
     result = TextContentValidator(texts_path="sequences").validate(str(path))
     assert result.is_valid
     assert result.metadata["docs_checked"] == 0
+
+
+def test_truncated_trailing_multibyte_in_small_file_is_rejected(staged):
+    # A small file ending in an INCOMPLETE multibyte sequence (truncated/corrupt
+    # UTF-8) must be flushed at EOF and rejected — not held unvalidated in the
+    # incremental decoder buffer. (Bugbot: UTF-8 EOF not finalized.)
+    _, seq, make_csv = staged
+    # b"\xe2\x82" is the first 2 bytes of a 3-byte char (€ = E2 82 AC), truncated.
+    (seq / "a.txt").write_bytes(b"hello \xe2\x82")
+    path = make_csv(["a"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert not result.is_valid
+    assert any("not valid UTF-8" in e for e in result.errors)

--- a/tests/test_text_content_validator.py
+++ b/tests/test_text_content_validator.py
@@ -137,3 +137,15 @@ def test_binary_errors_are_capped(staged):
     assert not result.is_valid
     assert any("further errors suppressed" in e for e in result.errors)
     assert len(result.errors) <= _MAX_REPORTED + 1
+
+
+def test_traversal_path_is_skipped_not_inspected(staged):
+    # A manifest value escaping SRC_PATH/<subdir> is rejected by the transfer;
+    # this validator neither reads nor flags a file outside the dataset dir.
+    src, _, make_csv = staged
+    outside = src.parent / "outside.bin"
+    outside.write_bytes(b"\x00\xff binary outside")  # would be flagged if read
+    path = make_csv([str(outside), "../../outside.bin"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert result.is_valid
+    assert result.metadata["docs_checked"] == 0

--- a/tests/test_text_content_validator.py
+++ b/tests/test_text_content_validator.py
@@ -1,0 +1,139 @@
+"""Tests for TextContentValidator — content-level UTF-8 / emptiness checks
+for NLP text files (the File Type Validator only checks the extension)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.validators.text_content_validator import TextContentValidator
+
+
+@pytest.fixture
+def staged(clean_env, tmp_path):
+    """Return (src_dir, sequences_dir, set_csv) with SRC_PATH pointed at src."""
+    src = tmp_path / "src"
+    seq = src / "sequences"
+    seq.mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+
+    def make_csv(filenames):
+        import pandas as pd
+
+        path = tmp_path / "data.csv"
+        pd.DataFrame({"filename": filenames}).to_csv(path, index=False)
+        return path
+
+    return src, seq, make_csv
+
+
+def test_valid_utf8_text_passes(staged):
+    _, seq, make_csv = staged
+    (seq / "a.txt").write_text("a clean english sentence", encoding="utf-8")
+    (seq / "b.txt").write_text("café — naïve façade", encoding="utf-8")
+    path = make_csv(["a", "b"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert result.is_valid, result.errors
+    assert result.metadata["docs_checked"] == 2
+
+
+def test_binary_content_is_rejected(staged):
+    _, seq, make_csv = staged
+    (seq / "a.txt").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00binary\xff\xfe")
+    path = make_csv(["a"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert not result.is_valid
+    assert any("a.txt" in e for e in result.errors)
+
+
+def test_non_utf8_bytes_are_rejected(staged):
+    _, seq, make_csv = staged
+    # Latin-1 encoded bytes that are not valid UTF-8 (0xE9 = é in latin-1).
+    (seq / "a.txt").write_bytes("Caf\xe9 do Brasil".encode("latin-1"))
+    path = make_csv(["a"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert not result.is_valid
+    assert any("not valid UTF-8" in e for e in result.errors)
+
+
+def test_empty_file_is_warned_not_rejected(staged):
+    _, seq, make_csv = staged
+    (seq / "a.txt").write_bytes(b"")
+    path = make_csv(["a"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert result.is_valid  # warn, don't fail
+    assert any("empty or whitespace-only" in w for w in result.warnings)
+
+
+def test_whitespace_only_file_is_warned(staged):
+    _, seq, make_csv = staged
+    (seq / "a.txt").write_text("   \n\t  \n", encoding="utf-8")
+    path = make_csv(["a"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert result.is_valid
+    assert any("empty or whitespace-only" in w for w in result.warnings)
+
+
+def test_missing_referenced_files_are_skipped_here(staged):
+    # Missing files are the IngestableRecordsValidator's concern; this validator
+    # only inspects content of files that exist.
+    _, _, make_csv = staged
+    path = make_csv(["does_not_exist"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert result.is_valid
+    assert result.metadata["docs_checked"] == 0
+
+
+def test_multibyte_char_split_at_byte_cap_is_not_a_false_positive(staged):
+    # A valid UTF-8 file longer than max_bytes whose cap lands mid-character
+    # must NOT be flagged as binary (incremental decode handles the partial).
+    _, seq, make_csv = staged
+    text = "é" * 100  # each char is 2 bytes in UTF-8
+    (seq / "a.txt").write_text(text, encoding="utf-8")
+    path = make_csv(["a"])
+    # max_bytes=51 lands in the middle of a 2-byte char (odd offset).
+    result = TextContentValidator(texts_path="sequences", max_bytes=51).validate(
+        str(path)
+    )
+    assert result.is_valid, result.errors
+
+
+def test_sampling_bounds_files_checked(staged):
+    _, seq, make_csv = staged
+    for i in range(20):
+        (seq / f"f{i}.txt").write_text("ok", encoding="utf-8")
+    path = make_csv([f"f{i}" for i in range(20)])
+    result = TextContentValidator(texts_path="sequences", sample_size=5).validate(
+        str(path)
+    )
+    assert result.is_valid
+    assert result.metadata["docs_checked"] == 5
+
+
+def test_no_filename_column_is_a_noop(staged):
+    _, _, _ = staged
+    import pandas as pd
+
+    src, _, _ = staged
+    path = src.parent / "noname.csv"
+    pd.DataFrame({"text": ["a", "b"]}).to_csv(path, index=False)
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert result.is_valid
+    assert result.metadata["docs_checked"] == 0
+
+
+def test_binary_errors_are_capped(staged):
+    # More than _MAX_REPORTED broken files -> errors are bounded with a
+    # suppression marker rather than thousands of lines.
+    from tracebloc_ingestor.validators.text_content_validator import _MAX_REPORTED
+
+    _, seq, make_csv = staged
+    n = _MAX_REPORTED + 10
+    for i in range(n):
+        (seq / f"f{i}.txt").write_bytes(b"\x00\xff binary")
+    path = make_csv([f"f{i}" for i in range(n)])
+    result = TextContentValidator(
+        texts_path="sequences", sample_size=n
+    ).validate(str(path))
+    assert not result.is_valid
+    assert any("further errors suppressed" in e for e in result.errors)
+    assert len(result.errors) <= _MAX_REPORTED + 1

--- a/tests/test_text_content_validator.py
+++ b/tests/test_text_content_validator.py
@@ -162,3 +162,20 @@ def test_truncated_trailing_multibyte_in_small_file_is_rejected(staged):
     result = TextContentValidator(texts_path="sequences").validate(str(path))
     assert not result.is_valid
     assert any("not valid UTF-8" in e for e in result.errors)
+
+
+def test_existing_binary_file_caught_even_amid_many_missing(staged):
+    # Many rows reference absent files; one real binary file sits in the middle.
+    # Existence-filtering before sampling ensures the present file is inspected
+    # and the binary content is caught (Bugbot: content sample skips existing).
+    _, seq, make_csv = staged
+    (seq / "real.txt").write_bytes(b"\x00\xff binary")
+    names = [f"missing{i}" for i in range(50)]
+    names.insert(25, "real")  # not at a strided-sample position of the raw list
+    path = make_csv(names)
+    result = TextContentValidator(texts_path="sequences", sample_size=5).validate(
+        str(path)
+    )
+    assert not result.is_valid
+    assert result.metadata["docs_checked"] >= 1
+    assert any("real.txt" in e for e in result.errors)

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -251,3 +251,62 @@ def test_map_validators_without_config_falls_back_to_module_global(monkeypatch):
     assert all(v._config is None for v in validators)
     dup = next(v for v in validators if isinstance(v, DuplicateValidator))
     assert dup.dest_path.endswith("/env_table")
+
+
+def test_nlp_categories_include_content_hygiene_validators():
+    """The text categories (text/token classification, MLM) gain the
+    zero-record and text-content validators; image/tabular do NOT."""
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    for cat in (
+        TaskCategory.TEXT_CLASSIFICATION,
+        TaskCategory.TOKEN_CLASSIFICATION,
+        TaskCategory.MASKED_LANGUAGE_MODELING,
+    ):
+        types = _types(map_validators(cat, {}))
+        assert IngestableRecordsValidator in types, cat
+        assert TextContentValidator in types, cat
+        # FileTypeValidator stays first (the content validators come after it).
+        assert types[0] is FileTypeValidator, cat
+
+    for cat in (TaskCategory.IMAGE_CLASSIFICATION, TaskCategory.TABULAR_CLASSIFICATION):
+        types = _types(map_validators(cat, IMAGE_OPTS))
+        assert IngestableRecordsValidator not in types, cat
+        assert TextContentValidator not in types, cat
+
+
+def test_mlm_content_validators_target_sequences_subdir():
+    """MLM stages files under ``sequences/`` (not ``texts/``); the content
+    validators must point at that subdirectory."""
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    v = map_validators(TaskCategory.MASKED_LANGUAGE_MODELING, {})
+    rec = next(x for x in v if isinstance(x, IngestableRecordsValidator))
+    txt = next(x for x in v if isinstance(x, TextContentValidator))
+    assert rec.file_subdir == "sequences"
+    assert txt.texts_path == "sequences"
+
+
+def test_text_classification_content_validators_target_texts_subdir():
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    v = map_validators(TaskCategory.TEXT_CLASSIFICATION, {})
+    rec = next(x for x in v if isinstance(x, IngestableRecordsValidator))
+    txt = next(x for x in v if isinstance(x, TextContentValidator))
+    assert rec.file_subdir == "texts"
+    assert txt.texts_path == "texts"

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -44,6 +44,23 @@ logger = logging.getLogger(__name__)
 __all__ = ["BaseIngestor", "IngestionSummary"]
 
 
+def _rows_state_clause(inserted_records: int) -> str:
+    """Phrase the parenthetical about what's already in the database for a
+    registration-failure message, truthfully for the row count actually
+    ingested.
+
+    The registration steps run AFTER the rows are committed, so when some rows
+    landed the message must warn they're already persisted. But when zero rows
+    were ingested (e.g. a header-only CSV or an all-files-missing manifest that
+    slipped to this point), the old fixed "(its rows are already in the
+    database)" wording was simply false and sent users hunting for rows that
+    don't exist. Switch on the count so the message can never claim phantom rows.
+    """
+    if inserted_records > 0:
+        return f"its {inserted_records} already-ingested row(s) remain in the database"
+    return "no rows were ingested, so nothing was left in the database"
+
+
 # NOTE: _TABULAR_FAMILY_CATEGORIES and _FILE_BEARING_CATEGORIES are imported
 # above from modalities.registry (derived from the per-category ModalitySpec
 # flags — backend#796 P3a). The ``self.category in <set>`` checks throughout
@@ -571,9 +588,10 @@ class BaseIngestor(ABC):
                     self.table_name, self.ingestor_id, self.intent
                 ):
                     raise RuntimeError(
-                        "Backend rejected edge-label metadata; the dataset was "
-                        "NOT registered (its rows are already in the database). "
-                        "See the logged API error above."
+                        f"Backend rejected edge-label metadata; the dataset was "
+                        f"NOT registered "
+                        f"({_rows_state_clause(stats['inserted_records'])}). "
+                        f"See the logged API error above."
                     )
 
                 # Ship a data-derived text profile for NLP datasets (#805):
@@ -591,9 +609,10 @@ class BaseIngestor(ABC):
                     self.table_name, schema_dict, self.file_options
                 ):
                     raise RuntimeError(
-                        "Backend rejected the dataset schema/metadata; the "
-                        "dataset was NOT registered (its rows are already in the "
-                        "database). See the logged API error above."
+                        f"Backend rejected the dataset schema/metadata; the "
+                        f"dataset was NOT registered "
+                        f"({_rows_state_clause(stats['inserted_records'])}). "
+                        f"See the logged API error above."
                     )
 
                 if not self.api_client.prepare_dataset(
@@ -614,7 +633,8 @@ class BaseIngestor(ABC):
                     )
                     raise RuntimeError(
                         f"Backend failed to prepare the dataset; it was NOT "
-                        f"registered (its rows are already in the database). "
+                        f"registered "
+                        f"({_rows_state_clause(stats['inserted_records'])}). "
                         f"Backend response: {detail}"
                     )
 

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -19,11 +19,13 @@ from ..validators.duplicate_validator import DuplicateValidator
 from ..validators.file_pairing_validator import FilePairingValidator
 from ..validators.file_validator import FileTypeValidator
 from ..validators.image_validator import ImageResolutionValidator
+from ..validators.ingestable_records_validator import IngestableRecordsValidator
 from ..validators.keypoint_annotation_validator import KeypointAnnotationValidator
 from ..validators.keypoint_visibility_validator import KeypointVisibilityValidator
 from ..validators.label_diversity_validator import LabelDiversityValidator
 from ..validators.numeric_columns_validator import NumericColumnsValidator
 from ..validators.table_name_validator import TableNameValidator
+from ..validators.text_content_validator import TextContentValidator
 from ..validators.time_before_today_validator import TimeBeforeTodayValidator
 from ..validators.time_format_validator import TimeFormatValidator
 from ..validators.time_ordered_validator import TimeOrderedValidator
@@ -94,6 +96,22 @@ def tabular_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     return validators
 
 
+def _nlp_content_validators(
+    options: Dict[str, Any], subdir: str
+) -> List[BaseValidator]:
+    """The NLP content-hygiene pair, gated on the text categories (text/token
+    classification, MLM): reject a manifest that would ingest zero records
+    (header-only CSV, or every referenced file missing), and reject text files
+    whose CONTENT is binary / non-UTF-8 (warn on empty docs). ``subdir`` is the
+    per-category text directory under ``SRC_PATH`` (``"texts"`` / ``"sequences"``),
+    matching the category's ``FileTypeValidator(path=...)``."""
+    extension = options.get("extension", FileExtension.TXT)
+    return [
+        IngestableRecordsValidator(file_subdir=subdir, extension=extension),
+        TextContentValidator(texts_path=subdir, extension=extension),
+    ]
+
+
 def text_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     validators: List[BaseValidator] = []
     # Add text file validator
@@ -103,6 +121,8 @@ def text_classification(options: Dict[str, Any]) -> List[BaseValidator]:
             path="texts",
         ),
     )
+    # Reject a zero-record manifest and binary/empty text content up front.
+    validators.extend(_nlp_content_validators(options, "texts"))
     # Add data validator if schema is provided
     if options.get("schema"):
         validators.append(DataValidator(schema=options["schema"]))
@@ -122,6 +142,8 @@ def token_classification(options: Dict[str, Any]) -> List[BaseValidator]:
             path="texts",
         ),
     )
+    # Reject a zero-record manifest and binary/empty text content up front.
+    validators.extend(_nlp_content_validators(options, "texts"))
     # Validate BIO labels: one tag per word, valid BIO/IOB2 format. Honor a
     # custom label column name when one is configured in the YAML.
     validators.append(
@@ -237,6 +259,8 @@ def masked_language_modeling(options: Dict[str, Any]) -> List[BaseValidator]:
             path="sequences",
         ),
     )
+    # Reject a zero-record manifest and binary/empty text content up front.
+    validators.extend(_nlp_content_validators(options, "sequences"))
     # Add data validator if schema is provided
     if options.get("schema"):
         validators.append(DataValidator(schema=options["schema"]))

--- a/tracebloc_ingestor/validators/base.py
+++ b/tracebloc_ingestor/validators/base.py
@@ -151,6 +151,22 @@ class BaseValidator(ABC):
             return None
 
     @staticmethod
+    def _match_column(columns: Any, name: str) -> Optional[str]:
+        """Return the actual column whose name matches ``name``, case-insensitively.
+
+        Centralises the case-insensitive header lookup several validators need
+        (``filename`` / ``label`` columns whose case the dataset author may not
+        match exactly). ``columns`` is any iterable of column names (a
+        DataFrame's ``.columns``, an Index, or a plain list). Returns ``None``
+        when no column matches.
+        """
+        cols = list(columns)
+        if name in cols:
+            return name
+        lowered = {str(c).lower(): c for c in cols}
+        return lowered.get(name.lower())
+
+    @staticmethod
     def _parse_json(row: Any, column: str) -> Optional[Any]:
         """Parse a JSON string from a DataFrame row column. Returns None on failure."""
         import pandas as pd

--- a/tracebloc_ingestor/validators/duplicate_validator.py
+++ b/tracebloc_ingestor/validators/duplicate_validator.py
@@ -88,6 +88,15 @@ class DuplicateValidator(BaseValidator):
                         f"Destination directory '{self.dest_path}' already exists"
                     )
 
+            # Within-CSV duplicate filename detection (warning). The check
+            # above guards re-ingesting into an existing TABLE; this catches the
+            # same filename appearing more than once in the INCOMING CSV, which
+            # would otherwise ingest as separate records with no notice. Warn
+            # only — repeated filenames may be intentional in some flows.
+            dup_warnings = self._within_csv_duplicate_warnings(data)
+            warnings.extend(dup_warnings)
+            metadata["within_csv_duplicate_filenames"] = len(dup_warnings) > 0
+
             # Check if parent directory exists (for creating the destination)
             parent_dir = Path(self.dest_path).parent
             parent_exists = parent_dir.exists()
@@ -111,6 +120,54 @@ class DuplicateValidator(BaseValidator):
                 errors=[f"Duplicate validation error: {str(e)}"],
                 metadata={"error_type": "validation_exception"},
             )
+
+    def _within_csv_duplicate_warnings(self, data: Any) -> List[str]:
+        """Warn when a filename appears more than once in the incoming CSV.
+
+        Bounded: reads only the ``filename`` column. A non-CSV input (e.g. a
+        ``None`` from the table-only callers, or a JSON path) is a no-op, and a
+        CSV with no ``filename`` column (tabular families) is skipped.
+        """
+        if not isinstance(data, (str, Path)) or Path(data).suffix.lower() != ".csv":
+            return []
+
+        import pandas as pd
+
+        try:
+            header = pd.read_csv(data, nrows=0, encoding="utf-8").columns
+        except Exception:  # noqa: BLE001 — header probe is best-effort
+            return []
+        filename_col = self._match_column(header, "filename")
+        if filename_col is None:
+            return []
+
+        try:
+            series = pd.read_csv(
+                data,
+                usecols=[filename_col],
+                encoding="utf-8",
+                dtype=str,
+                keep_default_na=False,
+            )[filename_col]
+        except Exception:  # noqa: BLE001 — let other validators surface read errors
+            return []
+
+        names = series.map(lambda v: str(v).strip())
+        names = names[names != ""]
+        counts = names.value_counts()
+        duplicated = counts[counts > 1]
+        if duplicated.empty:
+            return []
+
+        extra = int(duplicated.sum() - len(duplicated))  # rows beyond the first
+        sample = list(duplicated.index[:10])
+        suffix = " …" if len(duplicated) > 10 else ""
+        return [
+            f"{len(duplicated)} filename(s) appear more than once in the CSV "
+            f"({extra} duplicate row(s)): {sample}{suffix}. These will be "
+            f"ingested as separate records — remove the duplicates if this is "
+            f"unintended."
+        ]
 
     def _check_directory_exists(self) -> bool:
         """Check if the destination directory exists.

--- a/tracebloc_ingestor/validators/ingestable_records_validator.py
+++ b/tracebloc_ingestor/validators/ingestable_records_validator.py
@@ -28,7 +28,7 @@ from typing import Any, Optional
 import pandas as pd
 
 from ..config import Config
-from ..file_transfer import _has_extension
+from ..file_transfer import _has_extension, _safe_join
 from ..utils.constants import FileExtension
 from .base import BaseValidator, ValidationResult
 
@@ -162,7 +162,17 @@ class IngestableRecordsValidator(BaseValidator):
                         if _has_extension(filename)
                         else f"{filename}{self.extension}"
                     )
-                    if os.path.isfile(os.path.join(subdir, resolved)):
+                    # Resolve EXACTLY as the transfer does (``_safe_join`` under
+                    # SRC_PATH): an absolute / ``..`` manifest value that would
+                    # otherwise let a plain join "find" a file outside the
+                    # dataset dir is rejected by the transfer (#239), so it is
+                    # NOT an ingestable file here either — skip it rather than
+                    # let it mask the zero-record case this validator guards.
+                    try:
+                        candidate = _safe_join(src_root, self.file_subdir, resolved)
+                    except ValueError:
+                        continue
+                    if os.path.isfile(candidate):
                         return self._create_result(
                             is_valid=True,
                             metadata={

--- a/tracebloc_ingestor/validators/ingestable_records_validator.py
+++ b/tracebloc_ingestor/validators/ingestable_records_validator.py
@@ -1,0 +1,195 @@
+"""Ingestable Records Validator Module.
+
+Fail-fast guard for the "0 ingestable records" class of input error, run at
+preflight (before the destination table is created) so a dataset that would
+ingest nothing is rejected EARLY with a clear, source-truthful message — never
+left as an orphan empty table that fails LATE at backend registration with a
+misleading "its rows are already in the database" error.
+
+Two distinct ways a CSV manifest yields zero records, both caught here:
+
+1. **Header-only / empty CSV** — the file has a header row (or is empty) but no
+   data rows. The existing zero-byte guard (#250, in ``CSVIngestor.read_data``)
+   only fired on a *totally* empty file; a header-only CSV slipped through,
+   created the table, ingested 0 rows, then failed late. This catches both.
+2. **All referenced files missing** (file-bearing categories) — every
+   ``filename`` the CSV references is absent under ``SRC_PATH/<subdir>/``, so
+   every record is dropped at transfer time and 0 records land. Cross-checks the
+   referenced filenames against what's actually staged; the per-directory
+   ``FileTypeValidator`` only checks the *extension* of files that ARE present,
+   not whether the CSV's filenames resolve to any of them.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+
+from ..config import Config
+from ..file_transfer import _has_extension
+from ..utils.constants import FileExtension
+from .base import BaseValidator, ValidationResult
+
+config = Config()
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+
+class IngestableRecordsValidator(BaseValidator):
+    """Reject a CSV manifest that would ingest zero records.
+
+    Attributes:
+        file_subdir: Subdirectory under ``SRC_PATH`` holding this category's
+            referenced files (``"texts"`` / ``"sequences"`` / ``"images"`` …),
+            mirroring ``FileTypeValidator(path=...)``. ``None`` for
+            non-file-bearing (tabular / time-series) categories — only the
+            header-only / empty-CSV row check runs then.
+        extension: Expected file extension, appended to a CSV filename that
+            carries none (same rule the transfer uses).
+        filename_column: CSV column naming each sample's file (default
+            ``"filename"``; resolved case-insensitively).
+    """
+
+    def __init__(
+        self,
+        file_subdir: Optional[str] = None,
+        extension: str = FileExtension.TXT,
+        filename_column: str = "filename",
+        name: str = "Ingestable Records",
+    ):
+        super().__init__(name)
+        self.file_subdir = file_subdir
+        ext = extension or FileExtension.TXT
+        self.extension = ext if ext.startswith(".") else f".{ext}"
+        self.filename_column = filename_column
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            # Only CSV manifests are checked here. Non-CSV inputs (e.g. JSON)
+            # are covered by their own validators; a non-path input is a direct
+            # caller we don't second-guess.
+            if not isinstance(data, (str, Path)) or Path(data).suffix.lower() != ".csv":
+                return self._create_result(is_valid=True, metadata={"checked": False})
+
+            path = Path(data)
+
+            # 1) Header-only / empty CSV -> zero data rows.
+            row_result = self._check_has_rows(path)
+            if not row_result.is_valid:
+                return row_result
+
+            # 2) File-bearing: every referenced file missing -> zero records.
+            if self.file_subdir:
+                return self._check_referenced_files(path)
+
+            return self._create_result(is_valid=True, metadata={"checked": True})
+
+        except Exception as e:  # noqa: BLE001 — mirror sibling validators
+            logger.error(f"Error during ingestable-records validation: {str(e)}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Ingestable records validation error: {str(e)}"],
+                metadata={"error_type": "validation_exception"},
+            )
+
+    def _check_has_rows(self, path: Path) -> ValidationResult:
+        """Fail when the CSV has a header but no data rows (or is empty)."""
+        try:
+            # nrows=1 is enough to tell "has >=1 data row" from "header only",
+            # without materialising a large file. dtype=str / keep_default_na
+            # keep the read cheap and inference-free — we only count rows here.
+            head = pd.read_csv(
+                path,
+                nrows=1,
+                encoding="utf-8",
+                dtype=str,
+                keep_default_na=False,
+            )
+        except pd.errors.EmptyDataError:
+            head = None
+
+        if head is None or len(head) == 0:
+            return self._create_result(
+                is_valid=False,
+                errors=[
+                    f"No data rows found in CSV '{path.name}': the file has a "
+                    f"header but no data rows (0 ingestable records). Add at "
+                    f"least one data row and re-ingest."
+                ],
+                metadata={"data_rows": 0},
+            )
+        return self._create_result(is_valid=True, metadata={"data_rows": "at_least_1"})
+
+    def _check_referenced_files(self, path: Path) -> ValidationResult:
+        """Fail when NONE of the CSV's referenced files exist on disk.
+
+        Early-exits on the first file that resolves, so a healthy dataset costs
+        one ``stat``; only an all-missing dataset walks the whole column — which
+        is exactly the zero-records case we want to surface up front.
+        """
+        src_root = (self._config or config).SRC_PATH
+        subdir = os.path.join(src_root, self.file_subdir)
+
+        filename_col = self._resolve_filename_column(path)
+        if filename_col is None:
+            # No filename column to cross-check — not this validator's error to
+            # raise (the read/transfer path surfaces a missing column). Pass.
+            return self._create_result(
+                is_valid=True,
+                metadata={"checked": False, "reason": "no_filename_column"},
+            )
+
+        checked = 0
+        try:
+            chunks = pd.read_csv(
+                path,
+                usecols=[filename_col],
+                encoding="utf-8",
+                chunksize=50_000,
+                dtype=str,
+                keep_default_na=False,
+            )
+            for chunk in chunks:
+                for raw_name in chunk[filename_col]:
+                    filename = str(raw_name).strip()
+                    if not filename:
+                        continue
+                    checked += 1
+                    resolved = (
+                        filename
+                        if _has_extension(filename)
+                        else f"{filename}{self.extension}"
+                    )
+                    if os.path.isfile(os.path.join(subdir, resolved)):
+                        return self._create_result(
+                            is_valid=True,
+                            metadata={
+                                "referenced_files_checked": checked,
+                                "found_at_least_one": True,
+                            },
+                        )
+        except pd.errors.EmptyDataError:
+            checked = 0
+
+        return self._create_result(
+            is_valid=False,
+            errors=[
+                f"No referenced data files could be found under "
+                f"'{self.file_subdir}/'; nothing to ingest (0 ingestable "
+                f"records). Checked {checked} filename reference(s) against "
+                f"'{subdir}/' and none exist on disk. Verify the files are "
+                f"staged at that path and that the '{self.filename_column}' "
+                f"column matches the staged filenames."
+            ],
+            metadata={"referenced_files_checked": checked, "found_at_least_one": False},
+        )
+
+    def _resolve_filename_column(self, path: Path) -> Optional[str]:
+        """Case-insensitively resolve the filename column from the CSV header."""
+        try:
+            header = pd.read_csv(path, nrows=0, encoding="utf-8").columns
+        except Exception:  # noqa: BLE001 — header probe is best-effort
+            return None
+        return self._match_column(header, self.filename_column)

--- a/tracebloc_ingestor/validators/text_content_validator.py
+++ b/tracebloc_ingestor/validators/text_content_validator.py
@@ -162,11 +162,16 @@ class TextContentValidator(BaseValidator):
                 f"text and re-ingest.",
             )
 
-        # Incremental decode so a multibyte character split at the byte cap is
-        # NOT mistaken for invalid input (final=False holds the partial); a
-        # genuinely non-UTF-8 byte still raises.
+        # Incremental decode. ``final`` is True only when we read the WHOLE file
+        # (the read returned fewer bytes than the cap, i.e. EOF) — so a truncated
+        # / wrongly-encoded trailing multibyte sequence in a small file is
+        # FLUSHED and raises, instead of sitting unvalidated in the decoder
+        # buffer. When we stopped at the cap (len(raw) == max_bytes) the file may
+        # continue, so we DON'T finalize — a legitimate multibyte char split at
+        # the cap must not be mistaken for invalid input.
+        final = len(raw) < self.max_bytes
         try:
-            codecs.getincrementaldecoder("utf-8")().decode(raw, final=False)
+            codecs.getincrementaldecoder("utf-8")().decode(raw, final=final)
         except UnicodeDecodeError:
             return (
                 "error",

--- a/tracebloc_ingestor/validators/text_content_validator.py
+++ b/tracebloc_ingestor/validators/text_content_validator.py
@@ -1,0 +1,171 @@
+"""Text Content Validator Module.
+
+Content-level check for NLP categories (text_classification,
+token_classification, masked_language_modeling). ``FileTypeValidator`` only
+checks the file *extension*, so a file named ``doc1.txt`` that actually holds
+binary / non-UTF-8 bytes — or is empty — passed validation and was ingested
+silently; the dataset author only discovered the corruption at training time.
+
+This samples the referenced text files and asserts their *content* is decodable
+UTF-8 text:
+
+- **Binary / non-decodable content** (a NUL byte, or bytes that aren't valid
+  UTF-8) is REJECTED — that's silent data corruption.
+- **Empty / whitespace-only documents** are WARNED about (they carry no signal
+  for training but may be intentional placeholders in some flows).
+
+Sampling + a per-file byte cap keep the pass bounded on large datasets: a
+deterministic strided sample of files, and only the first chunk of each file is
+read (enough to catch binary content and emptiness).
+"""
+
+import codecs
+import logging
+import os
+from typing import Any, List, Optional, Tuple
+
+from ..config import Config
+from ..file_transfer import _has_extension
+from ..text_profile import _sample
+from ..utils.constants import FileExtension
+from .base import BaseValidator, ValidationResult
+
+config = Config()
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+# Cap reported messages so a wholly-broken dataset yields an actionable summary
+# rather than tens of thousands of lines (mirrors BIOLabelValidator).
+_MAX_REPORTED = 50
+
+
+class TextContentValidator(BaseValidator):
+    """Validate that referenced NLP text files hold decodable UTF-8 text.
+
+    Attributes:
+        texts_path: Subdirectory under ``SRC_PATH`` holding the text files
+            (``"texts"`` for text/token classification, ``"sequences"`` for
+            masked language modeling) — mirrors ``FileTypeValidator(path=...)``.
+        extension: Expected text-file extension (default ``.txt``).
+        filename_column: CSV column naming each sample's file (default
+            ``"filename"``; resolved case-insensitively).
+        sample_size: Max number of files to inspect (deterministic strided
+            sample over the referenced files).
+        max_bytes: Max bytes read per file for the content check.
+    """
+
+    def __init__(
+        self,
+        texts_path: str = "texts",
+        extension: str = FileExtension.TXT,
+        filename_column: str = "filename",
+        sample_size: int = 500,
+        max_bytes: int = 65_536,
+        name: str = "Text Content",
+    ):
+        super().__init__(name)
+        self.texts_path = texts_path
+        ext = extension or FileExtension.TXT
+        self.extension = ext if ext.startswith(".") else f".{ext}"
+        self.filename_column = filename_column
+        self.sample_size = sample_size
+        self.max_bytes = max_bytes
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            df = self._load_data(data)
+            if df is None or df.empty:
+                # Nothing to inspect; the empty-CSV case is the
+                # IngestableRecordsValidator's job, not this one.
+                return self._create_result(is_valid=True, metadata={"docs_checked": 0})
+
+            filename_col = self._match_column(df.columns, self.filename_column)
+            if filename_col is None:
+                return self._create_result(
+                    is_valid=True,
+                    metadata={"docs_checked": 0, "reason": "no_filename_column"},
+                )
+
+            texts_dir = os.path.join((self._config or config).SRC_PATH, self.texts_path)
+            filenames = [
+                str(v).strip() for v in df[filename_col].tolist() if str(v).strip()
+            ]
+
+            errors: List[str] = []
+            warnings: List[str] = []
+            checked = 0
+            for filename in _sample(filenames, self.sample_size):
+                resolved = (
+                    filename
+                    if _has_extension(filename)
+                    else f"{filename}{self.extension}"
+                )
+                text_path = os.path.join(texts_dir, resolved)
+                if not os.path.isfile(text_path):
+                    # A missing referenced file is surfaced by
+                    # IngestableRecordsValidator / the transfer path, not here.
+                    continue
+                checked += 1
+                level, message = self._inspect(text_path, resolved)
+                if level == "error":
+                    errors.append(message)
+                elif level == "warning":
+                    warnings.append(message)
+                if len(errors) >= _MAX_REPORTED:
+                    errors.append("... further errors suppressed.")
+                    break
+
+            return self._create_result(
+                is_valid=len(errors) == 0,
+                errors=errors,
+                warnings=warnings,
+                metadata={"docs_checked": checked},
+            )
+
+        except Exception as e:  # noqa: BLE001 — mirror sibling validators
+            logger.error(f"Error during text content validation: {str(e)}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Text content validation error: {str(e)}"],
+                metadata={"error_type": "validation_exception"},
+            )
+
+    def _inspect(self, path: str, label: str) -> Tuple[Optional[str], str]:
+        """Inspect one file's content. Returns ``(level, message)`` where level
+        is ``"error"`` (binary/non-UTF-8), ``"warning"`` (empty/whitespace), or
+        ``None`` (clean — message ignored)."""
+        try:
+            with open(path, "rb") as fh:
+                raw = fh.read(self.max_bytes)
+        except OSError as e:
+            return "error", f"'{self.texts_path}/{label}': could not read file: {e}"
+
+        if not raw.strip():
+            return (
+                "warning",
+                f"'{self.texts_path}/{label}' is empty or whitespace-only — it "
+                f"carries no text for training.",
+            )
+
+        if b"\x00" in raw:
+            return (
+                "error",
+                f"'{self.texts_path}/{label}' contains a NUL byte (0x00) — the "
+                f"file is binary, not UTF-8 text. Re-export it as plain UTF-8 "
+                f"text and re-ingest.",
+            )
+
+        # Incremental decode so a multibyte character split at the byte cap is
+        # NOT mistaken for invalid input (final=False holds the partial); a
+        # genuinely non-UTF-8 byte still raises.
+        try:
+            codecs.getincrementaldecoder("utf-8")().decode(raw, final=False)
+        except UnicodeDecodeError:
+            return (
+                "error",
+                f"'{self.texts_path}/{label}' is not valid UTF-8 text — it looks "
+                f"binary or wrongly encoded. Re-export it as plain UTF-8 text "
+                f"and re-ingest.",
+            )
+
+        return None, ""

--- a/tracebloc_ingestor/validators/text_content_validator.py
+++ b/tracebloc_ingestor/validators/text_content_validator.py
@@ -25,7 +25,7 @@ import os
 from typing import Any, List, Optional, Tuple
 
 from ..config import Config
-from ..file_transfer import _has_extension
+from ..file_transfer import _has_extension, _safe_join
 from ..text_profile import _sample
 from ..utils.constants import FileExtension
 from .base import BaseValidator, ValidationResult
@@ -86,7 +86,7 @@ class TextContentValidator(BaseValidator):
                     metadata={"docs_checked": 0, "reason": "no_filename_column"},
                 )
 
-            texts_dir = os.path.join((self._config or config).SRC_PATH, self.texts_path)
+            src_root = (self._config or config).SRC_PATH
             filenames = [
                 str(v).strip() for v in df[filename_col].tolist() if str(v).strip()
             ]
@@ -100,7 +100,14 @@ class TextContentValidator(BaseValidator):
                     if _has_extension(filename)
                     else f"{filename}{self.extension}"
                 )
-                text_path = os.path.join(texts_dir, resolved)
+                # Resolve as the transfer does (``_safe_join`` under SRC_PATH):
+                # an absolute / ``..`` manifest value is rejected by the transfer
+                # (#239), so we neither read nor flag a file outside the dataset
+                # dir — skip it (its missing-ness is the records validator's job).
+                try:
+                    text_path = _safe_join(src_root, self.texts_path, resolved)
+                except ValueError:
+                    continue
                 if not os.path.isfile(text_path):
                     # A missing referenced file is surfaced by
                     # IngestableRecordsValidator / the transfer path, not here.

--- a/tracebloc_ingestor/validators/text_content_validator.py
+++ b/tracebloc_ingestor/validators/text_content_validator.py
@@ -91,10 +91,15 @@ class TextContentValidator(BaseValidator):
                 str(v).strip() for v in df[filename_col].tolist() if str(v).strip()
             ]
 
-            errors: List[str] = []
-            warnings: List[str] = []
-            checked = 0
-            for filename in _sample(filenames, self.sample_size):
+            # Existence-filter FIRST, then sample the files that ACTUALLY exist.
+            # Sampling the raw manifest first (then skipping the missing ones)
+            # let a handful of present files fall outside the sample when most
+            # rows reference absent files — content went unread and binary files
+            # slipped through (Bugbot: content sample skips existing files). The
+            # cheap part (a stat per row) walks the manifest; the expensive part
+            # (reading + decoding content) stays bounded to ``sample_size``.
+            present = []
+            for filename in filenames:
                 resolved = (
                     filename
                     if _has_extension(filename)
@@ -103,15 +108,18 @@ class TextContentValidator(BaseValidator):
                 # Resolve as the transfer does (``_safe_join`` under SRC_PATH):
                 # an absolute / ``..`` manifest value is rejected by the transfer
                 # (#239), so we neither read nor flag a file outside the dataset
-                # dir — skip it (its missing-ness is the records validator's job).
+                # dir — its missing-ness is the records validator's job.
                 try:
                     text_path = _safe_join(src_root, self.texts_path, resolved)
                 except ValueError:
                     continue
-                if not os.path.isfile(text_path):
-                    # A missing referenced file is surfaced by
-                    # IngestableRecordsValidator / the transfer path, not here.
-                    continue
+                if os.path.isfile(text_path):
+                    present.append((text_path, resolved))
+
+            errors: List[str] = []
+            warnings: List[str] = []
+            checked = 0
+            for text_path, resolved in _sample(present, self.sample_size):
                 checked += 1
                 level, message = self._inspect(text_path, resolved)
                 if level == "error":


### PR DESCRIPTION
## Summary

Adversarial end-to-end MLM ingestion (dev cluster, `ingestor:0.3.12`) fed the validator chain malformed-but-realistic datasets. The tokenizer checks held up, but several **input-hygiene gaps** let bad data slip past pre-ingestion validation and fail late with misleading messages. This hardens them at the validator level (reproduced via temp CSVs + temp files driving the validators directly), so each is caught **before the table is created** — no orphan empty table, no misleading "rows already in the database".

## Fixes

### MUST FIX — "0 ingestable records" (two cases)
**Finding:** an empty/header-only CSV passes all current validators, creates the table, ingests 0 rows, then fails late at the edge-label step with `"…the dataset was NOT registered (its rows are already in the database)"` — but there are **0 rows**. Same misleading late error when a CSV references files that don't exist and *all* are missing (every record skipped at transfer → 0 transferred → orphan empty table). PR #250 only caught a *totally* empty file; a header-only CSV slipped through.

**Fix:**
- New `IngestableRecordsValidator` (wired into the NLP factories via `_nlp_content_validators`) rejects:
  - header-only / empty CSV → `"No data rows found in CSV …"`
  - file-bearing manifest with every referenced file missing → `"No referenced data files could be found; nothing to ingest"` (cross-checks the CSV filename column against `SRC_PATH/<subdir>/`, early-exiting on the first file that resolves)
  - It runs in `validate_data` **before** `create_table`, so a rejected ingest leaves **no orphan table** (the #260 guard, at the zero-records gate).
- `base.py`: `_rows_state_clause(inserted_records)` rephrases the three registration-failure messages so they can never claim "its rows are already in the database" when 0 rows were ingested ("no rows were ingested, so nothing was left in the database"). The `"NOT registered"` wording is kept.

**Repro (tests):** `test_header_only_csv_is_rejected`, `test_empty_zero_byte_csv_is_rejected`, `test_all_referenced_files_missing_is_rejected`, `test_mlm_header_only_csv_fails_before_table_creation` + `…all_files_missing…` (assert `create_table` is never called), `test_zero_inserted_registration_failure_message_is_truthful`.

### SHOULD FIX — NLP text-content validator (binary / empty docs)
**Finding:** the File Type Validator only checks the *extension*. A `.txt` holding non-UTF-8/binary bytes is ingested silently (5/5 "successfully processed" with garbage); an empty `.txt` is ingested with no warning. The user only finds out at training time.

**Fix:** new `TextContentValidator`, gated on `text_classification` / `token_classification` / `masked_language_modeling`. Samples the referenced text files (deterministic strided sample + per-file byte cap) and:
- **rejects** binary / non-UTF-8 content (NUL byte, or bytes that fail an incremental UTF-8 decode — incremental so a multibyte char split at the byte cap isn't a false positive)
- **warns** on empty / whitespace-only docs

**Repro (tests):** `test_binary_content_is_rejected`, `test_non_utf8_bytes_are_rejected`, `test_empty_file_is_warned_not_rejected`, `test_whitespace_only_file_is_warned`, `test_multibyte_char_split_at_byte_cap_is_not_a_false_positive`, `test_sampling_bounds_files_checked`.

### NICE TO HAVE — within-CSV duplicate detection
**Finding:** duplicate rows in the CSV (same filename twice) ingest as separate records; the existing Duplicate Validator only checks against the *existing table*, not within the incoming CSV.

**Fix:** `DuplicateValidator` now also **warns** (no hard-fail — repeats may be intentional) when a filename appears more than once in the incoming CSV. Bounded (reads only the filename column); no-op for non-CSV / tabular inputs without a filename column.

**Repro (tests):** `test_within_csv_duplicate_filenames_warn`, `…case_insensitive_column`, `…no_filename_column_is_noop`, `…none_input_is_noop`.

## Implementation notes
- Follows the existing validator framework: new validators wired via `map_validators` (per-category factories in `modalities/validators.py`), gated to NLP categories only (no impact on image/tabular).
- Extends the #250 empty-CSV guard rather than duplicating it; reuses `text_profile._sample` and `file_transfer._has_extension`.
- Shared `BaseValidator._match_column` centralises the case-insensitive header lookup (also fixed an existing unused `typing.List` import in `duplicate_validator.py`).
- Diff is surgical — only the 11 touched files; no repo-wide reformatting.

## Tests
- `pytest tests/ -q --cov=tracebloc_ingestor --cov-fail-under=95` → **1183 passed, 1 xfailed**, total coverage **96.7%** (gate 95%).
- Only ADDED tests; no existing tests removed or rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the pre-ingestion validation path and registration error text for NLP categories; behavior is well-covered by new tests but affects a critical ingest gate before table creation.
> 
> **Overview**
> Hardens **preflight validation** for NLP ingests so bad manifests fail **before** `create_table`, with clearer errors instead of late registration failures that wrongly claim rows are already in the database.
> 
> **Zero-record fail-fast:** Adds `IngestableRecordsValidator` for text/token classification and MLM. It rejects header-only or empty CSVs and manifests where **every** referenced file is missing under `SRC_PATH` (using the same `_safe_join` rules as transfer). Wired via `_nlp_content_validators` in `modalities/validators.py` (`texts/` vs `sequences/` per category).
> 
> **NLP text content:** Adds `TextContentValidator` on the same categories—samples staged files, **fails** on binary/NUL/non-UTF-8 bytes, **warns** on empty/whitespace-only docs, with bounded sampling and safe path handling.
> 
> **Registration messaging:** `base.py` introduces `_rows_state_clause(inserted_records)` so edge-label, global-meta, and prepare failures describe DB state accurately (e.g. “no rows were ingested…” when count is 0).
> 
> **Duplicate CSV filenames:** `DuplicateValidator` **warns** (does not fail) when the same `filename` appears multiple times in the incoming CSV; adds `BaseValidator._match_column` for case-insensitive headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 041ed130b131a273d6953db535ada59e7fe6a29b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->