### PR TITLE
chore(release): bump version to 0.4.0

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.12"
+__version__ = "0.4.0"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
## Summary

Bumps `__version__` from `0.3.12` to `0.4.0` to mark the minor-version cut after the substantive batch landed under 0.3.x.

`setup.py` reads the literal from `tracebloc_ingestor/__init__.py` (#175), so this is the only file to bump.

## What 0.4.0 includes (highlights since 0.3.0)

**Refactors (P3–P6) — consolidation into the ModalityRegistry**
- Per-category behavior flags → `ModalityRegistry` (#253)
- Validator / transfer / format factories moved into the registry (#255, #256, #257)
- Config injected into validators (#272) and file-transfer (#273)
- Run-level preflight extracted (#274); cross-ingest table lock extracted (#275)
- Per-record transform → `RecordProcessor` (#276); batch write path → `BatchWriter` (#278)
- mask_id split off the DB-bound record (#280); BOOL vocabulary consolidated (#284)

**Atomicity — validator-rejected ingest leaves no orphan**
- Defer `create_table` until `validate_data()` passes (#260 / #265, regression-tested in #279)
- Hoist missing-schema-column check into `DataValidator` so the same gate catches sparse-CSV cases (#289 / #292)

**Preflight UX**
- "Did you mean ...?" suggestions on typo'd schema types — shared between Database and DataValidator (#264, #266 / #293)
- JSONL detection at file load with an actionable fix message (#263)
- LabelDiversity now mirrors DataValidator's JSON load (single-dict accepted, JSONL benign-skipped) (#267 / #294)
- FileType validator's "invalid extension" error names the allowed extensions and points at the override knob (#291 / #295)
- TSF README example aligned with runtime validators (#290 / #296)

**Other**
- Canonical column-identifier grammar (#288)
- Tokenizer fingerprint hardening (#286)
- Self-supervised edge-label metadata fix (#297)

## Test plan
- [x] `__version__` resolves to `0.4.0` from a Python import.
- [x] Full suite green on the bump: 1151 passed, 1 xfailed.
- [x] Once merged, tagging `v0.4.0` will trigger the existing Release-image workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime or behavioral code changes in the diff.
> 
> **Overview**
> **Bumps the package release version** from `0.3.12` to `0.4.0` by updating the `__version__` literal in `tracebloc_ingestor/__init__.py`.
> 
> That file remains the single source of truth (#175); `setup.py` continues to parse it via `_read_version()`, so no other files need changing for the version cut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aabef2801a1ebe6df31eb74282ae5fae3bb08d8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->