### PR TITLE
Prod: Enhance validators for NLP and vision categories, update README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Data ingestion pipeline for the tracebloc platform. Validates, preprocesses, and
 
 ```bash
 pip install -e .            # editable install
-pip install -r requirements.txt  # includes dev/test deps
+pip install -r requirements-dev.txt  # runtime + dev/test deps
 pytest                      # run tests
 ```
 
@@ -50,4 +50,4 @@ Ingestor implementations are in `tracebloc_ingestor/ingestors/` (`base.py`, `csv
 
 ## Key Dependencies
 
-Python 3.8+, `sqlalchemy`, `mysql-connector-python`, `pandas`, `Pillow`, `requests`, `tenacity`, `tqdm`.
+Python 3.11+, `sqlalchemy`, `mysql-connector-python`, `pandas`, `Pillow`, `requests`, `tenacity`, `tqdm`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -148,17 +148,41 @@ docker run --rm --entrypoint python ${IMAGE}@${DIGEST} \
   -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
 ```
 
-## 7. (Optional) Bump the greenfield baseline in `tracebloc/client`
+## 7. Confirm the rollout (existing installs roll themselves forward)
 
-**Live clusters roll themselves forward — this step is not required for rollout.** Since [`tracebloc/client#159`](https://github.com/tracebloc/client/pull/159) (the [#158](https://github.com/tracebloc/client/issues/158) auto-refresh feature), the chart ships `images.ingestor.autoRefresh: true` with a floating tag (`images.ingestor.tag: "0.3"`). An image-refresh CronJob polls `ghcr.io/tracebloc/ingestor:0.3` and rewrites the live deployment's `INGESTOR_IMAGE_DIGEST` within ~15 min of a new image push — no chart change, no `helm upgrade`. Every existing install converges on its own, as long as the new image matches the chart's floating tag. (Authoritative explanation: the comment block around `images.ingestor` in [`client/values.yaml`](https://github.com/tracebloc/client/blob/develop/client/values.yaml).)
+**Existing installs pick up the new image with no chart change and no `helm upgrade` — this step only *confirms* that from the registry.** jobs-manager spawns each ingestion run as a short-lived Job from the floating tag `images.ingestor.tag` (`"0.3"`) with `imagePullPolicy: Always`, exactly the way training pods are spawned. The kubelet re-resolves the tag's current digest at **every job spawn** (a cheap registry manifest check — already-present layers are reused), so once the step-5 release moves `:0.3` to the new digest, the next ingestion run on any install runs it. Nothing rewrites a Deployment env, and there is no convergence window to wait on. (Authoritative sources: the `images.ingestor` comment block in [`client/values.yaml`](https://github.com/tracebloc/client/blob/develop/client/values.yaml), the `INGESTOR_IMAGE_*` env wiring in `client/templates/jobs-manager-deployment.yaml`, and `submit_ingestion_run._build_image_reference` in client-runtime — the mechanism landed in `client-runtime#40` / `client#125`.)
 
-The pinned `images.ingestor.digest` in the chart only sets the **greenfield baseline** — the digest a brand-new install lands on before its first refresh tick. Bumping it is a deliberate, optional chart release, not a release step. Do it when you want fresh installs to start on the version you just shipped:
+> **Corrects an earlier version of this doc.** Older text here described an image-refresh CronJob that polled `:0.3` and rewrote an `INGESTOR_IMAGE_DIGEST` env on the `*-jobs-manager` Deployment (via `kubectl set env`) within ~15 min. That "class-2" pass was **retired**: a `helm upgrade` that reset the env could revert the ingestor to a stale baseline — a regression a customer hit (a newer ingestor's fix disappeared on upgrade and resurfaced as a "non-numeric" validation error on data the new image handled correctly). The `INGESTOR_IMAGE_DIGEST` env on the jobs-manager Deployment is now **empty/unused by default**; spawning by floating tag is revert-proof and needs no env reconcile. `INGESTOR_IMAGE_DIGEST` survives only as an *opt-in* cluster-wide pin (see step 8).
+
+Because the rollout signal now lives entirely in the registry, you can verify it **without cluster access** — confirm the floating `:0.3` tag resolves to the digest you just released:
+
+```bash
+IMAGE=ghcr.io/tracebloc/ingestor
+
+# The digest the release published (the same sha256 surfaced in step 6).
+RELEASE_DIGEST=$(gh release view v${VERSION} --repo tracebloc/data-ingestors \
+  --json body --jq '.body' | grep -oE 'sha256:[a-f0-9]{64}' | head -1)
+
+# What :0.3 currently points at — the multi-arch index digest.
+TAG_DIGEST=$(docker buildx imagetools inspect ${IMAGE}:0.3 --format '{{ .Manifest.Digest }}')
+# (equivalent one-liner if you have crane:  crane digest ${IMAGE}:0.3 )
+
+[ "$TAG_DIGEST" = "$RELEASE_DIGEST" ] \
+  && echo "OK        :0.3 -> ${RELEASE_DIGEST}; every new ingestion Job runs v${VERSION}" \
+  || echo "MISMATCH  :0.3 is ${TAG_DIGEST}, release is ${RELEASE_DIGEST} (floating tag did not move)"
+```
+
+`release-image.yml` pushes `:X.Y.Z`, `:X.Y`, and `:X` to the same index digest, so a `v0.3.z` release moves `:0.3` (and `:0`) on its own — a match here means the whole fleet lands on the new image at its next ingestion-Job spawn. (Air-gapped installs that mirror `:0.3` into a private registry roll forward when *their* mirror syncs the tag; the check above confirms the upstream ghcr source that the release controls.)
+
+## 8. (Optional) Bump the greenfield baseline in `tracebloc/client`
+
+The pinned `images.ingestor.digest` in the chart only sets the **greenfield baseline** — the digest a brand-new install lands on for its first ingestion run, before it would otherwise resolve the floating `:0.3` tag. It does **not** drive rollout to existing installs (step 7 covers those). Bumping it is a deliberate, optional chart release, not a release step. Do it when you want fresh installs to start on the version you just shipped:
 
 - Bump `images.ingestor.digest` to the new digest **and** `client/Chart.yaml`'s `version` + `appVersion` in lockstep (the chart's own SemVer, independent of the ingestor's).
 - Open the PR against **`develop`**, like any other client change — this is not a `master`-targeting release PR.
 - Precedent: [`client#161`](https://github.com/tracebloc/client/pull/161) (baseline v0.3.0 → v0.3.1) and [`client#185`](https://github.com/tracebloc/client/pull/185) (v0.3.1 → v0.3.2, tracking [#184](https://github.com/tracebloc/client/issues/184)).
 
-(When you do pin, pull by digest, not tag — that's the whole point of signing.)
+(When you do pin, pull by digest, not tag — that's the whole point of signing — and the digest must be the multi-arch index, not a per-arch one, or arm64 nodes `ImagePullBackOff`.)
 
 ## Manual fallback (workflow_dispatch)
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE) [![PyPI](https://img.shields.io/pypi/v/tracebloc-ingestor.svg)](https://pypi.org/project/tracebloc-ingestor/) [![Python](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://python.org) [![Platform](https://img.shields.io/badge/platform-tracebloc-00C9A7.svg)](https://ai.tracebloc.io)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE) [![PyPI](https://img.shields.io/pypi/v/tracebloc-ingestor.svg)](https://pypi.org/project/tracebloc-ingestor/) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://python.org) [![Platform](https://img.shields.io/badge/platform-tracebloc-00C9A7.svg)](https://ai.tracebloc.io)
 
 # Data Ingestors 📊
 
@@ -34,7 +34,7 @@ Only metadata (schema, statistics, structure) syncs to the web app. Raw data sta
 | Type | Categories |
 |---|---|
 | **Image** | [`image_classification`](templates/image_classification), [`object_detection`](templates/object_detection), [`keypoint_detection`](templates/keypoint_detection), [`semantic_segmentation`](templates/semantic_segmentation) |
-| **Text / NLP** | [`text_classification`](templates/text_classification), [`masked_language_modeling`](templates/masked_language_modeling) |
+| **Text / NLP** | [`text_classification`](templates/text_classification), [`token_classification`](templates/token_classification), [`masked_language_modeling`](templates/masked_language_modeling) |
 | **Tabular** | [`tabular_classification`](templates/tabular_classification), [`tabular_regression`](templates/tabular_regression) |
 | **Time series** | [`time_series_forecasting`](templates/time_series_forecasting), [`time_to_event_prediction`](templates/time_to_event_prediction) |
 
@@ -175,27 +175,32 @@ spec:
             drop: ["ALL"]
 ```
 
-### Subclassing BaseIngestor
+### Driving the ingestor classes directly
 
-For data that doesn't fit any of the existing templates, subclass `BaseIngestor`:
+For data that doesn't fit a template, drive the ingestor classes yourself. The validator set and file handling are selected by `category` (via the modality registry); per-dataset tuning goes through `csv_options` / `file_options`:
 
 ```python
-from tracebloc_ingestor import BaseIngestor, FileTypeValidator
+from tracebloc_ingestor import Config, Database, APIClient, CSVIngestor, run_ingestion
+from tracebloc_ingestor.utils.constants import TaskCategory, Intent, DataFormat
 
-class MyIngestor(BaseIngestor):
-    validators = [FileTypeValidator(allowed=[".parquet"])]
-
-    def transform(self, record):
-        # your preprocessing
-        return record
-
-if __name__ == "__main__":
-    MyIngestor().ingest()
+config = Config()
+ingestor = CSVIngestor(
+    database=Database(config),
+    api_client=APIClient(config),
+    table_name=config.TABLE_NAME,
+    category=TaskCategory.IMAGE_CLASSIFICATION,
+    data_format=DataFormat.IMAGE,
+    label_column="label",
+    intent=Intent.TRAIN,
+)
+run_ingestion(ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE)
 ```
+
+The per-category scripts in [`templates/`](templates) are the canonical starting point — copy the closest one and adapt its `*_options`.
 
 ## Prerequisites
 
-- Python 3.8+
+- Python 3.11+
 - A [tracebloc account](https://ai.tracebloc.io/signup)
 - A running [tracebloc client](https://github.com/tracebloc/client) on your infrastructure
 

--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ Only metadata (schema, statistics, structure) syncs to the web app. Raw data sta
 | Type | Categories |
 |---|---|
 | **Image** | [`image_classification`](templates/image_classification), [`object_detection`](templates/object_detection), [`keypoint_detection`](templates/keypoint_detection), [`semantic_segmentation`](templates/semantic_segmentation) |
-| **Text / NLP** | [`text_classification`](templates/text_classification), [`token_classification`](templates/token_classification), [`masked_language_modeling`](templates/masked_language_modeling) |
+| **Text / NLP** | [`text_classification`](templates/text_classification), [`token_classification`](templates/token_classification), [`masked_language_modeling`](templates/masked_language_modeling), [`causal_language_modeling`](templates/causal_language_modeling) |
 | **Tabular** | [`tabular_classification`](templates/tabular_classification), [`tabular_regression`](templates/tabular_regression) |
 | **Time series** | [`time_series_forecasting`](templates/time_series_forecasting), [`time_to_event_prediction`](templates/time_to_event_prediction) |
 

--- a/Readme.md
+++ b/Readme.md
@@ -96,7 +96,7 @@ Full chart docs (data-staging recipe, schema, every category, update model, veri
 
 ## Advanced: custom processors (legacy Python pattern)
 
-Use this when the declarative schema can't express what your data needs — typically when you have non-trivial preprocessing logic, a custom validator, or a `BaseProcessor` subclass.
+Use this when the declarative schema can't express what your data needs — typically when you have non-trivial preprocessing logic, a custom validator, or a `BaseIngestor` subclass.
 
 **1. Install the package.**
 
@@ -110,7 +110,7 @@ pip install tracebloc-ingestor
 cp templates/image_classification/image_classification.py .
 ```
 
-The package exports `BaseIngestor`, `CSVIngestor`, `JSONIngestor`, plus validators (`FileTypeValidator`, `ImageResolutionValidator`, `TableNameValidator`, etc.) and the `Database` / `APIClient` helpers. See [`examples/`](examples) for working scripts.
+The package exports `BaseIngestor`, `CSVIngestor`, `JSONIngestor`, the `run_ingestion` runner, plus validators (`FileTypeValidator`, `ImageResolutionValidator`, `TableNameValidator`, etc.) and the `Config` / `Database` / `APIClient` helpers. See [`examples/`](examples) for working scripts.
 
 **3. Build + deploy as a Kubernetes Job.**
 

--- a/e2e/test_characterization.py
+++ b/e2e/test_characterization.py
@@ -212,6 +212,17 @@ CASES = [
         sidecars=[str(T / "masked_language_modeling/data/sequences")],
         roundtrip_col=None,
     ),
+    dict(
+        id="causal_language_modeling",
+        cfg=_cfg(
+            table="char_clm",
+            category="causal_language_modeling",
+            csv=str(T / "causal_language_modeling/data/labels_file_sample.csv"),
+            texts=str(T / "causal_language_modeling/data/texts"),
+        ),
+        sidecars=[str(T / "causal_language_modeling/data/texts")],
+        roundtrip_col=None,
+    ),
     # semantic_segmentation: the one file-bearing modality the harness never
     # characterized (audit gap). mask_id is DECLARED in schema so it's stored
     # (the training client SELECTs it to locate masks — backend#816); the masks

--- a/e2e/test_ingest_e2e.py
+++ b/e2e/test_ingest_e2e.py
@@ -187,6 +187,18 @@ CASES = [
         ),
         id="masked_language_modeling",
     ),
+    # causal_language_modeling: self-supervised raw text in texts/ (plain text
+    # or prompt<TAB>completion). No tokenizer.json at ingest — alignment is the
+    # data-derived text profile (#805).
+    pytest.param(
+        _cfg(
+            table="e2e_clm",
+            category="causal_language_modeling",
+            csv=str(T / "causal_language_modeling/data/labels_file_sample.csv"),
+            texts=str(T / "causal_language_modeling/data/texts"),
+        ),
+        id="causal_language_modeling",
+    ),
     # semantic_segmentation: masks now wire through the declarative path (the P5
     # mask_id work — the transfer resolves the mask via the schema-declared
     # mask_id), so #136's xfail is removed. The full contract (masks land in

--- a/examples/yaml/causal_language_modeling.yaml
+++ b/examples/yaml/causal_language_modeling.yaml
@@ -1,0 +1,12 @@
+# Causal language modeling: CSV manifest + .txt sidecar files (one per sample).
+# Self-supervised — no label column required.
+# `texts:` holds RAW text samples: each .txt is either plain text (pretraining)
+# or a tab-separated `prompt<TAB>completion` pair (SFT). The training client
+# builds next-token targets on-the-fly; pad=eos for decoder-only models.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: dolly_clm_train
+intent: train
+category: causal_language_modeling
+csv: /data/shared/dolly-clm/labels_file.csv
+texts: /data/shared/dolly-clm/texts/

--- a/templates/causal_language_modeling/README.md
+++ b/templates/causal_language_modeling/README.md
@@ -1,0 +1,145 @@
+# Causal Language Modeling Data Ingestion Template
+
+This template demonstrates how to ingest raw text samples for causal (next-token)
+language modeling (CLM) into a database using the tracebloc_ingestor framework.
+
+CLM is **self-supervised** — there is no `label:` field. Each sample is a single
+`.txt` file holding **raw text**, in one of two shapes:
+
+- **Pretraining:** the whole file is plain text. The training client builds
+  next-token targets from it on-the-fly.
+- **SFT (instruction tuning):** the file is a single tab-separated
+  `prompt<TAB>completion` pair. The client masks the prompt's loss and trains on
+  the completion.
+
+A dataset may mix both shapes freely; a file with no tab is treated as plain
+text, a file with one tab as a prompt/completion pair.
+
+## Quickstart — declarative (recommended)
+
+Ingest with ~8 lines of YAML using the official ingestor image
+(`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage
+> your files on the cluster's shared PVC first — see the
+> [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc)
+> in the chart docs (kubectl cp pattern for small datasets, init-container sync
+> for production).
+
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a
+`texts/` subdirectory holding the per-record `.txt` files.
+
+**2. Write `ingest.yaml`** — note there is **no** `label:` field (self-supervised):
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: causal_language_modeling
+table: dolly_clm_train
+intent: train
+csv: /data/shared/dolly-clm/labels_file.csv
+texts: /data/shared/dolly-clm/texts/
+```
+
+**3. Install:**
+
+```bash
+helm install my-clm-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+> **If install fails with `'causal_language_modeling' is not one of [...]`:** your
+> local Helm chart cache is stale. Refresh it and retry: `helm repo update`.
+
+Canonical example: [`examples/yaml/causal_language_modeling.yaml`](../../examples/yaml/causal_language_modeling.yaml).
+Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
+
+## Directory Structure
+
+```
+causal_language_modeling/
+├── causal_language_modeling.py   # Main ingestion script
+├── README.md                     # This file
+└── data/
+    ├── texts/                    # Text files (.txt), one per sample
+    │   ├── clm_0000001.txt       #   plain text (pretraining)
+    │   ├── clm_0000002.txt       #   plain text (pretraining)
+    │   ├── clm_0000003.txt       #   plain text (pretraining)
+    │   ├── clm_0000004.txt       #   prompt<TAB>completion (SFT)
+    │   └── clm_0000005.txt       #   prompt<TAB>completion (SFT)
+    └── labels_file_sample.csv    # CSV manifest mapping filenames to extensions
+```
+
+> The `texts/` subdir is the raw-text convention shared with text/token
+> classification. (Masked language modeling instead uses `sequences/`, which the
+> framework reserves for *pre-tokenized* data.)
+
+## Data Format
+
+### Text Files
+- Supported extension: `.txt`
+- One sample per file, placed in `data/texts/`
+- Either plain UTF-8 text, or a single `prompt<TAB>completion` line
+- Files must be decodable UTF-8 (validated at ingest by `TextContentValidator`);
+  binary / non-UTF-8 files are rejected, empty files are warned about.
+
+### CSV Labels File
+CLM is **self-supervised** — no label column is needed. The CSV contains:
+- `filename`: Base name of the text file, without extension (e.g. `clm_0000001`)
+- `extension`: File extension as a quoted string (e.g. `'.txt'`)
+
+## Tokenizer Alignment
+
+CLM does **not** ship a tokenizer at ingest. Instead, the ingestor computes a
+data-derived **text profile** (Unicode-script mix + document-length
+distribution — no raw text, no vocabulary, no hash; the FL guardrail) and ships
+it on the global-metadata channel (#805). The backend uses it for a warn-only
+contributor-tokenizer-fit check at dataset linking — the same alignment path as
+the other NLP modalities (text/token classification, MLM).
+
+Decoder-only models tie `pad` to `eos`, so — unlike masked language modeling —
+**no `[MASK]` token is required**; the tokenizer-fit check looks at vocabulary
+coverage and the pad token only. That check runs on the training-client side.
+
+## Usage
+
+1. Place your `.txt` sample files in `data/texts/`
+2. Update `labels_file_sample.csv` with one row per text file
+3. Configure environment variables (see below)
+4. Run the ingestion script:
+
+```bash
+python causal_language_modeling.py
+```
+
+## Configuration
+
+The script uses the following configuration:
+- **Extension**: TXT - Expected text file extension
+- **Chunk Size**: 100 - Batch size for CSV reading
+- **Encoding**: utf-8
+- **Category**: CAUSAL_LANGUAGE_MODELING
+- **Data Format**: TEXT
+- **Intent**: TRAIN (change to `Intent.TEST` for evaluation data)
+- **Label column**: None (self-supervised)
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TABLE_NAME` | Target database table | Required |
+| `LABEL_FILE` | Path to CSV manifest | Required |
+| `SRC_PATH` | Path to the parent of the `texts/` directory | Required |
+| `BATCH_SIZE` | Ingestion batch size | 4000 |
+| `BACKEND_TOKEN` | Auth token for API | Required |
+| `CLIENT_ENV` | Environment (local/dev/stg/prod) | prod |
+
+## Notes
+
+- The `filename` column does **not** include the extension — that's supplied
+  separately via the `extension` column.
+- No `label` column is needed because CLM training is self-supervised (the
+  next-token targets are derived from the text by the training client).
+- For SFT samples, put exactly one tab between prompt and completion; everything
+  before the first tab is the prompt, everything after is the completion.

--- a/templates/causal_language_modeling/causal_language_modeling.py
+++ b/templates/causal_language_modeling/causal_language_modeling.py
@@ -1,0 +1,86 @@
+"""Causal Language Modeling Data Ingestion Example.
+
+This example demonstrates how to ingest text samples for causal (next-token)
+language modeling (CLM) into a database and optionally send metadata to the
+tracebloc API.
+
+CLM is self-supervised — no label column is needed.  Each row in the CSV maps
+to a ``.txt`` file under ``texts/`` holding RAW text:
+
+- **Pretraining:** the whole file is plain text. The training client builds
+  next-token targets from it on-the-fly.
+- **SFT:** the file is a single tab-separated ``prompt\\tcompletion`` pair; the
+  client masks the prompt's loss and trains on the completion.
+
+Decoder-only models tie ``pad`` to ``eos`` — there is no ``[MASK]`` token, so
+(unlike masked language modeling) no mask token is required. The contributor's
+tokenizer alignment is checked centrally at dataset linking via the
+data-derived text profile (#805); nothing tokenizer-specific is needed here.
+"""
+
+import logging
+import os
+from typing import Dict, Any
+
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
+from tracebloc_ingestor.utils.logging import setup_logging
+from tracebloc_ingestor.utils.constants import (
+    TaskCategory,
+    Intent,
+    DataFormat,
+    FileExtension,
+)
+
+# Initialize config and configure logging
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+
+# Text file options
+text_options = {"extension": FileExtension.TXT}
+
+# CSV specific options
+csv_options = {
+    "chunk_size": 100,
+    "delimiter": ",",
+    "quotechar": '"',
+    "escapechar": "\\",
+    "on_bad_lines": "warn",
+    "encoding": "utf-8",
+}
+
+
+def main():
+    """Run the causal language modeling ingestion example."""
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
+
+    # Create ingestor for CLM data
+    # No label_column — CLM is self-supervised
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.TEXT,
+        category=TaskCategory.CAUSAL_LANGUAGE_MODELING,
+        csv_options=csv_options,
+        file_options=text_options,
+        intent=Intent.TRAIN,
+    )
+
+    # Ingest data with validation
+    logger.info("Starting causal language modeling ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/causal_language_modeling/data/labels_file_sample.csv
+++ b/templates/causal_language_modeling/data/labels_file_sample.csv
@@ -1,0 +1,6 @@
+filename,extension
+clm_0000001,'.txt'
+clm_0000002,'.txt'
+clm_0000003,'.txt'
+clm_0000004,'.txt'
+clm_0000005,'.txt'

--- a/templates/causal_language_modeling/data/texts/clm_0000001.txt
+++ b/templates/causal_language_modeling/data/texts/clm_0000001.txt
@@ -1,0 +1,1 @@
+Federated learning lets multiple data holders train a shared model without moving their raw data off-premise.

--- a/templates/causal_language_modeling/data/texts/clm_0000002.txt
+++ b/templates/causal_language_modeling/data/texts/clm_0000002.txt
@@ -1,0 +1,1 @@
+The mitochondria is the powerhouse of the cell, generating most of the chemical energy needed to power biochemical reactions.

--- a/templates/causal_language_modeling/data/texts/clm_0000003.txt
+++ b/templates/causal_language_modeling/data/texts/clm_0000003.txt
@@ -1,0 +1,1 @@
+In 1969, the Apollo 11 mission landed the first humans on the Moon, marking a turning point in space exploration.

--- a/templates/causal_language_modeling/data/texts/clm_0000004.txt
+++ b/templates/causal_language_modeling/data/texts/clm_0000004.txt
@@ -1,0 +1,1 @@
+Summarize: tracebloc trains models on data that never leaves the contributor cluster.	Only the model travels; the data stays on-premise.

--- a/templates/causal_language_modeling/data/texts/clm_0000005.txt
+++ b/templates/causal_language_modeling/data/texts/clm_0000005.txt
@@ -1,0 +1,1 @@
+Translate to French: Good morning.	Bonjour.

--- a/tests/test_bio_label_validator.py
+++ b/tests/test_bio_label_validator.py
@@ -144,3 +144,44 @@ def test_error_reporting_is_capped(validator, texts_dir):
     result = validator.validate(df)
     assert not result.is_valid
     assert any("further errors suppressed" in e for e in result.errors)
+
+
+# --- IOB2 sequence anomaly (warning, not a hard error) -----------------------
+
+
+def test_iob2_orphan_i_warns_but_does_not_block(validator, texts_dir):
+    # "I-PER" opens the entity (no preceding "B-PER"): malformed under IOB2,
+    # legal under IOB1 -> warn, but still valid (5 tags / 5 words).
+    _write(texts_dir, "s1", "John Smith works at Google")
+    df = pd.DataFrame({"filename": ["s1"], "label": ["I-PER O O O B-ORG"]})
+    result = validator.validate(df)
+    assert result.is_valid, result.errors
+    assert result.warnings and "IOB2 transition anomaly" in result.warnings[0]
+
+
+def test_iob2_type_switch_warns(validator, texts_dir):
+    # "I-ORG" right after "B-PER" is a type switch -> IOB2 anomaly.
+    _write(texts_dir, "s1", "Foo Bar baz")
+    df = pd.DataFrame({"filename": ["s1"], "label": ["B-PER I-ORG O"]})
+    result = validator.validate(df)
+    assert result.is_valid, result.errors
+    assert result.warnings and "IOB2 transition anomaly" in result.warnings[0]
+
+
+def test_iob2_well_formed_sequence_has_no_warning(validator, texts_dir):
+    _write(texts_dir, "s1", "John Smith works")
+    df = pd.DataFrame({"filename": ["s1"], "label": ["B-PER I-PER O"]})
+    result = validator.validate(df)
+    assert result.is_valid, result.errors
+    assert not result.warnings
+
+
+def test_iob2_check_skipped_when_tag_format_invalid(validator, texts_dir):
+    # A format-invalid tag is the (hard) error; don't also emit the IOB2
+    # sequence warning on garbage tags.
+    _write(texts_dir, "s1", "John lives here")
+    df = pd.DataFrame({"filename": ["s1"], "label": ["I-PER BOGUS O"]})
+    result = validator.validate(df)
+    assert not result.is_valid
+    assert any("invalid BIO tag" in e for e in result.errors)
+    assert not result.warnings

--- a/tests/test_causal_language_modeling.py
+++ b/tests/test_causal_language_modeling.py
@@ -1,0 +1,254 @@
+"""Causal language modeling (CLM) — modality wiring, mirroring the MLM /
+token_classification coverage.
+
+CLM is the self-supervised, raw-text decoder modality added alongside MLM. It
+shares MLM's self-supervised semantics (only a ``filename`` column, no label)
+but stages from ``texts/`` (raw text — plain text or a ``prompt\\tcompletion``
+SFT pair), not the pre-tokenized ``sequences/`` MLM uses. These tests pin the
+three behaviors the modality must get right:
+
+1. **CLI run** — a CLM ``ingest.yaml`` routes through ``cli.run.main`` to a
+   CSVIngestor with the resolved kwargs; a CLM config that (wrongly) sets
+   ``label:`` is rejected at the entrypoint (self-supervised, #213).
+2. **Validation boundaries** — header-only / all-files-missing manifests
+   fail fast before table creation; binary content is rejected; a clean
+   pretraining+SFT dataset validates.
+3. **Failure accounting** — a rejected batch POST surfaces every record as a
+   failure so the run exits non-zero.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Generator
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples" / "yaml"
+
+
+# ---------------------------------------------------------------------------
+# Local test doubles (mirror tests/test_ingestor_base.py so this file is
+# self-contained).
+# ---------------------------------------------------------------------------
+
+
+class FakeIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source: Any) -> Generator[Dict[str, Any], None, None]:
+        yield from self._records
+
+
+def make_ingestor(records=None, **overrides):
+    db = MagicMock(name="Database")
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = ([1, 2], [])
+    db.get_table_schema.return_value = {"a": "INT"}
+    api = MagicMock(name="APIClient")
+    api.send_batch.return_value = True
+    api.send_generate_edge_label_meta.return_value = True
+    api.send_global_meta_meta.return_value = True
+    api.prepare_dataset.return_value = True
+    api.create_dataset.return_value = {"id": 1}
+
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=TaskCategory.CAUSAL_LANGUAGE_MODELING,
+        label_column=None,
+    )
+    kwargs.update(overrides)
+    return FakeIngestor(records or [], **kwargs)
+
+
+def _clm_ingestor_on(tmp_path, clean_env, records):
+    """A CLM FakeIngestor wired to a real Config rooted at ``tmp_path/src`` with
+    a ``texts/`` subdir, so the path-reading validators run against a real FS."""
+    src = tmp_path / "src"
+    (src / "texts").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    clean_env.setenv("TABLE_NAME", "clm_train")
+    clean_env.setenv("DEST_PATH", str(tmp_path / "dest" / "clm_train"))
+    # Self-supervised CLM carries no feature schema (the manifest is just
+    # filename/extension), so no DataValidator — match that real shape.
+    ing = make_ingestor(records=records, schema={})
+    ing.database.config = Config()
+    return ing, src / "texts"
+
+
+# ---------------------------------------------------------------------------
+# 1. CLI run
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_runtime():
+    with patch("tracebloc_ingestor.cli.run.Config") as cfg_cls, patch(
+        "tracebloc_ingestor.cli.run.Database"
+    ) as db_cls, patch("tracebloc_ingestor.cli.run.APIClient") as api_cls, patch(
+        "tracebloc_ingestor.cli.run.CSVIngestor"
+    ) as csv_cls, patch(
+        "tracebloc_ingestor.cli.run.JSONIngestor"
+    ) as json_cls, patch(
+        "tracebloc_ingestor.cli.run.setup_logging"
+    ):
+        cfg = MagicMock()
+        cfg.BATCH_SIZE = 4000
+        cfg_cls.return_value = cfg
+        for cls_mock in (csv_cls, json_cls):
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.ingest = MagicMock(return_value=[])
+            cls_mock.return_value = inst
+        yield {"Config": cfg_cls, "Database": db_cls, "APIClient": api_cls,
+               "CSVIngestor": csv_cls, "JSONIngestor": json_cls}
+
+
+def test_cli_run_routes_clm_yaml_to_csv_ingestor(clean_env, mock_runtime, monkeypatch):
+    """The shipped CLM example yaml runs end-to-end-but-mocked: a CSVIngestor is
+    built with the resolved CLM kwargs (TEXT, self-supervised, no label) and
+    ingest() is called once; exit 0."""
+    monkeypatch.setenv(
+        "INGEST_CONFIG", str(EXAMPLES_DIR / "causal_language_modeling.yaml")
+    )
+    from tracebloc_ingestor.cli.run import main
+
+    rc = main()
+
+    assert rc == 0
+    assert mock_runtime["CSVIngestor"].call_count == 1
+    assert mock_runtime["JSONIngestor"].call_count == 0
+    _, kwargs = mock_runtime["CSVIngestor"].call_args
+    assert kwargs["category"] == TaskCategory.CAUSAL_LANGUAGE_MODELING
+    assert kwargs["data_format"] == "text"
+    assert kwargs["label_column"] == ""  # self-supervised
+    assert kwargs["file_options"]["extension"] == ".txt"
+    mock_runtime["CSVIngestor"].return_value.ingest.assert_called_once()
+
+
+def test_cli_run_rejects_clm_with_label(clean_env, mock_runtime, monkeypatch, tmp_path):
+    """Self-supervised: a CLM config that sets `label:` must be rejected at the
+    entrypoint (exit 2) before any DB/network call (#213)."""
+    bad = tmp_path / "clm_with_label.yaml"
+    bad.write_text(
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: causal_language_modeling\n"
+        "table: clm_test\n"
+        "intent: test\n"
+        "csv: /tmp/ignored.csv\n"
+        "texts: /tmp/ignored/\n"
+        "label: label\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(bad))
+    from tracebloc_ingestor.cli.run import main
+
+    rc = main()
+
+    assert rc == 2
+    mock_runtime["Database"].assert_not_called()
+    mock_runtime["APIClient"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. Validation boundaries (real filesystem)
+# ---------------------------------------------------------------------------
+
+
+def test_clm_header_only_csv_fails_before_table_creation(clean_env, tmp_path):
+    """A header-only CLM manifest is rejected during validation, before the
+    destination table is created — no orphan empty table."""
+    ing, _ = _clm_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame(columns=["filename"]).to_csv(csv, index=False)
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No data rows found"):
+            ing.ingest(str(csv), batch_size=10)
+    ing.database.create_table.assert_not_called()
+
+
+def test_clm_all_files_missing_fails_before_table_creation(clean_env, tmp_path):
+    """A populated manifest whose every referenced .txt is missing is rejected
+    before table creation."""
+    ing, _ = _clm_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["doc1", "doc2"]}).to_csv(csv, index=False)
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No referenced data files"):
+            ing.ingest(str(csv), batch_size=10)
+    ing.database.create_table.assert_not_called()
+
+
+def test_clm_clean_dataset_validates(clean_env, tmp_path):
+    """A clean dataset — plain text (pretraining) plus a prompt<TAB>completion
+    SFT line — passes validation. The tab is ordinary UTF-8 text."""
+    ing, texts = _clm_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "pre1.txt").write_text("plain pretraining text\n", encoding="utf-8")
+    (texts / "sft1.txt").write_text("Translate: Hi\tBonjour\n", encoding="utf-8")
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["pre1", "sft1"]}).to_csv(csv, index=False)
+
+    assert ing.validate_data(str(csv)) is True
+
+
+def test_clm_binary_content_rejected(clean_env, tmp_path):
+    """A .txt whose bytes are binary (a NUL byte) is rejected by the shared
+    TextContentValidator — the same content hygiene the other NLP modalities
+    get, here pointed at texts/."""
+    ing, texts = _clm_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "ok.txt").write_text("fine text\n", encoding="utf-8")
+    (texts / "bad.txt").write_bytes(b"\x00\x01\x02binary")
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["ok", "bad"]}).to_csv(csv, index=False)
+
+    with pytest.raises(ValueError, match="NUL byte"):
+        ing.validate_data(str(csv))
+
+
+# ---------------------------------------------------------------------------
+# 3. Failure accounting
+# ---------------------------------------------------------------------------
+
+
+def test_clm_api_send_failure_counts_every_record(clean_env):
+    """Every batch POST rejected -> every CLM record returns as a failure, so
+    the run exits non-zero (the file-transfer branch runs since CLM is
+    file-bearing)."""
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records)
+    ing.api_client.send_batch.return_value = False
+
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+
+    assert len(failed) == 2
+    assert all(f["error"] == "api_send_failed" for f in failed)

--- a/tests/test_duplicate_validator_extra.py
+++ b/tests/test_duplicate_validator_extra.py
@@ -50,3 +50,54 @@ def test_create_directory_if_needed_existing(tmp_path):
     dest = tmp_path / "already"
     dest.mkdir()
     assert DuplicateValidator(dest_path=str(dest))._create_directory_if_needed() is True
+
+
+# --- Within-CSV duplicate filename detection (warning, not a hard failure) ---
+
+
+def test_within_csv_duplicate_filenames_warn(tmp_path, make_csv):
+    dest = tmp_path / "new_table"  # does not exist -> no dest collision
+    path = make_csv(
+        [
+            {"filename": "a", "label": "x"},
+            {"filename": "b", "label": "y"},
+            {"filename": "a", "label": "z"},  # duplicate of row 1
+        ]
+    )
+    result = DuplicateValidator(dest_path=str(dest)).validate(str(path))
+    assert result.is_valid  # warning only — does NOT fail
+    assert any("appear more than once" in w for w in result.warnings)
+    assert result.metadata["within_csv_duplicate_filenames"] is True
+
+
+def test_within_csv_no_duplicates_no_warning(tmp_path, make_csv):
+    dest = tmp_path / "new_table"
+    path = make_csv([{"filename": "a"}, {"filename": "b"}])
+    result = DuplicateValidator(dest_path=str(dest)).validate(str(path))
+    assert result.is_valid
+    assert not any("appear more than once" in w for w in result.warnings)
+    assert result.metadata["within_csv_duplicate_filenames"] is False
+
+
+def test_within_csv_duplicate_case_insensitive_column(tmp_path, make_csv):
+    import pandas as pd
+
+    dest = tmp_path / "new_table"
+    path = make_csv(pd.DataFrame({"FileName": ["a", "a"]}))
+    result = DuplicateValidator(dest_path=str(dest)).validate(str(path))
+    assert any("appear more than once" in w for w in result.warnings)
+
+
+def test_within_csv_no_filename_column_is_noop(tmp_path, make_csv):
+    dest = tmp_path / "new_table"
+    path = make_csv([{"feature_a": "1"}, {"feature_a": "1"}])
+    result = DuplicateValidator(dest_path=str(dest)).validate(str(path))
+    assert not any("appear more than once" in w for w in result.warnings)
+
+
+def test_within_csv_none_input_is_noop(tmp_path):
+    # The table-only callers pass None; must not error or warn.
+    dest = tmp_path / "new_table"
+    result = DuplicateValidator(dest_path=str(dest)).validate(None)
+    assert result.is_valid
+    assert result.metadata["within_csv_duplicate_filenames"] is False

--- a/tests/test_image_validator_flow.py
+++ b/tests/test_image_validator_flow.py
@@ -73,6 +73,7 @@ def test_nonexistent_src_path_fails(clean_env):
 
 # ---- helpers --------------------------------------------------------------
 
+
 def test_is_image_file():
     v = ImageResolutionValidator()
     assert v._is_image_file(Path("a.JPG"))
@@ -119,7 +120,9 @@ def test_validate_image_resolutions_empty_list():
 def test_validate_image_resolutions_unprocessable(tmp_path):
     bad = tmp_path / "a.jpg"
     bad.write_text("nope")
-    res = ImageResolutionValidator(expected_resolution=(10, 10))._validate_image_resolutions([bad])
+    res = ImageResolutionValidator(
+        expected_resolution=(10, 10)
+    )._validate_image_resolutions([bad])
     assert not res.is_valid
     assert any("could not be processed" in e for e in res.errors)
     # the per-file reason is now surfaced, not just the bare path
@@ -127,6 +130,7 @@ def test_validate_image_resolutions_unprocessable(tmp_path):
 
 
 # --- _diagnose_image_error: distinct, actionable reasons --------------------
+
 
 def test_diagnose_empty_file(tmp_path):
     p = tmp_path / "empty.jpg"
@@ -141,4 +145,50 @@ def test_diagnose_corrupt_file(tmp_path):
 
 
 def test_diagnose_missing_file(tmp_path):
-    assert "not found" in ImageResolutionValidator._diagnose_image_error(tmp_path / "nope.jpg")
+    assert "not found" in ImageResolutionValidator._diagnose_image_error(
+        tmp_path / "nope.jpg"
+    )
+
+
+# --- masks subdir (semantic segmentation mask validation, PR #314) -----------
+
+
+def _make_png(directory, name, size):
+    from PIL import Image
+
+    directory.mkdir(exist_ok=True)
+    Image.new("L", size, 1).save(directory / name)
+
+
+def test_masks_subdir_validates_masks_directory(clean_env, tmp_path):
+    _make_png(tmp_path / "masks", "a_mask.png", (64, 64))
+    _make_png(tmp_path / "masks", "b_mask.png", (64, 64))
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = ImageResolutionValidator(
+        expected_resolution=(64, 64), subdir="masks"
+    ).validate(None)
+    assert result.is_valid, result.errors
+
+
+def test_masks_subdir_rejects_mask_resolution_mismatch(clean_env, tmp_path):
+    _make_png(tmp_path / "masks", "a_mask.png", (32, 32))  # != expected 64x64
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = ImageResolutionValidator(
+        expected_resolution=(64, 64), subdir="masks"
+    ).validate(None)
+    assert not result.is_valid
+
+
+def test_masks_subdir_rejects_corrupt_mask(clean_env, tmp_path):
+    (tmp_path / "masks").mkdir()
+    (tmp_path / "masks" / "a_mask.png").write_bytes(b"not a png \x00\xff")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = ImageResolutionValidator(
+        expected_resolution=(64, 64), subdir="masks"
+    ).validate(None)
+    assert not result.is_valid
+
+
+def test_default_subdir_is_images(clean_env, tmp_path):
+    # The default instance must still scan <SRC>/images, not masks.
+    assert ImageResolutionValidator().subdir == "images"

--- a/tests/test_ingestable_records_validator.py
+++ b/tests/test_ingestable_records_validator.py
@@ -1,0 +1,144 @@
+"""Tests for IngestableRecordsValidator — the zero-record fail-fast guard.
+
+Covers the two "0 ingestable records" inputs the adversarial MLM run surfaced:
+a header-only / empty CSV, and a CSV whose every referenced file is missing.
+Both must be rejected at preflight (before the table is created), not fail late
+with a misleading "rows already in the database" message.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from tracebloc_ingestor.validators.ingestable_records_validator import (
+    IngestableRecordsValidator,
+)
+
+
+def _write(path, text):
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_header_only_csv_is_rejected(make_csv):
+    # A CSV with a header row but no data rows.
+    path = make_csv(pd.DataFrame(columns=["filename", "label"]))
+    result = IngestableRecordsValidator().validate(str(path))
+    assert not result.is_valid
+    assert "No data rows found" in result.errors[0]
+    assert result.metadata["data_rows"] == 0
+
+
+def test_empty_zero_byte_csv_is_rejected(tmp_path):
+    path = _write(tmp_path / "empty.csv", "")
+    result = IngestableRecordsValidator().validate(str(path))
+    assert not result.is_valid
+    assert "No data rows found" in result.errors[0]
+
+
+def test_non_csv_input_is_a_noop():
+    # JSON / non-path inputs are handled by their own validators.
+    result = IngestableRecordsValidator().validate("data.json")
+    assert result.is_valid
+    assert result.metadata["checked"] is False
+    assert IngestableRecordsValidator().validate(None).is_valid
+
+
+def test_all_referenced_files_missing_is_rejected(clean_env, tmp_path, make_csv):
+    src = tmp_path / "src"
+    (src / "sequences").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    # CSV references two files that were never staged.
+    path = make_csv([{"filename": "doc1"}, {"filename": "doc2"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert not result.is_valid
+    assert "No referenced data files could be found" in result.errors[0]
+    assert result.metadata["found_at_least_one"] is False
+
+
+def test_passes_when_at_least_one_referenced_file_exists(clean_env, tmp_path, make_csv):
+    src = tmp_path / "src"
+    seq = src / "sequences"
+    seq.mkdir(parents=True)
+    _write(seq / "doc2.txt", "hello world")  # only the second file is staged
+    clean_env.setenv("SRC_PATH", str(src))
+    path = make_csv([{"filename": "doc1"}, {"filename": "doc2"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert result.is_valid, result.errors
+    assert result.metadata["found_at_least_one"] is True
+
+
+def test_filename_with_extension_resolves_without_double_suffix(
+    clean_env, tmp_path, make_csv
+):
+    src = tmp_path / "src"
+    seq = src / "sequences"
+    seq.mkdir(parents=True)
+    _write(seq / "doc1.txt", "x")
+    clean_env.setenv("SRC_PATH", str(src))
+    # filename already carries the extension -> must not become doc1.txt.txt
+    path = make_csv([{"filename": "doc1.txt"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert result.is_valid, result.errors
+
+
+def test_filename_column_is_case_insensitive(clean_env, tmp_path, make_csv):
+    src = tmp_path / "src"
+    (src / "sequences").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    path = make_csv([{"FileName": "doc1"}])  # header cased differently
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    # column resolves, file is missing -> rejected (not a no-op)
+    assert not result.is_valid
+    assert "No referenced data files" in result.errors[0]
+
+
+def test_tabular_style_no_subdir_only_checks_rows(make_csv):
+    # With no file_subdir, a populated CSV passes (no file cross-check).
+    path = make_csv([{"a": "1"}, {"a": "2"}])
+    result = IngestableRecordsValidator(file_subdir=None).validate(str(path))
+    assert result.is_valid
+
+
+def test_valid_dataset_with_files_passes(clean_env, tmp_path, make_csv):
+    src = tmp_path / "src"
+    seq = src / "sequences"
+    seq.mkdir(parents=True)
+    for name in ("a", "b", "c"):
+        _write(seq / f"{name}.txt", "content")
+    clean_env.setenv("SRC_PATH", str(src))
+    path = make_csv([{"filename": n} for n in ("a", "b", "c")])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert result.is_valid, result.errors
+
+
+def test_file_bearing_but_no_filename_column_is_noop(clean_env, tmp_path, make_csv):
+    # Rows present, file_subdir set, but the CSV has no filename column to
+    # cross-check -> not this validator's error to raise (pass through).
+    src = tmp_path / "src"
+    (src / "sequences").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    path = make_csv([{"text_col": "hi"}, {"text_col": "yo"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert result.is_valid
+    assert result.metadata["reason"] == "no_filename_column"
+
+
+def test_absolute_or_traversal_path_is_not_counted_as_found(
+    clean_env, tmp_path, make_csv
+):
+    # A manifest value that escapes SRC_PATH/<subdir> (absolute path or ``..``)
+    # is rejected by the transfer's _safe_join (#239); even though the file
+    # exists on disk it is NOT an ingestable file, so it must not mask the
+    # zero-record case. (Bugbot: unsafe manifest path resolution.)
+    src = tmp_path / "src"
+    (src / "sequences").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    outside = tmp_path / "outside.txt"  # exists, but outside the dataset dir
+    outside.write_text("secret", encoding="utf-8")
+    path = make_csv(
+        [{"filename": str(outside)}, {"filename": "../../outside.txt"}]
+    )
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert not result.is_valid
+    assert "No referenced data files" in result.errors[0]

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -1094,3 +1094,94 @@ def test_ingest_does_not_profile_non_nlp():
     profile.assert_not_called()
     args, _ = ing.api_client.send_global_meta_meta.call_args
     assert "text_profile" not in args[2]
+
+
+# --- Truthful registration-failure message about row state (0-record case) ---
+
+
+def test_rows_state_clause_phrasing():
+    """The parenthetical must never claim phantom rows: zero ingested -> says so;
+    nonzero -> warns the rows are persisted."""
+    assert (
+        base_mod._rows_state_clause(0)
+        == "no rows were ingested, so nothing was left in the database"
+    )
+    assert "3 already-ingested row(s)" in base_mod._rows_state_clause(3)
+
+
+def test_zero_inserted_registration_failure_message_is_truthful():
+    """A registration failure with 0 inserted rows must NOT say rows are already
+    in the database (the misleading message the adversarial run surfaced)."""
+    # insert_batch reports 0 inserted ids -> inserted_records stays 0.
+    ing = make_ingestor(records=[{"a": "1", "filename": "f1"}], category=None)
+    ing.database.insert_batch.return_value = ([], [])  # no ids inserted
+    ing.api_client.send_generate_edge_label_meta.return_value = False
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError) as exc:
+            ing.ingest("src", batch_size=10)
+    msg = str(exc.value)
+    assert "NOT registered" in msg
+    assert "already in the database" not in msg
+    assert "no rows were ingested" in msg
+
+
+def test_mlm_header_only_csv_fails_before_table_creation(clean_env, tmp_path):
+    """End-to-end fail-fast: a header-only MLM manifest is rejected during
+    validation, BEFORE the destination table is created — so no orphan empty
+    table is left behind (the #260 failure mode at the zero-records gate)."""
+    from tracebloc_ingestor.config import Config
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    src = tmp_path / "src"
+    (src / "sequences").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    clean_env.setenv("TABLE_NAME", "mlm_train")
+    clean_env.setenv("DEST_PATH", str(tmp_path / "dest" / "mlm_train"))
+
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame(columns=["filename"]).to_csv(csv, index=False)  # header only
+
+    ing = make_ingestor(
+        records=[],
+        category=TaskCategory.MASKED_LANGUAGE_MODELING,
+        label_column=None,
+    )
+    ing.database.config = Config()  # real config so path-reading validators work
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No data rows found"):
+            ing.ingest(str(csv), batch_size=10)
+
+    ing.database.create_table.assert_not_called()
+
+
+def test_mlm_all_files_missing_fails_before_table_creation(clean_env, tmp_path):
+    """The other zero-record path: a populated CSV whose every referenced file
+    is missing is rejected before table creation."""
+    from tracebloc_ingestor.config import Config
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    src = tmp_path / "src"
+    (src / "sequences").mkdir(parents=True)  # empty -> referenced files missing
+    clean_env.setenv("SRC_PATH", str(src))
+    clean_env.setenv("TABLE_NAME", "mlm_train")
+    clean_env.setenv("DEST_PATH", str(tmp_path / "dest" / "mlm_train"))
+
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["doc1", "doc2"]}).to_csv(csv, index=False)
+
+    ing = make_ingestor(
+        records=[],
+        category=TaskCategory.MASKED_LANGUAGE_MODELING,
+        label_column=None,
+    )
+    ing.database.config = Config()
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No referenced data files"):
+            ing.ingest(str(csv), batch_size=10)
+
+    ing.database.create_table.assert_not_called()

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -984,7 +984,7 @@ def test_check_src_path_only_runs_for_file_bearing_categories():
         TaskCategory.TIME_TO_EVENT_PREDICTION,
     ):
         assert cat not in _FILE_BEARING_CATEGORIES
-    # Image / text / segmentation / MLM all need a staged SRC_PATH.
+    # Image / text / segmentation / MLM / causal LM all need a staged SRC_PATH.
     for cat in (
         TaskCategory.IMAGE_CLASSIFICATION,
         TaskCategory.OBJECT_DETECTION,
@@ -992,6 +992,7 @@ def test_check_src_path_only_runs_for_file_bearing_categories():
         TaskCategory.SEMANTIC_SEGMENTATION,
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
+        TaskCategory.CAUSAL_LANGUAGE_MODELING,
     ):
         assert cat in _FILE_BEARING_CATEGORIES
 
@@ -1019,7 +1020,12 @@ _TEXT_PROFILE = {
 
 @pytest.mark.parametrize(
     "category",
-    ["MASKED_LANGUAGE_MODELING", "TEXT_CLASSIFICATION", "TOKEN_CLASSIFICATION"],
+    [
+        "MASKED_LANGUAGE_MODELING",
+        "CAUSAL_LANGUAGE_MODELING",
+        "TEXT_CLASSIFICATION",
+        "TOKEN_CLASSIFICATION",
+    ],
 )
 def test_ingest_attaches_text_profile_for_nlp(category):
     """For every NLP category, the data-derived text profile is attached to

--- a/tests/test_keypoint_annotation_validator.py
+++ b/tests/test_keypoint_annotation_validator.py
@@ -22,10 +22,12 @@ def _df(annotations):
 
 
 def test_valid_keypoints_pass(validator):
-    df = _df([
-        {"nose": [10, 20], "eye": [30, 40]},
-        {"nose": [11, 21], "eye": [31, 41]},
-    ])
+    df = _df(
+        [
+            {"nose": [10, 20], "eye": [30, 40]},
+            {"nose": [11, 21], "eye": [31, 41]},
+        ]
+    )
     result = validator.validate(df)
     assert result.is_valid
     assert result.metadata["rows_checked"] == 2
@@ -100,10 +102,12 @@ def test_degenerate_bounding_box_fails(validator):
 
 
 def test_inconsistent_keypoint_names_fail(validator):
-    df = _df([
-        {"nose": [1, 2], "eye": [3, 4]},
-        {"nose": [1, 2], "ear": [3, 4]},  # different key set
-    ])
+    df = _df(
+        [
+            {"nose": [1, 2], "eye": [3, 4]},
+            {"nose": [1, 2], "ear": [3, 4]},  # different key set
+        ]
+    )
     result = validator.validate(df)
     assert not result.is_valid
     assert any("differ from first record" in e for e in result.errors)
@@ -117,10 +121,12 @@ def test_inconsistent_keypoint_names_fail(validator):
 def test_num_keypoints_match_passes():
     """When every row has exactly the declared K, validation passes."""
     v = KeypointAnnotationValidator(num_keypoints=2)
-    df = _df([
-        {"nose": [1, 2], "eye": [3, 4]},
-        {"nose": [5, 6], "eye": [7, 8]},
-    ])
+    df = _df(
+        [
+            {"nose": [1, 2], "eye": [3, 4]},
+            {"nose": [5, 6], "eye": [7, 8]},
+        ]
+    )
     result = v.validate(df)
     assert result.is_valid
 
@@ -131,9 +137,11 @@ def test_num_keypoints_mismatch_fails():
     crashed the runtime mid-training; post-fix the ingest rejects with
     a clear error pointing the dataset author at the right line."""
     v = KeypointAnnotationValidator(num_keypoints=14)
-    df = _df([
-        {"a": [1, 2], "b": [3, 4], "c": [5, 6], "d": [7, 8]},
-    ])
+    df = _df(
+        [
+            {"a": [1, 2], "b": [3, 4], "c": [5, 6], "d": [7, 8]},
+        ]
+    )
     result = v.validate(df)
     assert not result.is_valid
     err = next(e for e in result.errors if "4 keypoint" in e)
@@ -145,11 +153,13 @@ def test_num_keypoints_mismatch_reports_every_offending_row():
     """Mismatches surface per-row so the dataset author can fix them
     in one pass — not just the first one."""
     v = KeypointAnnotationValidator(num_keypoints=3)
-    df = _df([
-        {"a": [1, 2], "b": [3, 4]},                     # row 1: 2 kp (bad)
-        {"a": [1, 2], "b": [3, 4], "c": [5, 6]},        # row 2: 3 kp (ok)
-        {"a": [1, 2]},                                  # row 3: 1 kp (bad)
-    ])
+    df = _df(
+        [
+            {"a": [1, 2], "b": [3, 4]},  # row 1: 2 kp (bad)
+            {"a": [1, 2], "b": [3, 4], "c": [5, 6]},  # row 2: 3 kp (ok)
+            {"a": [1, 2]},  # row 3: 1 kp (bad)
+        ]
+    )
     result = v.validate(df)
     assert not result.is_valid
     count_errs = [e for e in result.errors if "num_keypoints=3" in e]
@@ -172,10 +182,59 @@ def test_num_keypoints_check_compounds_with_coordinate_errors():
     """A mismatched count shouldn't suppress per-keypoint coordinate
     errors — operator sees both kinds in one pass."""
     v = KeypointAnnotationValidator(num_keypoints=3)
-    df = _df([
-        {"a": [-1, 2], "b": [3, 4]},  # wrong count AND a negative coord
-    ])
+    df = _df(
+        [
+            {"a": [-1, 2], "b": [3, 4]},  # wrong count AND a negative coord
+        ]
+    )
     result = v.validate(df)
     assert not result.is_valid
     assert any("num_keypoints=3" in e for e in result.errors)
     assert any("negative coordinates" in e for e in result.errors)
+
+
+# --- coordinate bounds vs declared image size (PR #314) ----------------------
+
+
+def test_keypoint_within_image_bounds_passes():
+    v = KeypointAnnotationValidator(expected_resolution=(64, 64))
+    df = _df([{"nose": [10, 10], "left_eye": [60, 60]}])
+    result = v.validate(df)
+    assert result.is_valid, result.errors
+
+
+def test_keypoint_out_of_bounds_fails():
+    v = KeypointAnnotationValidator(expected_resolution=(64, 64))
+    df = _df([{"nose": [9999, 9999], "left_eye": [20, 15]}])
+    result = v.validate(df)
+    assert not result.is_valid
+    assert any("outside the image bounds" in e for e in result.errors)
+
+
+def test_keypoint_bounds_skipped_without_resolution():
+    # No expected_resolution -> upper-bound check is a no-op (legacy behavior).
+    v = KeypointAnnotationValidator()
+    df = _df([{"nose": [9999, 9999], "left_eye": [20, 15]}])
+    result = v.validate(df)
+    assert result.is_valid, result.errors
+
+
+def test_keypoint_at_exact_width_is_out_of_bounds():
+    # Half-open [0, W): a coord equal to the width is the first index past the
+    # last pixel, so it must be rejected (bugbot PR #314).
+    v = KeypointAnnotationValidator(expected_resolution=(64, 64))
+    df = _df([{"nose": [64, 10], "left_eye": [20, 15]}])
+    result = v.validate(df)
+    assert not result.is_valid
+    assert any("outside the image bounds" in e for e in result.errors)
+
+
+def test_keypoint_negative_and_out_of_bounds_both_reported():
+    # (-1, 9999) on 64x64: independent checks must report BOTH the negative x
+    # and the out-of-bounds y in one pass (bugbot PR #314).
+    v = KeypointAnnotationValidator(expected_resolution=(64, 64))
+    df = _df([{"nose": [-1, 9999], "left_eye": [20, 15]}])
+    result = v.validate(df)
+    assert not result.is_valid
+    assert any("negative coordinates" in e for e in result.errors)
+    assert any("outside the image bounds" in e for e in result.errors)

--- a/tests/test_label_column_validator.py
+++ b/tests/test_label_column_validator.py
@@ -1,0 +1,107 @@
+"""Tests for LabelColumnValidator — the missing-label-column fail-fast guard.
+
+Adversarial text-classification ingestion surfaced a CSV whose header is
+``filename,extension`` (no ``label``), configured with ``label: label``,
+slipping past every validator: it ingested records with ``label=None`` and the
+backend rejected each row with ``HTTP 400 "label: may not be null"`` — a late,
+confusing failure. This validator rejects that at preflight with a clear,
+actionable message naming the columns that ARE present.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from tracebloc_ingestor.validators.label_column_validator import LabelColumnValidator
+
+
+def test_missing_label_column_is_rejected(make_csv):
+    path = make_csv(
+        pd.DataFrame({"filename": ["a", "b"], "extension": [".txt", ".txt"]})
+    )
+    result = LabelColumnValidator().validate(str(path))
+    assert not result.is_valid
+    assert "Configured label column 'label' not found" in result.errors[0]
+    # message lists the columns that ARE present, to guide the fix
+    assert "filename" in result.errors[0] and "extension" in result.errors[0]
+    assert result.metadata["columns"] == ["filename", "extension"]
+
+
+def test_present_label_column_passes(make_csv):
+    path = make_csv(
+        pd.DataFrame({"filename": ["a"], "extension": [".txt"], "label": ["pos"]})
+    )
+    result = LabelColumnValidator().validate(str(path))
+    assert result.is_valid
+    assert result.metadata["checked"] is True
+
+
+def test_custom_label_column_name_missing_is_rejected(make_csv):
+    # A YAML configuring label_column: sentiment, but the CSV only has 'label'.
+    path = make_csv(
+        pd.DataFrame({"filename": ["a"], "extension": [".txt"], "label": ["pos"]})
+    )
+    result = LabelColumnValidator(label_column="sentiment").validate(str(path))
+    assert not result.is_valid
+    assert "Configured label column 'sentiment' not found" in result.errors[0]
+
+
+def test_custom_label_column_name_present_passes(make_csv):
+    path = make_csv(
+        pd.DataFrame({"filename": ["a"], "extension": [".txt"], "sentiment": ["pos"]})
+    )
+    result = LabelColumnValidator(label_column="sentiment").validate(str(path))
+    assert result.is_valid
+
+
+def test_label_column_match_is_case_insensitive(make_csv):
+    # CSVIngestor resolves headers case-insensitively; mirror that here.
+    path = make_csv(
+        pd.DataFrame({"filename": ["a"], "extension": [".txt"], "Label": ["pos"]})
+    )
+    result = LabelColumnValidator().validate(str(path))
+    assert result.is_valid
+
+
+def test_label_column_match_ignores_surrounding_whitespace(tmp_path):
+    # CSVIngestor strips header whitespace on read, so a header like " label "
+    # ingests as "label" and must NOT fail this preflight check (bugbot #313).
+    path = tmp_path / "ws.csv"
+    path.write_text(
+        "filename,extension, label \nsample1,'.txt',pos\n", encoding="utf-8"
+    )
+    result = LabelColumnValidator().validate(str(path))
+    assert result.is_valid
+
+
+def test_none_or_empty_label_column_defaults_to_label(make_csv):
+    path = make_csv(pd.DataFrame({"filename": ["a"], "extension": [".txt"]}))
+    # An unset/blank configured name must default to "label", not crash.
+    result = LabelColumnValidator(label_column="").validate(str(path))
+    assert not result.is_valid
+    assert "'label'" in result.errors[0]
+
+
+def test_dataframe_input_missing_and_present():
+    missing = LabelColumnValidator().validate(pd.DataFrame({"filename": ["a"]}))
+    assert not missing.is_valid
+    present = LabelColumnValidator().validate(
+        pd.DataFrame({"filename": ["a"], "label": ["x"]})
+    )
+    assert present.is_valid
+
+
+def test_non_csv_input_is_a_noop():
+    # JSON / non-path inputs are covered by their own validators.
+    result = LabelColumnValidator().validate("data.json")
+    assert result.is_valid
+    assert result.metadata["checked"] is False
+    assert LabelColumnValidator().validate(None).is_valid
+
+
+def test_unreadable_csv_is_a_benign_skip(tmp_path):
+    # A missing CSV path can't be introspected here; the read/transfer path
+    # raises its own clear error. Don't double-report.
+    result = LabelColumnValidator().validate(str(tmp_path / "nope.csv"))
+    assert result.is_valid
+    assert result.metadata["checked"] is False

--- a/tests/test_modality_failure_accounting.py
+++ b/tests/test_modality_failure_accounting.py
@@ -47,11 +47,12 @@ from tracebloc_ingestor.utils.constants import TaskCategory
 # helpers (mirror test_batch_send_failure_accounting.py)
 # ---------------------------------------------------------------------------
 
-# One entry per template directory — the 11 supported modalities.
+# One entry per template directory — the 12 supported modalities.
 _TEMPLATE_CATEGORIES = [
     TaskCategory.IMAGE_CLASSIFICATION,
     TaskCategory.KEYPOINT_DETECTION,
     TaskCategory.MASKED_LANGUAGE_MODELING,
+    TaskCategory.CAUSAL_LANGUAGE_MODELING,
     TaskCategory.OBJECT_DETECTION,
     TaskCategory.SEMANTIC_SEGMENTATION,
     TaskCategory.TABULAR_CLASSIFICATION,

--- a/tests/test_modality_registry.py
+++ b/tests/test_modality_registry.py
@@ -58,13 +58,14 @@ def test_derived_sets_match_spec_flags():
     assert NLP_CATEGORIES == {c for c, s in REGISTRY.items() if s.is_nlp}
 
 
-def test_nlp_categories_are_the_three_text_categories():
-    """#805: the NLP set is exactly the text categories
-    (text/token classification + MLM) — never image/tabular."""
+def test_nlp_categories_are_exactly_the_text_categories():
+    """#805: the NLP set is exactly the text categories (text/token
+    classification + masked & causal language modeling) — never image/tabular."""
     assert NLP_CATEGORIES == {
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
+        TaskCategory.CAUSAL_LANGUAGE_MODELING,
     }
 
 
@@ -77,6 +78,13 @@ def test_known_flag_values():
     # Lock the data that used to live in the three base.py frozensets.
     mlm = spec_for(TaskCategory.MASKED_LANGUAGE_MODELING)
     assert mlm.is_file_bearing and mlm.is_self_supervised and not mlm.is_tabular_family
+
+    # causal LM mirrors MLM's flags (file-bearing + self-supervised + NLP) but
+    # stages raw text from texts/, not pre-tokenized sequences/.
+    clm = spec_for(TaskCategory.CAUSAL_LANGUAGE_MODELING)
+    assert clm.is_file_bearing and clm.is_self_supervised and clm.is_nlp
+    assert not clm.is_tabular_family and not clm.is_classification
+    assert clm.file_subdir == "texts"
 
     tab = spec_for(TaskCategory.TABULAR_CLASSIFICATION)
     assert (

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -256,6 +256,33 @@ def test_masked_language_modeling_without_label_accepted(validator):
     validator.validate(config)  # must not raise
 
 
+def test_causal_language_modeling_with_label_rejected(validator):
+    """Causal LM is self-supervised like MLM (#213): setting `label:` must be
+    rejected at submission. The CSV has no label column and no edge-label
+    metadata is registered for it."""
+    config = _load_example("causal_language_modeling.yaml")
+    config["label"] = "some_column"
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_causal_language_modeling_without_label_accepted(validator):
+    """The shipped causal LM example omits `label:` by design — it must
+    validate cleanly."""
+    config = _load_example("causal_language_modeling.yaml")
+    assert "label" not in config, "test premise: the example yaml has no label"
+    validator.validate(config)  # must not raise
+
+
+def test_causal_language_modeling_without_texts_rejected(validator):
+    """Causal LM stages raw .txt under `texts:`; omitting it must be rejected
+    (the directory is where the per-sample files live)."""
+    config = _load_example("causal_language_modeling.yaml")
+    del config["texts"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
 # Regression-class tasks must specify label.policy explicitly; the shorthand
 # string form must be rejected for these categories.
 @pytest.mark.parametrize(

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -285,6 +285,34 @@ CASES = [
     ),
 
     # -----------------------------------------------------------------------
+    # causal_language_modeling — self-supervised, no label column. CSV manifest
+    # points at .txt sidecar files holding RAW text (plain text or a
+    # prompt<TAB>completion SFT pair); the client builds next-token targets at
+    # train time. Sidecar dir is ``texts/`` (raw text — same layout as
+    # text/token classification), NOT MLM's ``sequences/`` (pre-tokenized).
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.CAUSAL_LANGUAGE_MODELING,
+            table="causal_language_modeling_train",
+            intent="train",
+            csv="/data/labels.csv",
+            texts="/data/texts/",
+        ),
+        {
+            "category": TaskCategory.CAUSAL_LANGUAGE_MODELING,
+            "data_format": DataFormat.TEXT,
+            "intent": Intent.TRAIN,
+            "label_column": "",  # self-supervised — no label
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"extension": FileExtension.TXT},
+        },
+        id="causal_language_modeling",
+    ),
+
+    # -----------------------------------------------------------------------
     # tabular_classification — template label_column="name"
     # -----------------------------------------------------------------------
     pytest.param(

--- a/tests/test_text_content_validator.py
+++ b/tests/test_text_content_validator.py
@@ -1,0 +1,181 @@
+"""Tests for TextContentValidator — content-level UTF-8 / emptiness checks
+for NLP text files (the File Type Validator only checks the extension)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracebloc_ingestor.validators.text_content_validator import TextContentValidator
+
+
+@pytest.fixture
+def staged(clean_env, tmp_path):
+    """Return (src_dir, sequences_dir, set_csv) with SRC_PATH pointed at src."""
+    src = tmp_path / "src"
+    seq = src / "sequences"
+    seq.mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+
+    def make_csv(filenames):
+        import pandas as pd
+
+        path = tmp_path / "data.csv"
+        pd.DataFrame({"filename": filenames}).to_csv(path, index=False)
+        return path
+
+    return src, seq, make_csv
+
+
+def test_valid_utf8_text_passes(staged):
+    _, seq, make_csv = staged
+    (seq / "a.txt").write_text("a clean english sentence", encoding="utf-8")
+    (seq / "b.txt").write_text("café — naïve façade", encoding="utf-8")
+    path = make_csv(["a", "b"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert result.is_valid, result.errors
+    assert result.metadata["docs_checked"] == 2
+
+
+def test_binary_content_is_rejected(staged):
+    _, seq, make_csv = staged
+    (seq / "a.txt").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00binary\xff\xfe")
+    path = make_csv(["a"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert not result.is_valid
+    assert any("a.txt" in e for e in result.errors)
+
+
+def test_non_utf8_bytes_are_rejected(staged):
+    _, seq, make_csv = staged
+    # Latin-1 encoded bytes that are not valid UTF-8 (0xE9 = é in latin-1).
+    (seq / "a.txt").write_bytes("Caf\xe9 do Brasil".encode("latin-1"))
+    path = make_csv(["a"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert not result.is_valid
+    assert any("not valid UTF-8" in e for e in result.errors)
+
+
+def test_empty_file_is_warned_not_rejected(staged):
+    _, seq, make_csv = staged
+    (seq / "a.txt").write_bytes(b"")
+    path = make_csv(["a"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert result.is_valid  # warn, don't fail
+    assert any("empty or whitespace-only" in w for w in result.warnings)
+
+
+def test_whitespace_only_file_is_warned(staged):
+    _, seq, make_csv = staged
+    (seq / "a.txt").write_text("   \n\t  \n", encoding="utf-8")
+    path = make_csv(["a"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert result.is_valid
+    assert any("empty or whitespace-only" in w for w in result.warnings)
+
+
+def test_missing_referenced_files_are_skipped_here(staged):
+    # Missing files are the IngestableRecordsValidator's concern; this validator
+    # only inspects content of files that exist.
+    _, _, make_csv = staged
+    path = make_csv(["does_not_exist"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert result.is_valid
+    assert result.metadata["docs_checked"] == 0
+
+
+def test_multibyte_char_split_at_byte_cap_is_not_a_false_positive(staged):
+    # A valid UTF-8 file longer than max_bytes whose cap lands mid-character
+    # must NOT be flagged as binary (incremental decode handles the partial).
+    _, seq, make_csv = staged
+    text = "é" * 100  # each char is 2 bytes in UTF-8
+    (seq / "a.txt").write_text(text, encoding="utf-8")
+    path = make_csv(["a"])
+    # max_bytes=51 lands in the middle of a 2-byte char (odd offset).
+    result = TextContentValidator(texts_path="sequences", max_bytes=51).validate(
+        str(path)
+    )
+    assert result.is_valid, result.errors
+
+
+def test_sampling_bounds_files_checked(staged):
+    _, seq, make_csv = staged
+    for i in range(20):
+        (seq / f"f{i}.txt").write_text("ok", encoding="utf-8")
+    path = make_csv([f"f{i}" for i in range(20)])
+    result = TextContentValidator(texts_path="sequences", sample_size=5).validate(
+        str(path)
+    )
+    assert result.is_valid
+    assert result.metadata["docs_checked"] == 5
+
+
+def test_no_filename_column_is_a_noop(staged):
+    _, _, _ = staged
+    import pandas as pd
+
+    src, _, _ = staged
+    path = src.parent / "noname.csv"
+    pd.DataFrame({"text": ["a", "b"]}).to_csv(path, index=False)
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert result.is_valid
+    assert result.metadata["docs_checked"] == 0
+
+
+def test_binary_errors_are_capped(staged):
+    # More than _MAX_REPORTED broken files -> errors are bounded with a
+    # suppression marker rather than thousands of lines.
+    from tracebloc_ingestor.validators.text_content_validator import _MAX_REPORTED
+
+    _, seq, make_csv = staged
+    n = _MAX_REPORTED + 10
+    for i in range(n):
+        (seq / f"f{i}.txt").write_bytes(b"\x00\xff binary")
+    path = make_csv([f"f{i}" for i in range(n)])
+    result = TextContentValidator(
+        texts_path="sequences", sample_size=n
+    ).validate(str(path))
+    assert not result.is_valid
+    assert any("further errors suppressed" in e for e in result.errors)
+    assert len(result.errors) <= _MAX_REPORTED + 1
+
+
+def test_traversal_path_is_skipped_not_inspected(staged):
+    # A manifest value escaping SRC_PATH/<subdir> is rejected by the transfer;
+    # this validator neither reads nor flags a file outside the dataset dir.
+    src, _, make_csv = staged
+    outside = src.parent / "outside.bin"
+    outside.write_bytes(b"\x00\xff binary outside")  # would be flagged if read
+    path = make_csv([str(outside), "../../outside.bin"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert result.is_valid
+    assert result.metadata["docs_checked"] == 0
+
+
+def test_truncated_trailing_multibyte_in_small_file_is_rejected(staged):
+    # A small file ending in an INCOMPLETE multibyte sequence (truncated/corrupt
+    # UTF-8) must be flushed at EOF and rejected — not held unvalidated in the
+    # incremental decoder buffer. (Bugbot: UTF-8 EOF not finalized.)
+    _, seq, make_csv = staged
+    # b"\xe2\x82" is the first 2 bytes of a 3-byte char (€ = E2 82 AC), truncated.
+    (seq / "a.txt").write_bytes(b"hello \xe2\x82")
+    path = make_csv(["a"])
+    result = TextContentValidator(texts_path="sequences").validate(str(path))
+    assert not result.is_valid
+    assert any("not valid UTF-8" in e for e in result.errors)
+
+
+def test_existing_binary_file_caught_even_amid_many_missing(staged):
+    # Many rows reference absent files; one real binary file sits in the middle.
+    # Existence-filtering before sampling ensures the present file is inspected
+    # and the binary content is caught (Bugbot: content sample skips existing).
+    _, seq, make_csv = staged
+    (seq / "real.txt").write_bytes(b"\x00\xff binary")
+    names = [f"missing{i}" for i in range(50)]
+    names.insert(25, "real")  # not at a strided-sample position of the raw list
+    path = make_csv(names)
+    result = TextContentValidator(texts_path="sequences", sample_size=5).validate(
+        str(path)
+    )
+    assert not result.is_valid
+    assert result.metadata["docs_checked"] >= 1
+    assert any("real.txt" in e for e in result.errors)

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -27,6 +27,9 @@ from tracebloc_ingestor.validators.keypoint_visibility_validator import (
 from tracebloc_ingestor.validators.label_diversity_validator import (
     LabelDiversityValidator,
 )
+from tracebloc_ingestor.validators.ingestable_records_validator import (
+    IngestableRecordsValidator,
+)
 
 IMAGE_OPTS = {"extension": FileExtension.JPG, "target_size": [224, 224]}
 
@@ -44,9 +47,12 @@ def test_image_classification():
     )
 
     v = map_validators(TaskCategory.IMAGE_CLASSIFICATION, IMAGE_OPTS)
+    # The 0-record guard, label-diversity, table-name and duplicate validators
+    # are composed by map_validators around the category-specific middle, so the
+    # guard now leads and the classification + tail validators trail.
     assert _types(v) == [
-        FileTypeValidator,
         IngestableRecordsValidator,
+        FileTypeValidator,
         ImageResolutionValidator,
         LabelColumnValidator,
         LabelDiversityValidator,
@@ -192,7 +198,9 @@ def test_tabular_regression_with_schema():
 
 def test_text_classification_defaults_extension():
     v = map_validators(TaskCategory.TEXT_CLASSIFICATION, {})
-    assert _types(v)[0] is FileTypeValidator
+    # The 0-record guard leads; the category's own FileTypeValidator follows.
+    assert _types(v)[0] is IngestableRecordsValidator
+    assert FileTypeValidator in _types(v)
 
 
 def test_text_classification_includes_label_column_validator_before_diversity():
@@ -235,7 +243,8 @@ def test_token_classification_includes_bio_validator():
 
     v = map_validators(TaskCategory.TOKEN_CLASSIFICATION, {})
     types = _types(v)
-    assert types[0] is FileTypeValidator
+    assert types[0] is IngestableRecordsValidator  # 0-record guard leads
+    assert FileTypeValidator in types
     assert BIOLabelValidator in types
     assert TableNameValidator in types and DuplicateValidator in types
 
@@ -360,10 +369,11 @@ def test_nlp_categories_include_content_hygiene_validators():
         TaskCategory.MASKED_LANGUAGE_MODELING,
     ):
         types = _types(map_validators(cat, {}))
-        assert IngestableRecordsValidator in types, cat
+        # 0-record guard leads (composed centrally); the category's own
+        # FileTypeValidator + text-content validator follow.
+        assert types[0] is IngestableRecordsValidator, cat
+        assert FileTypeValidator in types, cat
         assert TextContentValidator in types, cat
-        # FileTypeValidator stays first (the content validators come after it).
-        assert types[0] is FileTypeValidator, cat
 
     # Vision file-bearing categories get the zero-record guard but NOT the
     # text-content validator.
@@ -377,9 +387,10 @@ def test_nlp_categories_include_content_hygiene_validators():
         assert IngestableRecordsValidator in types, cat
         assert TextContentValidator not in types, cat
 
-    # Tabular has neither (no files, not text).
+    # Tabular gets the centralized 0-record guard (every category does) but NOT
+    # the text-content validator (no files, not text).
     types = _types(map_validators(TaskCategory.TABULAR_CLASSIFICATION, IMAGE_OPTS))
-    assert IngestableRecordsValidator not in types
+    assert IngestableRecordsValidator in types
     assert TextContentValidator not in types
 
 
@@ -438,3 +449,42 @@ def test_keypoint_annotation_validator_gets_image_bounds():
     )
     kp = next(x for x in v if isinstance(x, KeypointAnnotationValidator))
     assert kp.expected_resolution == IMAGE_OPTS["target_size"]
+
+
+ALL_CATEGORIES = (
+    TaskCategory.IMAGE_CLASSIFICATION,
+    TaskCategory.OBJECT_DETECTION,
+    TaskCategory.SEMANTIC_SEGMENTATION,
+    TaskCategory.KEYPOINT_DETECTION,
+    TaskCategory.TEXT_CLASSIFICATION,
+    TaskCategory.TOKEN_CLASSIFICATION,
+    TaskCategory.MASKED_LANGUAGE_MODELING,
+    TaskCategory.TABULAR_CLASSIFICATION,
+    TaskCategory.TABULAR_REGRESSION,
+    TaskCategory.TIME_SERIES_FORECASTING,
+    TaskCategory.TIME_TO_EVENT_PREDICTION,
+)
+_CLASSIFICATION = {
+    TaskCategory.IMAGE_CLASSIFICATION,
+    TaskCategory.OBJECT_DETECTION,
+    TaskCategory.SEMANTIC_SEGMENTATION,
+    TaskCategory.KEYPOINT_DETECTION,
+    TaskCategory.TEXT_CLASSIFICATION,
+    TaskCategory.TABULAR_CLASSIFICATION,
+}
+
+
+def test_common_validator_frame_composed_for_every_category():
+    """map_validators wraps every category's factory output in the common
+    frame: 0-record guard first, table-name + duplicate last, and label-diversity
+    second-to-last for classification families only — declared once, not per
+    factory."""
+    opts = {"extension": ".jpg", "target_size": [64, 64], "number_of_keypoints": 5}
+    for cat in ALL_CATEGORIES:
+        types = _types(map_validators(cat, opts))
+        assert types[0] is IngestableRecordsValidator, cat
+        assert types[-2:] == [TableNameValidator, DuplicateValidator], cat
+        if cat in _CLASSIFICATION:
+            assert types[-3] is LabelDiversityValidator, cat
+        else:
+            assert LabelDiversityValidator not in types, cat

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -127,6 +127,7 @@ def test_classification_categories_include_label_diversity():
         TaskCategory.TIME_SERIES_FORECASTING,
         TaskCategory.TIME_TO_EVENT_PREDICTION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
+        TaskCategory.CAUSAL_LANGUAGE_MODELING,
     ):
         assert LabelDiversityValidator not in _types(
             map_validators(cat, {"schema": {"a": "INT"}})
@@ -351,8 +352,8 @@ def test_map_validators_without_config_falls_back_to_module_global(monkeypatch):
 
 
 def test_nlp_categories_include_content_hygiene_validators():
-    """The text categories (text/token classification, MLM) gain BOTH the
-    zero-record guard and the (text-only) UTF-8 content validator. The
+    """The text categories (text/token classification, masked & causal LM) gain
+    BOTH the zero-record guard and the (text-only) UTF-8 content validator. The
     zero-record guard now also covers file-bearing vision categories, but
     TextContentValidator stays NLP-only (it decodes UTF-8 text, meaningless for
     images); tabular has neither."""
@@ -367,6 +368,7 @@ def test_nlp_categories_include_content_hygiene_validators():
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
+        TaskCategory.CAUSAL_LANGUAGE_MODELING,
     ):
         types = _types(map_validators(cat, {}))
         # 0-record guard leads (composed centrally); the category's own
@@ -409,6 +411,44 @@ def test_mlm_content_validators_target_sequences_subdir():
     txt = next(x for x in v if isinstance(x, TextContentValidator))
     assert rec.file_subdir == "sequences"
     assert txt.texts_path == "sequences"
+
+
+def test_causal_lm_content_validators_target_texts_subdir():
+    """Causal LM stages RAW text under ``texts/`` (not the pre-tokenized
+    ``sequences/`` MLM uses); the content validators must point there."""
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    v = map_validators(TaskCategory.CAUSAL_LANGUAGE_MODELING, {})
+    rec = next(x for x in v if isinstance(x, IngestableRecordsValidator))
+    txt = next(x for x in v if isinstance(x, TextContentValidator))
+    assert rec.file_subdir == "texts"
+    assert txt.texts_path == "texts"
+
+
+def test_causal_lm_excludes_all_label_validators():
+    """Causal LM is self-supervised: only ``filename`` is required, no label
+    column. It must carry none of the label-oriented validators (mirrors MLM)."""
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+    from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
+
+    types = _types(map_validators(TaskCategory.CAUSAL_LANGUAGE_MODELING, {}))
+    assert LabelColumnValidator not in types
+    assert BIOLabelValidator not in types
+    assert LabelDiversityValidator not in types
+
+
+def test_causal_lm_with_schema_adds_data_validator():
+    v = map_validators(
+        TaskCategory.CAUSAL_LANGUAGE_MODELING, {"schema": {"a": "INT"}}
+    )
+    assert DataValidator in _types(v)
 
 
 def test_text_classification_content_validators_target_texts_subdir():
@@ -459,6 +499,7 @@ ALL_CATEGORIES = (
     TaskCategory.TEXT_CLASSIFICATION,
     TaskCategory.TOKEN_CLASSIFICATION,
     TaskCategory.MASKED_LANGUAGE_MODELING,
+    TaskCategory.CAUSAL_LANGUAGE_MODELING,
     TaskCategory.TABULAR_CLASSIFICATION,
     TaskCategory.TABULAR_REGRESSION,
     TaskCategory.TIME_SERIES_FORECASTING,

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -36,14 +36,67 @@ def _types(validators):
 
 
 def test_image_classification():
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+
     v = map_validators(TaskCategory.IMAGE_CLASSIFICATION, IMAGE_OPTS)
     assert _types(v) == [
         FileTypeValidator,
+        IngestableRecordsValidator,
         ImageResolutionValidator,
+        LabelColumnValidator,
         LabelDiversityValidator,
         TableNameValidator,
         DuplicateValidator,
     ]
+
+
+def test_vision_categories_have_zero_record_guard():
+    """0-record fail-fast (header-only / empty CSV) is wired into every
+    file-bearing vision category — image/object/semantic/keypoint — so a
+    zero-record vision dataset is rejected at preflight instead of creating an
+    orphan empty table (extends #303 from NLP to vision)."""
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+
+    for cat in (
+        TaskCategory.IMAGE_CLASSIFICATION,
+        TaskCategory.OBJECT_DETECTION,
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        TaskCategory.KEYPOINT_DETECTION,
+    ):
+        rec = [
+            x
+            for x in map_validators(cat, IMAGE_OPTS)
+            if isinstance(x, IngestableRecordsValidator)
+        ]
+        assert len(rec) == 1, cat
+        assert rec[0].file_subdir == "images", cat
+
+
+def test_label_column_guard_is_image_classification_only():
+    """LabelColumnValidator gates only image_classification among vision
+    categories — object detection / segmentation / keypoint source labels from
+    XML / masks / annotation files, not a CSV label column, so adding it there
+    would wrongly reject every such dataset."""
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+
+    assert LabelColumnValidator in _types(
+        map_validators(TaskCategory.IMAGE_CLASSIFICATION, IMAGE_OPTS)
+    )
+    for cat in (
+        TaskCategory.OBJECT_DETECTION,
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        TaskCategory.KEYPOINT_DETECTION,
+    ):
+        assert LabelColumnValidator not in _types(map_validators(cat, IMAGE_OPTS)), cat
 
 
 def test_classification_categories_include_label_diversity():
@@ -289,8 +342,11 @@ def test_map_validators_without_config_falls_back_to_module_global(monkeypatch):
 
 
 def test_nlp_categories_include_content_hygiene_validators():
-    """The text categories (text/token classification, MLM) gain the
-    zero-record and text-content validators; image/tabular do NOT."""
+    """The text categories (text/token classification, MLM) gain BOTH the
+    zero-record guard and the (text-only) UTF-8 content validator. The
+    zero-record guard now also covers file-bearing vision categories, but
+    TextContentValidator stays NLP-only (it decodes UTF-8 text, meaningless for
+    images); tabular has neither."""
     from tracebloc_ingestor.validators.ingestable_records_validator import (
         IngestableRecordsValidator,
     )
@@ -309,10 +365,22 @@ def test_nlp_categories_include_content_hygiene_validators():
         # FileTypeValidator stays first (the content validators come after it).
         assert types[0] is FileTypeValidator, cat
 
-    for cat in (TaskCategory.IMAGE_CLASSIFICATION, TaskCategory.TABULAR_CLASSIFICATION):
+    # Vision file-bearing categories get the zero-record guard but NOT the
+    # text-content validator.
+    for cat in (
+        TaskCategory.IMAGE_CLASSIFICATION,
+        TaskCategory.OBJECT_DETECTION,
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        TaskCategory.KEYPOINT_DETECTION,
+    ):
         types = _types(map_validators(cat, IMAGE_OPTS))
-        assert IngestableRecordsValidator not in types, cat
+        assert IngestableRecordsValidator in types, cat
         assert TextContentValidator not in types, cat
+
+    # Tabular has neither (no files, not text).
+    types = _types(map_validators(TaskCategory.TABULAR_CLASSIFICATION, IMAGE_OPTS))
+    assert IngestableRecordsValidator not in types
+    assert TextContentValidator not in types
 
 
 def test_mlm_content_validators_target_sequences_subdir():
@@ -345,3 +413,28 @@ def test_text_classification_content_validators_target_texts_subdir():
     txt = next(x for x in v if isinstance(x, TextContentValidator))
     assert rec.file_subdir == "texts"
     assert txt.texts_path == "texts"
+
+
+def test_semantic_segmentation_validates_masks_resolution():
+    """Seg masks get their own ImageResolutionValidator(subdir="masks") so a
+    corrupt or wrong-sized mask is rejected (the default instance only scans
+    images). PR #314."""
+    v = map_validators(TaskCategory.SEMANTIC_SEGMENTATION, IMAGE_OPTS)
+    res = [x for x in v if isinstance(x, ImageResolutionValidator)]
+    subdirs = sorted(x.subdir for x in res)
+    assert subdirs == ["images", "masks"], subdirs
+
+
+def test_keypoint_annotation_validator_gets_image_bounds():
+    """KeypointAnnotationValidator is given the declared target_size so it can
+    reject keypoints past the image edge. PR #314."""
+    from tracebloc_ingestor.validators.keypoint_annotation_validator import (
+        KeypointAnnotationValidator,
+    )
+
+    v = map_validators(
+        TaskCategory.KEYPOINT_DETECTION,
+        {**IMAGE_OPTS, "number_of_keypoints": 5},
+    )
+    kp = next(x for x in v if isinstance(x, KeypointAnnotationValidator))
+    assert kp.expected_resolution == IMAGE_OPTS["target_size"]

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -142,6 +142,41 @@ def test_text_classification_defaults_extension():
     assert _types(v)[0] is FileTypeValidator
 
 
+def test_text_classification_includes_label_column_validator_before_diversity():
+    """A text-classification CSV missing the configured label column must fail
+    fast at preflight (not ingest label=None -> late backend 400). The presence
+    check runs BEFORE the diversity check, which only reads the column lazily."""
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+
+    types = _types(map_validators(TaskCategory.TEXT_CLASSIFICATION, {}))
+    assert LabelColumnValidator in types
+    assert types.index(LabelColumnValidator) < types.index(LabelDiversityValidator)
+
+
+def test_text_classification_threads_custom_label_column():
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+
+    v = map_validators(TaskCategory.TEXT_CLASSIFICATION, {"label_column": "sentiment"})
+    lc = next(x for x in v if isinstance(x, LabelColumnValidator))
+    assert lc.label_column == "sentiment"
+
+
+def test_token_classification_excludes_label_column_validator():
+    """Token classification already rejects a missing label column via
+    BIOLabelValidator, so it must NOT also carry LabelColumnValidator."""
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+
+    assert LabelColumnValidator not in _types(
+        map_validators(TaskCategory.TOKEN_CLASSIFICATION, {})
+    )
+
+
 def test_token_classification_includes_bio_validator():
     from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
 

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -251,3 +251,62 @@ def test_map_validators_without_config_falls_back_to_module_global(monkeypatch):
     assert all(v._config is None for v in validators)
     dup = next(v for v in validators if isinstance(v, DuplicateValidator))
     assert dup.dest_path.endswith("/env_table")
+
+
+def test_nlp_categories_include_content_hygiene_validators():
+    """The text categories (text/token classification, MLM) gain the
+    zero-record and text-content validators; image/tabular do NOT."""
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    for cat in (
+        TaskCategory.TEXT_CLASSIFICATION,
+        TaskCategory.TOKEN_CLASSIFICATION,
+        TaskCategory.MASKED_LANGUAGE_MODELING,
+    ):
+        types = _types(map_validators(cat, {}))
+        assert IngestableRecordsValidator in types, cat
+        assert TextContentValidator in types, cat
+        # FileTypeValidator stays first (the content validators come after it).
+        assert types[0] is FileTypeValidator, cat
+
+    for cat in (TaskCategory.IMAGE_CLASSIFICATION, TaskCategory.TABULAR_CLASSIFICATION):
+        types = _types(map_validators(cat, IMAGE_OPTS))
+        assert IngestableRecordsValidator not in types, cat
+        assert TextContentValidator not in types, cat
+
+
+def test_mlm_content_validators_target_sequences_subdir():
+    """MLM stages files under ``sequences/`` (not ``texts/``); the content
+    validators must point at that subdirectory."""
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    v = map_validators(TaskCategory.MASKED_LANGUAGE_MODELING, {})
+    rec = next(x for x in v if isinstance(x, IngestableRecordsValidator))
+    txt = next(x for x in v if isinstance(x, TextContentValidator))
+    assert rec.file_subdir == "sequences"
+    assert txt.texts_path == "sequences"
+
+
+def test_text_classification_content_validators_target_texts_subdir():
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    v = map_validators(TaskCategory.TEXT_CLASSIFICATION, {})
+    rec = next(x for x in v if isinstance(x, IngestableRecordsValidator))
+    txt = next(x for x in v if isinstance(x, TextContentValidator))
+    assert rec.file_subdir == "texts"
+    assert txt.texts_path == "texts"

--- a/tests/test_vision_input_validators.py
+++ b/tests/test_vision_input_validators.py
@@ -1,0 +1,56 @@
+"""End-to-end vision preflight: image_classification now rejects the 0-record
+and missing-label-column gaps that the NLP-only #303/#313 fixes had left open
+for vision. Drives the REAL `map_validators` chain (minus the DB-bound
+TableName/Duplicate validators) on staged image datasets.
+"""
+
+from __future__ import annotations
+
+import os
+
+from PIL import Image
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.utils.constants import TaskCategory
+from tracebloc_ingestor.utils.validators_mapping import map_validators
+
+_SKIP = {"TableNameValidator", "DuplicateValidator"}  # need a DB / not data-hygiene
+
+
+def _img(d, name, size=(64, 64)):
+    os.makedirs(os.path.join(d, "images"), exist_ok=True)
+    Image.new("RGB", size, (120, 120, 120)).save(os.path.join(d, "images", name))
+
+
+def _first_rejecter(tmp_path, csv_text, images=("a.jpeg", "b.jpeg")):
+    d = str(tmp_path)
+    for n in images:
+        _img(d, n)
+    csv = tmp_path / "labels.csv"
+    csv.write_text(csv_text, encoding="utf-8")
+    cfg = Config(SRC_PATH=d, TABLE_NAME="t")
+    opts = {"extension": ".jpeg", "target_size": [64, 64], "label_column": "label"}
+    for v in map_validators(TaskCategory.IMAGE_CLASSIFICATION, opts, cfg):
+        if type(v).__name__ in _SKIP:
+            continue
+        r = v.validate(str(csv))
+        if not r.is_valid:
+            return type(v).__name__
+    return None
+
+
+def test_image_valid_passes(tmp_path):
+    assert _first_rejecter(tmp_path, "filename,label\na.jpeg,cat\nb.jpeg,dog\n") is None
+
+
+def test_image_empty_csv_rejected_at_preflight(tmp_path):
+    # header-only CSV -> 0 records; previously ingested an orphan empty table.
+    assert _first_rejecter(tmp_path, "filename,label\n") == "IngestableRecordsValidator"
+
+
+def test_image_missing_label_column_rejected_at_preflight(tmp_path):
+    # no label column -> previously ingested label=None -> late backend 400.
+    assert (
+        _first_rejecter(tmp_path, "filename\na.jpeg\nb.jpeg\n")
+        == "LabelColumnValidator"
+    )

--- a/tests/test_xml_validator.py
+++ b/tests/test_xml_validator.py
@@ -8,14 +8,20 @@ import pytest
 
 from tracebloc_ingestor.validators.xml_validator import PascalVOCXMLValidator
 
-
 # ---------------------------------------------------------------------------
 # Builders for valid / customizable VOC XML.
 # ---------------------------------------------------------------------------
 
+
 def _object_xml(
-    name="cat", pose="Unspecified", truncated="0", difficult="0",
-    xmin=10, ymin=10, xmax=100, ymax=100,
+    name="cat",
+    pose="Unspecified",
+    truncated="0",
+    difficult="0",
+    xmin=10,
+    ymin=10,
+    xmax=100,
+    ymax=100,
 ):
     return f"""
   <object>
@@ -61,6 +67,7 @@ def validator():
 # validate() flow (reads config.SRC_PATH directory)
 # ---------------------------------------------------------------------------
 
+
 def test_valid_file_passes(clean_env, tmp_path, validator):
     (tmp_path / "ann.xml").write_text(_voc_xml(), encoding="utf-8")
     clean_env.setenv("SRC_PATH", str(tmp_path))
@@ -95,6 +102,7 @@ def test_nonexistent_src_path_fails(clean_env, validator):
 # _get_xml_files
 # ---------------------------------------------------------------------------
 
+
 def test_get_xml_files_single_file(tmp_path, validator):
     f = tmp_path / "a.xml"
     f.write_text(_voc_xml(), encoding="utf-8")
@@ -105,7 +113,9 @@ def test_get_xml_files_single_file(tmp_path, validator):
 def test_get_xml_files_list_input(tmp_path, validator):
     f = tmp_path / "a.xml"
     f.write_text(_voc_xml(), encoding="utf-8")
-    files = validator._get_xml_files([str(f), str(tmp_path / "missing.xml")], True, True)
+    files = validator._get_xml_files(
+        [str(f), str(tmp_path / "missing.xml")], True, True
+    )
     assert files == [f]
 
 
@@ -126,6 +136,7 @@ def test_get_xml_files_ignores_hidden(tmp_path, validator):
 # ---------------------------------------------------------------------------
 # _validate_single_xml + sub-validators
 # ---------------------------------------------------------------------------
+
 
 def test_single_xml_valid(tmp_path, validator):
     f = tmp_path / "a.xml"
@@ -163,7 +174,9 @@ def test_root_elements_missing():
 
 def test_root_empty_filename_fails():
     v = PascalVOCXMLValidator()
-    root = _root(_voc_xml().replace("<filename>img.jpg</filename>", "<filename></filename>"))
+    root = _root(
+        _voc_xml().replace("<filename>img.jpg</filename>", "<filename></filename>")
+    )
     res = v._validate_root_elements(root)
     assert any("Filename element must have non-empty" in e for e in res["errors"])
 
@@ -184,7 +197,9 @@ def test_source_missing_fails():
 
 def test_source_empty_database_fails():
     v = PascalVOCXMLValidator()
-    root = _root(_voc_xml().replace("<database>Unknown</database>", "<database></database>"))
+    root = _root(
+        _voc_xml().replace("<database>Unknown</database>", "<database></database>")
+    )
     res = v._validate_source_element(root)
     assert any("Database element must have non-empty" in e for e in res["errors"])
 
@@ -262,3 +277,84 @@ def test_bndbox_small_area_warns():
     obj = _root(_object_xml(xmin=10, ymin=10, xmax=12, ymax=12))  # area 4 < 10
     res = v._validate_bndbox_element(obj, 0)
     assert any("Very small bounding box" in w for w in res["warnings"])
+
+
+# --- bbox bounded by declared <size> (#314 vision-hardening follow-up) --------
+
+
+def test_bbox_exceeding_declared_width_fails(clean_env, tmp_path, validator):
+    xml = _voc_xml(
+        width=64, height=64, objects=[_object_xml(xmin=5, ymin=5, xmax=9999, ymax=30)]
+    )
+    (tmp_path / "ann.xml").write_text(xml, encoding="utf-8")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(str(tmp_path))
+    assert not result.is_valid
+    assert any("exceeds image width" in e for e in result.errors)
+
+
+def test_bbox_exceeding_declared_height_fails(clean_env, tmp_path, validator):
+    xml = _voc_xml(
+        width=64, height=64, objects=[_object_xml(xmin=5, ymin=5, xmax=30, ymax=9999)]
+    )
+    (tmp_path / "ann.xml").write_text(xml, encoding="utf-8")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(str(tmp_path))
+    assert not result.is_valid
+    assert any("exceeds image height" in e for e in result.errors)
+
+
+def test_bbox_within_declared_size_passes(clean_env, tmp_path, validator):
+    xml = _voc_xml(
+        width=64, height=64, objects=[_object_xml(xmin=5, ymin=5, xmax=60, ymax=60)]
+    )
+    (tmp_path / "ann.xml").write_text(xml, encoding="utf-8")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(str(tmp_path))
+    assert result.is_valid, result.errors
+
+
+# --- declared <size> cross-checked against the actual image -------------------
+
+
+def _setup_with_image(tmp_path, declared_wh, image_wh):
+    from PIL import Image
+
+    (tmp_path / "annotations").mkdir()
+    (tmp_path / "images").mkdir()
+    # The image is located by XML STEM (matching the ingestor's pairing), so the
+    # annotation "ann.xml" pairs with the image "ann.<ext>".
+    Image.new("RGB", image_wh, (120, 120, 120)).save(tmp_path / "images" / "ann.jpg")
+    # bbox kept small so it fits inside the declared sizes used by callers —
+    # we're exercising the size<->image cross-check, not the bbox-bounds check.
+    xml = _voc_xml(
+        width=declared_wh[0],
+        height=declared_wh[1],
+        objects=[_object_xml(xmin=5, ymin=5, xmax=40, ymax=40)],
+    )
+    (tmp_path / "annotations" / "ann.xml").write_text(xml, encoding="utf-8")
+
+
+def test_declared_size_matching_actual_image_passes(clean_env, tmp_path, validator):
+    _setup_with_image(tmp_path, declared_wh=(64, 64), image_wh=(64, 64))
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(str(tmp_path))
+    assert result.is_valid, result.errors
+
+
+def test_declared_size_mismatching_actual_image_fails(clean_env, tmp_path, validator):
+    _setup_with_image(tmp_path, declared_wh=(128, 128), image_wh=(64, 64))
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(str(tmp_path))
+    assert not result.is_valid
+    assert any("does not match the actual image" in e for e in result.errors)
+
+
+def test_size_check_skipped_when_image_absent(clean_env, tmp_path, validator):
+    # No images/ dir -> the size cross-check is a benign skip (FilePairing /
+    # FileType own the missing-image case), so a lone valid XML still passes.
+    xml = _voc_xml(width=128, height=128)
+    (tmp_path / "ann.xml").write_text(xml, encoding="utf-8")
+    clean_env.setenv("SRC_PATH", str(tmp_path))
+    result = validator.validate(str(tmp_path))
+    assert result.is_valid, result.errors

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.4.0"
+__version__ = "0.5.2"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -44,10 +44,16 @@ IMAGE_CATEGORIES: FrozenSet[str] = frozenset(
     }
 )
 
+# Categories that stage raw ``.txt`` files from ``texts/`` and default to the
+# ``.txt`` extension. causal_language_modeling joins text/token classification
+# here (it reads raw text, not the pre-tokenized ``sequences/`` MLM uses); it is
+# self-supervised, but that only governs label handling, not the file_options
+# default this set drives.
 TEXT_CATEGORIES: FrozenSet[str] = frozenset(
     {
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
+        TaskCategory.CAUSAL_LANGUAGE_MODELING,
     }
 )
 

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -44,6 +44,23 @@ logger = logging.getLogger(__name__)
 __all__ = ["BaseIngestor", "IngestionSummary"]
 
 
+def _rows_state_clause(inserted_records: int) -> str:
+    """Phrase the parenthetical about what's already in the database for a
+    registration-failure message, truthfully for the row count actually
+    ingested.
+
+    The registration steps run AFTER the rows are committed, so when some rows
+    landed the message must warn they're already persisted. But when zero rows
+    were ingested (e.g. a header-only CSV or an all-files-missing manifest that
+    slipped to this point), the old fixed "(its rows are already in the
+    database)" wording was simply false and sent users hunting for rows that
+    don't exist. Switch on the count so the message can never claim phantom rows.
+    """
+    if inserted_records > 0:
+        return f"its {inserted_records} already-ingested row(s) remain in the database"
+    return "no rows were ingested, so nothing was left in the database"
+
+
 # NOTE: _TABULAR_FAMILY_CATEGORIES and _FILE_BEARING_CATEGORIES are imported
 # above from modalities.registry (derived from the per-category ModalitySpec
 # flags — backend#796 P3a). The ``self.category in <set>`` checks throughout
@@ -571,9 +588,10 @@ class BaseIngestor(ABC):
                     self.table_name, self.ingestor_id, self.intent
                 ):
                     raise RuntimeError(
-                        "Backend rejected edge-label metadata; the dataset was "
-                        "NOT registered (its rows are already in the database). "
-                        "See the logged API error above."
+                        f"Backend rejected edge-label metadata; the dataset was "
+                        f"NOT registered "
+                        f"({_rows_state_clause(stats['inserted_records'])}). "
+                        f"See the logged API error above."
                     )
 
                 # Ship a data-derived text profile for NLP datasets (#805):
@@ -591,9 +609,10 @@ class BaseIngestor(ABC):
                     self.table_name, schema_dict, self.file_options
                 ):
                     raise RuntimeError(
-                        "Backend rejected the dataset schema/metadata; the "
-                        "dataset was NOT registered (its rows are already in the "
-                        "database). See the logged API error above."
+                        f"Backend rejected the dataset schema/metadata; the "
+                        f"dataset was NOT registered "
+                        f"({_rows_state_clause(stats['inserted_records'])}). "
+                        f"See the logged API error above."
                     )
 
                 if not self.api_client.prepare_dataset(
@@ -614,7 +633,8 @@ class BaseIngestor(ABC):
                     )
                     raise RuntimeError(
                         f"Backend failed to prepare the dataset; it was NOT "
-                        f"registered (its rows are already in the database). "
+                        f"registered "
+                        f"({_rows_state_clause(stats['inserted_records'])}). "
                         f"Backend response: {detail}"
                     )
 

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -32,6 +32,8 @@ _SPECS = (
         data_format=DataFormat.IMAGE,
         build_validators=v.image_classification,
         transfer=t.image_classification,
+        file_subdir="images",
+        is_classification=True,
     ),
     ModalitySpec(
         TaskCategory.OBJECT_DETECTION,
@@ -41,6 +43,8 @@ _SPECS = (
         data_format=DataFormat.IMAGE,
         build_validators=v.object_detection,
         transfer=t.object_detection,
+        file_subdir="images",
+        is_classification=True,
     ),
     ModalitySpec(
         TaskCategory.KEYPOINT_DETECTION,
@@ -50,6 +54,8 @@ _SPECS = (
         data_format=DataFormat.IMAGE,
         build_validators=v.keypoint_detection,
         transfer=t.keypoint_detection,
+        file_subdir="images",
+        is_classification=True,
     ),
     ModalitySpec(
         TaskCategory.SEMANTIC_SEGMENTATION,
@@ -59,6 +65,8 @@ _SPECS = (
         data_format=DataFormat.IMAGE,
         build_validators=v.semantic_segmentation,
         transfer=t.semantic_segmentation,
+        file_subdir="images",
+        is_classification=True,
     ),
     ModalitySpec(
         TaskCategory.TEXT_CLASSIFICATION,
@@ -69,6 +77,8 @@ _SPECS = (
         build_validators=v.text_classification,
         transfer=t.text_classification,
         is_nlp=True,
+        file_subdir="texts",
+        is_classification=True,
     ),
     ModalitySpec(
         TaskCategory.TOKEN_CLASSIFICATION,
@@ -79,6 +89,7 @@ _SPECS = (
         build_validators=v.token_classification,
         transfer=t.token_classification,
         is_nlp=True,
+        file_subdir="texts",
     ),
     # masked_language_modeling is file-bearing AND self-supervised (no label).
     ModalitySpec(
@@ -90,6 +101,7 @@ _SPECS = (
         build_validators=v.masked_language_modeling,
         transfer=t.masked_language_modeling,
         is_nlp=True,
+        file_subdir="sequences",
     ),
     # Tabular family (structured feature tables; no sidecar files -> no transfer).
     ModalitySpec(
@@ -99,6 +111,7 @@ _SPECS = (
         is_self_supervised=False,
         data_format=DataFormat.TABULAR,
         build_validators=v.tabular_classification,
+        is_classification=True,
     ),
     ModalitySpec(
         TaskCategory.TABULAR_REGRESSION,

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -103,6 +103,24 @@ _SPECS = (
         is_nlp=True,
         file_subdir="sequences",
     ),
+    # causal_language_modeling is file-bearing AND self-supervised (no label),
+    # like MLM. Unlike MLM it consumes RAW text — each sample is a ``.txt`` of
+    # either plain text (pretraining) or a tab-separated ``prompt\tcompletion``
+    # pair (SFT) — so it stages from ``texts/`` (the raw-text subdir shared with
+    # text/token classification), not ``sequences/`` (which the framework
+    # reserves for pre-tokenized data). It is NLP, so it ships the #805
+    # data-derived text profile for the contributor-tokenizer-fit check.
+    ModalitySpec(
+        TaskCategory.CAUSAL_LANGUAGE_MODELING,
+        is_file_bearing=True,
+        is_tabular_family=False,
+        is_self_supervised=True,
+        data_format=DataFormat.TEXT,
+        build_validators=v.causal_language_modeling,
+        transfer=t.causal_language_modeling,
+        is_nlp=True,
+        file_subdir="texts",
+    ),
     # Tabular family (structured feature tables; no sidecar files -> no transfer).
     ModalitySpec(
         TaskCategory.TABULAR_CLASSIFICATION,

--- a/tracebloc_ingestor/modalities/spec.py
+++ b/tracebloc_ingestor/modalities/spec.py
@@ -77,3 +77,16 @@ class ModalitySpec:
         Callable[[Dict[str, Any], Dict[str, Any], Any], Optional[Dict[str, Any]]]
     ] = None
     is_nlp: bool = False
+    # Subdirectory under SRC_PATH holding this category's per-row files
+    # (``images`` / ``texts`` / ``sequences``), or ``None`` for non-file-bearing
+    # (tabular / time-series) categories. Used by the centralized 0-record guard
+    # in ``map_validators``: with a subdir it also cross-checks the CSV's
+    # referenced files exist; with ``None`` only the header-only / empty-CSV row
+    # check runs.
+    file_subdir: Optional[str] = None
+    # Classification-family category whose dataset needs >= 2 distinct label
+    # values (image / object / semantic / keypoint / tabular / text
+    # classification). Gates the centralized LabelDiversityValidator. False for
+    # regression / self-supervised / token-classification (per-token BIO) and
+    # the time families.
+    is_classification: bool = False

--- a/tracebloc_ingestor/modalities/transfer.py
+++ b/tracebloc_ingestor/modalities/transfer.py
@@ -106,6 +106,16 @@ def masked_language_modeling(
     return text_transfer(record, options, src_subdir="sequences", cfg=cfg)
 
 
+def causal_language_modeling(
+    record: Dict[str, Any], options: Dict[str, Any], cfg: Optional[Config] = None
+) -> Optional[Dict[str, Any]]:
+    # Raw text, one .txt per sample in the ``texts`` subdir (same on-disk
+    # layout as text/token classification — the default text_transfer subdir).
+    # Self-supervised: the .txt holds plain text or a ``prompt\tcompletion``
+    # pair, never a label.
+    return text_transfer(record, options, cfg=cfg)
+
+
 def semantic_segmentation(
     record: Dict[str, Any], options: Dict[str, Any], cfg: Optional[Config] = None
 ) -> Optional[Dict[str, Any]]:

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -205,6 +205,26 @@ def masked_language_modeling(options: Dict[str, Any]) -> List[BaseValidator]:
     return validators
 
 
+def causal_language_modeling(options: Dict[str, Any]) -> List[BaseValidator]:
+    # Self-supervised, like MLM — only a ``filename`` column is required, no
+    # label column, so no LabelColumn/BIO/LabelDiversity validators. Each sample
+    # is one ``.txt`` of RAW text: plain text (pretraining) or a tab-separated
+    # ``prompt\tcompletion`` pair (SFT). Both are valid UTF-8 text content, so
+    # the shared TextContentValidator (binary/non-UTF-8 reject, empty warn) is
+    # the whole content check — there is no extra structural rule to enforce.
+    # Stages from ``texts/`` (raw text), not ``sequences/`` (pre-tokenized).
+    validators: List[BaseValidator] = [
+        FileTypeValidator(
+            allowed_extension=options.get("extension", FileExtension.TXT),
+            path="texts",
+        ),
+        _text_content_validator(options, "texts"),
+    ]
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
 def tabular_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     validators: List[BaseValidator] = []
     if options.get("schema"):

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -59,10 +59,32 @@ def _label_diversity_validator(options: Dict[str, Any]) -> LabelDiversityValidat
     )
 
 
+def _zero_record_validator(
+    options: Dict[str, Any], subdir: str = "images"
+) -> IngestableRecordsValidator:
+    """0-record fail-fast guard for file-bearing vision categories — the #303
+    pattern extended from NLP to vision. Rejects a header-only / empty CSV (and
+    a manifest whose every referenced file is missing) BEFORE the table is
+    created, so a zero-record vision dataset fails early with a clear message
+    instead of an orphan empty table + a late, misleading registration error.
+    ``subdir`` mirrors the category's image ``FileTypeValidator(path=...)``."""
+    return IngestableRecordsValidator(
+        file_subdir=subdir, extension=options.get("extension", FileExtension.JPG)
+    )
+
+
 def image_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
+        _zero_record_validator(options),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
+        # Fail fast when the configured label column is absent from the CSV
+        # (else every record cleans to label=None and the backend rejects each
+        # row with HTTP 400 "label: may not be null"). image_classification is
+        # the only vision category whose label is a CSV column — object
+        # detection / segmentation / keypoint source labels from XML / masks /
+        # annotation files, so they do NOT get this validator.
+        LabelColumnValidator(label_column=options.get("label_column") or "label"),
         _label_diversity_validator(options),
         TableNameValidator(),
         DuplicateValidator(),
@@ -73,6 +95,7 @@ def object_detection(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
         FileTypeValidator(allowed_extension=".xml", path="annotations"),
+        _zero_record_validator(options),
         PascalVOCXMLValidator(),
         FilePairingValidator(
             image_path="images",
@@ -225,6 +248,7 @@ def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
         FileTypeValidator(allowed_extension=FileExtension.PNG, path="masks"),
+        _zero_record_validator(options),
         FilePairingValidator(
             image_path="images",
             sidecar_path="masks",
@@ -236,6 +260,15 @@ def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
             sidecar_suffix="_mask",
         ),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
+        # Masks are pixel-wise label maps: validate they're readable PNGs and
+        # share the images' resolution. The default ImageResolution instance only
+        # scans <SRC>/images, so without this a corrupt mask, or a mask whose size
+        # differs from its image, would slip through to training.
+        ImageResolutionValidator(
+            expected_resolution=options["target_size"],
+            name="Mask Resolution Validator",
+            subdir="masks",
+        ),
         _label_diversity_validator(options),
         TableNameValidator(),
         DuplicateValidator(),
@@ -250,8 +283,14 @@ def keypoint_detection(options: Dict[str, Any]) -> List[BaseValidator]:
     # rejects datasets whose annotations drift from the declared K.
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
+        _zero_record_validator(options),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
-        KeypointAnnotationValidator(num_keypoints=options.get("number_of_keypoints")),
+        KeypointAnnotationValidator(
+            num_keypoints=options.get("number_of_keypoints"),
+            # Bound keypoint coords by the declared image size (images are
+            # enforced to target_size by ImageResolutionValidator above).
+            expected_resolution=options.get("target_size"),
+        ),
         KeypointVisibilityValidator(),
         _label_diversity_validator(options),
         TableNameValidator(),

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -22,6 +22,7 @@ from ..validators.image_validator import ImageResolutionValidator
 from ..validators.ingestable_records_validator import IngestableRecordsValidator
 from ..validators.keypoint_annotation_validator import KeypointAnnotationValidator
 from ..validators.keypoint_visibility_validator import KeypointVisibilityValidator
+from ..validators.label_column_validator import LabelColumnValidator
 from ..validators.label_diversity_validator import LabelDiversityValidator
 from ..validators.numeric_columns_validator import NumericColumnsValidator
 from ..validators.table_name_validator import TableNameValidator
@@ -123,6 +124,14 @@ def text_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     )
     # Reject a zero-record manifest and binary/empty text content up front.
     validators.extend(_nlp_content_validators(options, "texts"))
+    # Fail fast when the configured label column is absent from the CSV header
+    # (otherwise every record cleans to label=None and the backend rejects each
+    # row with HTTP 400 "label: may not be null" — a late, confusing failure).
+    # Token classification already covers this via BIOLabelValidator, which
+    # resolves and rejects a missing label column itself.
+    validators.append(
+        LabelColumnValidator(label_column=options.get("label_column") or "label")
+    )
     # Add data validator if schema is provided
     if options.get("schema"):
         validators.append(DataValidator(schema=options["schema"]))

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -1,10 +1,20 @@
 """Per-category validator factories (structural refactor — backend#796, P3b).
 
-One factory per task category, each ``(options) -> [validators]``. These are
-the bodies of the old ``utils.validators_mapping.map_validators`` if/elif arms,
-moved verbatim so the validator sets are byte-for-byte identical — now attached
-to each ModalitySpec (``build_validators``) instead of dispatched by a ladder.
-``map_validators`` is now a thin lookup over the registry.
+One factory per task category, each ``(options) -> [validators]``, attached to a
+``ModalitySpec`` (``build_validators``).
+
+Each factory returns ONLY the validators **specific to that category**. The
+universally-applicable validators are composed once in
+``utils.validators_mapping.map_validators`` around the factory's output, driven
+by declarative ``ModalitySpec`` traits, so they are not repeated per category:
+
+    [IngestableRecordsValidator]            # 0-record guard — every category
+      + <factory(options)>                  # category-specific (this file)
+      + [LabelDiversityValidator]           # iff spec.is_classification
+      + [TableNameValidator, DuplicateValidator]   # every category
+
+So a factory here never lists the 0-record guard, label-diversity, table-name,
+or duplicate validators — adding one would double it.
 """
 
 from __future__ import annotations
@@ -15,17 +25,14 @@ from ..utils.constants import FileExtension
 from ..validators.base import BaseValidator
 from ..validators.bio_label_validator import BIOLabelValidator
 from ..validators.data_validator import DataValidator
-from ..validators.duplicate_validator import DuplicateValidator
 from ..validators.file_pairing_validator import FilePairingValidator
 from ..validators.file_validator import FileTypeValidator
 from ..validators.image_validator import ImageResolutionValidator
-from ..validators.ingestable_records_validator import IngestableRecordsValidator
 from ..validators.keypoint_annotation_validator import KeypointAnnotationValidator
 from ..validators.keypoint_visibility_validator import KeypointVisibilityValidator
 from ..validators.label_column_validator import LabelColumnValidator
 from ..validators.label_diversity_validator import LabelDiversityValidator
 from ..validators.numeric_columns_validator import NumericColumnsValidator
-from ..validators.table_name_validator import TableNameValidator
 from ..validators.text_content_validator import TextContentValidator
 from ..validators.time_before_today_validator import TimeBeforeTodayValidator
 from ..validators.time_format_validator import TimeFormatValidator
@@ -34,10 +41,10 @@ from ..validators.time_to_event_validator import TimeToEventValidator
 from ..validators.xml_validator import PascalVOCXMLValidator
 
 
-def _label_diversity_validator(options: Dict[str, Any]) -> LabelDiversityValidator:
+def label_diversity_validator(options: Dict[str, Any]) -> LabelDiversityValidator:
     """Construct a LabelDiversityValidator using the user-configured label
-    column name (or the framework default ``label``). Centralised so every
-    classification-family factory wires the same instance shape.
+    column name (or the framework default ``label``). Composed centrally by
+    ``map_validators`` for every ``is_classification`` category.
 
     Issue #251: a classification dataset with one distinct label value is
     unlearnable and the backend rejects it at ``/global_meta/prepare/`` with
@@ -59,24 +66,21 @@ def _label_diversity_validator(options: Dict[str, Any]) -> LabelDiversityValidat
     )
 
 
-def _zero_record_validator(
-    options: Dict[str, Any], subdir: str = "images"
-) -> IngestableRecordsValidator:
-    """0-record fail-fast guard for file-bearing vision categories — the #303
-    pattern extended from NLP to vision. Rejects a header-only / empty CSV (and
-    a manifest whose every referenced file is missing) BEFORE the table is
-    created, so a zero-record vision dataset fails early with a clear message
-    instead of an orphan empty table + a late, misleading registration error.
-    ``subdir`` mirrors the category's image ``FileTypeValidator(path=...)``."""
-    return IngestableRecordsValidator(
-        file_subdir=subdir, extension=options.get("extension", FileExtension.JPG)
+def _text_content_validator(
+    options: Dict[str, Any], subdir: str
+) -> TextContentValidator:
+    """NLP text-content check: reject binary / non-UTF-8 files, warn on empty
+    docs. ``subdir`` is the per-category text directory (``texts`` / ``sequences``).
+    The 0-record guard that used to be paired with this is now applied centrally
+    in ``map_validators`` (via ``spec.file_subdir``)."""
+    return TextContentValidator(
+        texts_path=subdir, extension=options.get("extension", FileExtension.TXT)
     )
 
 
 def image_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
-        _zero_record_validator(options),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
         # Fail fast when the configured label column is absent from the CSV
         # (else every record cleans to label=None and the backend rejects each
@@ -85,9 +89,6 @@ def image_classification(options: Dict[str, Any]) -> List[BaseValidator]:
         # detection / segmentation / keypoint source labels from XML / masks /
         # annotation files, so they do NOT get this validator.
         LabelColumnValidator(label_column=options.get("label_column") or "label"),
-        _label_diversity_validator(options),
-        TableNameValidator(),
-        DuplicateValidator(),
     ]
 
 
@@ -95,7 +96,6 @@ def object_detection(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
         FileTypeValidator(allowed_extension=".xml", path="annotations"),
-        _zero_record_validator(options),
         PascalVOCXMLValidator(),
         FilePairingValidator(
             image_path="images",
@@ -103,152 +103,13 @@ def object_detection(options: Dict[str, Any]) -> List[BaseValidator]:
             sidecar_label="annotation",
         ),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
-        _label_diversity_validator(options),
-        TableNameValidator(),
-        DuplicateValidator(),
     ]
-
-
-def tabular_classification(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    # Add data validator if schema is provided
-    if options.get("schema"):
-        validators.append(DataValidator(schema=options["schema"]))
-    validators.append(_label_diversity_validator(options))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
-    return validators
-
-
-def _nlp_content_validators(
-    options: Dict[str, Any], subdir: str
-) -> List[BaseValidator]:
-    """The NLP content-hygiene pair, gated on the text categories (text/token
-    classification, MLM): reject a manifest that would ingest zero records
-    (header-only CSV, or every referenced file missing), and reject text files
-    whose CONTENT is binary / non-UTF-8 (warn on empty docs). ``subdir`` is the
-    per-category text directory under ``SRC_PATH`` (``"texts"`` / ``"sequences"``),
-    matching the category's ``FileTypeValidator(path=...)``."""
-    extension = options.get("extension", FileExtension.TXT)
-    return [
-        IngestableRecordsValidator(file_subdir=subdir, extension=extension),
-        TextContentValidator(texts_path=subdir, extension=extension),
-    ]
-
-
-def text_classification(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    # Add text file validator
-    validators.append(
-        FileTypeValidator(
-            allowed_extension=options.get("extension", FileExtension.TXT),
-            path="texts",
-        ),
-    )
-    # Reject a zero-record manifest and binary/empty text content up front.
-    validators.extend(_nlp_content_validators(options, "texts"))
-    # Fail fast when the configured label column is absent from the CSV header
-    # (otherwise every record cleans to label=None and the backend rejects each
-    # row with HTTP 400 "label: may not be null" — a late, confusing failure).
-    # Token classification already covers this via BIOLabelValidator, which
-    # resolves and rejects a missing label column itself.
-    validators.append(
-        LabelColumnValidator(label_column=options.get("label_column") or "label")
-    )
-    # Add data validator if schema is provided
-    if options.get("schema"):
-        validators.append(DataValidator(schema=options["schema"]))
-    validators.append(_label_diversity_validator(options))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
-    return validators
-
-
-def token_classification(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    # Validate text file extensions (one .txt of whitespace-tokenized words
-    # per sample, same layout as text classification).
-    validators.append(
-        FileTypeValidator(
-            allowed_extension=options.get("extension", FileExtension.TXT),
-            path="texts",
-        ),
-    )
-    # Reject a zero-record manifest and binary/empty text content up front.
-    validators.extend(_nlp_content_validators(options, "texts"))
-    # Validate BIO labels: one tag per word, valid BIO/IOB2 format. Honor a
-    # custom label column name when one is configured in the YAML.
-    validators.append(
-        BIOLabelValidator(
-            texts_path="texts",
-            extension=options.get("extension", FileExtension.TXT),
-            label_column=options.get("label_column") or "label",
-        )
-    )
-    # Add data validator if schema is provided
-    if options.get("schema"):
-        validators.append(DataValidator(schema=options["schema"]))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
-    return validators
-
-
-def time_series_forecasting(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    schema = options.get("schema", {})
-    validators.append(TimeFormatValidator(schema=schema))
-    validators.append(TimeOrderedValidator())
-    validators.append(TimeBeforeTodayValidator())
-    validators.append(NumericColumnsValidator(schema=schema))
-    if options.get("schema"):
-        schema_without_timestamp = {
-            k: v for k, v in options["schema"].items() if k.lower() != "timestamp"
-        }
-        if schema_without_timestamp:
-            validators.append(DataValidator(schema=schema_without_timestamp))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
-    return validators
-
-
-def tabular_regression(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    # Add data validator if schema is provided
-    if options.get("schema"):
-        validators.append(DataValidator(schema=options["schema"]))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
-    return validators
-
-
-def time_to_event_prediction(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    # Add time to event validator with schema to identify time column
-    if options.get("schema"):
-        validators.append(
-            TimeToEventValidator(
-                schema=options["schema"],
-                time_column=options.get("time_column"),
-            )
-        )
-    else:
-        # If no schema, use default time column name
-        validators.append(
-            TimeToEventValidator(time_column=options.get("time_column", "time"))
-        )
-    # Add data validator if schema is provided
-    if options.get("schema"):
-        validators.append(DataValidator(schema=options["schema"]))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
-    return validators
 
 
 def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
         FileTypeValidator(allowed_extension=FileExtension.PNG, path="masks"),
-        _zero_record_validator(options),
         FilePairingValidator(
             image_path="images",
             sidecar_path="masks",
@@ -269,9 +130,6 @@ def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
             name="Mask Resolution Validator",
             subdir="masks",
         ),
-        _label_diversity_validator(options),
-        TableNameValidator(),
-        DuplicateValidator(),
     ]
 
 
@@ -283,7 +141,6 @@ def keypoint_detection(options: Dict[str, Any]) -> List[BaseValidator]:
     # rejects datasets whose annotations drift from the declared K.
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
-        _zero_record_validator(options),
         ImageResolutionValidator(expected_resolution=options["target_size"]),
         KeypointAnnotationValidator(
             num_keypoints=options.get("number_of_keypoints"),
@@ -292,26 +149,109 @@ def keypoint_detection(options: Dict[str, Any]) -> List[BaseValidator]:
             expected_resolution=options.get("target_size"),
         ),
         KeypointVisibilityValidator(),
-        _label_diversity_validator(options),
-        TableNameValidator(),
-        DuplicateValidator(),
     ]
 
 
+def text_classification(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = [
+        FileTypeValidator(
+            allowed_extension=options.get("extension", FileExtension.TXT),
+            path="texts",
+        ),
+        _text_content_validator(options, "texts"),
+        # Fail fast when the configured label column is absent from the CSV
+        # header (otherwise every record cleans to label=None and the backend
+        # rejects each row with HTTP 400 "label: may not be null"). Token
+        # classification covers this via BIOLabelValidator instead.
+        LabelColumnValidator(label_column=options.get("label_column") or "label"),
+    ]
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
+def token_classification(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = [
+        # One .txt of whitespace-tokenized words per sample (same layout as
+        # text classification).
+        FileTypeValidator(
+            allowed_extension=options.get("extension", FileExtension.TXT),
+            path="texts",
+        ),
+        _text_content_validator(options, "texts"),
+        # Validate BIO labels: one tag per word, valid BIO/IOB2 format; also
+        # rejects a missing label column. Honor a custom label column name.
+        BIOLabelValidator(
+            texts_path="texts",
+            extension=options.get("extension", FileExtension.TXT),
+            label_column=options.get("label_column") or "label",
+        ),
+    ]
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
 def masked_language_modeling(options: Dict[str, Any]) -> List[BaseValidator]:
-    validators: List[BaseValidator] = []
-    # Validate text file extensions
-    validators.append(
+    validators: List[BaseValidator] = [
         FileTypeValidator(
             allowed_extension=options.get("extension", FileExtension.TXT),
             path="sequences",
         ),
-    )
-    # Reject a zero-record manifest and binary/empty text content up front.
-    validators.extend(_nlp_content_validators(options, "sequences"))
-    # Add data validator if schema is provided
+        _text_content_validator(options, "sequences"),
+    ]
     if options.get("schema"):
         validators.append(DataValidator(schema=options["schema"]))
-    validators.append(TableNameValidator())
-    validators.append(DuplicateValidator())
+    return validators
+
+
+def tabular_classification(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
+def tabular_regression(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
+def time_series_forecasting(options: Dict[str, Any]) -> List[BaseValidator]:
+    schema = options.get("schema", {})
+    validators: List[BaseValidator] = [
+        TimeFormatValidator(schema=schema),
+        TimeOrderedValidator(),
+        TimeBeforeTodayValidator(),
+        NumericColumnsValidator(schema=schema),
+    ]
+    if options.get("schema"):
+        schema_without_timestamp = {
+            k: v for k, v in options["schema"].items() if k.lower() != "timestamp"
+        }
+        if schema_without_timestamp:
+            validators.append(DataValidator(schema=schema_without_timestamp))
+    return validators
+
+
+def time_to_event_prediction(options: Dict[str, Any]) -> List[BaseValidator]:
+    validators: List[BaseValidator] = []
+    # Time-to-event validator identifies + checks the (non-negative, numeric)
+    # time column. With a schema it can resolve the column from it; otherwise it
+    # falls back to the default/declared name.
+    if options.get("schema"):
+        validators.append(
+            TimeToEventValidator(
+                schema=options["schema"],
+                time_column=options.get("time_column"),
+            )
+        )
+    else:
+        validators.append(
+            TimeToEventValidator(time_column=options.get("time_column", "time"))
+        )
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
     return validators

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -19,11 +19,13 @@ from ..validators.duplicate_validator import DuplicateValidator
 from ..validators.file_pairing_validator import FilePairingValidator
 from ..validators.file_validator import FileTypeValidator
 from ..validators.image_validator import ImageResolutionValidator
+from ..validators.ingestable_records_validator import IngestableRecordsValidator
 from ..validators.keypoint_annotation_validator import KeypointAnnotationValidator
 from ..validators.keypoint_visibility_validator import KeypointVisibilityValidator
 from ..validators.label_diversity_validator import LabelDiversityValidator
 from ..validators.numeric_columns_validator import NumericColumnsValidator
 from ..validators.table_name_validator import TableNameValidator
+from ..validators.text_content_validator import TextContentValidator
 from ..validators.time_before_today_validator import TimeBeforeTodayValidator
 from ..validators.time_format_validator import TimeFormatValidator
 from ..validators.time_ordered_validator import TimeOrderedValidator
@@ -94,6 +96,22 @@ def tabular_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     return validators
 
 
+def _nlp_content_validators(
+    options: Dict[str, Any], subdir: str
+) -> List[BaseValidator]:
+    """The NLP content-hygiene pair, gated on the text categories (text/token
+    classification, MLM): reject a manifest that would ingest zero records
+    (header-only CSV, or every referenced file missing), and reject text files
+    whose CONTENT is binary / non-UTF-8 (warn on empty docs). ``subdir`` is the
+    per-category text directory under ``SRC_PATH`` (``"texts"`` / ``"sequences"``),
+    matching the category's ``FileTypeValidator(path=...)``."""
+    extension = options.get("extension", FileExtension.TXT)
+    return [
+        IngestableRecordsValidator(file_subdir=subdir, extension=extension),
+        TextContentValidator(texts_path=subdir, extension=extension),
+    ]
+
+
 def text_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     validators: List[BaseValidator] = []
     # Add text file validator
@@ -103,6 +121,8 @@ def text_classification(options: Dict[str, Any]) -> List[BaseValidator]:
             path="texts",
         ),
     )
+    # Reject a zero-record manifest and binary/empty text content up front.
+    validators.extend(_nlp_content_validators(options, "texts"))
     # Add data validator if schema is provided
     if options.get("schema"):
         validators.append(DataValidator(schema=options["schema"]))
@@ -122,6 +142,8 @@ def token_classification(options: Dict[str, Any]) -> List[BaseValidator]:
             path="texts",
         ),
     )
+    # Reject a zero-record manifest and binary/empty text content up front.
+    validators.extend(_nlp_content_validators(options, "texts"))
     # Validate BIO labels: one tag per word, valid BIO/IOB2 format. Honor a
     # custom label column name when one is configured in the YAML.
     validators.append(
@@ -237,6 +259,8 @@ def masked_language_modeling(options: Dict[str, Any]) -> List[BaseValidator]:
             path="sequences",
         ),
     )
+    # Reject a zero-record manifest and binary/empty text content up front.
+    validators.extend(_nlp_content_validators(options, "sequences"))
     # Add data validator if schema is provided
     if options.get("schema"):
         validators.append(DataValidator(schema=options["schema"]))

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -36,7 +36,8 @@
         "tabular_regression",
         "time_series_forecasting",
         "time_to_event_prediction",
-        "masked_language_modeling"
+        "masked_language_modeling",
+        "causal_language_modeling"
       ],
       "description": "Task category. Drives convention defaults: validators, data_format, default columns, default file extensions, default validator set."
     },
@@ -86,7 +87,7 @@
     "texts": {
       "type": "string",
       "minLength": 1,
-      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification and token_classification."
+      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification, token_classification, and causal_language_modeling (raw .txt: plain text, or a tab-separated prompt\\tcompletion pair)."
     },
 
     "sequences": {
@@ -337,6 +338,14 @@
       "then": { "required": ["sequences"] }
     },
     {
+      "description": "causal_language_modeling requires `texts` (raw .txt samples). It is self-supervised, so unlike text/token classification it does NOT require `label`.",
+      "if": {
+        "properties": { "category": { "const": "causal_language_modeling" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["texts"] }
+    },
+    {
       "description": "tabular and time-series categories require `schema`.",
       "if": {
         "properties": {
@@ -411,7 +420,8 @@
         "properties": {
           "category": {
             "enum": [
-              "masked_language_modeling"
+              "masked_language_modeling",
+              "causal_language_modeling"
             ]
           }
         },

--- a/tracebloc_ingestor/utils/constants.py
+++ b/tracebloc_ingestor/utils/constants.py
@@ -46,6 +46,7 @@ class TaskCategory:
     TIME_TO_EVENT_PREDICTION = "time_to_event_prediction"
     SEMANTIC_SEGMENTATION = "semantic_segmentation"
     MASKED_LANGUAGE_MODELING = "masked_language_modeling"
+    CAUSAL_LANGUAGE_MODELING = "causal_language_modeling"
 
     # instance_segmentation is deliberately absent: it briefly shipped here
     # and in the schema enum with no validators and no file transfer, so
@@ -73,6 +74,7 @@ class TaskCategory:
             cls.TIME_TO_EVENT_PREDICTION,
             cls.SEMANTIC_SEGMENTATION,
             cls.MASKED_LANGUAGE_MODELING,
+            cls.CAUSAL_LANGUAGE_MODELING,
         ]
 
     @classmethod

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -24,7 +24,12 @@ from typing import Any, Dict, List, Optional
 
 from ..config import Config
 from ..modalities.registry import REGISTRY
+from ..modalities.validators import label_diversity_validator
+from ..utils.constants import FileExtension
 from ..validators.base import BaseValidator
+from ..validators.duplicate_validator import DuplicateValidator
+from ..validators.ingestable_records_validator import IngestableRecordsValidator
+from ..validators.table_name_validator import TableNameValidator
 
 
 def map_validators(
@@ -35,7 +40,28 @@ def map_validators(
     spec = REGISTRY.get(task_category)
     if spec is None:
         return []
-    validators = spec.build_validators(options)
+
+    # Compose the chain from a common frame + the category-specific middle, so
+    # the universally-applicable validators live ONCE here instead of being
+    # repeated in every per-category factory:
+    #   [0-record guard] + <category-specific> + [label-diversity?] + [tail]
+    validators: List[BaseValidator] = [
+        # Every CSV manifest must yield >= 1 ingestable record. ``file_subdir``
+        # (from the spec) adds the "all referenced files missing" check for
+        # file-bearing categories; ``None`` (tabular / time) runs the header-only
+        # / empty-CSV row check alone.
+        IngestableRecordsValidator(
+            file_subdir=spec.file_subdir,
+            extension=options.get("extension", FileExtension.TXT),
+        )
+    ]
+    validators += spec.build_validators(options)
+    # Classification-family datasets need >= 2 distinct labels.
+    if spec.is_classification:
+        validators.append(label_diversity_validator(options))
+    # Universal tail: a unique table name + de-duplicated record IDs.
+    validators += [TableNameValidator(), DuplicateValidator()]
+
     # Inject the run's Config into every validator (P4b). Optional so direct
     # callers / tests that omit it keep the prior behavior: the path-reading
     # validators fall back to their module-global ``config`` at the read site.

--- a/tracebloc_ingestor/validators/base.py
+++ b/tracebloc_ingestor/validators/base.py
@@ -152,19 +152,28 @@ class BaseValidator(ABC):
 
     @staticmethod
     def _match_column(columns: Any, name: str) -> Optional[str]:
-        """Return the actual column whose name matches ``name``, case-insensitively.
+        """Return the actual column matching ``name``, case- AND
+        whitespace-insensitively.
 
-        Centralises the case-insensitive header lookup several validators need
-        (``filename`` / ``label`` columns whose case the dataset author may not
-        match exactly). ``columns`` is any iterable of column names (a
-        DataFrame's ``.columns``, an Index, or a plain list). Returns ``None``
-        when no column matches.
+        Centralises the header lookup several validators need (``filename`` /
+        ``label`` columns whose case the dataset author may not match exactly).
+        ``columns`` is any iterable of column names (a DataFrame's ``.columns``,
+        an Index, or a plain list). Returns ``None`` when no column matches.
+
+        Surrounding whitespace is stripped on both sides of the comparison
+        because ``CSVIngestor`` strips header whitespace on read
+        (``chunk.columns.str.strip()``) — so a header like ``" label "`` is
+        ingested as ``label`` and must resolve here too, or a manifest that
+        ingests fine fails preflight as if the column were missing (matches
+        ``LabelDiversityValidator._resolve_column``). The ORIGINAL column name
+        is returned so callers can still index the (un-stripped) raw frame.
         """
         cols = list(columns)
         if name in cols:
             return name
-        lowered = {str(c).lower(): c for c in cols}
-        return lowered.get(name.lower())
+        target = str(name).strip().lower()
+        normalised = {str(c).strip().lower(): c for c in cols}
+        return normalised.get(target)
 
     @staticmethod
     def _parse_json(row: Any, column: str) -> Optional[Any]:

--- a/tracebloc_ingestor/validators/base.py
+++ b/tracebloc_ingestor/validators/base.py
@@ -151,6 +151,22 @@ class BaseValidator(ABC):
             return None
 
     @staticmethod
+    def _match_column(columns: Any, name: str) -> Optional[str]:
+        """Return the actual column whose name matches ``name``, case-insensitively.
+
+        Centralises the case-insensitive header lookup several validators need
+        (``filename`` / ``label`` columns whose case the dataset author may not
+        match exactly). ``columns`` is any iterable of column names (a
+        DataFrame's ``.columns``, an Index, or a plain list). Returns ``None``
+        when no column matches.
+        """
+        cols = list(columns)
+        if name in cols:
+            return name
+        lowered = {str(c).lower(): c for c in cols}
+        return lowered.get(name.lower())
+
+    @staticmethod
     def _parse_json(row: Any, column: str) -> Optional[Any]:
         """Parse a JSON string from a DataFrame row column. Returns None on failure."""
         import pandas as pd

--- a/tracebloc_ingestor/validators/bio_label_validator.py
+++ b/tracebloc_ingestor/validators/bio_label_validator.py
@@ -12,12 +12,17 @@ whitespace-tokenized word per token):
    A mismatch is the exact condition that makes the client drop tokens to
    ``-100`` (or raise), so we reject it here against the dataset author.
 2. **Tag format** — every tag must be ``O`` or ``B-XXX`` / ``I-XXX`` (IOB2).
+3. **IOB2 sequence (warning)** — an ``I-<TYPE>`` should be preceded by a
+   ``B-<TYPE>`` / ``I-<TYPE>`` of the same type (entities start with ``B-``).
+   An ``I-`` that opens an entity is malformed under IOB2 but LEGAL under IOB1,
+   so it's surfaced as a WARNING rather than a hard reject — failing it would
+   wrongly break valid IOB1 datasets.
 """
 
 import logging
 import os
 import re
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 import pandas as pd
 
@@ -89,18 +94,23 @@ class BIOLabelValidator(BaseValidator):
 
             texts_dir = os.path.join((self._config or config).SRC_PATH, self.texts_path)
             errors: List[str] = []
+            warnings: List[str] = []
 
             for idx, row in df.iterrows():
                 if len(errors) >= _MAX_REPORTED_ERRORS:
                     errors.append("... further errors suppressed.")
                     break
-                errors.extend(
-                    self._validate_row(row, idx, filename_col, label_col, texts_dir)
+                row_errors, row_warnings = self._validate_row(
+                    row, idx, filename_col, label_col, texts_dir
                 )
+                errors.extend(row_errors)
+                if len(warnings) < _MAX_REPORTED_ERRORS:
+                    warnings.extend(row_warnings)
 
             return self._create_result(
                 is_valid=len(errors) == 0,
                 errors=errors,
+                warnings=warnings or None,
                 metadata={"rows_checked": len(df)},
             )
 
@@ -118,7 +128,7 @@ class BIOLabelValidator(BaseValidator):
         filename_col: str,
         label_col: str,
         texts_dir: str,
-    ) -> List[str]:
+    ) -> Tuple[List[str], List[str]]:
         row_label = f"Row {idx}"
         filename = str(row[filename_col])
         tags = str(row[label_col]).strip().split()
@@ -126,11 +136,17 @@ class BIOLabelValidator(BaseValidator):
         # Invalid tag format (independent of the file).
         bad = [t for t in tags if not _BIO_TAG_RE.match(t)]
         errors: List[str] = []
+        warnings: List[str] = []
         if bad:
             errors.append(
                 f"{row_label} ('{filename}'): invalid BIO tag(s) {bad[:5]}; "
                 f"each tag must be 'O' or 'B-<TYPE>' / 'I-<TYPE>'."
             )
+        else:
+            # IOB2 sequence anomaly (warning) — only meaningful on well-formed
+            # tags, and independent of the .txt, so check it before file I/O so
+            # it's still surfaced when the file is missing/unreadable below.
+            warnings.extend(self._iob2_sequence_warnings(tags, filename, row_label))
 
         # Resolve the .txt with text_transfer's exact rule (shared
         # _has_extension): append the extension only when the CSV filename
@@ -148,14 +164,14 @@ class BIOLabelValidator(BaseValidator):
                 f"{row_label}: text file not found at "
                 f"'{self.texts_path}/{resolved}'."
             )
-            return errors
+            return errors, warnings
 
         try:
             with open(text_path, "r", encoding="utf-8") as f:
                 word_count = len(f.read().strip().split())
         except OSError as e:
             errors.append(f"{row_label}: could not read text file: {e}")
-            return errors
+            return errors, warnings
 
         if word_count != len(tags):
             errors.append(
@@ -164,7 +180,39 @@ class BIOLabelValidator(BaseValidator):
                 f"in the label column. Each word must have exactly one tag."
             )
 
-        return errors
+        return errors, warnings
+
+    @staticmethod
+    def _iob2_sequence_warnings(
+        tags: List[str], filename: str, row_label: str
+    ) -> List[str]:
+        """Flag IOB2 transition anomalies: an ``I-<TYPE>`` not immediately
+        preceded by a ``B-<TYPE>`` / ``I-<TYPE>`` of the SAME type — i.e. an
+        entity that opens with ``I-`` instead of ``B-`` (orphan ``I-`` at the
+        start, ``I-`` right after ``O``, or a type switch like ``B-PER I-ORG``).
+
+        Returned as warnings, not errors: such sequences are malformed under
+        IOB2 but LEGAL under IOB1 (a chunk may open with ``I-``), and this
+        validator is scheme-agnostic — hard-failing would wrongly reject valid
+        IOB1 datasets. The warning lets a user who intended IOB2 spot the
+        problem without blocking IOB1 ingests.
+        """
+        offenders: List[str] = []
+        prev = "O"
+        for t in tags:
+            if t.startswith("I-"):
+                etype = t[2:]
+                if prev != f"B-{etype}" and prev != f"I-{etype}":
+                    offenders.append(t)
+            prev = t
+        if not offenders:
+            return []
+        return [
+            f"{row_label} ('{filename}'): IOB2 transition anomaly — {offenders[:5]} "
+            f"open an entity with 'I-' (not preceded by a 'B-'/'I-' of the same "
+            f"type). Valid under IOB1 but malformed under IOB2; if you intended "
+            f"IOB2, the entity should start with 'B-'."
+        ]
 
     @staticmethod
     def _resolve_column(df: pd.DataFrame, name: str) -> Optional[str]:

--- a/tracebloc_ingestor/validators/duplicate_validator.py
+++ b/tracebloc_ingestor/validators/duplicate_validator.py
@@ -88,6 +88,15 @@ class DuplicateValidator(BaseValidator):
                         f"Destination directory '{self.dest_path}' already exists"
                     )
 
+            # Within-CSV duplicate filename detection (warning). The check
+            # above guards re-ingesting into an existing TABLE; this catches the
+            # same filename appearing more than once in the INCOMING CSV, which
+            # would otherwise ingest as separate records with no notice. Warn
+            # only — repeated filenames may be intentional in some flows.
+            dup_warnings = self._within_csv_duplicate_warnings(data)
+            warnings.extend(dup_warnings)
+            metadata["within_csv_duplicate_filenames"] = len(dup_warnings) > 0
+
             # Check if parent directory exists (for creating the destination)
             parent_dir = Path(self.dest_path).parent
             parent_exists = parent_dir.exists()
@@ -111,6 +120,54 @@ class DuplicateValidator(BaseValidator):
                 errors=[f"Duplicate validation error: {str(e)}"],
                 metadata={"error_type": "validation_exception"},
             )
+
+    def _within_csv_duplicate_warnings(self, data: Any) -> List[str]:
+        """Warn when a filename appears more than once in the incoming CSV.
+
+        Bounded: reads only the ``filename`` column. A non-CSV input (e.g. a
+        ``None`` from the table-only callers, or a JSON path) is a no-op, and a
+        CSV with no ``filename`` column (tabular families) is skipped.
+        """
+        if not isinstance(data, (str, Path)) or Path(data).suffix.lower() != ".csv":
+            return []
+
+        import pandas as pd
+
+        try:
+            header = pd.read_csv(data, nrows=0, encoding="utf-8").columns
+        except Exception:  # noqa: BLE001 — header probe is best-effort
+            return []
+        filename_col = self._match_column(header, "filename")
+        if filename_col is None:
+            return []
+
+        try:
+            series = pd.read_csv(
+                data,
+                usecols=[filename_col],
+                encoding="utf-8",
+                dtype=str,
+                keep_default_na=False,
+            )[filename_col]
+        except Exception:  # noqa: BLE001 — let other validators surface read errors
+            return []
+
+        names = series.map(lambda v: str(v).strip())
+        names = names[names != ""]
+        counts = names.value_counts()
+        duplicated = counts[counts > 1]
+        if duplicated.empty:
+            return []
+
+        extra = int(duplicated.sum() - len(duplicated))  # rows beyond the first
+        sample = list(duplicated.index[:10])
+        suffix = " …" if len(duplicated) > 10 else ""
+        return [
+            f"{len(duplicated)} filename(s) appear more than once in the CSV "
+            f"({extra} duplicate row(s)): {sample}{suffix}. These will be "
+            f"ingested as separate records — remove the duplicates if this is "
+            f"unintended."
+        ]
 
     def _check_directory_exists(self) -> bool:
         """Check if the destination directory exists.

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -43,6 +43,7 @@ class ImageResolutionValidator(BaseValidator):
         self,
         expected_resolution: Optional[Tuple[int, int]] = None,
         name: str = "Image Resolution Validator",
+        subdir: str = "images",
     ):
         """Initialize the image resolution validator.
 
@@ -50,9 +51,15 @@ class ImageResolutionValidator(BaseValidator):
             expected_resolution: Expected image resolution as (width, height)
             supported_formats: Set of supported image formats (e.g., {'.jpg', '.png'})
             name: Human-readable name of the validator
+            subdir: The ``<SRC_PATH>`` subdirectory whose images this instance
+                validates (default ``"images"``). Set to ``"masks"`` to validate
+                semantic-segmentation masks — pixel-wise label maps that must be
+                readable and share the images' resolution; the default instance
+                only ever scans ``<SRC_PATH>/images``.
         """
         super().__init__(name)
         self.expected_resolution = expected_resolution
+        self.subdir = subdir
         self.tolerance = 0  # Whether to enforce strict file type checking . we can later make this configurable
         self.supported_formats = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"}
 
@@ -86,7 +93,7 @@ class ImageResolutionValidator(BaseValidator):
             ValidationResult containing validation status and messages
         """
         try:
-            data = f"{(self._config or config).SRC_PATH}/images"
+            data = f"{(self._config or config).SRC_PATH}/{self.subdir}"
             if not PIL_AVAILABLE:
                 return self._create_result(
                     is_valid=False,

--- a/tracebloc_ingestor/validators/ingestable_records_validator.py
+++ b/tracebloc_ingestor/validators/ingestable_records_validator.py
@@ -1,0 +1,205 @@
+"""Ingestable Records Validator Module.
+
+Fail-fast guard for the "0 ingestable records" class of input error, run at
+preflight (before the destination table is created) so a dataset that would
+ingest nothing is rejected EARLY with a clear, source-truthful message — never
+left as an orphan empty table that fails LATE at backend registration with a
+misleading "its rows are already in the database" error.
+
+Two distinct ways a CSV manifest yields zero records, both caught here:
+
+1. **Header-only / empty CSV** — the file has a header row (or is empty) but no
+   data rows. The existing zero-byte guard (#250, in ``CSVIngestor.read_data``)
+   only fired on a *totally* empty file; a header-only CSV slipped through,
+   created the table, ingested 0 rows, then failed late. This catches both.
+2. **All referenced files missing** (file-bearing categories) — every
+   ``filename`` the CSV references is absent under ``SRC_PATH/<subdir>/``, so
+   every record is dropped at transfer time and 0 records land. Cross-checks the
+   referenced filenames against what's actually staged; the per-directory
+   ``FileTypeValidator`` only checks the *extension* of files that ARE present,
+   not whether the CSV's filenames resolve to any of them.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+
+from ..config import Config
+from ..file_transfer import _has_extension, _safe_join
+from ..utils.constants import FileExtension
+from .base import BaseValidator, ValidationResult
+
+config = Config()
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+
+class IngestableRecordsValidator(BaseValidator):
+    """Reject a CSV manifest that would ingest zero records.
+
+    Attributes:
+        file_subdir: Subdirectory under ``SRC_PATH`` holding this category's
+            referenced files (``"texts"`` / ``"sequences"`` / ``"images"`` …),
+            mirroring ``FileTypeValidator(path=...)``. ``None`` for
+            non-file-bearing (tabular / time-series) categories — only the
+            header-only / empty-CSV row check runs then.
+        extension: Expected file extension, appended to a CSV filename that
+            carries none (same rule the transfer uses).
+        filename_column: CSV column naming each sample's file (default
+            ``"filename"``; resolved case-insensitively).
+    """
+
+    def __init__(
+        self,
+        file_subdir: Optional[str] = None,
+        extension: str = FileExtension.TXT,
+        filename_column: str = "filename",
+        name: str = "Ingestable Records",
+    ):
+        super().__init__(name)
+        self.file_subdir = file_subdir
+        ext = extension or FileExtension.TXT
+        self.extension = ext if ext.startswith(".") else f".{ext}"
+        self.filename_column = filename_column
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            # Only CSV manifests are checked here. Non-CSV inputs (e.g. JSON)
+            # are covered by their own validators; a non-path input is a direct
+            # caller we don't second-guess.
+            if not isinstance(data, (str, Path)) or Path(data).suffix.lower() != ".csv":
+                return self._create_result(is_valid=True, metadata={"checked": False})
+
+            path = Path(data)
+
+            # 1) Header-only / empty CSV -> zero data rows.
+            row_result = self._check_has_rows(path)
+            if not row_result.is_valid:
+                return row_result
+
+            # 2) File-bearing: every referenced file missing -> zero records.
+            if self.file_subdir:
+                return self._check_referenced_files(path)
+
+            return self._create_result(is_valid=True, metadata={"checked": True})
+
+        except Exception as e:  # noqa: BLE001 — mirror sibling validators
+            logger.error(f"Error during ingestable-records validation: {str(e)}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Ingestable records validation error: {str(e)}"],
+                metadata={"error_type": "validation_exception"},
+            )
+
+    def _check_has_rows(self, path: Path) -> ValidationResult:
+        """Fail when the CSV has a header but no data rows (or is empty)."""
+        try:
+            # nrows=1 is enough to tell "has >=1 data row" from "header only",
+            # without materialising a large file. dtype=str / keep_default_na
+            # keep the read cheap and inference-free — we only count rows here.
+            head = pd.read_csv(
+                path,
+                nrows=1,
+                encoding="utf-8",
+                dtype=str,
+                keep_default_na=False,
+            )
+        except pd.errors.EmptyDataError:
+            head = None
+
+        if head is None or len(head) == 0:
+            return self._create_result(
+                is_valid=False,
+                errors=[
+                    f"No data rows found in CSV '{path.name}': the file has a "
+                    f"header but no data rows (0 ingestable records). Add at "
+                    f"least one data row and re-ingest."
+                ],
+                metadata={"data_rows": 0},
+            )
+        return self._create_result(is_valid=True, metadata={"data_rows": "at_least_1"})
+
+    def _check_referenced_files(self, path: Path) -> ValidationResult:
+        """Fail when NONE of the CSV's referenced files exist on disk.
+
+        Early-exits on the first file that resolves, so a healthy dataset costs
+        one ``stat``; only an all-missing dataset walks the whole column — which
+        is exactly the zero-records case we want to surface up front.
+        """
+        src_root = (self._config or config).SRC_PATH
+        subdir = os.path.join(src_root, self.file_subdir)
+
+        filename_col = self._resolve_filename_column(path)
+        if filename_col is None:
+            # No filename column to cross-check — not this validator's error to
+            # raise (the read/transfer path surfaces a missing column). Pass.
+            return self._create_result(
+                is_valid=True,
+                metadata={"checked": False, "reason": "no_filename_column"},
+            )
+
+        checked = 0
+        try:
+            chunks = pd.read_csv(
+                path,
+                usecols=[filename_col],
+                encoding="utf-8",
+                chunksize=50_000,
+                dtype=str,
+                keep_default_na=False,
+            )
+            for chunk in chunks:
+                for raw_name in chunk[filename_col]:
+                    filename = str(raw_name).strip()
+                    if not filename:
+                        continue
+                    checked += 1
+                    resolved = (
+                        filename
+                        if _has_extension(filename)
+                        else f"{filename}{self.extension}"
+                    )
+                    # Resolve EXACTLY as the transfer does (``_safe_join`` under
+                    # SRC_PATH): an absolute / ``..`` manifest value that would
+                    # otherwise let a plain join "find" a file outside the
+                    # dataset dir is rejected by the transfer (#239), so it is
+                    # NOT an ingestable file here either — skip it rather than
+                    # let it mask the zero-record case this validator guards.
+                    try:
+                        candidate = _safe_join(src_root, self.file_subdir, resolved)
+                    except ValueError:
+                        continue
+                    if os.path.isfile(candidate):
+                        return self._create_result(
+                            is_valid=True,
+                            metadata={
+                                "referenced_files_checked": checked,
+                                "found_at_least_one": True,
+                            },
+                        )
+        except pd.errors.EmptyDataError:
+            checked = 0
+
+        return self._create_result(
+            is_valid=False,
+            errors=[
+                f"No referenced data files could be found under "
+                f"'{self.file_subdir}/'; nothing to ingest (0 ingestable "
+                f"records). Checked {checked} filename reference(s) against "
+                f"'{subdir}/' and none exist on disk. Verify the files are "
+                f"staged at that path and that the '{self.filename_column}' "
+                f"column matches the staged filenames."
+            ],
+            metadata={"referenced_files_checked": checked, "found_at_least_one": False},
+        )
+
+    def _resolve_filename_column(self, path: Path) -> Optional[str]:
+        """Case-insensitively resolve the filename column from the CSV header."""
+        try:
+            header = pd.read_csv(path, nrows=0, encoding="utf-8").columns
+        except Exception:  # noqa: BLE001 — header probe is best-effort
+            return None
+        return self._match_column(header, self.filename_column)

--- a/tracebloc_ingestor/validators/keypoint_annotation_validator.py
+++ b/tracebloc_ingestor/validators/keypoint_annotation_validator.py
@@ -51,10 +51,15 @@ class KeypointAnnotationValidator(BaseValidator):
         annotation_column: str = "Annotation",
         num_keypoints: Optional[int] = None,
         name: str = "Keypoint Annotation",
+        expected_resolution: Optional[Tuple[int, int]] = None,
     ):
         super().__init__(name)
         self.annotation_column = annotation_column
         self.num_keypoints = num_keypoints
+        # Declared image size (width, height) — when known, keypoint coordinates
+        # are bounded by it (coords are already checked non-negative; without an
+        # upper bound a coord past the image edge reaches training).
+        self.expected_resolution = expected_resolution
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         try:
@@ -143,9 +148,7 @@ class KeypointAnnotationValidator(BaseValidator):
         x_coords = []
         y_coords = []
         for kp_name, value in annotation.items():
-            kp_errors, x, y = self._validate_keypoint_value(
-                kp_name, value, row_label
-            )
+            kp_errors, x, y = self._validate_keypoint_value(kp_name, value, row_label)
             errors.extend(kp_errors)
             if x is not None and y is not None:
                 x_coords.append(x)
@@ -182,7 +185,7 @@ class KeypointAnnotationValidator(BaseValidator):
         else:
             errors.append(
                 f"{row_label}: Keypoint '{kp_name}' must be [x, y] list or "
-                f"{{\"x\": x, \"y\": y}} dict"
+                f'{{"x": x, "y": y}} dict'
             )
             return errors, None, None
 
@@ -192,11 +195,27 @@ class KeypointAnnotationValidator(BaseValidator):
             )
             return errors, None, None
 
+        # Lower- and upper-bound checks run INDEPENDENTLY (not elif) so a row
+        # like (-1, 9999) reports both the negative x AND the out-of-bounds y in
+        # one pass, instead of hiding the second issue until a re-ingest (bugbot,
+        # PR #314).
         if x < 0 or y < 0:
             errors.append(
                 f"{row_label}: Keypoint '{kp_name}' has negative coordinates "
                 f"({x}, {y})"
             )
+        if self.expected_resolution is not None:
+            width, height = self.expected_resolution
+            # Valid coordinates lie in the half-open range [0, width) / [0, height)
+            # — consistent with the inclusive-0 lower bound. A coordinate equal to
+            # width/height is the first index PAST the last pixel (0..W-1), so it
+            # is out of bounds.
+            if x >= width or y >= height:
+                errors.append(
+                    f"{row_label}: Keypoint '{kp_name}' ({x}, {y}) lies outside "
+                    f"the image bounds ({width}x{height}) — coordinates must be "
+                    f"within [0, {width}) x [0, {height})."
+                )
 
         return errors, float(x), float(y)
 

--- a/tracebloc_ingestor/validators/label_column_validator.py
+++ b/tracebloc_ingestor/validators/label_column_validator.py
@@ -1,0 +1,125 @@
+"""Label Column Validator Module.
+
+Fail-fast guard for the "configured label column is missing from the CSV
+header" class of input error, run at preflight (before the destination table
+is created) so a classification dataset whose CSV lacks the configured label
+column is rejected EARLY with a clear, actionable message.
+
+Why this exists (adversarial text-classification ingestion, dev ``ingestor:0.3.12``):
+a ``text_classification`` CSV whose header is ``filename,extension`` (no
+``label``), with ``label: label`` configured in the ingest config, slipped past
+every validator:
+
+  1. ``LabelDiversityValidator`` reads the label column lazily; when it's
+     absent its loader returns ``None``, which the validator treats as the
+     benign empty-input case and PASSES (it explicitly defers the missing-column
+     case to "DataValidator or the ingestor").
+  2. but the label column is stripped out of the schema before
+     ``DataValidator`` sees it, so DataValidator never checks it either.
+  3. so every record was cleaned with ``label=None``, sent to the backend, and
+     rejected per-row with ``HTTP 400: {"label":["This field may not be
+     null."]}`` — a late, confusing failure for what is simply a mis-named /
+     missing column in the manifest.
+
+This validator closes that gap for the classification categories that source
+their label from a CSV column. Token classification already fails fast on the
+same input via ``BIOLabelValidator`` (which resolves both the filename and
+label columns and rejects a missing one), so it does not need this validator;
+object detection sources its labels from XML annotations, not a CSV column, so
+it is deliberately NOT wired to this validator.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+
+from .base import BaseValidator, ValidationResult
+from ..config import Config
+
+config = Config()
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+
+class LabelColumnValidator(BaseValidator):
+    """Reject a classification manifest whose configured label column is absent.
+
+    Attributes:
+        label_column: CSV column expected to hold the class label, as
+            configured in the ingest YAML (default ``"label"``). Resolved
+            case-insensitively against the actual header via
+            :meth:`BaseValidator._match_column`, matching how the ingestor and
+            the sibling label validators resolve it.
+    """
+
+    def __init__(
+        self,
+        label_column: str = "label",
+        name: str = "Label Column",
+    ):
+        super().__init__(name)
+        self.label_column = label_column or "label"
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            columns = self._read_columns(data)
+            if columns is None:
+                # Not a CSV manifest / DataFrame we can introspect (e.g. a JSON
+                # input or an unreadable file) — not this validator's error to
+                # raise; the read path / sibling validators surface those. Pass.
+                return self._create_result(
+                    is_valid=True,
+                    metadata={"checked": False, "label_column": self.label_column},
+                )
+
+            if self._match_column(columns, self.label_column) is not None:
+                return self._create_result(
+                    is_valid=True,
+                    metadata={"checked": True, "label_column": self.label_column},
+                )
+
+            return self._create_result(
+                is_valid=False,
+                errors=[
+                    f"Configured label column '{self.label_column}' not found in "
+                    f"CSV header (columns: {', '.join(map(str, columns))}). Set "
+                    f"'label:' in the ingest config to an existing column, or add "
+                    f"the '{self.label_column}' column to the CSV."
+                ],
+                metadata={
+                    "label_column": self.label_column,
+                    "columns": list(map(str, columns)),
+                },
+            )
+
+        except Exception as e:  # noqa: BLE001 — mirror sibling validators
+            logger.error(f"Error during label-column validation: {str(e)}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Label-column validation error: {str(e)}"],
+                metadata={"error_type": "validation_exception"},
+            )
+
+    def _read_columns(self, data: Any) -> Optional[list]:
+        """Return the column names of the manifest, or ``None`` when the input
+        isn't an introspectable CSV / DataFrame.
+
+        Reads only the header row for a CSV path (``nrows=0``) so a wide or
+        multi-GB manifest costs almost nothing. A read error (missing file,
+        unparseable) returns ``None`` — a benign skip, since the read/transfer
+        path raises its own clear error for those.
+        """
+        if isinstance(data, pd.DataFrame):
+            return list(data.columns)
+        if isinstance(data, (str, Path)):
+            path = Path(data)
+            if path.suffix.lower() != ".csv":
+                return None
+            try:
+                header = pd.read_csv(path, nrows=0, encoding="utf-8")
+            except Exception:  # noqa: BLE001 — missing/unparseable -> benign skip
+                return None
+            return list(header.columns)
+        return None

--- a/tracebloc_ingestor/validators/text_content_validator.py
+++ b/tracebloc_ingestor/validators/text_content_validator.py
@@ -1,0 +1,191 @@
+"""Text Content Validator Module.
+
+Content-level check for NLP categories (text_classification,
+token_classification, masked_language_modeling). ``FileTypeValidator`` only
+checks the file *extension*, so a file named ``doc1.txt`` that actually holds
+binary / non-UTF-8 bytes — or is empty — passed validation and was ingested
+silently; the dataset author only discovered the corruption at training time.
+
+This samples the referenced text files and asserts their *content* is decodable
+UTF-8 text:
+
+- **Binary / non-decodable content** (a NUL byte, or bytes that aren't valid
+  UTF-8) is REJECTED — that's silent data corruption.
+- **Empty / whitespace-only documents** are WARNED about (they carry no signal
+  for training but may be intentional placeholders in some flows).
+
+Sampling + a per-file byte cap keep the pass bounded on large datasets: a
+deterministic strided sample of files, and only the first chunk of each file is
+read (enough to catch binary content and emptiness).
+"""
+
+import codecs
+import logging
+import os
+from typing import Any, List, Optional, Tuple
+
+from ..config import Config
+from ..file_transfer import _has_extension, _safe_join
+from ..text_profile import _sample
+from ..utils.constants import FileExtension
+from .base import BaseValidator, ValidationResult
+
+config = Config()
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+# Cap reported messages so a wholly-broken dataset yields an actionable summary
+# rather than tens of thousands of lines (mirrors BIOLabelValidator).
+_MAX_REPORTED = 50
+
+
+class TextContentValidator(BaseValidator):
+    """Validate that referenced NLP text files hold decodable UTF-8 text.
+
+    Attributes:
+        texts_path: Subdirectory under ``SRC_PATH`` holding the text files
+            (``"texts"`` for text/token classification, ``"sequences"`` for
+            masked language modeling) — mirrors ``FileTypeValidator(path=...)``.
+        extension: Expected text-file extension (default ``.txt``).
+        filename_column: CSV column naming each sample's file (default
+            ``"filename"``; resolved case-insensitively).
+        sample_size: Max number of files to inspect (deterministic strided
+            sample over the referenced files).
+        max_bytes: Max bytes read per file for the content check.
+    """
+
+    def __init__(
+        self,
+        texts_path: str = "texts",
+        extension: str = FileExtension.TXT,
+        filename_column: str = "filename",
+        sample_size: int = 500,
+        max_bytes: int = 65_536,
+        name: str = "Text Content",
+    ):
+        super().__init__(name)
+        self.texts_path = texts_path
+        ext = extension or FileExtension.TXT
+        self.extension = ext if ext.startswith(".") else f".{ext}"
+        self.filename_column = filename_column
+        self.sample_size = sample_size
+        self.max_bytes = max_bytes
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            df = self._load_data(data)
+            if df is None or df.empty:
+                # Nothing to inspect; the empty-CSV case is the
+                # IngestableRecordsValidator's job, not this one.
+                return self._create_result(is_valid=True, metadata={"docs_checked": 0})
+
+            filename_col = self._match_column(df.columns, self.filename_column)
+            if filename_col is None:
+                return self._create_result(
+                    is_valid=True,
+                    metadata={"docs_checked": 0, "reason": "no_filename_column"},
+                )
+
+            src_root = (self._config or config).SRC_PATH
+            filenames = [
+                str(v).strip() for v in df[filename_col].tolist() if str(v).strip()
+            ]
+
+            # Existence-filter FIRST, then sample the files that ACTUALLY exist.
+            # Sampling the raw manifest first (then skipping the missing ones)
+            # let a handful of present files fall outside the sample when most
+            # rows reference absent files — content went unread and binary files
+            # slipped through (Bugbot: content sample skips existing files). The
+            # cheap part (a stat per row) walks the manifest; the expensive part
+            # (reading + decoding content) stays bounded to ``sample_size``.
+            present = []
+            for filename in filenames:
+                resolved = (
+                    filename
+                    if _has_extension(filename)
+                    else f"{filename}{self.extension}"
+                )
+                # Resolve as the transfer does (``_safe_join`` under SRC_PATH):
+                # an absolute / ``..`` manifest value is rejected by the transfer
+                # (#239), so we neither read nor flag a file outside the dataset
+                # dir — its missing-ness is the records validator's job.
+                try:
+                    text_path = _safe_join(src_root, self.texts_path, resolved)
+                except ValueError:
+                    continue
+                if os.path.isfile(text_path):
+                    present.append((text_path, resolved))
+
+            errors: List[str] = []
+            warnings: List[str] = []
+            checked = 0
+            for text_path, resolved in _sample(present, self.sample_size):
+                checked += 1
+                level, message = self._inspect(text_path, resolved)
+                if level == "error":
+                    errors.append(message)
+                elif level == "warning":
+                    warnings.append(message)
+                if len(errors) >= _MAX_REPORTED:
+                    errors.append("... further errors suppressed.")
+                    break
+
+            return self._create_result(
+                is_valid=len(errors) == 0,
+                errors=errors,
+                warnings=warnings,
+                metadata={"docs_checked": checked},
+            )
+
+        except Exception as e:  # noqa: BLE001 — mirror sibling validators
+            logger.error(f"Error during text content validation: {str(e)}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Text content validation error: {str(e)}"],
+                metadata={"error_type": "validation_exception"},
+            )
+
+    def _inspect(self, path: str, label: str) -> Tuple[Optional[str], str]:
+        """Inspect one file's content. Returns ``(level, message)`` where level
+        is ``"error"`` (binary/non-UTF-8), ``"warning"`` (empty/whitespace), or
+        ``None`` (clean — message ignored)."""
+        try:
+            with open(path, "rb") as fh:
+                raw = fh.read(self.max_bytes)
+        except OSError as e:
+            return "error", f"'{self.texts_path}/{label}': could not read file: {e}"
+
+        if not raw.strip():
+            return (
+                "warning",
+                f"'{self.texts_path}/{label}' is empty or whitespace-only — it "
+                f"carries no text for training.",
+            )
+
+        if b"\x00" in raw:
+            return (
+                "error",
+                f"'{self.texts_path}/{label}' contains a NUL byte (0x00) — the "
+                f"file is binary, not UTF-8 text. Re-export it as plain UTF-8 "
+                f"text and re-ingest.",
+            )
+
+        # Incremental decode. ``final`` is True only when we read the WHOLE file
+        # (the read returned fewer bytes than the cap, i.e. EOF) — so a truncated
+        # / wrongly-encoded trailing multibyte sequence in a small file is
+        # FLUSHED and raises, instead of sitting unvalidated in the decoder
+        # buffer. When we stopped at the cap (len(raw) == max_bytes) the file may
+        # continue, so we DON'T finalize — a legitimate multibyte char split at
+        # the cap must not be mistaken for invalid input.
+        final = len(raw) < self.max_bytes
+        try:
+            codecs.getincrementaldecoder("utf-8")().decode(raw, final=final)
+        except UnicodeDecodeError:
+            return (
+                "error",
+                f"'{self.texts_path}/{label}' is not valid UTF-8 text — it looks "
+                f"binary or wrongly encoded. Re-export it as plain UTF-8 text "
+                f"and re-ingest.",
+            )
+
+        return None, ""

--- a/tracebloc_ingestor/validators/text_content_validator.py
+++ b/tracebloc_ingestor/validators/text_content_validator.py
@@ -1,7 +1,8 @@
 """Text Content Validator Module.
 
 Content-level check for NLP categories (text_classification,
-token_classification, masked_language_modeling). ``FileTypeValidator`` only
+token_classification, masked_language_modeling, causal_language_modeling).
+``FileTypeValidator`` only
 checks the file *extension*, so a file named ``doc1.txt`` that actually holds
 binary / non-UTF-8 bytes — or is empty — passed validation and was ingested
 silently; the dataset author only discovered the corruption at training time.
@@ -44,8 +45,9 @@ class TextContentValidator(BaseValidator):
 
     Attributes:
         texts_path: Subdirectory under ``SRC_PATH`` holding the text files
-            (``"texts"`` for text/token classification, ``"sequences"`` for
-            masked language modeling) — mirrors ``FileTypeValidator(path=...)``.
+            (``"texts"`` for text/token classification and causal language
+            modeling, ``"sequences"`` for masked language modeling) — mirrors
+            ``FileTypeValidator(path=...)``.
         extension: Expected text-file extension (default ``.txt``).
         filename_column: CSV column naming each sample's file (default
             ``"filename"``; resolved case-insensitively).

--- a/tracebloc_ingestor/validators/xml_validator.py
+++ b/tracebloc_ingestor/validators/xml_validator.py
@@ -268,8 +268,28 @@ class PascalVOCXMLValidator(BaseValidator):
             warnings.extend(size_validation["warnings"])
             metadata.update(size_validation["metadata"])
 
-            # Validate objects
-            objects_validation = self._validate_objects(root)
+            # Declared image dimensions (only when they parsed cleanly as
+            # positive ints) — used to bound bbox coordinates and to cross-check
+            # against the actual image below.
+            declared_w = size_validation["metadata"].get("width")
+            declared_h = size_validation["metadata"].get("height")
+
+            # Cross-check the declared <size> against the ACTUAL image: a wrong
+            # declared size silently corrupts coordinate scaling at training
+            # (and would let a bbox that's "within" a too-large declared size sit
+            # outside the real image). Best-effort — skips when the image can't
+            # be located/read (FilePairing/FileType own the missing-image case).
+            errors.extend(
+                self._validate_size_matches_image(
+                    file_path,
+                    declared_w,
+                    declared_h,
+                )
+            )
+
+            # Validate objects (bbox coordinates are bounded by the declared
+            # image size when it's known).
+            objects_validation = self._validate_objects(root, declared_w, declared_h)
             errors.extend(objects_validation["errors"])
             warnings.extend(objects_validation["warnings"])
             metadata.update(objects_validation["metadata"])
@@ -440,11 +460,20 @@ class PascalVOCXMLValidator(BaseValidator):
 
         return {"errors": errors, "warnings": warnings, "metadata": metadata}
 
-    def _validate_objects(self, root: ET.Element) -> Dict[str, Any]:
+    def _validate_objects(
+        self,
+        root: ET.Element,
+        declared_w: Optional[int] = None,
+        declared_h: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """Validate object elements and their sub-elements.
 
         Args:
             root: Root XML element
+            declared_w: Declared image width (from <size>), or None — used to
+                bound each bbox's xmax.
+            declared_h: Declared image height (from <size>), or None — used to
+                bound each bbox's ymax.
 
         Returns:
             Dictionary containing validation results
@@ -461,19 +490,29 @@ class PascalVOCXMLValidator(BaseValidator):
             return {"errors": errors, "warnings": warnings, "metadata": metadata}
 
         for i, obj in enumerate(objects):
-            obj_validation = self._validate_single_object(obj, i)
+            obj_validation = self._validate_single_object(
+                obj, i, declared_w, declared_h
+            )
             errors.extend(obj_validation["errors"])
             warnings.extend(obj_validation["warnings"])
             metadata["objects"].append(obj_validation["metadata"])
 
         return {"errors": errors, "warnings": warnings, "metadata": metadata}
 
-    def _validate_single_object(self, obj: ET.Element, index: int) -> Dict[str, Any]:
+    def _validate_single_object(
+        self,
+        obj: ET.Element,
+        index: int,
+        declared_w: Optional[int] = None,
+        declared_h: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """Validate a single object element.
 
         Args:
             obj: Object XML element
             index: Index of the object in the list
+            declared_w: Declared image width, or None.
+            declared_h: Declared image height, or None.
 
         Returns:
             Dictionary containing validation results
@@ -557,19 +596,29 @@ class PascalVOCXMLValidator(BaseValidator):
             errors.append(f"Object {index}: Missing required 'difficult' element")
 
         # Validate bndbox element
-        bndbox_validation = self._validate_bndbox_element(obj, index)
+        bndbox_validation = self._validate_bndbox_element(
+            obj, index, declared_w, declared_h
+        )
         errors.extend(bndbox_validation["errors"])
         warnings.extend(bndbox_validation["warnings"])
         metadata.update(bndbox_validation["metadata"])
 
         return {"errors": errors, "warnings": warnings, "metadata": metadata}
 
-    def _validate_bndbox_element(self, obj: ET.Element, index: int) -> Dict[str, Any]:
+    def _validate_bndbox_element(
+        self,
+        obj: ET.Element,
+        index: int,
+        declared_w: Optional[int] = None,
+        declared_h: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """Validate bndbox element and its coordinates.
 
         Args:
             obj: Object XML element
             index: Index of the object in the list
+            declared_w: Declared image width, or None — bounds xmax.
+            declared_h: Declared image height, or None — bounds ymax.
 
         Returns:
             Dictionary containing validation results
@@ -639,7 +688,83 @@ class PascalVOCXMLValidator(BaseValidator):
                     f"Object {index}: Very small bounding box (area: {area})"
                 )
 
+            # Bound the box by the declared image size: a bbox extending past the
+            # image edge is malformed and crashes / corrupts training. (xmin/ymin
+            # are already checked non-negative above.)
+            if declared_w is not None and coords["xmax"] > declared_w:
+                errors.append(
+                    f"Object {index}: xmax ({coords['xmax']}) exceeds image width "
+                    f"({declared_w}) — bounding box extends past the image edge."
+                )
+            if declared_h is not None and coords["ymax"] > declared_h:
+                errors.append(
+                    f"Object {index}: ymax ({coords['ymax']}) exceeds image height "
+                    f"({declared_h}) — bounding box extends past the image edge."
+                )
+
             metadata["bbox"] = coords
             metadata["area"] = area
 
         return {"errors": errors, "warnings": warnings, "metadata": metadata}
+
+    def _validate_size_matches_image(
+        self,
+        file_path: Path,
+        declared_w: Optional[int],
+        declared_h: Optional[int],
+    ) -> List[str]:
+        """Cross-check the annotation's declared ``<size>`` against the ACTUAL
+        image dimensions.
+
+        The XML lives at ``<SRC>/annotations/<stem>.xml`` and its image at
+        ``<SRC>/images/<stem>.<imgext>``; a declared size that disagrees with the
+        real image silently corrupts coordinate scaling at training (and lets a
+        bbox that's "within" a too-large declared size sit outside the real
+        image).
+
+        The image is located by the XML **stem** — NOT the annotation's
+        ``<filename>`` element — because the ingestor pairs images to annotations
+        by stem (``FilePairingValidator``). A stale / wrong ``<filename>`` could
+        otherwise point the check at a different on-disk image that happens to
+        match the declared size, while the actually-paired image still disagrees
+        (bugbot, PR #314).
+
+        Best-effort — returns no error (a benign skip) when the declared size is
+        unknown, the image can't be located, or it can't be read: the
+        FilePairing / FileType validators own the missing-image case, and Pillow
+        may be unavailable. Returns a one-item error list on a real mismatch.
+        """
+        if declared_w is None or declared_h is None:
+            return []
+        try:
+            from PIL import Image, UnidentifiedImageError
+        except ImportError:  # pragma: no cover - Pillow is a runtime dep
+            return []
+
+        # Resolve the images dir from SRC_PATH (the same root FileTypeValidator
+        # uses, ``SRC_PATH/images``) rather than ``file_path.parent.parent`` —
+        # ``validate`` discovers XML via a recursive ``**/*.xml`` glob, so an XML
+        # nested deeper or at the root would otherwise resolve the wrong images
+        # tree (bugbot, PR #314).
+        images_dir = Path((self._config or config).SRC_PATH) / "images"
+        # Match the stem-based pairing the ingestor uses; the image extension is
+        # whatever's on disk (datasets ship .jpg / .jpeg / .png).
+        candidates = [
+            images_dir / f"{file_path.stem}{ext}" for ext in (".jpg", ".jpeg", ".png")
+        ]
+        img_path = next((c for c in candidates if c.is_file()), None)
+        if img_path is None:
+            return []
+        try:
+            with Image.open(img_path) as im:
+                actual_w, actual_h = im.size
+        except (OSError, UnidentifiedImageError):  # corrupt/unreadable image
+            return []
+
+        if (actual_w, actual_h) != (declared_w, declared_h):
+            return [
+                f"declared <size> {declared_w}x{declared_h} does not match the "
+                f"actual image '{img_path.name}' ({actual_w}x{actual_h}); fix the "
+                f"annotation's <size> or the image."
+            ]
+        return []


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ingestion preflight for all modalities and adds a new task category wired through schema, CLI, and backend registration paths; changes are well-tested but affect every ingest run’s validation order and failure modes.
> 
> **Overview**
> Adds **`causal_language_modeling`** as a self-supervised NLP modality (CSV manifest + raw `.txt` under `texts/`, no `label:`), with registry/transfer wiring, example YAML, template + sample data, schema rules, and e2e/characterization coverage. **CLM** joins the NLP text-profile path like MLM/text/token categories.
> 
> **Preflight validation** is centralized in `map_validators`: **`IngestableRecordsValidator`** (empty/header-only CSVs; all referenced files missing) and **`TextContentValidator`** (UTF-8 / binary checks) for NLP; vision gets the zero-record guard with `file_subdir=images`. **`LabelColumnValidator`** fails fast when the configured label column is missing (image + text classification). Validator factories no longer duplicate table-name/duplicate/label-diversity wiring—those come from **`ModalitySpec`** traits (`file_subdir`, `is_classification`).
> 
> **Vision hardening:** semantic segmentation validates **masks** via `ImageResolutionValidator(subdir="masks")`; keypoints get **image-bounds** checks; Pascal VOC XML validates **bbox vs declared size** and **declared size vs actual image** (stem-paired). BIO tags emit **IOB2 transition warnings** (not hard errors); duplicate filenames in a CSV warn only.
> 
> **UX / ops:** registration failure messages use **`_rows_state_clause`** so zero-row runs are not told rows are already in the DB. Docs bump **Python 3.11+**, **`requirements-dev.txt`**, README advanced flow (`run_ingestion` / `BaseIngestor`), and **RELEASING.md** rollout (floating `:0.3` tag vs retired CronJob env reconcile). Package version **0.5.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8baed7bf478e9f402cbcdd4f71957eca202ec45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->