### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.4.0"
+__version__ = "0.6.0"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
## What

Bumps `__version__` in `tracebloc_ingestor/__init__.py` from `0.4.0` → **`0.6.0`** (single-sourced; `setup.py` derives it). No other changes.

## Why

`0.6.0` is the first release to ship the **`causal_language_modeling`** modality ([#318](https://github.com/tracebloc/data-ingestors/pull/318), already merged to `develop`). The dev/prod ingestor image is built only on a `vX.Y.Z` tag, so causal LM is not in any published image yet — this bump is step 1 of cutting that release.

**Why `0.6.0` and not `0.5.1`:** the `v0.5.0` tag already exists, but the `__version__` literal on `develop` still read `0.4.0` (a drift). Bumping straight to `0.6.0` keeps the literal strictly ahead of every published tag and avoids colliding with `0.5.x`.

## Verification

- `git diff` touches only the version string (per `RELEASING.md` step 2 — `setup.py` not edited).
- `python setup.py --version` → `0.6.0`.
- `tests/test_version_single_source.py` passes (runtime `__version__` == the literal `setup.py` parses).

## Scope / what this is NOT

This PR is **only** the version bump, targeting `develop`. It does **not** publish anything. The outward-facing steps follow separately per [`RELEASING.md`](https://github.com/tracebloc/data-ingestors/blob/develop/RELEASING.md):

1. ✅ this bump → `develop`
2. ⬜ `sync/develop-to-master-v0.6.0` PR → merge → `publish-master.yml` publishes the package
3. ⬜ `git tag v0.6.0` → `release-image.yml` builds/signs the image + advances the floating tag → dev picks it up at the next ingestion job spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line version string change with no logic, security, or data-path impact.
> 
> **Overview**
> Bumps the package’s single-sourced **`__version__`** in `tracebloc_ingestor/__init__.py` from **`0.4.0`** to **`0.6.0`**. `setup.py` still reads that literal via `_read_version()`, so the published/PyPI version follows without editing `setup.py`.
> 
> This is a release-prep change only (no runtime or ingestor behavior in the diff). It aligns the in-tree version with the planned **`v0.6.0`** tag ahead of shipping **`causal_language_modeling`** in the ingestor image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8868ee3274fe32c3892553ffaef9678f3a428e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->