### PR TITLE
feat: add causal_language_modeling modality

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ Only metadata (schema, statistics, structure) syncs to the web app. Raw data sta
 | Type | Categories |
 |---|---|
 | **Image** | [`image_classification`](templates/image_classification), [`object_detection`](templates/object_detection), [`keypoint_detection`](templates/keypoint_detection), [`semantic_segmentation`](templates/semantic_segmentation) |
-| **Text / NLP** | [`text_classification`](templates/text_classification), [`token_classification`](templates/token_classification), [`masked_language_modeling`](templates/masked_language_modeling) |
+| **Text / NLP** | [`text_classification`](templates/text_classification), [`token_classification`](templates/token_classification), [`masked_language_modeling`](templates/masked_language_modeling), [`causal_language_modeling`](templates/causal_language_modeling) |
 | **Tabular** | [`tabular_classification`](templates/tabular_classification), [`tabular_regression`](templates/tabular_regression) |
 | **Time series** | [`time_series_forecasting`](templates/time_series_forecasting), [`time_to_event_prediction`](templates/time_to_event_prediction) |
 

--- a/e2e/test_characterization.py
+++ b/e2e/test_characterization.py
@@ -212,6 +212,17 @@ CASES = [
         sidecars=[str(T / "masked_language_modeling/data/sequences")],
         roundtrip_col=None,
     ),
+    dict(
+        id="causal_language_modeling",
+        cfg=_cfg(
+            table="char_clm",
+            category="causal_language_modeling",
+            csv=str(T / "causal_language_modeling/data/labels_file_sample.csv"),
+            texts=str(T / "causal_language_modeling/data/texts"),
+        ),
+        sidecars=[str(T / "causal_language_modeling/data/texts")],
+        roundtrip_col=None,
+    ),
     # semantic_segmentation: the one file-bearing modality the harness never
     # characterized (audit gap). mask_id is DECLARED in schema so it's stored
     # (the training client SELECTs it to locate masks — backend#816); the masks

--- a/e2e/test_ingest_e2e.py
+++ b/e2e/test_ingest_e2e.py
@@ -187,6 +187,18 @@ CASES = [
         ),
         id="masked_language_modeling",
     ),
+    # causal_language_modeling: self-supervised raw text in texts/ (plain text
+    # or prompt<TAB>completion). No tokenizer.json at ingest — alignment is the
+    # data-derived text profile (#805).
+    pytest.param(
+        _cfg(
+            table="e2e_clm",
+            category="causal_language_modeling",
+            csv=str(T / "causal_language_modeling/data/labels_file_sample.csv"),
+            texts=str(T / "causal_language_modeling/data/texts"),
+        ),
+        id="causal_language_modeling",
+    ),
     # semantic_segmentation: masks now wire through the declarative path (the P5
     # mask_id work — the transfer resolves the mask via the schema-declared
     # mask_id), so #136's xfail is removed. The full contract (masks land in

--- a/examples/yaml/causal_language_modeling.yaml
+++ b/examples/yaml/causal_language_modeling.yaml
@@ -1,0 +1,12 @@
+# Causal language modeling: CSV manifest + .txt sidecar files (one per sample).
+# Self-supervised — no label column required.
+# `texts:` holds RAW text samples: each .txt is either plain text (pretraining)
+# or a tab-separated `prompt<TAB>completion` pair (SFT). The training client
+# builds next-token targets on-the-fly; pad=eos for decoder-only models.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: dolly_clm_train
+intent: train
+category: causal_language_modeling
+csv: /data/shared/dolly-clm/labels_file.csv
+texts: /data/shared/dolly-clm/texts/

--- a/templates/causal_language_modeling/README.md
+++ b/templates/causal_language_modeling/README.md
@@ -1,0 +1,145 @@
+# Causal Language Modeling Data Ingestion Template
+
+This template demonstrates how to ingest raw text samples for causal (next-token)
+language modeling (CLM) into a database using the tracebloc_ingestor framework.
+
+CLM is **self-supervised** — there is no `label:` field. Each sample is a single
+`.txt` file holding **raw text**, in one of two shapes:
+
+- **Pretraining:** the whole file is plain text. The training client builds
+  next-token targets from it on-the-fly.
+- **SFT (instruction tuning):** the file is a single tab-separated
+  `prompt<TAB>completion` pair. The client masks the prompt's loss and trains on
+  the completion.
+
+A dataset may mix both shapes freely; a file with no tab is treated as plain
+text, a file with one tab as a prompt/completion pair.
+
+## Quickstart — declarative (recommended)
+
+Ingest with ~8 lines of YAML using the official ingestor image
+(`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage
+> your files on the cluster's shared PVC first — see the
+> [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc)
+> in the chart docs (kubectl cp pattern for small datasets, init-container sync
+> for production).
+
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a
+`texts/` subdirectory holding the per-record `.txt` files.
+
+**2. Write `ingest.yaml`** — note there is **no** `label:` field (self-supervised):
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: causal_language_modeling
+table: dolly_clm_train
+intent: train
+csv: /data/shared/dolly-clm/labels_file.csv
+texts: /data/shared/dolly-clm/texts/
+```
+
+**3. Install:**
+
+```bash
+helm install my-clm-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+> **If install fails with `'causal_language_modeling' is not one of [...]`:** your
+> local Helm chart cache is stale. Refresh it and retry: `helm repo update`.
+
+Canonical example: [`examples/yaml/causal_language_modeling.yaml`](../../examples/yaml/causal_language_modeling.yaml).
+Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
+
+## Directory Structure
+
+```
+causal_language_modeling/
+├── causal_language_modeling.py   # Main ingestion script
+├── README.md                     # This file
+└── data/
+    ├── texts/                    # Text files (.txt), one per sample
+    │   ├── clm_0000001.txt       #   plain text (pretraining)
+    │   ├── clm_0000002.txt       #   plain text (pretraining)
+    │   ├── clm_0000003.txt       #   plain text (pretraining)
+    │   ├── clm_0000004.txt       #   prompt<TAB>completion (SFT)
+    │   └── clm_0000005.txt       #   prompt<TAB>completion (SFT)
+    └── labels_file_sample.csv    # CSV manifest mapping filenames to extensions
+```
+
+> The `texts/` subdir is the raw-text convention shared with text/token
+> classification. (Masked language modeling instead uses `sequences/`, which the
+> framework reserves for *pre-tokenized* data.)
+
+## Data Format
+
+### Text Files
+- Supported extension: `.txt`
+- One sample per file, placed in `data/texts/`
+- Either plain UTF-8 text, or a single `prompt<TAB>completion` line
+- Files must be decodable UTF-8 (validated at ingest by `TextContentValidator`);
+  binary / non-UTF-8 files are rejected, empty files are warned about.
+
+### CSV Labels File
+CLM is **self-supervised** — no label column is needed. The CSV contains:
+- `filename`: Base name of the text file, without extension (e.g. `clm_0000001`)
+- `extension`: File extension as a quoted string (e.g. `'.txt'`)
+
+## Tokenizer Alignment
+
+CLM does **not** ship a tokenizer at ingest. Instead, the ingestor computes a
+data-derived **text profile** (Unicode-script mix + document-length
+distribution — no raw text, no vocabulary, no hash; the FL guardrail) and ships
+it on the global-metadata channel (#805). The backend uses it for a warn-only
+contributor-tokenizer-fit check at dataset linking — the same alignment path as
+the other NLP modalities (text/token classification, MLM).
+
+Decoder-only models tie `pad` to `eos`, so — unlike masked language modeling —
+**no `[MASK]` token is required**; the tokenizer-fit check looks at vocabulary
+coverage and the pad token only. That check runs on the training-client side.
+
+## Usage
+
+1. Place your `.txt` sample files in `data/texts/`
+2. Update `labels_file_sample.csv` with one row per text file
+3. Configure environment variables (see below)
+4. Run the ingestion script:
+
+```bash
+python causal_language_modeling.py
+```
+
+## Configuration
+
+The script uses the following configuration:
+- **Extension**: TXT - Expected text file extension
+- **Chunk Size**: 100 - Batch size for CSV reading
+- **Encoding**: utf-8
+- **Category**: CAUSAL_LANGUAGE_MODELING
+- **Data Format**: TEXT
+- **Intent**: TRAIN (change to `Intent.TEST` for evaluation data)
+- **Label column**: None (self-supervised)
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TABLE_NAME` | Target database table | Required |
+| `LABEL_FILE` | Path to CSV manifest | Required |
+| `SRC_PATH` | Path to the parent of the `texts/` directory | Required |
+| `BATCH_SIZE` | Ingestion batch size | 4000 |
+| `BACKEND_TOKEN` | Auth token for API | Required |
+| `CLIENT_ENV` | Environment (local/dev/stg/prod) | prod |
+
+## Notes
+
+- The `filename` column does **not** include the extension — that's supplied
+  separately via the `extension` column.
+- No `label` column is needed because CLM training is self-supervised (the
+  next-token targets are derived from the text by the training client).
+- For SFT samples, put exactly one tab between prompt and completion; everything
+  before the first tab is the prompt, everything after is the completion.

--- a/templates/causal_language_modeling/causal_language_modeling.py
+++ b/templates/causal_language_modeling/causal_language_modeling.py
@@ -1,0 +1,86 @@
+"""Causal Language Modeling Data Ingestion Example.
+
+This example demonstrates how to ingest text samples for causal (next-token)
+language modeling (CLM) into a database and optionally send metadata to the
+tracebloc API.
+
+CLM is self-supervised — no label column is needed.  Each row in the CSV maps
+to a ``.txt`` file under ``texts/`` holding RAW text:
+
+- **Pretraining:** the whole file is plain text. The training client builds
+  next-token targets from it on-the-fly.
+- **SFT:** the file is a single tab-separated ``prompt\\tcompletion`` pair; the
+  client masks the prompt's loss and trains on the completion.
+
+Decoder-only models tie ``pad`` to ``eos`` — there is no ``[MASK]`` token, so
+(unlike masked language modeling) no mask token is required. The contributor's
+tokenizer alignment is checked centrally at dataset linking via the
+data-derived text profile (#805); nothing tokenizer-specific is needed here.
+"""
+
+import logging
+import os
+from typing import Dict, Any
+
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
+from tracebloc_ingestor.utils.logging import setup_logging
+from tracebloc_ingestor.utils.constants import (
+    TaskCategory,
+    Intent,
+    DataFormat,
+    FileExtension,
+)
+
+# Initialize config and configure logging
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+
+# Text file options
+text_options = {"extension": FileExtension.TXT}
+
+# CSV specific options
+csv_options = {
+    "chunk_size": 100,
+    "delimiter": ",",
+    "quotechar": '"',
+    "escapechar": "\\",
+    "on_bad_lines": "warn",
+    "encoding": "utf-8",
+}
+
+
+def main():
+    """Run the causal language modeling ingestion example."""
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
+
+    # Create ingestor for CLM data
+    # No label_column — CLM is self-supervised
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.TEXT,
+        category=TaskCategory.CAUSAL_LANGUAGE_MODELING,
+        csv_options=csv_options,
+        file_options=text_options,
+        intent=Intent.TRAIN,
+    )
+
+    # Ingest data with validation
+    logger.info("Starting causal language modeling ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/causal_language_modeling/data/labels_file_sample.csv
+++ b/templates/causal_language_modeling/data/labels_file_sample.csv
@@ -1,0 +1,6 @@
+filename,extension
+clm_0000001,'.txt'
+clm_0000002,'.txt'
+clm_0000003,'.txt'
+clm_0000004,'.txt'
+clm_0000005,'.txt'

--- a/templates/causal_language_modeling/data/texts/clm_0000001.txt
+++ b/templates/causal_language_modeling/data/texts/clm_0000001.txt
@@ -1,0 +1,1 @@
+Federated learning lets multiple data holders train a shared model without moving their raw data off-premise.

--- a/templates/causal_language_modeling/data/texts/clm_0000002.txt
+++ b/templates/causal_language_modeling/data/texts/clm_0000002.txt
@@ -1,0 +1,1 @@
+The mitochondria is the powerhouse of the cell, generating most of the chemical energy needed to power biochemical reactions.

--- a/templates/causal_language_modeling/data/texts/clm_0000003.txt
+++ b/templates/causal_language_modeling/data/texts/clm_0000003.txt
@@ -1,0 +1,1 @@
+In 1969, the Apollo 11 mission landed the first humans on the Moon, marking a turning point in space exploration.

--- a/templates/causal_language_modeling/data/texts/clm_0000004.txt
+++ b/templates/causal_language_modeling/data/texts/clm_0000004.txt
@@ -1,0 +1,1 @@
+Summarize: tracebloc trains models on data that never leaves the contributor cluster.	Only the model travels; the data stays on-premise.

--- a/templates/causal_language_modeling/data/texts/clm_0000005.txt
+++ b/templates/causal_language_modeling/data/texts/clm_0000005.txt
@@ -1,0 +1,1 @@
+Translate to French: Good morning.	Bonjour.

--- a/tests/test_causal_language_modeling.py
+++ b/tests/test_causal_language_modeling.py
@@ -1,0 +1,254 @@
+"""Causal language modeling (CLM) — modality wiring, mirroring the MLM /
+token_classification coverage.
+
+CLM is the self-supervised, raw-text decoder modality added alongside MLM. It
+shares MLM's self-supervised semantics (only a ``filename`` column, no label)
+but stages from ``texts/`` (raw text — plain text or a ``prompt\\tcompletion``
+SFT pair), not the pre-tokenized ``sequences/`` MLM uses. These tests pin the
+three behaviors the modality must get right:
+
+1. **CLI run** — a CLM ``ingest.yaml`` routes through ``cli.run.main`` to a
+   CSVIngestor with the resolved kwargs; a CLM config that (wrongly) sets
+   ``label:`` is rejected at the entrypoint (self-supervised, #213).
+2. **Validation boundaries** — header-only / all-files-missing manifests
+   fail fast before table creation; binary content is rejected; a clean
+   pretraining+SFT dataset validates.
+3. **Failure accounting** — a rejected batch POST surfaces every record as a
+   failure so the run exits non-zero.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Generator
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples" / "yaml"
+
+
+# ---------------------------------------------------------------------------
+# Local test doubles (mirror tests/test_ingestor_base.py so this file is
+# self-contained).
+# ---------------------------------------------------------------------------
+
+
+class FakeIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source: Any) -> Generator[Dict[str, Any], None, None]:
+        yield from self._records
+
+
+def make_ingestor(records=None, **overrides):
+    db = MagicMock(name="Database")
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = ([1, 2], [])
+    db.get_table_schema.return_value = {"a": "INT"}
+    api = MagicMock(name="APIClient")
+    api.send_batch.return_value = True
+    api.send_generate_edge_label_meta.return_value = True
+    api.send_global_meta_meta.return_value = True
+    api.prepare_dataset.return_value = True
+    api.create_dataset.return_value = {"id": 1}
+
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=TaskCategory.CAUSAL_LANGUAGE_MODELING,
+        label_column=None,
+    )
+    kwargs.update(overrides)
+    return FakeIngestor(records or [], **kwargs)
+
+
+def _clm_ingestor_on(tmp_path, clean_env, records):
+    """A CLM FakeIngestor wired to a real Config rooted at ``tmp_path/src`` with
+    a ``texts/`` subdir, so the path-reading validators run against a real FS."""
+    src = tmp_path / "src"
+    (src / "texts").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    clean_env.setenv("TABLE_NAME", "clm_train")
+    clean_env.setenv("DEST_PATH", str(tmp_path / "dest" / "clm_train"))
+    # Self-supervised CLM carries no feature schema (the manifest is just
+    # filename/extension), so no DataValidator — match that real shape.
+    ing = make_ingestor(records=records, schema={})
+    ing.database.config = Config()
+    return ing, src / "texts"
+
+
+# ---------------------------------------------------------------------------
+# 1. CLI run
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_runtime():
+    with patch("tracebloc_ingestor.cli.run.Config") as cfg_cls, patch(
+        "tracebloc_ingestor.cli.run.Database"
+    ) as db_cls, patch("tracebloc_ingestor.cli.run.APIClient") as api_cls, patch(
+        "tracebloc_ingestor.cli.run.CSVIngestor"
+    ) as csv_cls, patch(
+        "tracebloc_ingestor.cli.run.JSONIngestor"
+    ) as json_cls, patch(
+        "tracebloc_ingestor.cli.run.setup_logging"
+    ):
+        cfg = MagicMock()
+        cfg.BATCH_SIZE = 4000
+        cfg_cls.return_value = cfg
+        for cls_mock in (csv_cls, json_cls):
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.ingest = MagicMock(return_value=[])
+            cls_mock.return_value = inst
+        yield {"Config": cfg_cls, "Database": db_cls, "APIClient": api_cls,
+               "CSVIngestor": csv_cls, "JSONIngestor": json_cls}
+
+
+def test_cli_run_routes_clm_yaml_to_csv_ingestor(clean_env, mock_runtime, monkeypatch):
+    """The shipped CLM example yaml runs end-to-end-but-mocked: a CSVIngestor is
+    built with the resolved CLM kwargs (TEXT, self-supervised, no label) and
+    ingest() is called once; exit 0."""
+    monkeypatch.setenv(
+        "INGEST_CONFIG", str(EXAMPLES_DIR / "causal_language_modeling.yaml")
+    )
+    from tracebloc_ingestor.cli.run import main
+
+    rc = main()
+
+    assert rc == 0
+    assert mock_runtime["CSVIngestor"].call_count == 1
+    assert mock_runtime["JSONIngestor"].call_count == 0
+    _, kwargs = mock_runtime["CSVIngestor"].call_args
+    assert kwargs["category"] == TaskCategory.CAUSAL_LANGUAGE_MODELING
+    assert kwargs["data_format"] == "text"
+    assert kwargs["label_column"] == ""  # self-supervised
+    assert kwargs["file_options"]["extension"] == ".txt"
+    mock_runtime["CSVIngestor"].return_value.ingest.assert_called_once()
+
+
+def test_cli_run_rejects_clm_with_label(clean_env, mock_runtime, monkeypatch, tmp_path):
+    """Self-supervised: a CLM config that sets `label:` must be rejected at the
+    entrypoint (exit 2) before any DB/network call (#213)."""
+    bad = tmp_path / "clm_with_label.yaml"
+    bad.write_text(
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: causal_language_modeling\n"
+        "table: clm_test\n"
+        "intent: test\n"
+        "csv: /tmp/ignored.csv\n"
+        "texts: /tmp/ignored/\n"
+        "label: label\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(bad))
+    from tracebloc_ingestor.cli.run import main
+
+    rc = main()
+
+    assert rc == 2
+    mock_runtime["Database"].assert_not_called()
+    mock_runtime["APIClient"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. Validation boundaries (real filesystem)
+# ---------------------------------------------------------------------------
+
+
+def test_clm_header_only_csv_fails_before_table_creation(clean_env, tmp_path):
+    """A header-only CLM manifest is rejected during validation, before the
+    destination table is created — no orphan empty table."""
+    ing, _ = _clm_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame(columns=["filename"]).to_csv(csv, index=False)
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No data rows found"):
+            ing.ingest(str(csv), batch_size=10)
+    ing.database.create_table.assert_not_called()
+
+
+def test_clm_all_files_missing_fails_before_table_creation(clean_env, tmp_path):
+    """A populated manifest whose every referenced .txt is missing is rejected
+    before table creation."""
+    ing, _ = _clm_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["doc1", "doc2"]}).to_csv(csv, index=False)
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No referenced data files"):
+            ing.ingest(str(csv), batch_size=10)
+    ing.database.create_table.assert_not_called()
+
+
+def test_clm_clean_dataset_validates(clean_env, tmp_path):
+    """A clean dataset — plain text (pretraining) plus a prompt<TAB>completion
+    SFT line — passes validation. The tab is ordinary UTF-8 text."""
+    ing, texts = _clm_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "pre1.txt").write_text("plain pretraining text\n", encoding="utf-8")
+    (texts / "sft1.txt").write_text("Translate: Hi\tBonjour\n", encoding="utf-8")
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["pre1", "sft1"]}).to_csv(csv, index=False)
+
+    assert ing.validate_data(str(csv)) is True
+
+
+def test_clm_binary_content_rejected(clean_env, tmp_path):
+    """A .txt whose bytes are binary (a NUL byte) is rejected by the shared
+    TextContentValidator — the same content hygiene the other NLP modalities
+    get, here pointed at texts/."""
+    ing, texts = _clm_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "ok.txt").write_text("fine text\n", encoding="utf-8")
+    (texts / "bad.txt").write_bytes(b"\x00\x01\x02binary")
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["ok", "bad"]}).to_csv(csv, index=False)
+
+    with pytest.raises(ValueError, match="NUL byte"):
+        ing.validate_data(str(csv))
+
+
+# ---------------------------------------------------------------------------
+# 3. Failure accounting
+# ---------------------------------------------------------------------------
+
+
+def test_clm_api_send_failure_counts_every_record(clean_env):
+    """Every batch POST rejected -> every CLM record returns as a failure, so
+    the run exits non-zero (the file-transfer branch runs since CLM is
+    file-bearing)."""
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records)
+    ing.api_client.send_batch.return_value = False
+
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+
+    assert len(failed) == 2
+    assert all(f["error"] == "api_send_failed" for f in failed)

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -984,7 +984,7 @@ def test_check_src_path_only_runs_for_file_bearing_categories():
         TaskCategory.TIME_TO_EVENT_PREDICTION,
     ):
         assert cat not in _FILE_BEARING_CATEGORIES
-    # Image / text / segmentation / MLM all need a staged SRC_PATH.
+    # Image / text / segmentation / MLM / causal LM all need a staged SRC_PATH.
     for cat in (
         TaskCategory.IMAGE_CLASSIFICATION,
         TaskCategory.OBJECT_DETECTION,
@@ -992,6 +992,7 @@ def test_check_src_path_only_runs_for_file_bearing_categories():
         TaskCategory.SEMANTIC_SEGMENTATION,
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
+        TaskCategory.CAUSAL_LANGUAGE_MODELING,
     ):
         assert cat in _FILE_BEARING_CATEGORIES
 
@@ -1019,7 +1020,12 @@ _TEXT_PROFILE = {
 
 @pytest.mark.parametrize(
     "category",
-    ["MASKED_LANGUAGE_MODELING", "TEXT_CLASSIFICATION", "TOKEN_CLASSIFICATION"],
+    [
+        "MASKED_LANGUAGE_MODELING",
+        "CAUSAL_LANGUAGE_MODELING",
+        "TEXT_CLASSIFICATION",
+        "TOKEN_CLASSIFICATION",
+    ],
 )
 def test_ingest_attaches_text_profile_for_nlp(category):
     """For every NLP category, the data-derived text profile is attached to

--- a/tests/test_modality_failure_accounting.py
+++ b/tests/test_modality_failure_accounting.py
@@ -47,11 +47,12 @@ from tracebloc_ingestor.utils.constants import TaskCategory
 # helpers (mirror test_batch_send_failure_accounting.py)
 # ---------------------------------------------------------------------------
 
-# One entry per template directory — the 11 supported modalities.
+# One entry per template directory — the 12 supported modalities.
 _TEMPLATE_CATEGORIES = [
     TaskCategory.IMAGE_CLASSIFICATION,
     TaskCategory.KEYPOINT_DETECTION,
     TaskCategory.MASKED_LANGUAGE_MODELING,
+    TaskCategory.CAUSAL_LANGUAGE_MODELING,
     TaskCategory.OBJECT_DETECTION,
     TaskCategory.SEMANTIC_SEGMENTATION,
     TaskCategory.TABULAR_CLASSIFICATION,

--- a/tests/test_modality_registry.py
+++ b/tests/test_modality_registry.py
@@ -58,13 +58,14 @@ def test_derived_sets_match_spec_flags():
     assert NLP_CATEGORIES == {c for c, s in REGISTRY.items() if s.is_nlp}
 
 
-def test_nlp_categories_are_the_three_text_categories():
-    """#805: the NLP set is exactly the text categories
-    (text/token classification + MLM) — never image/tabular."""
+def test_nlp_categories_are_exactly_the_text_categories():
+    """#805: the NLP set is exactly the text categories (text/token
+    classification + masked & causal language modeling) — never image/tabular."""
     assert NLP_CATEGORIES == {
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
+        TaskCategory.CAUSAL_LANGUAGE_MODELING,
     }
 
 
@@ -77,6 +78,13 @@ def test_known_flag_values():
     # Lock the data that used to live in the three base.py frozensets.
     mlm = spec_for(TaskCategory.MASKED_LANGUAGE_MODELING)
     assert mlm.is_file_bearing and mlm.is_self_supervised and not mlm.is_tabular_family
+
+    # causal LM mirrors MLM's flags (file-bearing + self-supervised + NLP) but
+    # stages raw text from texts/, not pre-tokenized sequences/.
+    clm = spec_for(TaskCategory.CAUSAL_LANGUAGE_MODELING)
+    assert clm.is_file_bearing and clm.is_self_supervised and clm.is_nlp
+    assert not clm.is_tabular_family and not clm.is_classification
+    assert clm.file_subdir == "texts"
 
     tab = spec_for(TaskCategory.TABULAR_CLASSIFICATION)
     assert (

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -256,6 +256,33 @@ def test_masked_language_modeling_without_label_accepted(validator):
     validator.validate(config)  # must not raise
 
 
+def test_causal_language_modeling_with_label_rejected(validator):
+    """Causal LM is self-supervised like MLM (#213): setting `label:` must be
+    rejected at submission. The CSV has no label column and no edge-label
+    metadata is registered for it."""
+    config = _load_example("causal_language_modeling.yaml")
+    config["label"] = "some_column"
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_causal_language_modeling_without_label_accepted(validator):
+    """The shipped causal LM example omits `label:` by design — it must
+    validate cleanly."""
+    config = _load_example("causal_language_modeling.yaml")
+    assert "label" not in config, "test premise: the example yaml has no label"
+    validator.validate(config)  # must not raise
+
+
+def test_causal_language_modeling_without_texts_rejected(validator):
+    """Causal LM stages raw .txt under `texts:`; omitting it must be rejected
+    (the directory is where the per-sample files live)."""
+    config = _load_example("causal_language_modeling.yaml")
+    del config["texts"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
 # Regression-class tasks must specify label.policy explicitly; the shorthand
 # string form must be rejected for these categories.
 @pytest.mark.parametrize(

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -285,6 +285,34 @@ CASES = [
     ),
 
     # -----------------------------------------------------------------------
+    # causal_language_modeling — self-supervised, no label column. CSV manifest
+    # points at .txt sidecar files holding RAW text (plain text or a
+    # prompt<TAB>completion SFT pair); the client builds next-token targets at
+    # train time. Sidecar dir is ``texts/`` (raw text — same layout as
+    # text/token classification), NOT MLM's ``sequences/`` (pre-tokenized).
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.CAUSAL_LANGUAGE_MODELING,
+            table="causal_language_modeling_train",
+            intent="train",
+            csv="/data/labels.csv",
+            texts="/data/texts/",
+        ),
+        {
+            "category": TaskCategory.CAUSAL_LANGUAGE_MODELING,
+            "data_format": DataFormat.TEXT,
+            "intent": Intent.TRAIN,
+            "label_column": "",  # self-supervised — no label
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"extension": FileExtension.TXT},
+        },
+        id="causal_language_modeling",
+    ),
+
+    # -----------------------------------------------------------------------
     # tabular_classification — template label_column="name"
     # -----------------------------------------------------------------------
     pytest.param(

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -127,6 +127,7 @@ def test_classification_categories_include_label_diversity():
         TaskCategory.TIME_SERIES_FORECASTING,
         TaskCategory.TIME_TO_EVENT_PREDICTION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
+        TaskCategory.CAUSAL_LANGUAGE_MODELING,
     ):
         assert LabelDiversityValidator not in _types(
             map_validators(cat, {"schema": {"a": "INT"}})
@@ -351,8 +352,8 @@ def test_map_validators_without_config_falls_back_to_module_global(monkeypatch):
 
 
 def test_nlp_categories_include_content_hygiene_validators():
-    """The text categories (text/token classification, MLM) gain BOTH the
-    zero-record guard and the (text-only) UTF-8 content validator. The
+    """The text categories (text/token classification, masked & causal LM) gain
+    BOTH the zero-record guard and the (text-only) UTF-8 content validator. The
     zero-record guard now also covers file-bearing vision categories, but
     TextContentValidator stays NLP-only (it decodes UTF-8 text, meaningless for
     images); tabular has neither."""
@@ -367,6 +368,7 @@ def test_nlp_categories_include_content_hygiene_validators():
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
+        TaskCategory.CAUSAL_LANGUAGE_MODELING,
     ):
         types = _types(map_validators(cat, {}))
         # 0-record guard leads (composed centrally); the category's own
@@ -409,6 +411,44 @@ def test_mlm_content_validators_target_sequences_subdir():
     txt = next(x for x in v if isinstance(x, TextContentValidator))
     assert rec.file_subdir == "sequences"
     assert txt.texts_path == "sequences"
+
+
+def test_causal_lm_content_validators_target_texts_subdir():
+    """Causal LM stages RAW text under ``texts/`` (not the pre-tokenized
+    ``sequences/`` MLM uses); the content validators must point there."""
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    v = map_validators(TaskCategory.CAUSAL_LANGUAGE_MODELING, {})
+    rec = next(x for x in v if isinstance(x, IngestableRecordsValidator))
+    txt = next(x for x in v if isinstance(x, TextContentValidator))
+    assert rec.file_subdir == "texts"
+    assert txt.texts_path == "texts"
+
+
+def test_causal_lm_excludes_all_label_validators():
+    """Causal LM is self-supervised: only ``filename`` is required, no label
+    column. It must carry none of the label-oriented validators (mirrors MLM)."""
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+    from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
+
+    types = _types(map_validators(TaskCategory.CAUSAL_LANGUAGE_MODELING, {}))
+    assert LabelColumnValidator not in types
+    assert BIOLabelValidator not in types
+    assert LabelDiversityValidator not in types
+
+
+def test_causal_lm_with_schema_adds_data_validator():
+    v = map_validators(
+        TaskCategory.CAUSAL_LANGUAGE_MODELING, {"schema": {"a": "INT"}}
+    )
+    assert DataValidator in _types(v)
 
 
 def test_text_classification_content_validators_target_texts_subdir():
@@ -459,6 +499,7 @@ ALL_CATEGORIES = (
     TaskCategory.TEXT_CLASSIFICATION,
     TaskCategory.TOKEN_CLASSIFICATION,
     TaskCategory.MASKED_LANGUAGE_MODELING,
+    TaskCategory.CAUSAL_LANGUAGE_MODELING,
     TaskCategory.TABULAR_CLASSIFICATION,
     TaskCategory.TABULAR_REGRESSION,
     TaskCategory.TIME_SERIES_FORECASTING,

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -44,10 +44,16 @@ IMAGE_CATEGORIES: FrozenSet[str] = frozenset(
     }
 )
 
+# Categories that stage raw ``.txt`` files from ``texts/`` and default to the
+# ``.txt`` extension. causal_language_modeling joins text/token classification
+# here (it reads raw text, not the pre-tokenized ``sequences/`` MLM uses); it is
+# self-supervised, but that only governs label handling, not the file_options
+# default this set drives.
 TEXT_CATEGORIES: FrozenSet[str] = frozenset(
     {
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
+        TaskCategory.CAUSAL_LANGUAGE_MODELING,
     }
 )
 

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -103,6 +103,24 @@ _SPECS = (
         is_nlp=True,
         file_subdir="sequences",
     ),
+    # causal_language_modeling is file-bearing AND self-supervised (no label),
+    # like MLM. Unlike MLM it consumes RAW text — each sample is a ``.txt`` of
+    # either plain text (pretraining) or a tab-separated ``prompt\tcompletion``
+    # pair (SFT) — so it stages from ``texts/`` (the raw-text subdir shared with
+    # text/token classification), not ``sequences/`` (which the framework
+    # reserves for pre-tokenized data). It is NLP, so it ships the #805
+    # data-derived text profile for the contributor-tokenizer-fit check.
+    ModalitySpec(
+        TaskCategory.CAUSAL_LANGUAGE_MODELING,
+        is_file_bearing=True,
+        is_tabular_family=False,
+        is_self_supervised=True,
+        data_format=DataFormat.TEXT,
+        build_validators=v.causal_language_modeling,
+        transfer=t.causal_language_modeling,
+        is_nlp=True,
+        file_subdir="texts",
+    ),
     # Tabular family (structured feature tables; no sidecar files -> no transfer).
     ModalitySpec(
         TaskCategory.TABULAR_CLASSIFICATION,

--- a/tracebloc_ingestor/modalities/transfer.py
+++ b/tracebloc_ingestor/modalities/transfer.py
@@ -106,6 +106,16 @@ def masked_language_modeling(
     return text_transfer(record, options, src_subdir="sequences", cfg=cfg)
 
 
+def causal_language_modeling(
+    record: Dict[str, Any], options: Dict[str, Any], cfg: Optional[Config] = None
+) -> Optional[Dict[str, Any]]:
+    # Raw text, one .txt per sample in the ``texts`` subdir (same on-disk
+    # layout as text/token classification — the default text_transfer subdir).
+    # Self-supervised: the .txt holds plain text or a ``prompt\tcompletion``
+    # pair, never a label.
+    return text_transfer(record, options, cfg=cfg)
+
+
 def semantic_segmentation(
     record: Dict[str, Any], options: Dict[str, Any], cfg: Optional[Config] = None
 ) -> Optional[Dict[str, Any]]:

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -205,6 +205,26 @@ def masked_language_modeling(options: Dict[str, Any]) -> List[BaseValidator]:
     return validators
 
 
+def causal_language_modeling(options: Dict[str, Any]) -> List[BaseValidator]:
+    # Self-supervised, like MLM — only a ``filename`` column is required, no
+    # label column, so no LabelColumn/BIO/LabelDiversity validators. Each sample
+    # is one ``.txt`` of RAW text: plain text (pretraining) or a tab-separated
+    # ``prompt\tcompletion`` pair (SFT). Both are valid UTF-8 text content, so
+    # the shared TextContentValidator (binary/non-UTF-8 reject, empty warn) is
+    # the whole content check — there is no extra structural rule to enforce.
+    # Stages from ``texts/`` (raw text), not ``sequences/`` (pre-tokenized).
+    validators: List[BaseValidator] = [
+        FileTypeValidator(
+            allowed_extension=options.get("extension", FileExtension.TXT),
+            path="texts",
+        ),
+        _text_content_validator(options, "texts"),
+    ]
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
 def tabular_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     validators: List[BaseValidator] = []
     if options.get("schema"):

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -36,7 +36,8 @@
         "tabular_regression",
         "time_series_forecasting",
         "time_to_event_prediction",
-        "masked_language_modeling"
+        "masked_language_modeling",
+        "causal_language_modeling"
       ],
       "description": "Task category. Drives convention defaults: validators, data_format, default columns, default file extensions, default validator set."
     },
@@ -86,7 +87,7 @@
     "texts": {
       "type": "string",
       "minLength": 1,
-      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification and token_classification."
+      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification, token_classification, and causal_language_modeling (raw .txt: plain text, or a tab-separated prompt\\tcompletion pair)."
     },
 
     "sequences": {
@@ -337,6 +338,14 @@
       "then": { "required": ["sequences"] }
     },
     {
+      "description": "causal_language_modeling requires `texts` (raw .txt samples). It is self-supervised, so unlike text/token classification it does NOT require `label`.",
+      "if": {
+        "properties": { "category": { "const": "causal_language_modeling" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["texts"] }
+    },
+    {
       "description": "tabular and time-series categories require `schema`.",
       "if": {
         "properties": {
@@ -411,7 +420,8 @@
         "properties": {
           "category": {
             "enum": [
-              "masked_language_modeling"
+              "masked_language_modeling",
+              "causal_language_modeling"
             ]
           }
         },

--- a/tracebloc_ingestor/utils/constants.py
+++ b/tracebloc_ingestor/utils/constants.py
@@ -46,6 +46,7 @@ class TaskCategory:
     TIME_TO_EVENT_PREDICTION = "time_to_event_prediction"
     SEMANTIC_SEGMENTATION = "semantic_segmentation"
     MASKED_LANGUAGE_MODELING = "masked_language_modeling"
+    CAUSAL_LANGUAGE_MODELING = "causal_language_modeling"
 
     # instance_segmentation is deliberately absent: it briefly shipped here
     # and in the schema enum with no validators and no file transfer, so
@@ -73,6 +74,7 @@ class TaskCategory:
             cls.TIME_TO_EVENT_PREDICTION,
             cls.SEMANTIC_SEGMENTATION,
             cls.MASKED_LANGUAGE_MODELING,
+            cls.CAUSAL_LANGUAGE_MODELING,
         ]
 
     @classmethod

--- a/tracebloc_ingestor/validators/text_content_validator.py
+++ b/tracebloc_ingestor/validators/text_content_validator.py
@@ -1,7 +1,8 @@
 """Text Content Validator Module.
 
 Content-level check for NLP categories (text_classification,
-token_classification, masked_language_modeling). ``FileTypeValidator`` only
+token_classification, masked_language_modeling, causal_language_modeling).
+``FileTypeValidator`` only
 checks the file *extension*, so a file named ``doc1.txt`` that actually holds
 binary / non-UTF-8 bytes — or is empty — passed validation and was ingested
 silently; the dataset author only discovered the corruption at training time.
@@ -44,8 +45,9 @@ class TextContentValidator(BaseValidator):
 
     Attributes:
         texts_path: Subdirectory under ``SRC_PATH`` holding the text files
-            (``"texts"`` for text/token classification, ``"sequences"`` for
-            masked language modeling) — mirrors ``FileTypeValidator(path=...)``.
+            (``"texts"`` for text/token classification and causal language
+            modeling, ``"sequences"`` for masked language modeling) — mirrors
+            ``FileTypeValidator(path=...)``.
         extension: Expected text-file extension (default ``.txt``).
         filename_column: CSV column naming each sample's file (default
             ``"filename"``; resolved case-insensitively).


### PR DESCRIPTION
## What

Wires `causal_language_modeling` as a first-class supported modality across **every** per-category dispatch site, mirroring how `masked_language_modeling` (self-supervised) and `token_classification` (`texts/` raw-text layout) are already wired. It previously had **0 references** in this repo; the training-container side (tracebloc-client) already supports it, so this closes the ingestor-side gap.

## Why / design

- **Self-supervised** like MLM — only a `filename` column, no label. (Schema rejects `label:` per #213.)
- **NLP** — ships the #805 data-derived text profile (`is_nlp=True`) for the contributor-tokenizer-fit check.
- Each sample is one `.txt`: either **plain text** (pretraining) or a tab-separated **`prompt\tcompletion`** pair (SFT). Both are ordinary UTF-8, so the **centralized `TextContentValidator`** is the whole content check — no bespoke per-modality validator (honors the #317 centralization).
- Stages raw text from **`texts/`**, *not* MLM's `sequences/` — the framework reserves `sequences/` for *pre-tokenized* data ([`test_template_equivalence.py:264`](https://github.com/tracebloc/data-ingestors/blob/develop/tests/test_template_equivalence.py)).
- **Tokenizer alignment:** decoder-only models tie `pad=eos`, so there is no `[MASK]` requirement. The ingest-time tokenizer/fingerprint was dropped in #299; the only ingestor-side #805 mechanism is the `is_nlp`-gated text profile, which causal LM now ships exactly like MLM/token. The vocab+pad check itself lives on the training-client side.

## Production wiring

| File | Change |
|---|---|
| `utils/constants.py` | `CAUSAL_LANGUAGE_MODELING` constant + `get_all_categories()` |
| `modalities/registry.py` | `ModalitySpec` — file-bearing, self-supervised, NLP, TEXT, `file_subdir="texts"` |
| `modalities/validators.py` | `causal_language_modeling` factory (FileType + `TextContentValidator` + optional `DataValidator`; **no** label validators) |
| `modalities/transfer.py` | `causal_language_modeling` → `text_transfer` (`texts/`) |
| `cli/conventions.py` | added to `TEXT_CATEGORIES` (`.txt` default, `texts/` SRC_PATH derivation) |
| `schema/ingest.v1.json` | enum value, "requires `texts`" rule, self-supervised "must not set `label`" rule (#213), `texts` description |
| `validators/text_content_validator.py` | docstrings |

## Template + example

- New `templates/causal_language_modeling/` — ingestion script (delegates to `run_ingestion`, no exception swallowing), README (reflects the current no-`tokenizer.json` reality), labels CSV, and 5 samples (3 plain-text + 2 real-tab SFT pairs).
- `examples/yaml/causal_language_modeling.yaml` + root README "Supported data types" table.

## Tests

- Updated every category enumeration: registry NLP set, `_TEMPLATE_CATEGORIES`, `ALL_CATEGORIES`, NLP/non-classification lists, text-profile params, equivalence `CASES`, e2e cases, plus schema accept/reject.
- New `tests/test_causal_language_modeling.py` covering **CLI run** (routes to CSVIngestor; rejects `label:` at the entrypoint), **validation boundaries** (header-only & all-files-missing fail before table creation; binary content rejected; clean pretraining+SFT validates), and **failure accounting**.

## Reviewer notes

- The two flagged conventions hold: the template re-raises loudly (covered by `test_template_except_handler_reraises[causal_language_modeling]`), and the shared `zip(ids, batch)` id-pairing is unchanged (covered by `test_mid_batch_db_failure_sends_only_inserted_records`).
- Base is **`develop`** (matches the repo's feature-PR-into-develop flow).

**Full unit suite: 1250 passed, 1 xfailed** (pre-existing). No env was present, so a `.venv` (python3.11) was created locally to run tests — not committed (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive modality wiring with broad test and schema coverage; no changes to auth, existing categories’ transfer logic, or shared ingest hot paths beyond new dispatch entries.
> 
> **Overview**
> Adds **`causal_language_modeling`** as a supported ingest modality so declarative YAML and the Python templates can ingest decoder-style LM data the training client already expects.
> 
> **Engine wiring:** New `TaskCategory`, `ModalitySpec` (file-bearing, self-supervised, NLP, `texts/` + `text_transfer`), validator factory (UTF-8 `TextContentValidator`, no label validators), and `TEXT_CATEGORIES` / schema rules requiring `texts:` and forbidding `label:` (#213, same as MLM).
> 
> **User-facing assets:** `examples/yaml/causal_language_modeling.yaml`, `templates/causal_language_modeling/` (script, README, sample CSV + plain-text and tab-separated SFT `.txt` files), and README supported-types table update.
> 
> **Tests:** Registry/equivalence/schema enumerations extended; dedicated `test_causal_language_modeling.py`; e2e and characterization cases for full ingest of bundled sample data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20615edd449ce285611be59d1bf798566359612e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->