### PR TITLE
refactor(validators): compose common validators centrally (supersedes #316)

### DIFF
--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -27,6 +27,9 @@ from tracebloc_ingestor.validators.keypoint_visibility_validator import (
 from tracebloc_ingestor.validators.label_diversity_validator import (
     LabelDiversityValidator,
 )
+from tracebloc_ingestor.validators.ingestable_records_validator import (
+    IngestableRecordsValidator,
+)
 
 IMAGE_OPTS = {"extension": FileExtension.JPG, "target_size": [224, 224]}
 
@@ -44,9 +47,12 @@ def test_image_classification():
     )
 
     v = map_validators(TaskCategory.IMAGE_CLASSIFICATION, IMAGE_OPTS)
+    # The 0-record guard, label-diversity, table-name and duplicate validators
+    # are composed by map_validators around the category-specific middle, so the
+    # guard now leads and the classification + tail validators trail.
     assert _types(v) == [
-        FileTypeValidator,
         IngestableRecordsValidator,
+        FileTypeValidator,
         ImageResolutionValidator,
         LabelColumnValidator,
         LabelDiversityValidator,
@@ -192,7 +198,9 @@ def test_tabular_regression_with_schema():
 
 def test_text_classification_defaults_extension():
     v = map_validators(TaskCategory.TEXT_CLASSIFICATION, {})
-    assert _types(v)[0] is FileTypeValidator
+    # The 0-record guard leads; the category's own FileTypeValidator follows.
+    assert _types(v)[0] is IngestableRecordsValidator
+    assert FileTypeValidator in _types(v)
 
 
 def test_text_classification_includes_label_column_validator_before_diversity():
@@ -235,7 +243,8 @@ def test_token_classification_includes_bio_validator():
 
     v = map_validators(TaskCategory.TOKEN_CLASSIFICATION, {})
     types = _types(v)
-    assert types[0] is FileTypeValidator
+    assert types[0] is IngestableRecordsValidator  # 0-record guard leads
+    assert FileTypeValidator in types
     assert BIOLabelValidator in types
     assert TableNameValidator in types and DuplicateValidator in types
 
@@ -360,10 +369,11 @@ def test_nlp_categories_include_content_hygiene_validators():
         TaskCategory.MASKED_LANGUAGE_MODELING,
     ):
         types = _types(map_validators(cat, {}))
-        assert IngestableRecordsValidator in types, cat
+        # 0-record guard leads (composed centrally); the category's own
+        # FileTypeValidator + text-content validator follow.
+        assert types[0] is IngestableRecordsValidator, cat
+        assert FileTypeValidator in types, cat
         assert TextContentValidator in types, cat
-        # FileTypeValidator stays first (the content validators come after it).
-        assert types[0] is FileTypeValidator, cat
 
     # Vision file-bearing categories get the zero-record guard but NOT the
     # text-content validator.
@@ -377,9 +387,10 @@ def test_nlp_categories_include_content_hygiene_validators():
         assert IngestableRecordsValidator in types, cat
         assert TextContentValidator not in types, cat
 
-    # Tabular has neither (no files, not text).
+    # Tabular gets the centralized 0-record guard (every category does) but NOT
+    # the text-content validator (no files, not text).
     types = _types(map_validators(TaskCategory.TABULAR_CLASSIFICATION, IMAGE_OPTS))
-    assert IngestableRecordsValidator not in types
+    assert IngestableRecordsValidator in types
     assert TextContentValidator not in types
 
 
@@ -438,3 +449,42 @@ def test_keypoint_annotation_validator_gets_image_bounds():
     )
     kp = next(x for x in v if isinstance(x, KeypointAnnotationValidator))
     assert kp.expected_resolution == IMAGE_OPTS["target_size"]
+
+
+ALL_CATEGORIES = (
+    TaskCategory.IMAGE_CLASSIFICATION,
+    TaskCategory.OBJECT_DETECTION,
+    TaskCategory.SEMANTIC_SEGMENTATION,
+    TaskCategory.KEYPOINT_DETECTION,
+    TaskCategory.TEXT_CLASSIFICATION,
+    TaskCategory.TOKEN_CLASSIFICATION,
+    TaskCategory.MASKED_LANGUAGE_MODELING,
+    TaskCategory.TABULAR_CLASSIFICATION,
+    TaskCategory.TABULAR_REGRESSION,
+    TaskCategory.TIME_SERIES_FORECASTING,
+    TaskCategory.TIME_TO_EVENT_PREDICTION,
+)
+_CLASSIFICATION = {
+    TaskCategory.IMAGE_CLASSIFICATION,
+    TaskCategory.OBJECT_DETECTION,
+    TaskCategory.SEMANTIC_SEGMENTATION,
+    TaskCategory.KEYPOINT_DETECTION,
+    TaskCategory.TEXT_CLASSIFICATION,
+    TaskCategory.TABULAR_CLASSIFICATION,
+}
+
+
+def test_common_validator_frame_composed_for_every_category():
+    """map_validators wraps every category's factory output in the common
+    frame: 0-record guard first, table-name + duplicate last, and label-diversity
+    second-to-last for classification families only — declared once, not per
+    factory."""
+    opts = {"extension": ".jpg", "target_size": [64, 64], "number_of_keypoints": 5}
+    for cat in ALL_CATEGORIES:
+        types = _types(map_validators(cat, opts))
+        assert types[0] is IngestableRecordsValidator, cat
+        assert types[-2:] == [TableNameValidator, DuplicateValidator], cat
+        if cat in _CLASSIFICATION:
+            assert types[-3] is LabelDiversityValidator, cat
+        else:
+            assert LabelDiversityValidator not in types, cat

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -32,6 +32,8 @@ _SPECS = (
         data_format=DataFormat.IMAGE,
         build_validators=v.image_classification,
         transfer=t.image_classification,
+        file_subdir="images",
+        is_classification=True,
     ),
     ModalitySpec(
         TaskCategory.OBJECT_DETECTION,
@@ -41,6 +43,8 @@ _SPECS = (
         data_format=DataFormat.IMAGE,
         build_validators=v.object_detection,
         transfer=t.object_detection,
+        file_subdir="images",
+        is_classification=True,
     ),
     ModalitySpec(
         TaskCategory.KEYPOINT_DETECTION,
@@ -50,6 +54,8 @@ _SPECS = (
         data_format=DataFormat.IMAGE,
         build_validators=v.keypoint_detection,
         transfer=t.keypoint_detection,
+        file_subdir="images",
+        is_classification=True,
     ),
     ModalitySpec(
         TaskCategory.SEMANTIC_SEGMENTATION,
@@ -59,6 +65,8 @@ _SPECS = (
         data_format=DataFormat.IMAGE,
         build_validators=v.semantic_segmentation,
         transfer=t.semantic_segmentation,
+        file_subdir="images",
+        is_classification=True,
     ),
     ModalitySpec(
         TaskCategory.TEXT_CLASSIFICATION,
@@ -69,6 +77,8 @@ _SPECS = (
         build_validators=v.text_classification,
         transfer=t.text_classification,
         is_nlp=True,
+        file_subdir="texts",
+        is_classification=True,
     ),
     ModalitySpec(
         TaskCategory.TOKEN_CLASSIFICATION,
@@ -79,6 +89,7 @@ _SPECS = (
         build_validators=v.token_classification,
         transfer=t.token_classification,
         is_nlp=True,
+        file_subdir="texts",
     ),
     # masked_language_modeling is file-bearing AND self-supervised (no label).
     ModalitySpec(
@@ -90,6 +101,7 @@ _SPECS = (
         build_validators=v.masked_language_modeling,
         transfer=t.masked_language_modeling,
         is_nlp=True,
+        file_subdir="sequences",
     ),
     # Tabular family (structured feature tables; no sidecar files -> no transfer).
     ModalitySpec(
@@ -99,6 +111,7 @@ _SPECS = (
         is_self_supervised=False,
         data_format=DataFormat.TABULAR,
         build_validators=v.tabular_classification,
+        is_classification=True,
     ),
     ModalitySpec(
         TaskCategory.TABULAR_REGRESSION,

--- a/tracebloc_ingestor/modalities/spec.py
+++ b/tracebloc_ingestor/modalities/spec.py
@@ -77,3 +77,16 @@ class ModalitySpec:
         Callable[[Dict[str, Any], Dict[str, Any], Any], Optional[Dict[str, Any]]]
     ] = None
     is_nlp: bool = False
+    # Subdirectory under SRC_PATH holding this category's per-row files
+    # (``images`` / ``texts`` / ``sequences``), or ``None`` for non-file-bearing
+    # (tabular / time-series) categories. Used by the centralized 0-record guard
+    # in ``map_validators``: with a subdir it also cross-checks the CSV's
+    # referenced files exist; with ``None`` only the header-only / empty-CSV row
+    # check runs.
+    file_subdir: Optional[str] = None
+    # Classification-family category whose dataset needs >= 2 distinct label
+    # values (image / object / semantic / keypoint / tabular / text
+    # classification). Gates the centralized LabelDiversityValidator. False for
+    # regression / self-supervised / token-classification (per-token BIO) and
+    # the time families.
+    is_classification: bool = False

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -1,10 +1,20 @@
 """Per-category validator factories (structural refactor — backend#796, P3b).
 
-One factory per task category, each ``(options) -> [validators]``. These are
-the bodies of the old ``utils.validators_mapping.map_validators`` if/elif arms,
-moved verbatim so the validator sets are byte-for-byte identical — now attached
-to each ModalitySpec (``build_validators``) instead of dispatched by a ladder.
-``map_validators`` is now a thin lookup over the registry.
+One factory per task category, each ``(options) -> [validators]``, attached to a
+``ModalitySpec`` (``build_validators``).
+
+Each factory returns ONLY the validators **specific to that category**. The
+universally-applicable validators are composed once in
+``utils.validators_mapping.map_validators`` around the factory's output, driven
+by declarative ``ModalitySpec`` traits, so they are not repeated per category:
+
+    [IngestableRecordsValidator]            # 0-record guard — every category
+      + <factory(options)>                  # category-specific (this file)
+      + [LabelDiversityValidator]           # iff spec.is_classification
+      + [TableNameValidator, DuplicateValidator]   # every category
+
+So a factory here never lists the 0-record guard, label-diversity, table-name,
+or duplicate validators — adding one would double it.
 """
 
 from __future__ import annotations
@@ -15,17 +25,14 @@ from ..utils.constants import FileExtension
 from ..validators.base import BaseValidator
 from ..validators.bio_label_validator import BIOLabelValidator
 from ..validators.data_validator import DataValidator
-from ..validators.duplicate_validator import DuplicateValidator
 from ..validators.file_pairing_validator import FilePairingValidator
 from ..validators.file_validator import FileTypeValidator
 from ..validators.image_validator import ImageResolutionValidator
-from ..validators.ingestable_records_validator import IngestableRecordsValidator
 from ..validators.keypoint_annotation_validator import KeypointAnnotationValidator
 from ..validators.keypoint_visibility_validator import KeypointVisibilityValidator
 from ..validators.label_column_validator import LabelColumnValidator
 from ..validators.label_diversity_validator import LabelDiversityValidator
 from ..validators.numeric_columns_validator import NumericColumnsValidator
-from ..validators.table_name_validator import TableNameValidator
 from ..validators.text_content_validator import TextContentValidator
 from ..validators.time_before_today_validator import TimeBeforeTodayValidator
 from ..validators.time_format_validator import TimeFormatValidator
@@ -34,10 +41,10 @@ from ..validators.time_to_event_validator import TimeToEventValidator
 from ..validators.xml_validator import PascalVOCXMLValidator
 
 
-def _label_diversity_validator(options: Dict[str, Any]) -> LabelDiversityValidator:
+def label_diversity_validator(options: Dict[str, Any]) -> LabelDiversityValidator:
     """Construct a LabelDiversityValidator using the user-configured label
-    column name (or the framework default ``label``). Centralised so every
-    classification-family factory wires the same instance shape.
+    column name (or the framework default ``label``). Composed centrally by
+    ``map_validators`` for every ``is_classification`` category.
 
     Issue #251: a classification dataset with one distinct label value is
     unlearnable and the backend rejects it at ``/global_meta/prepare/`` with
@@ -59,24 +66,21 @@ def _label_diversity_validator(options: Dict[str, Any]) -> LabelDiversityValidat
     )
 
 
-def _zero_record_validator(
-    options: Dict[str, Any], subdir: str = "images"
-) -> IngestableRecordsValidator:
-    """0-record fail-fast guard for file-bearing vision categories — the #303
-    pattern extended from NLP to vision. Rejects a header-only / empty CSV (and
-    a manifest whose every referenced file is missing) BEFORE the table is
-    created, so a zero-record vision dataset fails early with a clear message
-    instead of an orphan empty table + a late, misleading registration error.
-    ``subdir`` mirrors the category's image ``FileTypeValidator(path=...)``."""
-    return IngestableRecordsValidator(
-        file_subdir=subdir, extension=options.get("extension", FileExtension.JPG)
+def _text_content_validator(
+    options: Dict[str, Any], subdir: str
+) -> TextContentValidator:
+    """NLP text-content check: reject binary / non-UTF-8 files, warn on empty
+    docs. ``subdir`` is the per-category text directory (``texts`` / ``sequences``).
+    The 0-record guard that used to be paired with this is now applied centrally
+    in ``map_validators`` (via ``spec.file_subdir``)."""
+    return TextContentValidator(
+        texts_path=subdir, extension=options.get("extension", FileExtension.TXT)
     )
 
 
 def image_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
-        _zero_record_validator(options),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
         # Fail fast when the configured label column is absent from the CSV
         # (else every record cleans to label=None and the backend rejects each
@@ -85,9 +89,6 @@ def image_classification(options: Dict[str, Any]) -> List[BaseValidator]:
         # detection / segmentation / keypoint source labels from XML / masks /
         # annotation files, so they do NOT get this validator.
         LabelColumnValidator(label_column=options.get("label_column") or "label"),
-        _label_diversity_validator(options),
-        TableNameValidator(),
-        DuplicateValidator(),
     ]
 
 
@@ -95,7 +96,6 @@ def object_detection(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
         FileTypeValidator(allowed_extension=".xml", path="annotations"),
-        _zero_record_validator(options),
         PascalVOCXMLValidator(),
         FilePairingValidator(
             image_path="images",
@@ -103,152 +103,13 @@ def object_detection(options: Dict[str, Any]) -> List[BaseValidator]:
             sidecar_label="annotation",
         ),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
-        _label_diversity_validator(options),
-        TableNameValidator(),
-        DuplicateValidator(),
     ]
-
-
-def tabular_classification(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    # Add data validator if schema is provided
-    if options.get("schema"):
-        validators.append(DataValidator(schema=options["schema"]))
-    validators.append(_label_diversity_validator(options))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
-    return validators
-
-
-def _nlp_content_validators(
-    options: Dict[str, Any], subdir: str
-) -> List[BaseValidator]:
-    """The NLP content-hygiene pair, gated on the text categories (text/token
-    classification, MLM): reject a manifest that would ingest zero records
-    (header-only CSV, or every referenced file missing), and reject text files
-    whose CONTENT is binary / non-UTF-8 (warn on empty docs). ``subdir`` is the
-    per-category text directory under ``SRC_PATH`` (``"texts"`` / ``"sequences"``),
-    matching the category's ``FileTypeValidator(path=...)``."""
-    extension = options.get("extension", FileExtension.TXT)
-    return [
-        IngestableRecordsValidator(file_subdir=subdir, extension=extension),
-        TextContentValidator(texts_path=subdir, extension=extension),
-    ]
-
-
-def text_classification(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    # Add text file validator
-    validators.append(
-        FileTypeValidator(
-            allowed_extension=options.get("extension", FileExtension.TXT),
-            path="texts",
-        ),
-    )
-    # Reject a zero-record manifest and binary/empty text content up front.
-    validators.extend(_nlp_content_validators(options, "texts"))
-    # Fail fast when the configured label column is absent from the CSV header
-    # (otherwise every record cleans to label=None and the backend rejects each
-    # row with HTTP 400 "label: may not be null" — a late, confusing failure).
-    # Token classification already covers this via BIOLabelValidator, which
-    # resolves and rejects a missing label column itself.
-    validators.append(
-        LabelColumnValidator(label_column=options.get("label_column") or "label")
-    )
-    # Add data validator if schema is provided
-    if options.get("schema"):
-        validators.append(DataValidator(schema=options["schema"]))
-    validators.append(_label_diversity_validator(options))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
-    return validators
-
-
-def token_classification(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    # Validate text file extensions (one .txt of whitespace-tokenized words
-    # per sample, same layout as text classification).
-    validators.append(
-        FileTypeValidator(
-            allowed_extension=options.get("extension", FileExtension.TXT),
-            path="texts",
-        ),
-    )
-    # Reject a zero-record manifest and binary/empty text content up front.
-    validators.extend(_nlp_content_validators(options, "texts"))
-    # Validate BIO labels: one tag per word, valid BIO/IOB2 format. Honor a
-    # custom label column name when one is configured in the YAML.
-    validators.append(
-        BIOLabelValidator(
-            texts_path="texts",
-            extension=options.get("extension", FileExtension.TXT),
-            label_column=options.get("label_column") or "label",
-        )
-    )
-    # Add data validator if schema is provided
-    if options.get("schema"):
-        validators.append(DataValidator(schema=options["schema"]))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
-    return validators
-
-
-def time_series_forecasting(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    schema = options.get("schema", {})
-    validators.append(TimeFormatValidator(schema=schema))
-    validators.append(TimeOrderedValidator())
-    validators.append(TimeBeforeTodayValidator())
-    validators.append(NumericColumnsValidator(schema=schema))
-    if options.get("schema"):
-        schema_without_timestamp = {
-            k: v for k, v in options["schema"].items() if k.lower() != "timestamp"
-        }
-        if schema_without_timestamp:
-            validators.append(DataValidator(schema=schema_without_timestamp))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
-    return validators
-
-
-def tabular_regression(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    # Add data validator if schema is provided
-    if options.get("schema"):
-        validators.append(DataValidator(schema=options["schema"]))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
-    return validators
-
-
-def time_to_event_prediction(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    # Add time to event validator with schema to identify time column
-    if options.get("schema"):
-        validators.append(
-            TimeToEventValidator(
-                schema=options["schema"],
-                time_column=options.get("time_column"),
-            )
-        )
-    else:
-        # If no schema, use default time column name
-        validators.append(
-            TimeToEventValidator(time_column=options.get("time_column", "time"))
-        )
-    # Add data validator if schema is provided
-    if options.get("schema"):
-        validators.append(DataValidator(schema=options["schema"]))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
-    return validators
 
 
 def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
         FileTypeValidator(allowed_extension=FileExtension.PNG, path="masks"),
-        _zero_record_validator(options),
         FilePairingValidator(
             image_path="images",
             sidecar_path="masks",
@@ -269,9 +130,6 @@ def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
             name="Mask Resolution Validator",
             subdir="masks",
         ),
-        _label_diversity_validator(options),
-        TableNameValidator(),
-        DuplicateValidator(),
     ]
 
 
@@ -283,7 +141,6 @@ def keypoint_detection(options: Dict[str, Any]) -> List[BaseValidator]:
     # rejects datasets whose annotations drift from the declared K.
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
-        _zero_record_validator(options),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
         KeypointAnnotationValidator(
             num_keypoints=options.get("number_of_keypoints"),
@@ -292,26 +149,109 @@ def keypoint_detection(options: Dict[str, Any]) -> List[BaseValidator]:
             expected_resolution=options.get("target_size"),
         ),
         KeypointVisibilityValidator(),
-        _label_diversity_validator(options),
-        TableNameValidator(),
-        DuplicateValidator(),
     ]
 
 
+def text_classification(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = [
+        FileTypeValidator(
+            allowed_extension=options.get("extension", FileExtension.TXT),
+            path="texts",
+        ),
+        _text_content_validator(options, "texts"),
+        # Fail fast when the configured label column is absent from the CSV
+        # header (otherwise every record cleans to label=None and the backend
+        # rejects each row with HTTP 400 "label: may not be null"). Token
+        # classification covers this via BIOLabelValidator instead.
+        LabelColumnValidator(label_column=options.get("label_column") or "label"),
+    ]
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
+def token_classification(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = [
+        # One .txt of whitespace-tokenized words per sample (same layout as
+        # text classification).
+        FileTypeValidator(
+            allowed_extension=options.get("extension", FileExtension.TXT),
+            path="texts",
+        ),
+        _text_content_validator(options, "texts"),
+        # Validate BIO labels: one tag per word, valid BIO/IOB2 format; also
+        # rejects a missing label column. Honor a custom label column name.
+        BIOLabelValidator(
+            texts_path="texts",
+            extension=options.get("extension", FileExtension.TXT),
+            label_column=options.get("label_column") or "label",
+        ),
+    ]
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
 def masked_language_modeling(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    # Validate text file extensions
-    validators.append(
+    validators: List[BaseValidator] = [
         FileTypeValidator(
             allowed_extension=options.get("extension", FileExtension.TXT),
             path="sequences",
         ),
-    )
-    # Reject a zero-record manifest and binary/empty text content up front.
-    validators.extend(_nlp_content_validators(options, "sequences"))
-    # Add data validator if schema is provided
+        _text_content_validator(options, "sequences"),
+    ]
     if options.get("schema"):
         validators.append(DataValidator(schema=options["schema"]))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
+    return validators
+
+
+def tabular_classification(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
+def tabular_regression(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
+def time_series_forecasting(options: Dict[str, Any]) -> List[BaseValidator]:
+    schema = options.get("schema", {})
+    validators: List[BaseValidator] = [
+        TimeFormatValidator(schema=schema),
+        TimeOrderedValidator(),
+        TimeBeforeTodayValidator(),
+        NumericColumnsValidator(schema=schema),
+    ]
+    if options.get("schema"):
+        schema_without_timestamp = {
+            k: v for k, v in options["schema"].items() if k.lower() != "timestamp"
+        }
+        if schema_without_timestamp:
+            validators.append(DataValidator(schema=schema_without_timestamp))
+    return validators
+
+
+def time_to_event_prediction(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    # Time-to-event validator identifies + checks the (non-negative, numeric)
+    # time column. With a schema it can resolve the column from it; otherwise it
+    # falls back to the default/declared name.
+    if options.get("schema"):
+        validators.append(
+            TimeToEventValidator(
+                schema=options["schema"],
+                time_column=options.get("time_column"),
+            )
+        )
+    else:
+        validators.append(
+            TimeToEventValidator(time_column=options.get("time_column", "time"))
+        )
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
     return validators

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -24,7 +24,12 @@ from typing import Any, Dict, List, Optional
 
 from ..config import Config
 from ..modalities.registry import REGISTRY
+from ..modalities.validators import label_diversity_validator
+from ..utils.constants import FileExtension
 from ..validators.base import BaseValidator
+from ..validators.duplicate_validator import DuplicateValidator
+from ..validators.ingestable_records_validator import IngestableRecordsValidator
+from ..validators.table_name_validator import TableNameValidator
 
 
 def map_validators(
@@ -35,7 +40,28 @@ def map_validators(
     spec = REGISTRY.get(task_category)
     if spec is None:
         return []
-    validators = spec.build_validators(options)
+
+    # Compose the chain from a common frame + the category-specific middle, so
+    # the universally-applicable validators live ONCE here instead of being
+    # repeated in every per-category factory:
+    #   [0-record guard] + <category-specific> + [label-diversity?] + [tail]
+    validators: List[BaseValidator] = [
+        # Every CSV manifest must yield >= 1 ingestable record. ``file_subdir``
+        # (from the spec) adds the "all referenced files missing" check for
+        # file-bearing categories; ``None`` (tabular / time) runs the header-only
+        # / empty-CSV row check alone.
+        IngestableRecordsValidator(
+            file_subdir=spec.file_subdir,
+            extension=options.get("extension", FileExtension.TXT),
+        )
+    ]
+    validators += spec.build_validators(options)
+    # Classification-family datasets need >= 2 distinct labels.
+    if spec.is_classification:
+        validators.append(label_diversity_validator(options))
+    # Universal tail: a unique table name + de-duplicated record IDs.
+    validators += [TableNameValidator(), DuplicateValidator()]
+
     # Inject the run's Config into every validator (P4b). Optional so direct
     # callers / tests that omit it keep the prior behavior: the path-reading
     # validators fall back to their module-global ``config`` at the read site.


### PR DESCRIPTION
## Summary

The 0-record guard, `TableNameValidator`, `DuplicateValidator`, and `LabelDiversityValidator` were **copy-pasted across the per-category factories** — `TableName`+`Duplicate` in **all 11**, the 0-record guard wired **three different ways** (NLP `_nlp_content_validators`, vision `_zero_record_validator`, inline for tabular), label-diversity in each of the 6 classification factories. That repetition is exactly what let the **tabular 0-record gap** happen — a factory just forgot to add it.

This centralizes the universally-applicable validators in `map_validators`, driven by declarative `ModalitySpec` traits, so each factory returns **only its category-specific validators**.

## Composition (one place)
```
[IngestableRecordsValidator(file_subdir=spec.file_subdir)]   # every category
  + spec.build_validators(options)                           # category-specific
  + [LabelDiversityValidator] if spec.is_classification
  + [TableNameValidator, DuplicateValidator]                 # every category
```

## Changes
- New `ModalitySpec` traits: **`file_subdir`** (`images`/`texts`/`sequences`/`None`) and **`is_classification`**.
- `map_validators` builds the common frame around the factory output.
- Factories drop the repeated lines; deleted `_zero_record_validator`; `_nlp_content_validators` → `_text_content_validator` (text-content only); `label_diversity_validator` made public.

## Behavior
**Set-preserving** — the resulting validator *set* per category is unchanged, **except** `tabular_classification` / `tabular_regression` / `time_series_forecasting` / `time_to_event_prediction` now correctly carry the 0-record guard. This **closes the tabular gap centrally and supersedes #316.** Only order changes: the 0-record guard now leads (fail-fast); pass/fail is order-independent.

## Tests
Updated the order-sensitive mapping assertions; added `test_common_validator_frame_composed_for_every_category` that locks the frame (guard first, table/duplicate last, label-diversity for classification only). Full suite: **1226 passed, 1 xfailed**, coverage 96.6% (gate 95%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the preflight validator chain for all 11 task categories and intentionally adds 0-record checks to tabular/time paths; regression risk is mitigated by broad mapping tests but empty-manifest failures will surface earlier for those categories.
> 
> **Overview**
> **Shared preflight validators** (`IngestableRecordsValidator`, optional `LabelDiversityValidator`, `TableNameValidator`, `DuplicateValidator`) are no longer duplicated in each per-category factory. `map_validators` now wraps every `ModalitySpec.build_validators` output in a single frame, driven by new spec fields **`file_subdir`** and **`is_classification`** on `ModalitySpec` / `registry.py`.
> 
> Per-category factories in `modalities/validators.py` return **only category-specific** checks; `_zero_record_validator` is removed and NLP wiring is split so **`_text_content_validator`** handles UTF-8 content while the 0-record guard is built centrally from `spec.file_subdir`.
> 
> **Behavior:** Validator *sets* stay the same for most categories, but **tabular / time-series families now get the 0-record guard** (header-only / empty CSV), closing the gap called out in #316. **Order** changes so the guard runs first for fail-fast; pass/fail is otherwise order-independent.
> 
> Tests update expected ordering and add **`test_common_validator_frame_composed_for_every_category`** to lock guard-first, table/duplicate-last, and label-diversity only on classification categories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e20467ad5fe4c200555e4fb50184ef75b7bc8b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->