### PR TITLE
Develop to prod 0.4.0

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.3.12"
+__version__ = "0.4.0"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The visible diff is a one-line version change with no runtime logic; overall release risk depends on other commits in the sync PR, not shown here.
> 
> **Overview**
> **Release version bump for v0.4.0** as part of the develop → prod sync (`Develop to prod 0.4.0`).
> 
> Updates `__version__` in `tracebloc_ingestor/__init__.py` from `0.3.12` to `0.4.0`. Per existing release practice, this is the only file that must change for the version string; `setup.py` reads it via `_read_version()` at build time so PyPI and `import tracebloc_ingestor` stay aligned.
> 
> The **major** SemVer step (0.3 → 0.4) signals breaking or otherwise significant changes that are expected to land with this sync, even though this diff is only the version literal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df307e5a22fa77e1d37003d9ef86c3433ccf287c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->