### PR TITLE
fix(ingest): canonical feature-column order for tabular schemas (#763 mode A)

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -123,6 +123,42 @@ def test_init_injects_number_of_columns_for_tabular():
     assert ing.file_options["number_of_columns"] == 2
 
 
+def test_init_canonical_orders_tabular_schema():
+    """#763 mode A: tabular feature columns are stored in one deterministic
+    (sorted) order so every edge agrees on feature positions, regardless of the
+    order the template declared them in. This is what lets the trainer's
+    schema-ordered SELECT align edges without a runtime feature_columns
+    broadcast."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    ing = make_ingestor(
+        schema={"charlie": "INT", "alpha": "FLOAT", "bravo": "INT"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    assert list(ing.file_options["schema"].keys()) == ["alpha", "bravo", "charlie"]
+    assert list(ing._table_schema.keys()) == ["alpha", "bravo", "charlie"]
+    # label/unique-id stripping still happens before the sort
+    ing2 = make_ingestor(
+        schema={"charlie": "INT", "alpha": "FLOAT", "target": "INT"},
+        category=TaskCategory.TABULAR_REGRESSION,
+        label_column="target",
+    )
+    assert list(ing2._table_schema.keys()) == ["alpha", "charlie"]
+    assert ing2.file_options["number_of_columns"] == 2
+
+
+def test_init_does_not_reorder_non_tabular_schema():
+    """Only tabular-family categories are canonicalised; image/keypoint schemas
+    keep their declared order (their columns aren't averaged by position)."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    ing = make_ingestor(
+        schema={"charlie": "INT", "alpha": "FLOAT", "bravo": "INT"},
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+    )
+    assert list(ing._table_schema.keys()) == ["charlie", "alpha", "bravo"]
+
+
 # ---------------------------------------------------------------------------
 # process_record / _map_unique_id
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -192,6 +192,23 @@ class BaseIngestor(ABC):
         if self.unique_id_column and self.unique_id_column in table_schema:
             del table_schema[self.unique_id_column]
 
+        # Canonical feature-column ordering (#763, mode A). Tabular-family
+        # trainers read features positionally and the averaging service sums
+        # weights by tensor position, so every edge must agree on which feature
+        # lives at which position. Left alone, the order is whatever each edge's
+        # template ``schema`` dict happened to declare, so two sites can
+        # silently average misaligned features (pos 0 = "age" at one site,
+        # "bmi" at another) with no error. Sorting the cleaned feature columns
+        # into one deterministic order *here* -- the ingest layer, the single
+        # point that defines the stored table schema every edge's trainer later
+        # reads back via its schema-ordered SELECT -- makes the cross-site
+        # contract hold by construction, with no runtime feature_columns
+        # broadcast/reindex needed. Only tabular-family categories are
+        # reordered; image/keypoint schemas (e.g. a "Visibility" column) keep
+        # their declared order.
+        if self.category in _TABULAR_FAMILY_CATEGORIES:
+            table_schema = {key: table_schema[key] for key in sorted(table_schema)}
+
         # Add cleaned schema to file_options for validators / downstream metadata.
         # Always overwrite so a schema passed in by the template (which may still
         # contain the label/annotation/unique_id columns) is sanitized before


### PR DESCRIPTION
## Problem (#763, mode A)

Federated **tabular** runs average weights **by tensor position** with no cross-site agreement on feature order. The stored schema order was simply whatever each edge's template `schema = {...}` dict happened to declare. Two edges that ingest the same dataset with the columns listed in a different order therefore end up with **different feature positions**, and the averaging service sums their weights position-by-position — silently averaging `age` against `bmi` and producing a garbage model with plausible-looking metrics and no error.

This is the **column-order half (mode A)** of #763.

## Why fix it here (the ingest layer)

The trainer already reads its feature order from the **stored table schema** (it builds a schema-ordered `SELECT` and `pd.DataFrame(rows, columns=...)`). So the schema *is* the contract — it just wasn't canonical. The ingestor is the single point that defines that stored schema for every edge, so canonicalising the order here makes the cross-site contract hold **by construction**:

```python
if self.category in _TABULAR_FAMILY_CATEGORIES:
    table_schema = {key: table_schema[key] for key in sorted(table_schema)}
```

Every edge that ingests the same column set now stores features in the same deterministic order → trainers align with **no runtime `feature_columns` broadcast or client-side reindex**. This is the migration-free alternative to a train-time reindex, and it fails at the right layer (data preparation) rather than mid-training.

- Gated to tabular-family categories (classification, regression, time-series, time-to-event). Image/keypoint schemas (e.g. a `Visibility` column) keep their declared order — their columns aren't averaged by position.
- Label / annotation / unique-id stripping still happens **before** the sort, so `number_of_columns` is unchanged.

## Tests
- `test_init_canonical_orders_tabular_schema` — out-of-order tabular schema is stored sorted; label-strip still precedes the sort; `number_of_columns` correct.
- `test_init_does_not_reorder_non_tabular_schema` — non-tabular schemas keep declared order.
- Full `test_ingestor_base.py`, `test_csv_file_options.py`, `test_template_equivalence.py`, `test_csv_ingestor.py` green (124 passed). Black-clean.

## Scope / not in this PR
- **Mode B (the dangerous half):** per-site preprocessing-state divergence — scaler means/stds, imputation medians, categorical label-maps fit independently per site. Column order does nothing for it. Tracked separately (backend #792). **This PR does not close #763 on its own.**
- **Cross-edge column-NAME/set validation:** the loud-fail for "same column count, different names" (which the now-superseded client reindex caught). Belongs as backend schema-upsert validation — follow-up.
- **Existing datasets:** keep their stored order until re-ingested. A one-off backfill migration to canonicalise already-stored schemas will follow.

## Supersedes
Replaces the runtime approach in backend tracebloc/backend#825 + tracebloc-client tracebloc/tracebloc-client#396 for mode A (column ordering), moving the contract to the ingest layer. Those PRs are being closed in favour of this; see their closing comments.

Refs #763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the stored schema contract for new tabular ingests (federated correctness fix); existing datasets keep prior order until re-ingested, per PR scope.
> 
> **Overview**
> **Federated tabular training** can silently corrupt models when edges list the same features in different template order: weight averaging is positional, so misaligned columns never error. This PR fixes **mode A (column order)** at ingest time.
> 
> After stripping label/annotation/unique-id columns, **`BaseIngestor`** now **sorts feature column names** for categories in `_TABULAR_FAMILY_CATEGORIES` before persisting `file_options["schema"]` and `_table_schema`. Every edge that ingests the same feature set therefore stores the same column order, matching trainers that build schema-ordered `SELECT`s—**no runtime `feature_columns` broadcast**. Image/keypoint and other non-tabular schemas are **unchanged**.
> 
> Tests assert sorted tabular schemas (including post-strip `number_of_columns`), and that non-tabular categories keep declared order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 372c35f0165783592bee5590714ad7c802e66cad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->