### PR TITLE
test(nlp-profile): accept source_record kwarg in map_file_transfer stubs (bugbot #304)

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -1032,7 +1032,9 @@ def test_ingest_attaches_text_profile_for_nlp(category):
     with patch.object(base_mod, "Session") as Sess, patch.object(
         ing, "validate_data", return_value=True
     ), patch.object(
-        base_mod, "map_file_transfer", side_effect=lambda c, r, o, cfg=None: r
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
     ), patch.object(
         base_mod, "compute_text_profile", return_value=_TEXT_PROFILE
     ):
@@ -1056,7 +1058,9 @@ def test_ingest_omits_text_profile_when_none_for_nlp():
     with patch.object(base_mod, "Session") as Sess, patch.object(
         ing, "validate_data", return_value=True
     ), patch.object(
-        base_mod, "map_file_transfer", side_effect=lambda c, r, o, cfg=None: r
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
     ), patch.object(
         base_mod, "compute_text_profile", return_value=None
     ):
@@ -1079,7 +1083,9 @@ def test_ingest_does_not_profile_non_nlp():
     with patch.object(base_mod, "Session") as Sess, patch.object(
         ing, "validate_data", return_value=True
     ), patch.object(
-        base_mod, "map_file_transfer", side_effect=lambda c, r, o, cfg=None: r
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
     ), patch.object(
         base_mod, "compute_text_profile"
     ) as profile:


### PR DESCRIPTION
## Summary

Fixes a bugbot finding on the v0.3.12 release PR [#304](https://github.com/tracebloc/data-ingestors/pull/304).

The #805 NLP text-profile tests in `test_ingestor_base.py` stubbed `map_file_transfer` with a 4-arg lambda `(c, r, o, cfg=None)`, but production calls it with `source_record` as a keyword (`base.py:456`). The stub raised `TypeError` on the first file-bearing NLP record — which was swallowed by the per-record `try/except`, so the tests passed **without actually exercising** the file-transfer / profile-attachment path (false confidence).

Aligned the 3 stubs (lines ~1035/1059/1082) with the already-correct ones (568/597/623) by accepting `source_record=None`.

## Note on the other bugbot finding (#304: "MLM tokenizer preflight removed")

That one is a **false positive** — commit `82a52bb` (#805 / #299, "refactor(ingest): drop ingest-time tokenizer + fingerprint") *intentionally* removed the entire `TokenizerValidator` + fingerprint machinery from the ingest path (it deleted `test_tokenizer_validator.py`, `test_tokenizer_fingerprint.py`, and `TokenizerValidator` no longer exists anywhere). The MLM factory dropping the tokenizer preflight is the designed behavior of #805, not a regression — so no change is made for it.

## Test plan

- [x] `pytest` green locally — **1151 passed, 1 xfailed**
- [x] The 3 profile tests now exercise the real `map_file_transfer(..., source_record=...)` path instead of swallowing a `TypeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only stub signature changes; no production code paths are modified.
> 
> **Overview**
> Updates three NLP text-profile tests in `test_ingestor_base.py` so their `map_file_transfer` patch stubs accept **`source_record=None`**, matching how `BaseIngestor.ingest` calls the real function.
> 
> Previously the four-argument lambdas raised **`TypeError`** on that keyword; the per-record handler swallowed it, so the tests still passed without running file transfer or the text-profile attachment path. The stubs now match the ones already used elsewhere in the same file (e.g. self-supervised ingest tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 576a3cd9bae0cbf4a6898742db6752f8bb1fd56c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->