### PR TITLE
fix(validators): vision input hardening — 0-record, label-column, bbox/size geometry

### DIFF
--- a/tests/test_image_validator_flow.py
+++ b/tests/test_image_validator_flow.py
@@ -73,6 +73,7 @@ def test_nonexistent_src_path_fails(clean_env):
 
 # ---- helpers --------------------------------------------------------------
 
+
 def test_is_image_file():
     v = ImageResolutionValidator()
     assert v._is_image_file(Path("a.JPG"))
@@ -119,7 +120,9 @@ def test_validate_image_resolutions_empty_list():
 def test_validate_image_resolutions_unprocessable(tmp_path):
     bad = tmp_path / "a.jpg"
     bad.write_text("nope")
-    res = ImageResolutionValidator(expected_resolution=(10, 10))._validate_image_resolutions([bad])
+    res = ImageResolutionValidator(
+        expected_resolution=(10, 10)
+    )._validate_image_resolutions([bad])
     assert not res.is_valid
     assert any("could not be processed" in e for e in res.errors)
     # the per-file reason is now surfaced, not just the bare path
@@ -127,6 +130,7 @@ def test_validate_image_resolutions_unprocessable(tmp_path):
 
 
 # --- _diagnose_image_error: distinct, actionable reasons --------------------
+
 
 def test_diagnose_empty_file(tmp_path):
     p = tmp_path / "empty.jpg"
@@ -141,4 +145,50 @@ def test_diagnose_corrupt_file(tmp_path):
 
 
 def test_diagnose_missing_file(tmp_path):
-    assert "not found" in ImageResolutionValidator._diagnose_image_error(tmp_path / "nope.jpg")
+    assert "not found" in ImageResolutionValidator._diagnose_image_error(
+        tmp_path / "nope.jpg"
+    )
+
+
+# --- masks subdir (semantic segmentation mask validation, PR #314) -----------
+
+
+def _make_png(directory, name, size):
+    from PIL import Image
+
+    directory.mkdir(exist_ok=True)
+    Image.new("L", size, 1).save(directory / name)
+
+
+def test_masks_subdir_validates_masks_directory(clean_env, tmp_path):
+    _make_png(tmp_path / "masks", "a_mask.png", (64, 64))
+    _make_png(tmp_path / "masks", "b_mask.png", (64, 64))
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = ImageResolutionValidator(
+        expected_resolution=(64, 64), subdir="masks"
+    ).validate(None)
+    assert result.is_valid, result.errors
+
+
+def test_masks_subdir_rejects_mask_resolution_mismatch(clean_env, tmp_path):
+    _make_png(tmp_path / "masks", "a_mask.png", (32, 32))  # != expected 64x64
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = ImageResolutionValidator(
+        expected_resolution=(64, 64), subdir="masks"
+    ).validate(None)
+    assert not result.is_valid
+
+
+def test_masks_subdir_rejects_corrupt_mask(clean_env, tmp_path):
+    (tmp_path / "masks").mkdir()
+    (tmp_path / "masks" / "a_mask.png").write_bytes(b"not a png \x00\xff")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = ImageResolutionValidator(
+        expected_resolution=(64, 64), subdir="masks"
+    ).validate(None)
+    assert not result.is_valid
+
+
+def test_default_subdir_is_images(clean_env, tmp_path):
+    # The default instance must still scan <SRC>/images, not masks.
+    assert ImageResolutionValidator().subdir == "images"

--- a/tests/test_keypoint_annotation_validator.py
+++ b/tests/test_keypoint_annotation_validator.py
@@ -227,3 +227,14 @@ def test_keypoint_at_exact_width_is_out_of_bounds():
     result = v.validate(df)
     assert not result.is_valid
     assert any("outside the image bounds" in e for e in result.errors)
+
+
+def test_keypoint_negative_and_out_of_bounds_both_reported():
+    # (-1, 9999) on 64x64: independent checks must report BOTH the negative x
+    # and the out-of-bounds y in one pass (bugbot PR #314).
+    v = KeypointAnnotationValidator(expected_resolution=(64, 64))
+    df = _df([{"nose": [-1, 9999], "left_eye": [20, 15]}])
+    result = v.validate(df)
+    assert not result.is_valid
+    assert any("negative coordinates" in e for e in result.errors)
+    assert any("outside the image bounds" in e for e in result.errors)

--- a/tests/test_keypoint_annotation_validator.py
+++ b/tests/test_keypoint_annotation_validator.py
@@ -217,3 +217,13 @@ def test_keypoint_bounds_skipped_without_resolution():
     df = _df([{"nose": [9999, 9999], "left_eye": [20, 15]}])
     result = v.validate(df)
     assert result.is_valid, result.errors
+
+
+def test_keypoint_at_exact_width_is_out_of_bounds():
+    # Half-open [0, W): a coord equal to the width is the first index past the
+    # last pixel, so it must be rejected (bugbot PR #314).
+    v = KeypointAnnotationValidator(expected_resolution=(64, 64))
+    df = _df([{"nose": [64, 10], "left_eye": [20, 15]}])
+    result = v.validate(df)
+    assert not result.is_valid
+    assert any("outside the image bounds" in e for e in result.errors)

--- a/tests/test_keypoint_annotation_validator.py
+++ b/tests/test_keypoint_annotation_validator.py
@@ -22,10 +22,12 @@ def _df(annotations):
 
 
 def test_valid_keypoints_pass(validator):
-    df = _df([
-        {"nose": [10, 20], "eye": [30, 40]},
-        {"nose": [11, 21], "eye": [31, 41]},
-    ])
+    df = _df(
+        [
+            {"nose": [10, 20], "eye": [30, 40]},
+            {"nose": [11, 21], "eye": [31, 41]},
+        ]
+    )
     result = validator.validate(df)
     assert result.is_valid
     assert result.metadata["rows_checked"] == 2
@@ -100,10 +102,12 @@ def test_degenerate_bounding_box_fails(validator):
 
 
 def test_inconsistent_keypoint_names_fail(validator):
-    df = _df([
-        {"nose": [1, 2], "eye": [3, 4]},
-        {"nose": [1, 2], "ear": [3, 4]},  # different key set
-    ])
+    df = _df(
+        [
+            {"nose": [1, 2], "eye": [3, 4]},
+            {"nose": [1, 2], "ear": [3, 4]},  # different key set
+        ]
+    )
     result = validator.validate(df)
     assert not result.is_valid
     assert any("differ from first record" in e for e in result.errors)
@@ -117,10 +121,12 @@ def test_inconsistent_keypoint_names_fail(validator):
 def test_num_keypoints_match_passes():
     """When every row has exactly the declared K, validation passes."""
     v = KeypointAnnotationValidator(num_keypoints=2)
-    df = _df([
-        {"nose": [1, 2], "eye": [3, 4]},
-        {"nose": [5, 6], "eye": [7, 8]},
-    ])
+    df = _df(
+        [
+            {"nose": [1, 2], "eye": [3, 4]},
+            {"nose": [5, 6], "eye": [7, 8]},
+        ]
+    )
     result = v.validate(df)
     assert result.is_valid
 
@@ -131,9 +137,11 @@ def test_num_keypoints_mismatch_fails():
     crashed the runtime mid-training; post-fix the ingest rejects with
     a clear error pointing the dataset author at the right line."""
     v = KeypointAnnotationValidator(num_keypoints=14)
-    df = _df([
-        {"a": [1, 2], "b": [3, 4], "c": [5, 6], "d": [7, 8]},
-    ])
+    df = _df(
+        [
+            {"a": [1, 2], "b": [3, 4], "c": [5, 6], "d": [7, 8]},
+        ]
+    )
     result = v.validate(df)
     assert not result.is_valid
     err = next(e for e in result.errors if "4 keypoint" in e)
@@ -145,11 +153,13 @@ def test_num_keypoints_mismatch_reports_every_offending_row():
     """Mismatches surface per-row so the dataset author can fix them
     in one pass — not just the first one."""
     v = KeypointAnnotationValidator(num_keypoints=3)
-    df = _df([
-        {"a": [1, 2], "b": [3, 4]},                     # row 1: 2 kp (bad)
-        {"a": [1, 2], "b": [3, 4], "c": [5, 6]},        # row 2: 3 kp (ok)
-        {"a": [1, 2]},                                  # row 3: 1 kp (bad)
-    ])
+    df = _df(
+        [
+            {"a": [1, 2], "b": [3, 4]},  # row 1: 2 kp (bad)
+            {"a": [1, 2], "b": [3, 4], "c": [5, 6]},  # row 2: 3 kp (ok)
+            {"a": [1, 2]},  # row 3: 1 kp (bad)
+        ]
+    )
     result = v.validate(df)
     assert not result.is_valid
     count_errs = [e for e in result.errors if "num_keypoints=3" in e]
@@ -172,10 +182,38 @@ def test_num_keypoints_check_compounds_with_coordinate_errors():
     """A mismatched count shouldn't suppress per-keypoint coordinate
     errors — operator sees both kinds in one pass."""
     v = KeypointAnnotationValidator(num_keypoints=3)
-    df = _df([
-        {"a": [-1, 2], "b": [3, 4]},  # wrong count AND a negative coord
-    ])
+    df = _df(
+        [
+            {"a": [-1, 2], "b": [3, 4]},  # wrong count AND a negative coord
+        ]
+    )
     result = v.validate(df)
     assert not result.is_valid
     assert any("num_keypoints=3" in e for e in result.errors)
     assert any("negative coordinates" in e for e in result.errors)
+
+
+# --- coordinate bounds vs declared image size (PR #314) ----------------------
+
+
+def test_keypoint_within_image_bounds_passes():
+    v = KeypointAnnotationValidator(expected_resolution=(64, 64))
+    df = _df([{"nose": [10, 10], "left_eye": [60, 60]}])
+    result = v.validate(df)
+    assert result.is_valid, result.errors
+
+
+def test_keypoint_out_of_bounds_fails():
+    v = KeypointAnnotationValidator(expected_resolution=(64, 64))
+    df = _df([{"nose": [9999, 9999], "left_eye": [20, 15]}])
+    result = v.validate(df)
+    assert not result.is_valid
+    assert any("outside the image bounds" in e for e in result.errors)
+
+
+def test_keypoint_bounds_skipped_without_resolution():
+    # No expected_resolution -> upper-bound check is a no-op (legacy behavior).
+    v = KeypointAnnotationValidator()
+    df = _df([{"nose": [9999, 9999], "left_eye": [20, 15]}])
+    result = v.validate(df)
+    assert result.is_valid, result.errors

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -36,14 +36,67 @@ def _types(validators):
 
 
 def test_image_classification():
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+
     v = map_validators(TaskCategory.IMAGE_CLASSIFICATION, IMAGE_OPTS)
     assert _types(v) == [
         FileTypeValidator,
+        IngestableRecordsValidator,
         ImageResolutionValidator,
+        LabelColumnValidator,
         LabelDiversityValidator,
         TableNameValidator,
         DuplicateValidator,
     ]
+
+
+def test_vision_categories_have_zero_record_guard():
+    """0-record fail-fast (header-only / empty CSV) is wired into every
+    file-bearing vision category — image/object/semantic/keypoint — so a
+    zero-record vision dataset is rejected at preflight instead of creating an
+    orphan empty table (extends #303 from NLP to vision)."""
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+
+    for cat in (
+        TaskCategory.IMAGE_CLASSIFICATION,
+        TaskCategory.OBJECT_DETECTION,
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        TaskCategory.KEYPOINT_DETECTION,
+    ):
+        rec = [
+            x
+            for x in map_validators(cat, IMAGE_OPTS)
+            if isinstance(x, IngestableRecordsValidator)
+        ]
+        assert len(rec) == 1, cat
+        assert rec[0].file_subdir == "images", cat
+
+
+def test_label_column_guard_is_image_classification_only():
+    """LabelColumnValidator gates only image_classification among vision
+    categories — object detection / segmentation / keypoint source labels from
+    XML / masks / annotation files, not a CSV label column, so adding it there
+    would wrongly reject every such dataset."""
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+
+    assert LabelColumnValidator in _types(
+        map_validators(TaskCategory.IMAGE_CLASSIFICATION, IMAGE_OPTS)
+    )
+    for cat in (
+        TaskCategory.OBJECT_DETECTION,
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        TaskCategory.KEYPOINT_DETECTION,
+    ):
+        assert LabelColumnValidator not in _types(map_validators(cat, IMAGE_OPTS)), cat
 
 
 def test_classification_categories_include_label_diversity():
@@ -289,8 +342,11 @@ def test_map_validators_without_config_falls_back_to_module_global(monkeypatch):
 
 
 def test_nlp_categories_include_content_hygiene_validators():
-    """The text categories (text/token classification, MLM) gain the
-    zero-record and text-content validators; image/tabular do NOT."""
+    """The text categories (text/token classification, MLM) gain BOTH the
+    zero-record guard and the (text-only) UTF-8 content validator. The
+    zero-record guard now also covers file-bearing vision categories, but
+    TextContentValidator stays NLP-only (it decodes UTF-8 text, meaningless for
+    images); tabular has neither."""
     from tracebloc_ingestor.validators.ingestable_records_validator import (
         IngestableRecordsValidator,
     )
@@ -309,10 +365,22 @@ def test_nlp_categories_include_content_hygiene_validators():
         # FileTypeValidator stays first (the content validators come after it).
         assert types[0] is FileTypeValidator, cat
 
-    for cat in (TaskCategory.IMAGE_CLASSIFICATION, TaskCategory.TABULAR_CLASSIFICATION):
+    # Vision file-bearing categories get the zero-record guard but NOT the
+    # text-content validator.
+    for cat in (
+        TaskCategory.IMAGE_CLASSIFICATION,
+        TaskCategory.OBJECT_DETECTION,
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        TaskCategory.KEYPOINT_DETECTION,
+    ):
         types = _types(map_validators(cat, IMAGE_OPTS))
-        assert IngestableRecordsValidator not in types, cat
+        assert IngestableRecordsValidator in types, cat
         assert TextContentValidator not in types, cat
+
+    # Tabular has neither (no files, not text).
+    types = _types(map_validators(TaskCategory.TABULAR_CLASSIFICATION, IMAGE_OPTS))
+    assert IngestableRecordsValidator not in types
+    assert TextContentValidator not in types
 
 
 def test_mlm_content_validators_target_sequences_subdir():

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -413,3 +413,28 @@ def test_text_classification_content_validators_target_texts_subdir():
     txt = next(x for x in v if isinstance(x, TextContentValidator))
     assert rec.file_subdir == "texts"
     assert txt.texts_path == "texts"
+
+
+def test_semantic_segmentation_validates_masks_resolution():
+    """Seg masks get their own ImageResolutionValidator(subdir="masks") so a
+    corrupt or wrong-sized mask is rejected (the default instance only scans
+    images). PR #314."""
+    v = map_validators(TaskCategory.SEMANTIC_SEGMENTATION, IMAGE_OPTS)
+    res = [x for x in v if isinstance(x, ImageResolutionValidator)]
+    subdirs = sorted(x.subdir for x in res)
+    assert subdirs == ["images", "masks"], subdirs
+
+
+def test_keypoint_annotation_validator_gets_image_bounds():
+    """KeypointAnnotationValidator is given the declared target_size so it can
+    reject keypoints past the image edge. PR #314."""
+    from tracebloc_ingestor.validators.keypoint_annotation_validator import (
+        KeypointAnnotationValidator,
+    )
+
+    v = map_validators(
+        TaskCategory.KEYPOINT_DETECTION,
+        {**IMAGE_OPTS, "number_of_keypoints": 5},
+    )
+    kp = next(x for x in v if isinstance(x, KeypointAnnotationValidator))
+    assert kp.expected_resolution == IMAGE_OPTS["target_size"]

--- a/tests/test_vision_input_validators.py
+++ b/tests/test_vision_input_validators.py
@@ -1,0 +1,56 @@
+"""End-to-end vision preflight: image_classification now rejects the 0-record
+and missing-label-column gaps that the NLP-only #303/#313 fixes had left open
+for vision. Drives the REAL `map_validators` chain (minus the DB-bound
+TableName/Duplicate validators) on staged image datasets.
+"""
+
+from __future__ import annotations
+
+import os
+
+from PIL import Image
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.utils.constants import TaskCategory
+from tracebloc_ingestor.utils.validators_mapping import map_validators
+
+_SKIP = {"TableNameValidator", "DuplicateValidator"}  # need a DB / not data-hygiene
+
+
+def _img(d, name, size=(64, 64)):
+    os.makedirs(os.path.join(d, "images"), exist_ok=True)
+    Image.new("RGB", size, (120, 120, 120)).save(os.path.join(d, "images", name))
+
+
+def _first_rejecter(tmp_path, csv_text, images=("a.jpeg", "b.jpeg")):
+    d = str(tmp_path)
+    for n in images:
+        _img(d, n)
+    csv = tmp_path / "labels.csv"
+    csv.write_text(csv_text, encoding="utf-8")
+    cfg = Config(SRC_PATH=d, TABLE_NAME="t")
+    opts = {"extension": ".jpeg", "target_size": [64, 64], "label_column": "label"}
+    for v in map_validators(TaskCategory.IMAGE_CLASSIFICATION, opts, cfg):
+        if type(v).__name__ in _SKIP:
+            continue
+        r = v.validate(str(csv))
+        if not r.is_valid:
+            return type(v).__name__
+    return None
+
+
+def test_image_valid_passes(tmp_path):
+    assert _first_rejecter(tmp_path, "filename,label\na.jpeg,cat\nb.jpeg,dog\n") is None
+
+
+def test_image_empty_csv_rejected_at_preflight(tmp_path):
+    # header-only CSV -> 0 records; previously ingested an orphan empty table.
+    assert _first_rejecter(tmp_path, "filename,label\n") == "IngestableRecordsValidator"
+
+
+def test_image_missing_label_column_rejected_at_preflight(tmp_path):
+    # no label column -> previously ingested label=None -> late backend 400.
+    assert (
+        _first_rejecter(tmp_path, "filename\na.jpeg\nb.jpeg\n")
+        == "LabelColumnValidator"
+    )

--- a/tests/test_xml_validator.py
+++ b/tests/test_xml_validator.py
@@ -8,14 +8,20 @@ import pytest
 
 from tracebloc_ingestor.validators.xml_validator import PascalVOCXMLValidator
 
-
 # ---------------------------------------------------------------------------
 # Builders for valid / customizable VOC XML.
 # ---------------------------------------------------------------------------
 
+
 def _object_xml(
-    name="cat", pose="Unspecified", truncated="0", difficult="0",
-    xmin=10, ymin=10, xmax=100, ymax=100,
+    name="cat",
+    pose="Unspecified",
+    truncated="0",
+    difficult="0",
+    xmin=10,
+    ymin=10,
+    xmax=100,
+    ymax=100,
 ):
     return f"""
   <object>
@@ -61,6 +67,7 @@ def validator():
 # validate() flow (reads config.SRC_PATH directory)
 # ---------------------------------------------------------------------------
 
+
 def test_valid_file_passes(clean_env, tmp_path, validator):
     (tmp_path / "ann.xml").write_text(_voc_xml(), encoding="utf-8")
     clean_env.setenv("SRC_PATH", str(tmp_path))
@@ -95,6 +102,7 @@ def test_nonexistent_src_path_fails(clean_env, validator):
 # _get_xml_files
 # ---------------------------------------------------------------------------
 
+
 def test_get_xml_files_single_file(tmp_path, validator):
     f = tmp_path / "a.xml"
     f.write_text(_voc_xml(), encoding="utf-8")
@@ -105,7 +113,9 @@ def test_get_xml_files_single_file(tmp_path, validator):
 def test_get_xml_files_list_input(tmp_path, validator):
     f = tmp_path / "a.xml"
     f.write_text(_voc_xml(), encoding="utf-8")
-    files = validator._get_xml_files([str(f), str(tmp_path / "missing.xml")], True, True)
+    files = validator._get_xml_files(
+        [str(f), str(tmp_path / "missing.xml")], True, True
+    )
     assert files == [f]
 
 
@@ -126,6 +136,7 @@ def test_get_xml_files_ignores_hidden(tmp_path, validator):
 # ---------------------------------------------------------------------------
 # _validate_single_xml + sub-validators
 # ---------------------------------------------------------------------------
+
 
 def test_single_xml_valid(tmp_path, validator):
     f = tmp_path / "a.xml"
@@ -163,7 +174,9 @@ def test_root_elements_missing():
 
 def test_root_empty_filename_fails():
     v = PascalVOCXMLValidator()
-    root = _root(_voc_xml().replace("<filename>img.jpg</filename>", "<filename></filename>"))
+    root = _root(
+        _voc_xml().replace("<filename>img.jpg</filename>", "<filename></filename>")
+    )
     res = v._validate_root_elements(root)
     assert any("Filename element must have non-empty" in e for e in res["errors"])
 
@@ -184,7 +197,9 @@ def test_source_missing_fails():
 
 def test_source_empty_database_fails():
     v = PascalVOCXMLValidator()
-    root = _root(_voc_xml().replace("<database>Unknown</database>", "<database></database>"))
+    root = _root(
+        _voc_xml().replace("<database>Unknown</database>", "<database></database>")
+    )
     res = v._validate_source_element(root)
     assert any("Database element must have non-empty" in e for e in res["errors"])
 
@@ -262,3 +277,82 @@ def test_bndbox_small_area_warns():
     obj = _root(_object_xml(xmin=10, ymin=10, xmax=12, ymax=12))  # area 4 < 10
     res = v._validate_bndbox_element(obj, 0)
     assert any("Very small bounding box" in w for w in res["warnings"])
+
+
+# --- bbox bounded by declared <size> (#314 vision-hardening follow-up) --------
+
+
+def test_bbox_exceeding_declared_width_fails(clean_env, tmp_path, validator):
+    xml = _voc_xml(
+        width=64, height=64, objects=[_object_xml(xmin=5, ymin=5, xmax=9999, ymax=30)]
+    )
+    (tmp_path / "ann.xml").write_text(xml, encoding="utf-8")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(str(tmp_path))
+    assert not result.is_valid
+    assert any("exceeds image width" in e for e in result.errors)
+
+
+def test_bbox_exceeding_declared_height_fails(clean_env, tmp_path, validator):
+    xml = _voc_xml(
+        width=64, height=64, objects=[_object_xml(xmin=5, ymin=5, xmax=30, ymax=9999)]
+    )
+    (tmp_path / "ann.xml").write_text(xml, encoding="utf-8")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(str(tmp_path))
+    assert not result.is_valid
+    assert any("exceeds image height" in e for e in result.errors)
+
+
+def test_bbox_within_declared_size_passes(clean_env, tmp_path, validator):
+    xml = _voc_xml(
+        width=64, height=64, objects=[_object_xml(xmin=5, ymin=5, xmax=60, ymax=60)]
+    )
+    (tmp_path / "ann.xml").write_text(xml, encoding="utf-8")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(str(tmp_path))
+    assert result.is_valid, result.errors
+
+
+# --- declared <size> cross-checked against the actual image -------------------
+
+
+def _setup_with_image(tmp_path, declared_wh, image_wh, image_name="img.jpg"):
+    from PIL import Image
+
+    (tmp_path / "annotations").mkdir()
+    (tmp_path / "images").mkdir()
+    Image.new("RGB", image_wh, (120, 120, 120)).save(tmp_path / "images" / image_name)
+    # bbox kept small so it fits inside the declared sizes used by callers —
+    # we're exercising the size<->image cross-check, not the bbox-bounds check.
+    xml = _voc_xml(
+        width=declared_wh[0],
+        height=declared_wh[1],
+        objects=[_object_xml(xmin=5, ymin=5, xmax=40, ymax=40)],
+    )
+    (tmp_path / "annotations" / "ann.xml").write_text(xml, encoding="utf-8")
+
+
+def test_declared_size_matching_actual_image_passes(clean_env, tmp_path, validator):
+    _setup_with_image(tmp_path, declared_wh=(64, 64), image_wh=(64, 64))
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(str(tmp_path))
+    assert result.is_valid, result.errors
+
+
+def test_declared_size_mismatching_actual_image_fails(clean_env, tmp_path, validator):
+    _setup_with_image(tmp_path, declared_wh=(128, 128), image_wh=(64, 64))
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(str(tmp_path))
+    assert not result.is_valid
+    assert any("does not match the actual image" in e for e in result.errors)
+
+
+def test_size_check_skipped_when_image_absent(clean_env, tmp_path, validator):
+    # No images/ dir -> the size cross-check is a benign skip (FilePairing /
+    # FileType own the missing-image case), so a lone valid XML still passes.
+    xml = _voc_xml(width=128, height=128)
+    (tmp_path / "ann.xml").write_text(xml, encoding="utf-8")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(str(tmp_path))
+    assert result.is_valid, result.errors

--- a/tests/test_xml_validator.py
+++ b/tests/test_xml_validator.py
@@ -317,12 +317,14 @@ def test_bbox_within_declared_size_passes(clean_env, tmp_path, validator):
 # --- declared <size> cross-checked against the actual image -------------------
 
 
-def _setup_with_image(tmp_path, declared_wh, image_wh, image_name="img.jpg"):
+def _setup_with_image(tmp_path, declared_wh, image_wh):
     from PIL import Image
 
     (tmp_path / "annotations").mkdir()
     (tmp_path / "images").mkdir()
-    Image.new("RGB", image_wh, (120, 120, 120)).save(tmp_path / "images" / image_name)
+    # The image is located by XML STEM (matching the ingestor's pairing), so the
+    # annotation "ann.xml" pairs with the image "ann.<ext>".
+    Image.new("RGB", image_wh, (120, 120, 120)).save(tmp_path / "images" / "ann.jpg")
     # bbox kept small so it fits inside the declared sizes used by callers —
     # we're exercising the size<->image cross-check, not the bbox-bounds check.
     xml = _voc_xml(

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -59,10 +59,32 @@ def _label_diversity_validator(options: Dict[str, Any]) -> LabelDiversityValidat
     )
 
 
+def _zero_record_validator(
+    options: Dict[str, Any], subdir: str = "images"
+) -> IngestableRecordsValidator:
+    """0-record fail-fast guard for file-bearing vision categories — the #303
+    pattern extended from NLP to vision. Rejects a header-only / empty CSV (and
+    a manifest whose every referenced file is missing) BEFORE the table is
+    created, so a zero-record vision dataset fails early with a clear message
+    instead of an orphan empty table + a late, misleading registration error.
+    ``subdir`` mirrors the category's image ``FileTypeValidator(path=...)``."""
+    return IngestableRecordsValidator(
+        file_subdir=subdir, extension=options.get("extension", FileExtension.JPG)
+    )
+
+
 def image_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
+        _zero_record_validator(options),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
+        # Fail fast when the configured label column is absent from the CSV
+        # (else every record cleans to label=None and the backend rejects each
+        # row with HTTP 400 "label: may not be null"). image_classification is
+        # the only vision category whose label is a CSV column — object
+        # detection / segmentation / keypoint source labels from XML / masks /
+        # annotation files, so they do NOT get this validator.
+        LabelColumnValidator(label_column=options.get("label_column") or "label"),
         _label_diversity_validator(options),
         TableNameValidator(),
         DuplicateValidator(),
@@ -73,6 +95,7 @@ def object_detection(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
         FileTypeValidator(allowed_extension=".xml", path="annotations"),
+        _zero_record_validator(options),
         PascalVOCXMLValidator(),
         FilePairingValidator(
             image_path="images",
@@ -225,6 +248,7 @@ def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
         FileTypeValidator(allowed_extension=FileExtension.PNG, path="masks"),
+        _zero_record_validator(options),
         FilePairingValidator(
             image_path="images",
             sidecar_path="masks",
@@ -250,6 +274,7 @@ def keypoint_detection(options: Dict[str, Any]) -> List[BaseValidator]:
     # rejects datasets whose annotations drift from the declared K.
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
+        _zero_record_validator(options),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
         KeypointAnnotationValidator(num_keypoints=options.get("number_of_keypoints")),
         KeypointVisibilityValidator(),

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -260,6 +260,15 @@ def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
             sidecar_suffix="_mask",
         ),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
+        # Masks are pixel-wise label maps: validate they're readable PNGs and
+        # share the images' resolution. The default ImageResolution instance only
+        # scans <SRC>/images, so without this a corrupt mask, or a mask whose size
+        # differs from its image, would slip through to training.
+        ImageResolutionValidator(
+            expected_resolution=options["target_size"],
+            name="Mask Resolution Validator",
+            subdir="masks",
+        ),
         _label_diversity_validator(options),
         TableNameValidator(),
         DuplicateValidator(),
@@ -276,7 +285,12 @@ def keypoint_detection(options: Dict[str, Any]) -> List[BaseValidator]:
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
         _zero_record_validator(options),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
-        KeypointAnnotationValidator(num_keypoints=options.get("number_of_keypoints")),
+        KeypointAnnotationValidator(
+            num_keypoints=options.get("number_of_keypoints"),
+            # Bound keypoint coords by the declared image size (images are
+            # enforced to target_size by ImageResolutionValidator above).
+            expected_resolution=options.get("target_size"),
+        ),
         KeypointVisibilityValidator(),
         _label_diversity_validator(options),
         TableNameValidator(),

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -43,6 +43,7 @@ class ImageResolutionValidator(BaseValidator):
         self,
         expected_resolution: Optional[Tuple[int, int]] = None,
         name: str = "Image Resolution Validator",
+        subdir: str = "images",
     ):
         """Initialize the image resolution validator.
 
@@ -50,9 +51,15 @@ class ImageResolutionValidator(BaseValidator):
             expected_resolution: Expected image resolution as (width, height)
             supported_formats: Set of supported image formats (e.g., {'.jpg', '.png'})
             name: Human-readable name of the validator
+            subdir: The ``<SRC_PATH>`` subdirectory whose images this instance
+                validates (default ``"images"``). Set to ``"masks"`` to validate
+                semantic-segmentation masks — pixel-wise label maps that must be
+                readable and share the images' resolution; the default instance
+                only ever scans ``<SRC_PATH>/images``.
         """
         super().__init__(name)
         self.expected_resolution = expected_resolution
+        self.subdir = subdir
         self.tolerance = 0  # Whether to enforce strict file type checking . we can later make this configurable
         self.supported_formats = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"}
 
@@ -86,7 +93,7 @@ class ImageResolutionValidator(BaseValidator):
             ValidationResult containing validation status and messages
         """
         try:
-            data = f"{(self._config or config).SRC_PATH}/images"
+            data = f"{(self._config or config).SRC_PATH}/{self.subdir}"
             if not PIL_AVAILABLE:
                 return self._create_result(
                     is_valid=False,

--- a/tracebloc_ingestor/validators/keypoint_annotation_validator.py
+++ b/tracebloc_ingestor/validators/keypoint_annotation_validator.py
@@ -195,17 +195,21 @@ class KeypointAnnotationValidator(BaseValidator):
             )
             return errors, None, None
 
+        # Lower- and upper-bound checks run INDEPENDENTLY (not elif) so a row
+        # like (-1, 9999) reports both the negative x AND the out-of-bounds y in
+        # one pass, instead of hiding the second issue until a re-ingest (bugbot,
+        # PR #314).
         if x < 0 or y < 0:
             errors.append(
                 f"{row_label}: Keypoint '{kp_name}' has negative coordinates "
                 f"({x}, {y})"
             )
-        elif self.expected_resolution is not None:
+        if self.expected_resolution is not None:
             width, height = self.expected_resolution
             # Valid coordinates lie in the half-open range [0, width) / [0, height)
-            # — consistent with the inclusive-0 lower bound above. A coordinate
-            # equal to width/height is the first index PAST the last pixel
-            # (indices run 0..W-1), so it's out of bounds (bugbot, PR #314).
+            # — consistent with the inclusive-0 lower bound. A coordinate equal to
+            # width/height is the first index PAST the last pixel (0..W-1), so it
+            # is out of bounds.
             if x >= width or y >= height:
                 errors.append(
                     f"{row_label}: Keypoint '{kp_name}' ({x}, {y}) lies outside "

--- a/tracebloc_ingestor/validators/keypoint_annotation_validator.py
+++ b/tracebloc_ingestor/validators/keypoint_annotation_validator.py
@@ -202,11 +202,15 @@ class KeypointAnnotationValidator(BaseValidator):
             )
         elif self.expected_resolution is not None:
             width, height = self.expected_resolution
-            if x > width or y > height:
+            # Valid coordinates lie in the half-open range [0, width) / [0, height)
+            # — consistent with the inclusive-0 lower bound above. A coordinate
+            # equal to width/height is the first index PAST the last pixel
+            # (indices run 0..W-1), so it's out of bounds (bugbot, PR #314).
+            if x >= width or y >= height:
                 errors.append(
                     f"{row_label}: Keypoint '{kp_name}' ({x}, {y}) lies outside "
-                    f"the image bounds ({width}x{height}) — the coordinate is past "
-                    f"the image edge."
+                    f"the image bounds ({width}x{height}) — coordinates must be "
+                    f"within [0, {width}) x [0, {height})."
                 )
 
         return errors, float(x), float(y)

--- a/tracebloc_ingestor/validators/keypoint_annotation_validator.py
+++ b/tracebloc_ingestor/validators/keypoint_annotation_validator.py
@@ -51,10 +51,15 @@ class KeypointAnnotationValidator(BaseValidator):
         annotation_column: str = "Annotation",
         num_keypoints: Optional[int] = None,
         name: str = "Keypoint Annotation",
+        expected_resolution: Optional[Tuple[int, int]] = None,
     ):
         super().__init__(name)
         self.annotation_column = annotation_column
         self.num_keypoints = num_keypoints
+        # Declared image size (width, height) — when known, keypoint coordinates
+        # are bounded by it (coords are already checked non-negative; without an
+        # upper bound a coord past the image edge reaches training).
+        self.expected_resolution = expected_resolution
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         try:
@@ -143,9 +148,7 @@ class KeypointAnnotationValidator(BaseValidator):
         x_coords = []
         y_coords = []
         for kp_name, value in annotation.items():
-            kp_errors, x, y = self._validate_keypoint_value(
-                kp_name, value, row_label
-            )
+            kp_errors, x, y = self._validate_keypoint_value(kp_name, value, row_label)
             errors.extend(kp_errors)
             if x is not None and y is not None:
                 x_coords.append(x)
@@ -182,7 +185,7 @@ class KeypointAnnotationValidator(BaseValidator):
         else:
             errors.append(
                 f"{row_label}: Keypoint '{kp_name}' must be [x, y] list or "
-                f"{{\"x\": x, \"y\": y}} dict"
+                f'{{"x": x, "y": y}} dict'
             )
             return errors, None, None
 
@@ -197,6 +200,14 @@ class KeypointAnnotationValidator(BaseValidator):
                 f"{row_label}: Keypoint '{kp_name}' has negative coordinates "
                 f"({x}, {y})"
             )
+        elif self.expected_resolution is not None:
+            width, height = self.expected_resolution
+            if x > width or y > height:
+                errors.append(
+                    f"{row_label}: Keypoint '{kp_name}' ({x}, {y}) lies outside "
+                    f"the image bounds ({width}x{height}) — the coordinate is past "
+                    f"the image edge."
+                )
 
         return errors, float(x), float(y)
 

--- a/tracebloc_ingestor/validators/xml_validator.py
+++ b/tracebloc_ingestor/validators/xml_validator.py
@@ -268,8 +268,29 @@ class PascalVOCXMLValidator(BaseValidator):
             warnings.extend(size_validation["warnings"])
             metadata.update(size_validation["metadata"])
 
-            # Validate objects
-            objects_validation = self._validate_objects(root)
+            # Declared image dimensions (only when they parsed cleanly as
+            # positive ints) — used to bound bbox coordinates and to cross-check
+            # against the actual image below.
+            declared_w = size_validation["metadata"].get("width")
+            declared_h = size_validation["metadata"].get("height")
+
+            # Cross-check the declared <size> against the ACTUAL image: a wrong
+            # declared size silently corrupts coordinate scaling at training
+            # (and would let a bbox that's "within" a too-large declared size sit
+            # outside the real image). Best-effort — skips when the image can't
+            # be located/read (FilePairing/FileType own the missing-image case).
+            errors.extend(
+                self._validate_size_matches_image(
+                    file_path,
+                    root_validation["metadata"].get("filename"),
+                    declared_w,
+                    declared_h,
+                )
+            )
+
+            # Validate objects (bbox coordinates are bounded by the declared
+            # image size when it's known).
+            objects_validation = self._validate_objects(root, declared_w, declared_h)
             errors.extend(objects_validation["errors"])
             warnings.extend(objects_validation["warnings"])
             metadata.update(objects_validation["metadata"])
@@ -440,11 +461,20 @@ class PascalVOCXMLValidator(BaseValidator):
 
         return {"errors": errors, "warnings": warnings, "metadata": metadata}
 
-    def _validate_objects(self, root: ET.Element) -> Dict[str, Any]:
+    def _validate_objects(
+        self,
+        root: ET.Element,
+        declared_w: Optional[int] = None,
+        declared_h: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """Validate object elements and their sub-elements.
 
         Args:
             root: Root XML element
+            declared_w: Declared image width (from <size>), or None — used to
+                bound each bbox's xmax.
+            declared_h: Declared image height (from <size>), or None — used to
+                bound each bbox's ymax.
 
         Returns:
             Dictionary containing validation results
@@ -461,19 +491,29 @@ class PascalVOCXMLValidator(BaseValidator):
             return {"errors": errors, "warnings": warnings, "metadata": metadata}
 
         for i, obj in enumerate(objects):
-            obj_validation = self._validate_single_object(obj, i)
+            obj_validation = self._validate_single_object(
+                obj, i, declared_w, declared_h
+            )
             errors.extend(obj_validation["errors"])
             warnings.extend(obj_validation["warnings"])
             metadata["objects"].append(obj_validation["metadata"])
 
         return {"errors": errors, "warnings": warnings, "metadata": metadata}
 
-    def _validate_single_object(self, obj: ET.Element, index: int) -> Dict[str, Any]:
+    def _validate_single_object(
+        self,
+        obj: ET.Element,
+        index: int,
+        declared_w: Optional[int] = None,
+        declared_h: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """Validate a single object element.
 
         Args:
             obj: Object XML element
             index: Index of the object in the list
+            declared_w: Declared image width, or None.
+            declared_h: Declared image height, or None.
 
         Returns:
             Dictionary containing validation results
@@ -557,19 +597,29 @@ class PascalVOCXMLValidator(BaseValidator):
             errors.append(f"Object {index}: Missing required 'difficult' element")
 
         # Validate bndbox element
-        bndbox_validation = self._validate_bndbox_element(obj, index)
+        bndbox_validation = self._validate_bndbox_element(
+            obj, index, declared_w, declared_h
+        )
         errors.extend(bndbox_validation["errors"])
         warnings.extend(bndbox_validation["warnings"])
         metadata.update(bndbox_validation["metadata"])
 
         return {"errors": errors, "warnings": warnings, "metadata": metadata}
 
-    def _validate_bndbox_element(self, obj: ET.Element, index: int) -> Dict[str, Any]:
+    def _validate_bndbox_element(
+        self,
+        obj: ET.Element,
+        index: int,
+        declared_w: Optional[int] = None,
+        declared_h: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """Validate bndbox element and its coordinates.
 
         Args:
             obj: Object XML element
             index: Index of the object in the list
+            declared_w: Declared image width, or None — bounds xmax.
+            declared_h: Declared image height, or None — bounds ymax.
 
         Returns:
             Dictionary containing validation results
@@ -639,7 +689,73 @@ class PascalVOCXMLValidator(BaseValidator):
                     f"Object {index}: Very small bounding box (area: {area})"
                 )
 
+            # Bound the box by the declared image size: a bbox extending past the
+            # image edge is malformed and crashes / corrupts training. (xmin/ymin
+            # are already checked non-negative above.)
+            if declared_w is not None and coords["xmax"] > declared_w:
+                errors.append(
+                    f"Object {index}: xmax ({coords['xmax']}) exceeds image width "
+                    f"({declared_w}) — bounding box extends past the image edge."
+                )
+            if declared_h is not None and coords["ymax"] > declared_h:
+                errors.append(
+                    f"Object {index}: ymax ({coords['ymax']}) exceeds image height "
+                    f"({declared_h}) — bounding box extends past the image edge."
+                )
+
             metadata["bbox"] = coords
             metadata["area"] = area
 
         return {"errors": errors, "warnings": warnings, "metadata": metadata}
+
+    def _validate_size_matches_image(
+        self,
+        file_path: Path,
+        image_name: Optional[str],
+        declared_w: Optional[int],
+        declared_h: Optional[int],
+    ) -> List[str]:
+        """Cross-check the annotation's declared ``<size>`` against the ACTUAL
+        image dimensions.
+
+        The XML lives at ``<SRC>/annotations/<name>.xml`` and its image at
+        ``<SRC>/images/<filename>``; a declared size that disagrees with the real
+        image silently corrupts coordinate scaling at training (and lets a bbox
+        that's "within" a too-large declared size sit outside the real image).
+
+        Best-effort — returns no error (a benign skip) when the declared size is
+        unknown, the image can't be located, or it can't be read: the
+        FilePairing / FileType validators own the missing-image case, and Pillow
+        may be unavailable. Returns a one-item error list on a real mismatch.
+        """
+        if declared_w is None or declared_h is None:
+            return []
+        try:
+            from PIL import Image, UnidentifiedImageError
+        except ImportError:  # pragma: no cover - Pillow is a runtime dep
+            return []
+
+        images_dir = file_path.parent.parent / "images"
+        candidates = []
+        if image_name:
+            candidates.append(images_dir / image_name)
+        # Fall back to the XML stem with the common image extensions, mirroring
+        # how the dataset pairs <stem>.xml with <stem>.<imgext>.
+        for ext in (".jpg", ".jpeg", ".png"):
+            candidates.append(images_dir / f"{file_path.stem}{ext}")
+        img_path = next((c for c in candidates if c.is_file()), None)
+        if img_path is None:
+            return []
+        try:
+            with Image.open(img_path) as im:
+                actual_w, actual_h = im.size
+        except (OSError, UnidentifiedImageError):  # corrupt/unreadable image
+            return []
+
+        if (actual_w, actual_h) != (declared_w, declared_h):
+            return [
+                f"declared <size> {declared_w}x{declared_h} does not match the "
+                f"actual image '{img_path.name}' ({actual_w}x{actual_h}); fix the "
+                f"annotation's <size> or the image."
+            ]
+        return []

--- a/tracebloc_ingestor/validators/xml_validator.py
+++ b/tracebloc_ingestor/validators/xml_validator.py
@@ -282,7 +282,6 @@ class PascalVOCXMLValidator(BaseValidator):
             errors.extend(
                 self._validate_size_matches_image(
                     file_path,
-                    root_validation["metadata"].get("filename"),
                     declared_w,
                     declared_h,
                 )
@@ -711,17 +710,24 @@ class PascalVOCXMLValidator(BaseValidator):
     def _validate_size_matches_image(
         self,
         file_path: Path,
-        image_name: Optional[str],
         declared_w: Optional[int],
         declared_h: Optional[int],
     ) -> List[str]:
         """Cross-check the annotation's declared ``<size>`` against the ACTUAL
         image dimensions.
 
-        The XML lives at ``<SRC>/annotations/<name>.xml`` and its image at
-        ``<SRC>/images/<filename>``; a declared size that disagrees with the real
-        image silently corrupts coordinate scaling at training (and lets a bbox
-        that's "within" a too-large declared size sit outside the real image).
+        The XML lives at ``<SRC>/annotations/<stem>.xml`` and its image at
+        ``<SRC>/images/<stem>.<imgext>``; a declared size that disagrees with the
+        real image silently corrupts coordinate scaling at training (and lets a
+        bbox that's "within" a too-large declared size sit outside the real
+        image).
+
+        The image is located by the XML **stem** — NOT the annotation's
+        ``<filename>`` element — because the ingestor pairs images to annotations
+        by stem (``FilePairingValidator``). A stale / wrong ``<filename>`` could
+        otherwise point the check at a different on-disk image that happens to
+        match the declared size, while the actually-paired image still disagrees
+        (bugbot, PR #314).
 
         Best-effort — returns no error (a benign skip) when the declared size is
         unknown, the image can't be located, or it can't be read: the
@@ -736,13 +742,11 @@ class PascalVOCXMLValidator(BaseValidator):
             return []
 
         images_dir = file_path.parent.parent / "images"
-        candidates = []
-        if image_name:
-            candidates.append(images_dir / image_name)
-        # Fall back to the XML stem with the common image extensions, mirroring
-        # how the dataset pairs <stem>.xml with <stem>.<imgext>.
-        for ext in (".jpg", ".jpeg", ".png"):
-            candidates.append(images_dir / f"{file_path.stem}{ext}")
+        # Match the stem-based pairing the ingestor uses; the image extension is
+        # whatever's on disk (datasets ship .jpg / .jpeg / .png).
+        candidates = [
+            images_dir / f"{file_path.stem}{ext}" for ext in (".jpg", ".jpeg", ".png")
+        ]
         img_path = next((c for c in candidates if c.is_file()), None)
         if img_path is None:
             return []

--- a/tracebloc_ingestor/validators/xml_validator.py
+++ b/tracebloc_ingestor/validators/xml_validator.py
@@ -741,7 +741,12 @@ class PascalVOCXMLValidator(BaseValidator):
         except ImportError:  # pragma: no cover - Pillow is a runtime dep
             return []
 
-        images_dir = file_path.parent.parent / "images"
+        # Resolve the images dir from SRC_PATH (the same root FileTypeValidator
+        # uses, ``SRC_PATH/images``) rather than ``file_path.parent.parent`` —
+        # ``validate`` discovers XML via a recursive ``**/*.xml`` glob, so an XML
+        # nested deeper or at the root would otherwise resolve the wrong images
+        # tree (bugbot, PR #314).
+        images_dir = Path((self._config or config).SRC_PATH) / "images"
         # Match the stem-based pairing the ingestor uses; the image extension is
         # whatever's on disk (datasets ship .jpg / .jpeg / .png).
         candidates = [


### PR DESCRIPTION
## Summary

Adversarial **image-classification** ingestion — re-verified against the **merged develop** validator chain (not the stale deployed image) — showed the #303 zero-record guard and #313 label-column guard were wired **NLP-only**, so vision still had the same two gaps. This extends both to the vision factories.

## Gaps (confirmed on develop HEAD via the real `map_validators` chain)

| Case | Before | Cause |
|---|---|---|
| header-only / empty CSV | ✅ passes preflight → ingests 0 rows → orphan empty table + late "rows already in the database" | no `IngestableRecordsValidator` |
| missing configured label column | ✅ passes preflight → records clean to `label=None` → backend rejects each row `HTTP 400 "label: may not be null"` | no `LabelColumnValidator` |

(corrupt image, wrong resolution, single label, all-images-missing were already caught.)

## Fix

- New `_zero_record_validator` helper wires **`IngestableRecordsValidator(file_subdir="images")`** into **all file-bearing vision categories** — `image_classification`, `object_detection`, `semantic_segmentation`, `keypoint_detection` — so a zero-record vision manifest fails fast at preflight (no orphan table).
- **`LabelColumnValidator`** added to **`image_classification` only** — it is the only vision category whose label is a CSV column. Object detection / segmentation / keypoint source labels from XML / masks / annotation files, so adding it there would wrongly reject every such dataset.
- `TextContentValidator` stays **NLP-only** (it decodes UTF-8 text — meaningless for images).

Resulting `image_classification` chain: `FileType → IngestableRecords → ImageResolution → LabelColumn → LabelDiversity → TableName → Duplicate`.

## Tests

- Mapping: image gets both guards (exact-list updated); OD/seg/keypoint get the zero-record guard only and **never** `LabelColumnValidator`; updated the prior NLP-only content-hygiene assertion (TextContent stays NLP-only).
- Behavioral (`test_vision_input_validators.py`): real chain on staged images — empty CSV → `IngestableRecordsValidator` reject; missing label column → `LabelColumnValidator` reject; valid → passes.
- Full suite: **1209 passed, 1 xfailed**, total coverage **96.7%** (gate 95%). `black`-clean.

Follow-up to #303 / #313, extending the same hardening from NLP to vision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes expand which datasets fail at preflight across all vision modalities and add coordinate/size logic in VOC and keypoint validators; behavior is well-tested but mis-tuned `target_size` or edge cases in best-effort image lookup could reject previously accepted datasets.
> 
> **Overview**
> Extends **NLP-style preflight guards** to vision ingest: **`IngestableRecordsValidator`** (via `_zero_record_validator`) is wired into all file-bearing vision categories so header-only/empty manifests fail before creating orphan tables; **`LabelColumnValidator`** is added **only** to `image_classification` (other vision tasks don’t use a CSV label column).
> 
> **Semantic segmentation** adds a second **`ImageResolutionValidator`** with `subdir="masks"` so masks are readable and match `target_size`, not just images under `images/`.
> 
> **Keypoint detection** passes `target_size` into **`KeypointAnnotationValidator`** as `expected_resolution` to reject coords outside `[0, W) × [0, H)`, with negative and out-of-bounds errors reported independently.
> 
> **Object detection** **`PascalVOCXMLValidator`** now rejects bboxes past declared `<size>`, cross-checks declared dimensions against the stem-paired file under `SRC_PATH/images`, and resolves images from `SRC_PATH` (not XML parent paths).
> 
> Tests cover mapping chains, end-to-end image-classification preflight, masks/keypoints/XML geometry, plus minor formatting in existing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fa816cc66fc060ebeb048805253558be391f8dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Added: semantic segmentation + keypoint detection (vision sweep complete)

**Semantic segmentation** — masks were unvalidated (`ImageResolutionValidator` only scans `<SRC>/images`):
- mask resolution ≠ image → **passed** (breaks pixel-wise labels); corrupt/unreadable mask → **passed** (only `.png` extension checked).
- Fix: `ImageResolutionValidator` gains a `subdir` param; seg factory adds a `subdir="masks"` instance → masks must be readable + share the images' target resolution.

**Keypoint detection** — keypoint coords past the image edge **passed** (validator never saw image size; only non-negative was checked).
- Fix: thread `target_size` into `KeypointAnnotationValidator` as `expected_resolution`; coords > width/height now rejected.

**Not changed (pending product call):** keypoint `Visibility` stays restricted to `0/1`. Accepting COCO's `0/1/2` is a format decision (could admit data the runtime doesn't support), so it's flagged rather than silently relaxed.

Vision sweep now complete across all four categories (image, object detection, semantic segmentation, keypoint).