### PR TITLE
fix(validators): wire 0-record guard into tabular categories (dropped from #314 merge)

### DIFF
--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -377,9 +377,10 @@ def test_nlp_categories_include_content_hygiene_validators():
         assert IngestableRecordsValidator in types, cat
         assert TextContentValidator not in types, cat
 
-    # Tabular has neither (no files, not text).
+    # Tabular gets the 0-record guard (file_subdir=None -> header-only / empty
+    # CSV row check) but NOT the text-content validator.
     types = _types(map_validators(TaskCategory.TABULAR_CLASSIFICATION, IMAGE_OPTS))
-    assert IngestableRecordsValidator not in types
+    assert IngestableRecordsValidator in types
     assert TextContentValidator not in types
 
 
@@ -438,3 +439,21 @@ def test_keypoint_annotation_validator_gets_image_bounds():
     )
     kp = next(x for x in v if isinstance(x, KeypointAnnotationValidator))
     assert kp.expected_resolution == IMAGE_OPTS["target_size"]
+
+
+def test_tabular_categories_have_zero_record_guard():
+    """Tabular classification + regression get IngestableRecordsValidator with
+    file_subdir=None (header-only / empty CSV row check only) so a no-schema
+    tabular ingest can't slip an empty manifest past preflight. PR #314."""
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+
+    for cat in (TaskCategory.TABULAR_CLASSIFICATION, TaskCategory.TABULAR_REGRESSION):
+        rec = [
+            x
+            for x in map_validators(cat, {})
+            if isinstance(x, IngestableRecordsValidator)
+        ]
+        assert len(rec) == 1, cat
+        assert rec[0].file_subdir is None, cat

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -111,6 +111,11 @@ def object_detection(options: Dict[str, Any]) -> List[BaseValidator]:
 
 def tabular_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     validators: List[BaseValidator] = []
+    # Reject a header-only / empty CSV up front (file_subdir=None -> row-count
+    # check only, no file pairing). DataValidator catches this too, but only
+    # when a schema is supplied; this closes the no-schema path that would
+    # otherwise create an empty table and fail late at registration.
+    validators.append(IngestableRecordsValidator(file_subdir=None))
     # Add data validator if schema is provided
     if options.get("schema"):
         validators.append(DataValidator(schema=options["schema"]))
@@ -213,6 +218,9 @@ def time_series_forecasting(options: Dict[str, Any]) -> List[BaseValidator]:
 
 def tabular_regression(options: Dict[str, Any]) -> List[BaseValidator]:
     validators: List[BaseValidator] = []
+    # Reject a header-only / empty CSV up front (no-schema path has no
+    # DataValidator to catch it; file_subdir=None -> row-count check only).
+    validators.append(IngestableRecordsValidator(file_subdir=None))
     # Add data validator if schema is provided
     if options.get("schema"):
         validators.append(DataValidator(schema=options["schema"]))


### PR DESCRIPTION
## Summary

Re-applies a fix that was **dropped from the #314 squash merge**. The tabular 0-record guard was committed to the #314 branch but landed after the squash point, so merged `develop` still lacks it — verified by re-testing the merged code: a **no-schema header-only / empty tabular CSV still passes preflight** on `develop`.

## Gap

`tabular_classification` / `tabular_regression` add `DataValidator` (which rejects an empty CSV with "No data found to validate") **only when a schema is supplied**. With no schema there's no `DataValidator` and no 0-record guard, so a header-only CSV creates an empty table and fails late at registration. `IngestableRecordsValidator` was explicitly designed for this ("non-file-bearing tabular / time-series categories", `file_subdir=None`) but was never wired into the tabular factories.

## Fix

Add `IngestableRecordsValidator(file_subdir=None)` (row-count check only, no file pairing) to both tabular factories — rejects a zero-record manifest regardless of schema (with a schema, `DataValidator` still reports first).

## Verification (against merged develop)
- before: no-schema empty CSV → PASS (clf + reg)
- after: → REJECT (`IngestableRecordsValidator`, "No data rows found in CSV…")
- A full cross-modality re-check on merged develop confirms every other category (NLP, image, OD, segmentation, keypoint, time-series, time-to-event) already rejects its gap cases — tabular was the only one still open.

Tests: mapping assertion (both tabular categories carry `IngestableRecordsValidator(file_subdir=None)`). Full suite: **1227 passed, 1 xfailed**, coverage 96.6% (gate 95%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow preflight validation change for tabular ingest; rejects empty manifests earlier with no auth, data-model, or broad behavioral refactors.
> 
> **Overview**
> **Tabular classification and regression** now run `IngestableRecordsValidator(file_subdir=None)` during preflight so header-only or empty CSV manifests are rejected before ingest, even when no schema is provided.
> 
> Previously, `DataValidator` only ran with a schema, so a no-schema empty tabular CSV could pass preflight and fail later at registration. With `file_subdir=None`, the guard performs a row-count check only (no file pairing), matching the existing design for non-file-bearing categories.
> 
> Tests assert both tabular categories include this validator with `file_subdir is None`, and the NLP/vision mapping test docstring is updated to reflect tabular now having the guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5759e97ab2e75f931b2b525435180c862e916350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->