### PR TITLE
fix(validators): classification label hardening — missing label column + IOB2 transition warning

### DIFF
--- a/tests/test_bio_label_validator.py
+++ b/tests/test_bio_label_validator.py
@@ -144,3 +144,44 @@ def test_error_reporting_is_capped(validator, texts_dir):
     result = validator.validate(df)
     assert not result.is_valid
     assert any("further errors suppressed" in e for e in result.errors)
+
+
+# --- IOB2 sequence anomaly (warning, not a hard error) -----------------------
+
+
+def test_iob2_orphan_i_warns_but_does_not_block(validator, texts_dir):
+    # "I-PER" opens the entity (no preceding "B-PER"): malformed under IOB2,
+    # legal under IOB1 -> warn, but still valid (5 tags / 5 words).
+    _write(texts_dir, "s1", "John Smith works at Google")
+    df = pd.DataFrame({"filename": ["s1"], "label": ["I-PER O O O B-ORG"]})
+    result = validator.validate(df)
+    assert result.is_valid, result.errors
+    assert result.warnings and "IOB2 transition anomaly" in result.warnings[0]
+
+
+def test_iob2_type_switch_warns(validator, texts_dir):
+    # "I-ORG" right after "B-PER" is a type switch -> IOB2 anomaly.
+    _write(texts_dir, "s1", "Foo Bar baz")
+    df = pd.DataFrame({"filename": ["s1"], "label": ["B-PER I-ORG O"]})
+    result = validator.validate(df)
+    assert result.is_valid, result.errors
+    assert result.warnings and "IOB2 transition anomaly" in result.warnings[0]
+
+
+def test_iob2_well_formed_sequence_has_no_warning(validator, texts_dir):
+    _write(texts_dir, "s1", "John Smith works")
+    df = pd.DataFrame({"filename": ["s1"], "label": ["B-PER I-PER O"]})
+    result = validator.validate(df)
+    assert result.is_valid, result.errors
+    assert not result.warnings
+
+
+def test_iob2_check_skipped_when_tag_format_invalid(validator, texts_dir):
+    # A format-invalid tag is the (hard) error; don't also emit the IOB2
+    # sequence warning on garbage tags.
+    _write(texts_dir, "s1", "John lives here")
+    df = pd.DataFrame({"filename": ["s1"], "label": ["I-PER BOGUS O"]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("invalid BIO tag" in e for e in result.errors)
+    assert not result.warnings

--- a/tests/test_label_column_validator.py
+++ b/tests/test_label_column_validator.py
@@ -1,0 +1,96 @@
+"""Tests for LabelColumnValidator — the missing-label-column fail-fast guard.
+
+Adversarial text-classification ingestion surfaced a CSV whose header is
+``filename,extension`` (no ``label``), configured with ``label: label``,
+slipping past every validator: it ingested records with ``label=None`` and the
+backend rejected each row with ``HTTP 400 "label: may not be null"`` — a late,
+confusing failure. This validator rejects that at preflight with a clear,
+actionable message naming the columns that ARE present.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from tracebloc_ingestor.validators.label_column_validator import LabelColumnValidator
+
+
+def test_missing_label_column_is_rejected(make_csv):
+    path = make_csv(
+        pd.DataFrame({"filename": ["a", "b"], "extension": [".txt", ".txt"]})
+    )
+    result = LabelColumnValidator().validate(str(path))
+    assert not result.is_valid
+    assert "Configured label column 'label' not found" in result.errors[0]
+    # message lists the columns that ARE present, to guide the fix
+    assert "filename" in result.errors[0] and "extension" in result.errors[0]
+    assert result.metadata["columns"] == ["filename", "extension"]
+
+
+def test_present_label_column_passes(make_csv):
+    path = make_csv(
+        pd.DataFrame({"filename": ["a"], "extension": [".txt"], "label": ["pos"]})
+    )
+    result = LabelColumnValidator().validate(str(path))
+    assert result.is_valid
+    assert result.metadata["checked"] is True
+
+
+def test_custom_label_column_name_missing_is_rejected(make_csv):
+    # A YAML configuring label_column: sentiment, but the CSV only has 'label'.
+    path = make_csv(
+        pd.DataFrame({"filename": ["a"], "extension": [".txt"], "label": ["pos"]})
+    )
+    result = LabelColumnValidator(label_column="sentiment").validate(str(path))
+    assert not result.is_valid
+    assert "Configured label column 'sentiment' not found" in result.errors[0]
+
+
+def test_custom_label_column_name_present_passes(make_csv):
+    path = make_csv(
+        pd.DataFrame({"filename": ["a"], "extension": [".txt"], "sentiment": ["pos"]})
+    )
+    result = LabelColumnValidator(label_column="sentiment").validate(str(path))
+    assert result.is_valid
+
+
+def test_label_column_match_is_case_insensitive(make_csv):
+    # CSVIngestor resolves headers case-insensitively; mirror that here.
+    path = make_csv(
+        pd.DataFrame({"filename": ["a"], "extension": [".txt"], "Label": ["pos"]})
+    )
+    result = LabelColumnValidator().validate(str(path))
+    assert result.is_valid
+
+
+def test_none_or_empty_label_column_defaults_to_label(make_csv):
+    path = make_csv(pd.DataFrame({"filename": ["a"], "extension": [".txt"]}))
+    # An unset/blank configured name must default to "label", not crash.
+    result = LabelColumnValidator(label_column="").validate(str(path))
+    assert not result.is_valid
+    assert "'label'" in result.errors[0]
+
+
+def test_dataframe_input_missing_and_present():
+    missing = LabelColumnValidator().validate(pd.DataFrame({"filename": ["a"]}))
+    assert not missing.is_valid
+    present = LabelColumnValidator().validate(
+        pd.DataFrame({"filename": ["a"], "label": ["x"]})
+    )
+    assert present.is_valid
+
+
+def test_non_csv_input_is_a_noop():
+    # JSON / non-path inputs are covered by their own validators.
+    result = LabelColumnValidator().validate("data.json")
+    assert result.is_valid
+    assert result.metadata["checked"] is False
+    assert LabelColumnValidator().validate(None).is_valid
+
+
+def test_unreadable_csv_is_a_benign_skip(tmp_path):
+    # A missing CSV path can't be introspected here; the read/transfer path
+    # raises its own clear error. Don't double-report.
+    result = LabelColumnValidator().validate(str(tmp_path / "nope.csv"))
+    assert result.is_valid
+    assert result.metadata["checked"] is False

--- a/tests/test_label_column_validator.py
+++ b/tests/test_label_column_validator.py
@@ -63,6 +63,17 @@ def test_label_column_match_is_case_insensitive(make_csv):
     assert result.is_valid
 
 
+def test_label_column_match_ignores_surrounding_whitespace(tmp_path):
+    # CSVIngestor strips header whitespace on read, so a header like " label "
+    # ingests as "label" and must NOT fail this preflight check (bugbot #313).
+    path = tmp_path / "ws.csv"
+    path.write_text(
+        "filename,extension, label \nsample1,'.txt',pos\n", encoding="utf-8"
+    )
+    result = LabelColumnValidator().validate(str(path))
+    assert result.is_valid
+
+
 def test_none_or_empty_label_column_defaults_to_label(make_csv):
     path = make_csv(pd.DataFrame({"filename": ["a"], "extension": [".txt"]}))
     # An unset/blank configured name must default to "label", not crash.

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -142,6 +142,41 @@ def test_text_classification_defaults_extension():
     assert _types(v)[0] is FileTypeValidator
 
 
+def test_text_classification_includes_label_column_validator_before_diversity():
+    """A text-classification CSV missing the configured label column must fail
+    fast at preflight (not ingest label=None -> late backend 400). The presence
+    check runs BEFORE the diversity check, which only reads the column lazily."""
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+
+    types = _types(map_validators(TaskCategory.TEXT_CLASSIFICATION, {}))
+    assert LabelColumnValidator in types
+    assert types.index(LabelColumnValidator) < types.index(LabelDiversityValidator)
+
+
+def test_text_classification_threads_custom_label_column():
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+
+    v = map_validators(TaskCategory.TEXT_CLASSIFICATION, {"label_column": "sentiment"})
+    lc = next(x for x in v if isinstance(x, LabelColumnValidator))
+    assert lc.label_column == "sentiment"
+
+
+def test_token_classification_excludes_label_column_validator():
+    """Token classification already rejects a missing label column via
+    BIOLabelValidator, so it must NOT also carry LabelColumnValidator."""
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+
+    assert LabelColumnValidator not in _types(
+        map_validators(TaskCategory.TOKEN_CLASSIFICATION, {})
+    )
+
+
 def test_token_classification_includes_bio_validator():
     from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
 

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -22,6 +22,7 @@ from ..validators.image_validator import ImageResolutionValidator
 from ..validators.ingestable_records_validator import IngestableRecordsValidator
 from ..validators.keypoint_annotation_validator import KeypointAnnotationValidator
 from ..validators.keypoint_visibility_validator import KeypointVisibilityValidator
+from ..validators.label_column_validator import LabelColumnValidator
 from ..validators.label_diversity_validator import LabelDiversityValidator
 from ..validators.numeric_columns_validator import NumericColumnsValidator
 from ..validators.table_name_validator import TableNameValidator
@@ -123,6 +124,14 @@ def text_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     )
     # Reject a zero-record manifest and binary/empty text content up front.
     validators.extend(_nlp_content_validators(options, "texts"))
+    # Fail fast when the configured label column is absent from the CSV header
+    # (otherwise every record cleans to label=None and the backend rejects each
+    # row with HTTP 400 "label: may not be null" — a late, confusing failure).
+    # Token classification already covers this via BIOLabelValidator, which
+    # resolves and rejects a missing label column itself.
+    validators.append(
+        LabelColumnValidator(label_column=options.get("label_column") or "label")
+    )
     # Add data validator if schema is provided
     if options.get("schema"):
         validators.append(DataValidator(schema=options["schema"]))

--- a/tracebloc_ingestor/validators/base.py
+++ b/tracebloc_ingestor/validators/base.py
@@ -152,19 +152,28 @@ class BaseValidator(ABC):
 
     @staticmethod
     def _match_column(columns: Any, name: str) -> Optional[str]:
-        """Return the actual column whose name matches ``name``, case-insensitively.
+        """Return the actual column matching ``name``, case- AND
+        whitespace-insensitively.
 
-        Centralises the case-insensitive header lookup several validators need
-        (``filename`` / ``label`` columns whose case the dataset author may not
-        match exactly). ``columns`` is any iterable of column names (a
-        DataFrame's ``.columns``, an Index, or a plain list). Returns ``None``
-        when no column matches.
+        Centralises the header lookup several validators need (``filename`` /
+        ``label`` columns whose case the dataset author may not match exactly).
+        ``columns`` is any iterable of column names (a DataFrame's ``.columns``,
+        an Index, or a plain list). Returns ``None`` when no column matches.
+
+        Surrounding whitespace is stripped on both sides of the comparison
+        because ``CSVIngestor`` strips header whitespace on read
+        (``chunk.columns.str.strip()``) — so a header like ``" label "`` is
+        ingested as ``label`` and must resolve here too, or a manifest that
+        ingests fine fails preflight as if the column were missing (matches
+        ``LabelDiversityValidator._resolve_column``). The ORIGINAL column name
+        is returned so callers can still index the (un-stripped) raw frame.
         """
         cols = list(columns)
         if name in cols:
             return name
-        lowered = {str(c).lower(): c for c in cols}
-        return lowered.get(name.lower())
+        target = str(name).strip().lower()
+        normalised = {str(c).strip().lower(): c for c in cols}
+        return normalised.get(target)
 
     @staticmethod
     def _parse_json(row: Any, column: str) -> Optional[Any]:

--- a/tracebloc_ingestor/validators/bio_label_validator.py
+++ b/tracebloc_ingestor/validators/bio_label_validator.py
@@ -12,12 +12,17 @@ whitespace-tokenized word per token):
    A mismatch is the exact condition that makes the client drop tokens to
    ``-100`` (or raise), so we reject it here against the dataset author.
 2. **Tag format** — every tag must be ``O`` or ``B-XXX`` / ``I-XXX`` (IOB2).
+3. **IOB2 sequence (warning)** — an ``I-<TYPE>`` should be preceded by a
+   ``B-<TYPE>`` / ``I-<TYPE>`` of the same type (entities start with ``B-``).
+   An ``I-`` that opens an entity is malformed under IOB2 but LEGAL under IOB1,
+   so it's surfaced as a WARNING rather than a hard reject — failing it would
+   wrongly break valid IOB1 datasets.
 """
 
 import logging
 import os
 import re
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 import pandas as pd
 
@@ -89,18 +94,23 @@ class BIOLabelValidator(BaseValidator):
 
             texts_dir = os.path.join((self._config or config).SRC_PATH, self.texts_path)
             errors: List[str] = []
+            warnings: List[str] = []
 
             for idx, row in df.iterrows():
                 if len(errors) >= _MAX_REPORTED_ERRORS:
                     errors.append("... further errors suppressed.")
                     break
-                errors.extend(
-                    self._validate_row(row, idx, filename_col, label_col, texts_dir)
+                row_errors, row_warnings = self._validate_row(
+                    row, idx, filename_col, label_col, texts_dir
                 )
+                errors.extend(row_errors)
+                if len(warnings) < _MAX_REPORTED_ERRORS:
+                    warnings.extend(row_warnings)
 
             return self._create_result(
                 is_valid=len(errors) == 0,
                 errors=errors,
+                warnings=warnings or None,
                 metadata={"rows_checked": len(df)},
             )
 
@@ -118,7 +128,7 @@ class BIOLabelValidator(BaseValidator):
         filename_col: str,
         label_col: str,
         texts_dir: str,
-    ) -> List[str]:
+    ) -> Tuple[List[str], List[str]]:
         row_label = f"Row {idx}"
         filename = str(row[filename_col])
         tags = str(row[label_col]).strip().split()
@@ -126,11 +136,17 @@ class BIOLabelValidator(BaseValidator):
         # Invalid tag format (independent of the file).
         bad = [t for t in tags if not _BIO_TAG_RE.match(t)]
         errors: List[str] = []
+        warnings: List[str] = []
         if bad:
             errors.append(
                 f"{row_label} ('{filename}'): invalid BIO tag(s) {bad[:5]}; "
                 f"each tag must be 'O' or 'B-<TYPE>' / 'I-<TYPE>'."
             )
+        else:
+            # IOB2 sequence anomaly (warning) — only meaningful on well-formed
+            # tags, and independent of the .txt, so check it before file I/O so
+            # it's still surfaced when the file is missing/unreadable below.
+            warnings.extend(self._iob2_sequence_warnings(tags, filename, row_label))
 
         # Resolve the .txt with text_transfer's exact rule (shared
         # _has_extension): append the extension only when the CSV filename
@@ -148,14 +164,14 @@ class BIOLabelValidator(BaseValidator):
                 f"{row_label}: text file not found at "
                 f"'{self.texts_path}/{resolved}'."
             )
-            return errors
+            return errors, warnings
 
         try:
             with open(text_path, "r", encoding="utf-8") as f:
                 word_count = len(f.read().strip().split())
         except OSError as e:
             errors.append(f"{row_label}: could not read text file: {e}")
-            return errors
+            return errors, warnings
 
         if word_count != len(tags):
             errors.append(
@@ -164,7 +180,39 @@ class BIOLabelValidator(BaseValidator):
                 f"in the label column. Each word must have exactly one tag."
             )
 
-        return errors
+        return errors, warnings
+
+    @staticmethod
+    def _iob2_sequence_warnings(
+        tags: List[str], filename: str, row_label: str
+    ) -> List[str]:
+        """Flag IOB2 transition anomalies: an ``I-<TYPE>`` not immediately
+        preceded by a ``B-<TYPE>`` / ``I-<TYPE>`` of the SAME type — i.e. an
+        entity that opens with ``I-`` instead of ``B-`` (orphan ``I-`` at the
+        start, ``I-`` right after ``O``, or a type switch like ``B-PER I-ORG``).
+
+        Returned as warnings, not errors: such sequences are malformed under
+        IOB2 but LEGAL under IOB1 (a chunk may open with ``I-``), and this
+        validator is scheme-agnostic — hard-failing would wrongly reject valid
+        IOB1 datasets. The warning lets a user who intended IOB2 spot the
+        problem without blocking IOB1 ingests.
+        """
+        offenders: List[str] = []
+        prev = "O"
+        for t in tags:
+            if t.startswith("I-"):
+                etype = t[2:]
+                if prev != f"B-{etype}" and prev != f"I-{etype}":
+                    offenders.append(t)
+            prev = t
+        if not offenders:
+            return []
+        return [
+            f"{row_label} ('{filename}'): IOB2 transition anomaly — {offenders[:5]} "
+            f"open an entity with 'I-' (not preceded by a 'B-'/'I-' of the same "
+            f"type). Valid under IOB1 but malformed under IOB2; if you intended "
+            f"IOB2, the entity should start with 'B-'."
+        ]
 
     @staticmethod
     def _resolve_column(df: pd.DataFrame, name: str) -> Optional[str]:

--- a/tracebloc_ingestor/validators/label_column_validator.py
+++ b/tracebloc_ingestor/validators/label_column_validator.py
@@ -1,0 +1,125 @@
+"""Label Column Validator Module.
+
+Fail-fast guard for the "configured label column is missing from the CSV
+header" class of input error, run at preflight (before the destination table
+is created) so a classification dataset whose CSV lacks the configured label
+column is rejected EARLY with a clear, actionable message.
+
+Why this exists (adversarial text-classification ingestion, dev ``ingestor:0.3.12``):
+a ``text_classification`` CSV whose header is ``filename,extension`` (no
+``label``), with ``label: label`` configured in the ingest config, slipped past
+every validator:
+
+  1. ``LabelDiversityValidator`` reads the label column lazily; when it's
+     absent its loader returns ``None``, which the validator treats as the
+     benign empty-input case and PASSES (it explicitly defers the missing-column
+     case to "DataValidator or the ingestor").
+  2. but the label column is stripped out of the schema before
+     ``DataValidator`` sees it, so DataValidator never checks it either.
+  3. so every record was cleaned with ``label=None``, sent to the backend, and
+     rejected per-row with ``HTTP 400: {"label":["This field may not be
+     null."]}`` — a late, confusing failure for what is simply a mis-named /
+     missing column in the manifest.
+
+This validator closes that gap for the classification categories that source
+their label from a CSV column. Token classification already fails fast on the
+same input via ``BIOLabelValidator`` (which resolves both the filename and
+label columns and rejects a missing one), so it does not need this validator;
+object detection sources its labels from XML annotations, not a CSV column, so
+it is deliberately NOT wired to this validator.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+
+from .base import BaseValidator, ValidationResult
+from ..config import Config
+
+config = Config()
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+
+class LabelColumnValidator(BaseValidator):
+    """Reject a classification manifest whose configured label column is absent.
+
+    Attributes:
+        label_column: CSV column expected to hold the class label, as
+            configured in the ingest YAML (default ``"label"``). Resolved
+            case-insensitively against the actual header via
+            :meth:`BaseValidator._match_column`, matching how the ingestor and
+            the sibling label validators resolve it.
+    """
+
+    def __init__(
+        self,
+        label_column: str = "label",
+        name: str = "Label Column",
+    ):
+        super().__init__(name)
+        self.label_column = label_column or "label"
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            columns = self._read_columns(data)
+            if columns is None:
+                # Not a CSV manifest / DataFrame we can introspect (e.g. a JSON
+                # input or an unreadable file) — not this validator's error to
+                # raise; the read path / sibling validators surface those. Pass.
+                return self._create_result(
+                    is_valid=True,
+                    metadata={"checked": False, "label_column": self.label_column},
+                )
+
+            if self._match_column(columns, self.label_column) is not None:
+                return self._create_result(
+                    is_valid=True,
+                    metadata={"checked": True, "label_column": self.label_column},
+                )
+
+            return self._create_result(
+                is_valid=False,
+                errors=[
+                    f"Configured label column '{self.label_column}' not found in "
+                    f"CSV header (columns: {', '.join(map(str, columns))}). Set "
+                    f"'label:' in the ingest config to an existing column, or add "
+                    f"the '{self.label_column}' column to the CSV."
+                ],
+                metadata={
+                    "label_column": self.label_column,
+                    "columns": list(map(str, columns)),
+                },
+            )
+
+        except Exception as e:  # noqa: BLE001 — mirror sibling validators
+            logger.error(f"Error during label-column validation: {str(e)}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Label-column validation error: {str(e)}"],
+                metadata={"error_type": "validation_exception"},
+            )
+
+    def _read_columns(self, data: Any) -> Optional[list]:
+        """Return the column names of the manifest, or ``None`` when the input
+        isn't an introspectable CSV / DataFrame.
+
+        Reads only the header row for a CSV path (``nrows=0``) so a wide or
+        multi-GB manifest costs almost nothing. A read error (missing file,
+        unparseable) returns ``None`` — a benign skip, since the read/transfer
+        path raises its own clear error for those.
+        """
+        if isinstance(data, pd.DataFrame):
+            return list(data.columns)
+        if isinstance(data, (str, Path)):
+            path = Path(data)
+            if path.suffix.lower() != ".csv":
+                return None
+            try:
+                header = pd.read_csv(path, nrows=0, encoding="utf-8")
+            except Exception:  # noqa: BLE001 — missing/unparseable -> benign skip
+                return None
+            return list(header.columns)
+        return None


### PR DESCRIPTION
## Summary

Follow-up to merged #303. Adversarial **text-classification** ingestion (dev cluster, `ingestor:0.3.12`) surfaced one input-validation gap #303 did not cover: a CSV missing the configured label column is not caught at preflight.

## Finding (repro)

A `text_classification` CSV whose header is `filename,extension` (no `label`), with `label: label` configured in the ingest YAML:
- `LabelDiversityValidator` reads the label column lazily; when it's absent its loader returns `None`, which the validator treats as the benign empty-input case and **passes** (it explicitly defers the missing-column case to "DataValidator or the ingestor").
- but the label column is **stripped out of the schema** before `DataValidator` sees it, so DataValidator never checks it either.
- so every record was cleaned with `label=None`, sent to the backend, and rejected per-row with `HTTP 400: {"label":["This field may not be null."]}` — a late, confusing failure. (#303's message fix made the terminal text truthful, but the root cause remained.)

## Fix

New **`LabelColumnValidator`** — a preflight presence check that fails fast (before the destination table is created) with a clear, actionable message naming the columns that are present:

> `Configured label column 'label' not found in CSV header (columns: filename, extension). Set 'label:' in the ingest config to an existing column, or add the 'label' column to the CSV.`

- Reuses `BaseValidator._match_column` (case-insensitive header match, mirroring the ingestor and sibling label validators).
- Reads only the CSV header (`nrows=0`); benign skip for non-CSV/JSON/unreadable inputs (their own validators surface those).

### Categories it gates
- **`text_classification`** — wired into the factory **before** `LabelDiversityValidator`.
- **`token_classification`** — *not* wired: `BIOLabelValidator` already resolves and rejects a missing label column.
- **object detection** — excluded: labels come from XML annotations, not a CSV column.

## Tests

Added `tests/test_label_column_validator.py` + mapping assertions in `tests/test_validators_mapping.py`:
- missing column (default + custom `label_column` name) → fails fast with the clear message
- present column (incl. case-insensitive) → passes
- DataFrame input (missing/present); non-CSV / unreadable CSV → benign skip
- factory wiring: text-clf includes it before diversity; token-clf excludes it; custom `label_column` threaded through

Only **ADDED** tests; none removed/rewritten. Full suite: **1199 passed, 1 xfailed**, total coverage **97%** (gate 95%). Files are `black`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to ingest preflight validation and additive BIO warnings; shared header matching is a small behavioral alignment with the CSV reader, covered by new tests.
> 
> **Overview**
> Adds **`LabelColumnValidator`** so **text classification** preflight rejects CSV manifests whose configured label column is absent from the header, with an error that lists existing columns—closing the path where rows were ingested as `label=None` and failed late with backend HTTP 400.
> 
> The validator is wired in **`text_classification`** **before** `LabelDiversityValidator`, honors custom `label_column` from options, and is **not** added for token classification (already covered by `BIOLabelValidator`) or object detection.
> 
> **`BaseValidator._match_column`** now strips surrounding whitespace on header names (aligned with `CSVIngestor`), so headers like `" label "` resolve correctly at preflight.
> 
> **`BIOLabelValidator`** emits **warnings** (not hard failures) for IOB2 transition anomalies—orphan `I-` tags and cross-type `I-` after `B-`—so IOB1-style sequences still pass; IOB2 checks are skipped when tag format is already invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 691699a50eec7c8d3e3e57c12ae16af5db957b2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Added: IOB2 transition warning (token classification)

The same NLP adversarial sweep found that token-classification labels accept an `I-<TYPE>` that opens an entity (no preceding `B-/I-` of the same type) — e.g. `I-PER O O O B-ORG` ingests cleanly. `BIOLabelValidator` checked each tag's **format** but not the IOB2 **sequence**, despite advertising "BIO/IOB2".

**Fix:** `_iob2_sequence_warnings` flags entities that open with `I-` (orphan `I-`, `I-` after `O`, or a type switch like `B-PER I-ORG`) as a **warning, not a hard error** — such sequences are malformed under IOB2 but **legal under IOB1** (a chunk may open with `I-`), and the validator is scheme-agnostic, so hard-failing would wrongly reject valid IOB1 datasets. Checked only on format-valid tags (no double-report) and before file I/O. Tests added; full suite 1204 passed, coverage 96.7%.