### PR TITLE
docs: fix README + CLAUDE.md facts not covered by #309

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Data ingestion pipeline for the tracebloc platform. Validates, preprocesses, and
 
 ```bash
 pip install -e .            # editable install
-pip install -r requirements.txt  # includes dev/test deps
+pip install -r requirements-dev.txt  # runtime + dev/test deps
 pytest                      # run tests
 ```
 
@@ -50,4 +50,4 @@ Ingestor implementations are in `tracebloc_ingestor/ingestors/` (`base.py`, `csv
 
 ## Key Dependencies
 
-Python 3.8+, `sqlalchemy`, `mysql-connector-python`, `pandas`, `Pillow`, `requests`, `tenacity`, `tqdm`.
+Python 3.11+, `sqlalchemy`, `mysql-connector-python`, `pandas`, `Pillow`, `requests`, `tenacity`, `tqdm`.

--- a/Readme.md
+++ b/Readme.md
@@ -96,7 +96,7 @@ Full chart docs (data-staging recipe, schema, every category, update model, veri
 
 ## Advanced: custom processors (legacy Python pattern)
 
-Use this when the declarative schema can't express what your data needs — typically when you have non-trivial preprocessing logic, a custom validator, or a `BaseProcessor` subclass.
+Use this when the declarative schema can't express what your data needs — typically when you have non-trivial preprocessing logic, a custom validator, or a `BaseIngestor` subclass.
 
 **1. Install the package.**
 
@@ -110,7 +110,7 @@ pip install tracebloc-ingestor
 cp templates/image_classification/image_classification.py .
 ```
 
-The package exports `BaseIngestor`, `CSVIngestor`, `JSONIngestor`, plus validators (`FileTypeValidator`, `ImageResolutionValidator`, `TableNameValidator`, etc.) and the `Database` / `APIClient` helpers. See [`examples/`](examples) for working scripts.
+The package exports `BaseIngestor`, `CSVIngestor`, `JSONIngestor`, the `run_ingestion` runner, plus validators (`FileTypeValidator`, `ImageResolutionValidator`, `TableNameValidator`, etc.) and the `Config` / `Database` / `APIClient` helpers. See [`examples/`](examples) for working scripts.
 
 **3. Build + deploy as a Kubernetes Job.**
 


### PR DESCRIPTION
## Summary

Follow-on to #309 (merged), which corrected the README's Python floor, added `token_classification`, and rewrote the custom-processor example for v0.4.0. I'd independently audited the README and fixed the same items — this PR is now **trimmed to only the stale facts #309 did not touch**:

### `Readme.md`
- **`BaseProcessor` → `BaseIngestor`** (line 99) — there is no `BaseProcessor` class.
- Exports sentence now also lists **`run_ingestion`** + **`Config`** — consistent with the example #309 added (which imports both).

### `CLAUDE.md` (not touched by #309)
- `Python 3.8+` → `3.11+` (matches `setup.py` `python_requires=">=3.11"`).
- Dev install `requirements.txt` → `requirements-dev.txt` — the runtime/dev split landed in #246, so `requirements.txt` is runtime-only.

## Test plan
Docs-only. Verified `BaseIngestor` / `run_ingestion` / `Config` are top-level exports (`__all__`), and `requirements-dev.txt` pulls in runtime via `-r requirements.txt`.

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)
