### PR TITLE
chore(release): bump version to 0.5.2

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.4.0"
+__version__ = "0.5.2"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
Lands the `__version__` bump on `develop`: `0.4.0` → **`0.5.2`**.

v0.5.1 was tagged to ship `causal_language_modeling` (#318), so the released `ghcr.io/tracebloc/ingestor:0.5.1` image is correct. `develop` had drifted (still `0.4.0`); this sets it to `0.5.2` so the branch sits one patch ahead of the last released tag.

No functional change — single-line version literal (setup.py reads it via `_read_version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only; no logic, dependencies, or ingestion behavior changes.
> 
> **Overview**
> Bumps the package **`__version__`** in `tracebloc_ingestor/__init__.py` from **`0.4.0`** to **`0.5.2`**, aligning `develop` with release history after v0.5.1 shipped elsewhere.
> 
> `setup.py` still picks up the version via **`_read_version()`** — no other files change. **No runtime or API behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b546a12ccf26e873071285c1370b09152e2bb12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->