### PR TITLE
feat: add seq2seq modality

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ Only metadata (schema, statistics, structure) syncs to the web app. Raw data sta
 | Type | Categories |
 |---|---|
 | **Image** | [`image_classification`](templates/image_classification), [`object_detection`](templates/object_detection), [`keypoint_detection`](templates/keypoint_detection), [`semantic_segmentation`](templates/semantic_segmentation) |
-| **Text / NLP** | [`text_classification`](templates/text_classification), [`token_classification`](templates/token_classification), [`masked_language_modeling`](templates/masked_language_modeling), [`causal_language_modeling`](templates/causal_language_modeling) |
+| **Text / NLP** | [`text_classification`](templates/text_classification), [`token_classification`](templates/token_classification), [`masked_language_modeling`](templates/masked_language_modeling), [`causal_language_modeling`](templates/causal_language_modeling), [`seq2seq`](templates/seq2seq) |
 | **Tabular** | [`tabular_classification`](templates/tabular_classification), [`tabular_regression`](templates/tabular_regression) |
 | **Time series** | [`time_series_forecasting`](templates/time_series_forecasting), [`time_to_event_prediction`](templates/time_to_event_prediction) |
 

--- a/e2e/test_characterization.py
+++ b/e2e/test_characterization.py
@@ -223,6 +223,17 @@ CASES = [
         sidecars=[str(T / "causal_language_modeling/data/texts")],
         roundtrip_col=None,
     ),
+    dict(
+        id="seq2seq",
+        cfg=_cfg(
+            table="char_s2s",
+            category="seq2seq",
+            csv=str(T / "seq2seq/data/labels_file_sample.csv"),
+            texts=str(T / "seq2seq/data/texts"),
+        ),
+        sidecars=[str(T / "seq2seq/data/texts")],
+        roundtrip_col=None,
+    ),
     # semantic_segmentation: the one file-bearing modality the harness never
     # characterized (audit gap). mask_id is DECLARED in schema so it's stored
     # (the training client SELECTs it to locate masks — backend#816); the masks

--- a/e2e/test_ingest_e2e.py
+++ b/e2e/test_ingest_e2e.py
@@ -199,6 +199,18 @@ CASES = [
         ),
         id="causal_language_modeling",
     ),
+    # seq2seq: self-supervised raw text in texts/ (a source<TAB>target pair —
+    # same on-disk shape as causal LM). No tokenizer.json at ingest — alignment
+    # is the data-derived text profile (#805).
+    pytest.param(
+        _cfg(
+            table="e2e_s2s",
+            category="seq2seq",
+            csv=str(T / "seq2seq/data/labels_file_sample.csv"),
+            texts=str(T / "seq2seq/data/texts"),
+        ),
+        id="seq2seq",
+    ),
     # semantic_segmentation: masks now wire through the declarative path (the P5
     # mask_id work — the transfer resolves the mask via the schema-declared
     # mask_id), so #136's xfail is removed. The full contract (masks land in

--- a/examples/yaml/seq2seq.yaml
+++ b/examples/yaml/seq2seq.yaml
@@ -1,0 +1,12 @@
+# Sequence-to-sequence: CSV manifest + .txt sidecar files (one per sample).
+# Self-supervised — no label column required.
+# `texts:` holds RAW text samples: each .txt is a single tab-separated
+# `source<TAB>target` pair (e.g. an input sentence and its translation/summary).
+# The training client builds encoder inputs and decoder targets on-the-fly.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: wmt_seq2seq_train
+intent: train
+category: seq2seq
+csv: /data/shared/wmt-seq2seq/labels_file.csv
+texts: /data/shared/wmt-seq2seq/texts/

--- a/templates/seq2seq/README.md
+++ b/templates/seq2seq/README.md
@@ -1,0 +1,142 @@
+# Sequence-to-Sequence (seq2seq) Data Ingestion Template
+
+This template demonstrates how to ingest raw text samples for sequence-to-sequence
+(encoder-decoder) modeling into a database using the tracebloc_ingestor framework.
+
+seq2seq is **self-supervised** — there is no `label:` field. Each sample is a
+single `.txt` file holding **raw text**:
+
+- A single tab-separated `source<TAB>target` pair. The training client feeds the
+  source to the encoder and trains the decoder to produce the target (e.g.
+  translation, summarization, paraphrase).
+
+This is the same on-disk shape as causal language modeling's
+`prompt<TAB>completion` pair — one `.txt` per sample under `texts/` — so it
+reuses the same raw-text ingestion path.
+
+## Quickstart — declarative (recommended)
+
+Ingest with ~8 lines of YAML using the official ingestor image
+(`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage
+> your files on the cluster's shared PVC first — see the
+> [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc)
+> in the chart docs (kubectl cp pattern for small datasets, init-container sync
+> for production).
+
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a
+`texts/` subdirectory holding the per-record `.txt` files.
+
+**2. Write `ingest.yaml`** — note there is **no** `label:` field (self-supervised):
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: seq2seq
+table: wmt_seq2seq_train
+intent: train
+csv: /data/shared/wmt-seq2seq/labels_file.csv
+texts: /data/shared/wmt-seq2seq/texts/
+```
+
+**3. Install:**
+
+```bash
+helm install my-seq2seq-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+> **If install fails with `'seq2seq' is not one of [...]`:** your local Helm
+> chart cache is stale. Refresh it and retry: `helm repo update`.
+
+Canonical example: [`examples/yaml/seq2seq.yaml`](../../examples/yaml/seq2seq.yaml).
+Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
+
+## Directory Structure
+
+```
+seq2seq/
+├── seq2seq.py                    # Main ingestion script
+├── README.md                     # This file
+└── data/
+    ├── texts/                    # Text files (.txt), one per sample
+    │   ├── s2s_0000001.txt       #   source<TAB>target (translation)
+    │   ├── s2s_0000002.txt       #   source<TAB>target (translation)
+    │   ├── s2s_0000003.txt       #   source<TAB>target (summarization)
+    │   ├── s2s_0000004.txt       #   source<TAB>target (translation)
+    │   └── s2s_0000005.txt       #   source<TAB>target (paraphrase)
+    └── labels_file_sample.csv    # CSV manifest mapping filenames to extensions
+```
+
+> The `texts/` subdir is the raw-text convention shared with text/token
+> classification and causal language modeling. (Masked language modeling instead
+> uses `sequences/`, which the framework reserves for *pre-tokenized* data.)
+
+## Data Format
+
+### Text Files
+- Supported extension: `.txt`
+- One sample per file, placed in `data/texts/`
+- A single `source<TAB>target` line
+- Files must be decodable UTF-8 (validated at ingest by `TextContentValidator`);
+  binary / non-UTF-8 files are rejected, empty files are warned about.
+
+### CSV Labels File
+seq2seq is **self-supervised** — no label column is needed. The CSV contains:
+- `filename`: Base name of the text file, without extension (e.g. `s2s_0000001`)
+- `extension`: File extension as a quoted string (e.g. `'.txt'`)
+
+## Tokenizer Alignment
+
+seq2seq does **not** ship a tokenizer at ingest. Instead, the ingestor computes a
+data-derived **text profile** (Unicode-script mix + document-length
+distribution — no raw text, no vocabulary, no hash; the FL guardrail) and ships
+it on the global-metadata channel (#805). The backend uses it for a warn-only
+contributor-tokenizer-fit check at dataset linking — the same alignment path as
+the other NLP modalities (text/token classification, MLM, causal LM). That check
+runs on the training-client side.
+
+## Usage
+
+1. Place your `.txt` sample files in `data/texts/`
+2. Update `labels_file_sample.csv` with one row per text file
+3. Configure environment variables (see below)
+4. Run the ingestion script:
+
+```bash
+python seq2seq.py
+```
+
+## Configuration
+
+The script uses the following configuration:
+- **Extension**: TXT - Expected text file extension
+- **Chunk Size**: 100 - Batch size for CSV reading
+- **Encoding**: utf-8
+- **Category**: SEQ2SEQ
+- **Data Format**: TEXT
+- **Intent**: TRAIN (change to `Intent.TEST` for evaluation data)
+- **Label column**: None (self-supervised)
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TABLE_NAME` | Target database table | Required |
+| `LABEL_FILE` | Path to CSV manifest | Required |
+| `SRC_PATH` | Path to the parent of the `texts/` directory | Required |
+| `BATCH_SIZE` | Ingestion batch size | 4000 |
+| `BACKEND_TOKEN` | Auth token for API | Required |
+| `CLIENT_ENV` | Environment (local/dev/stg/prod) | prod |
+
+## Notes
+
+- The `filename` column does **not** include the extension — that's supplied
+  separately via the `extension` column.
+- No `label` column is needed because seq2seq training is self-supervised (the
+  target side of each pair is the supervision signal, derived from the text by
+  the training client).
+- Put exactly one tab between source and target; everything before the first tab
+  is the source, everything after is the target.

--- a/templates/seq2seq/data/labels_file_sample.csv
+++ b/templates/seq2seq/data/labels_file_sample.csv
@@ -1,0 +1,6 @@
+filename,extension
+s2s_0000001,'.txt'
+s2s_0000002,'.txt'
+s2s_0000003,'.txt'
+s2s_0000004,'.txt'
+s2s_0000005,'.txt'

--- a/templates/seq2seq/data/texts/s2s_0000001.txt
+++ b/templates/seq2seq/data/texts/s2s_0000001.txt
@@ -1,0 +1,1 @@
+Translate to French: Good morning.	Bonjour.

--- a/templates/seq2seq/data/texts/s2s_0000002.txt
+++ b/templates/seq2seq/data/texts/s2s_0000002.txt
@@ -1,0 +1,1 @@
+Translate to German: The weather is nice today.	Das Wetter ist heute schön.

--- a/templates/seq2seq/data/texts/s2s_0000003.txt
+++ b/templates/seq2seq/data/texts/s2s_0000003.txt
@@ -1,0 +1,1 @@
+Summarize: tracebloc trains models on data that never leaves the contributor cluster, so raw data stays on-premise.	Models travel to the data; the data stays on-premise.

--- a/templates/seq2seq/data/texts/s2s_0000004.txt
+++ b/templates/seq2seq/data/texts/s2s_0000004.txt
@@ -1,0 +1,1 @@
+Translate to Spanish: Where is the train station?	¿Dónde está la estación de tren?

--- a/templates/seq2seq/data/texts/s2s_0000005.txt
+++ b/templates/seq2seq/data/texts/s2s_0000005.txt
@@ -1,0 +1,1 @@
+Paraphrase: Federated learning trains a shared model without moving raw data.	Federated learning builds one model while each party keeps its own data in place.

--- a/templates/seq2seq/seq2seq.py
+++ b/templates/seq2seq/seq2seq.py
@@ -1,0 +1,86 @@
+"""Sequence-to-Sequence (seq2seq) Data Ingestion Example.
+
+This example demonstrates how to ingest text samples for sequence-to-sequence
+(encoder-decoder) modeling into a database and optionally send metadata to the
+tracebloc API.
+
+seq2seq is self-supervised — no label column is needed.  Each row in the CSV
+maps to a ``.txt`` file under ``texts/`` holding RAW text:
+
+- Each file is a single tab-separated ``source\\ttarget`` pair; the training
+  client feeds the source to the encoder and trains the decoder to produce the
+  target (e.g. translation, summarization, paraphrase).
+
+This is the same on-disk shape as causal language modeling's
+``prompt\\tcompletion`` pair — one ``.txt`` per sample under ``texts/`` — so it
+reuses the same raw-text ingestion path. The contributor's tokenizer alignment
+is checked centrally at dataset linking via the data-derived text profile
+(#805); nothing tokenizer-specific is needed here.
+"""
+
+import logging
+import os
+from typing import Dict, Any
+
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
+from tracebloc_ingestor.utils.logging import setup_logging
+from tracebloc_ingestor.utils.constants import (
+    TaskCategory,
+    Intent,
+    DataFormat,
+    FileExtension,
+)
+
+# Initialize config and configure logging
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+
+# Text file options
+text_options = {"extension": FileExtension.TXT}
+
+# CSV specific options
+csv_options = {
+    "chunk_size": 100,
+    "delimiter": ",",
+    "quotechar": '"',
+    "escapechar": "\\",
+    "on_bad_lines": "warn",
+    "encoding": "utf-8",
+}
+
+
+def main():
+    """Run the sequence-to-sequence ingestion example."""
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
+
+    # Create ingestor for seq2seq data
+    # No label_column — seq2seq is self-supervised
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.TEXT,
+        category=TaskCategory.SEQ2SEQ,
+        csv_options=csv_options,
+        file_options=text_options,
+        intent=Intent.TRAIN,
+    )
+
+    # Ingest data with validation
+    logger.info("Starting sequence-to-sequence ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -984,7 +984,8 @@ def test_check_src_path_only_runs_for_file_bearing_categories():
         TaskCategory.TIME_TO_EVENT_PREDICTION,
     ):
         assert cat not in _FILE_BEARING_CATEGORIES
-    # Image / text / segmentation / MLM / causal LM all need a staged SRC_PATH.
+    # Image / text / segmentation / MLM / causal LM / seq2seq all need a staged
+    # SRC_PATH.
     for cat in (
         TaskCategory.IMAGE_CLASSIFICATION,
         TaskCategory.OBJECT_DETECTION,
@@ -993,6 +994,7 @@ def test_check_src_path_only_runs_for_file_bearing_categories():
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
         TaskCategory.CAUSAL_LANGUAGE_MODELING,
+        TaskCategory.SEQ2SEQ,
     ):
         assert cat in _FILE_BEARING_CATEGORIES
 
@@ -1023,6 +1025,7 @@ _TEXT_PROFILE = {
     [
         "MASKED_LANGUAGE_MODELING",
         "CAUSAL_LANGUAGE_MODELING",
+        "SEQ2SEQ",
         "TEXT_CLASSIFICATION",
         "TOKEN_CLASSIFICATION",
     ],

--- a/tests/test_modality_failure_accounting.py
+++ b/tests/test_modality_failure_accounting.py
@@ -47,12 +47,13 @@ from tracebloc_ingestor.utils.constants import TaskCategory
 # helpers (mirror test_batch_send_failure_accounting.py)
 # ---------------------------------------------------------------------------
 
-# One entry per template directory — the 12 supported modalities.
+# One entry per template directory — the 13 supported modalities.
 _TEMPLATE_CATEGORIES = [
     TaskCategory.IMAGE_CLASSIFICATION,
     TaskCategory.KEYPOINT_DETECTION,
     TaskCategory.MASKED_LANGUAGE_MODELING,
     TaskCategory.CAUSAL_LANGUAGE_MODELING,
+    TaskCategory.SEQ2SEQ,
     TaskCategory.OBJECT_DETECTION,
     TaskCategory.SEMANTIC_SEGMENTATION,
     TaskCategory.TABULAR_CLASSIFICATION,

--- a/tests/test_modality_registry.py
+++ b/tests/test_modality_registry.py
@@ -60,12 +60,14 @@ def test_derived_sets_match_spec_flags():
 
 def test_nlp_categories_are_exactly_the_text_categories():
     """#805: the NLP set is exactly the text categories (text/token
-    classification + masked & causal language modeling) — never image/tabular."""
+    classification + masked & causal language modeling + seq2seq) — never
+    image/tabular."""
     assert NLP_CATEGORIES == {
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
         TaskCategory.CAUSAL_LANGUAGE_MODELING,
+        TaskCategory.SEQ2SEQ,
     }
 
 
@@ -85,6 +87,13 @@ def test_known_flag_values():
     assert clm.is_file_bearing and clm.is_self_supervised and clm.is_nlp
     assert not clm.is_tabular_family and not clm.is_classification
     assert clm.file_subdir == "texts"
+
+    # seq2seq mirrors causal LM's flags exactly (file-bearing + self-supervised
+    # + NLP, raw text from texts/).
+    s2s = spec_for(TaskCategory.SEQ2SEQ)
+    assert s2s.is_file_bearing and s2s.is_self_supervised and s2s.is_nlp
+    assert not s2s.is_tabular_family and not s2s.is_classification
+    assert s2s.file_subdir == "texts"
 
     tab = spec_for(TaskCategory.TABULAR_CLASSIFICATION)
     assert (

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -283,6 +283,33 @@ def test_causal_language_modeling_without_texts_rejected(validator):
         validator.validate(config)
 
 
+def test_seq2seq_with_label_rejected(validator):
+    """seq2seq is self-supervised like causal LM (#213): setting `label:` must be
+    rejected at submission. The CSV has no label column and no edge-label
+    metadata is registered for it."""
+    config = _load_example("seq2seq.yaml")
+    config["label"] = "some_column"
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_seq2seq_without_label_accepted(validator):
+    """The shipped seq2seq example omits `label:` by design — it must validate
+    cleanly."""
+    config = _load_example("seq2seq.yaml")
+    assert "label" not in config, "test premise: the example yaml has no label"
+    validator.validate(config)  # must not raise
+
+
+def test_seq2seq_without_texts_rejected(validator):
+    """seq2seq stages raw .txt under `texts:`; omitting it must be rejected
+    (the directory is where the per-sample source\\ttarget files live)."""
+    config = _load_example("seq2seq.yaml")
+    del config["texts"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
 # Regression-class tasks must specify label.policy explicitly; the shorthand
 # string form must be rejected for these categories.
 @pytest.mark.parametrize(

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -1,0 +1,257 @@
+"""Sequence-to-sequence (seq2seq) — modality wiring, mirroring the causal
+language modeling / MLM / token_classification coverage.
+
+seq2seq is the self-supervised, raw-text encoder-decoder modality added
+alongside causal LM. It shares causal LM's self-supervised semantics (only a
+``filename`` column, no label) and its on-disk shape — each sample is one
+``.txt`` of RAW text, a tab-separated ``source\\ttarget`` pair (the same layout
+as causal LM's ``prompt\\tcompletion``), staged from ``texts/`` (not the
+pre-tokenized ``sequences/`` MLM uses). These tests pin the three behaviors the
+modality must get right:
+
+1. **CLI run** — a seq2seq ``ingest.yaml`` routes through ``cli.run.main`` to a
+   CSVIngestor with the resolved kwargs; a seq2seq config that (wrongly) sets
+   ``label:`` is rejected at the entrypoint (self-supervised, #213).
+2. **Validation boundaries** — header-only / all-files-missing manifests
+   fail fast before table creation; binary content is rejected; a clean
+   source/target dataset validates.
+3. **Failure accounting** — a rejected batch POST surfaces every record as a
+   failure so the run exits non-zero.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Generator
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples" / "yaml"
+
+
+# ---------------------------------------------------------------------------
+# Local test doubles (mirror tests/test_ingestor_base.py so this file is
+# self-contained).
+# ---------------------------------------------------------------------------
+
+
+class FakeIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source: Any) -> Generator[Dict[str, Any], None, None]:
+        yield from self._records
+
+
+def make_ingestor(records=None, **overrides):
+    db = MagicMock(name="Database")
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = ([1, 2], [])
+    db.get_table_schema.return_value = {"a": "INT"}
+    api = MagicMock(name="APIClient")
+    api.send_batch.return_value = True
+    api.send_generate_edge_label_meta.return_value = True
+    api.send_global_meta_meta.return_value = True
+    api.prepare_dataset.return_value = True
+    api.create_dataset.return_value = {"id": 1}
+
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=TaskCategory.SEQ2SEQ,
+        label_column=None,
+    )
+    kwargs.update(overrides)
+    return FakeIngestor(records or [], **kwargs)
+
+
+def _s2s_ingestor_on(tmp_path, clean_env, records):
+    """A seq2seq FakeIngestor wired to a real Config rooted at ``tmp_path/src``
+    with a ``texts/`` subdir, so the path-reading validators run against a real
+    FS."""
+    src = tmp_path / "src"
+    (src / "texts").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    clean_env.setenv("TABLE_NAME", "s2s_train")
+    clean_env.setenv("DEST_PATH", str(tmp_path / "dest" / "s2s_train"))
+    # Self-supervised seq2seq carries no feature schema (the manifest is just
+    # filename/extension), so no DataValidator — match that real shape.
+    ing = make_ingestor(records=records, schema={})
+    ing.database.config = Config()
+    return ing, src / "texts"
+
+
+# ---------------------------------------------------------------------------
+# 1. CLI run
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_runtime():
+    with patch("tracebloc_ingestor.cli.run.Config") as cfg_cls, patch(
+        "tracebloc_ingestor.cli.run.Database"
+    ) as db_cls, patch("tracebloc_ingestor.cli.run.APIClient") as api_cls, patch(
+        "tracebloc_ingestor.cli.run.CSVIngestor"
+    ) as csv_cls, patch(
+        "tracebloc_ingestor.cli.run.JSONIngestor"
+    ) as json_cls, patch(
+        "tracebloc_ingestor.cli.run.setup_logging"
+    ):
+        cfg = MagicMock()
+        cfg.BATCH_SIZE = 4000
+        cfg_cls.return_value = cfg
+        for cls_mock in (csv_cls, json_cls):
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.ingest = MagicMock(return_value=[])
+            cls_mock.return_value = inst
+        yield {"Config": cfg_cls, "Database": db_cls, "APIClient": api_cls,
+               "CSVIngestor": csv_cls, "JSONIngestor": json_cls}
+
+
+def test_cli_run_routes_s2s_yaml_to_csv_ingestor(clean_env, mock_runtime, monkeypatch):
+    """The shipped seq2seq example yaml runs end-to-end-but-mocked: a CSVIngestor
+    is built with the resolved seq2seq kwargs (TEXT, self-supervised, no label)
+    and ingest() is called once; exit 0."""
+    monkeypatch.setenv(
+        "INGEST_CONFIG", str(EXAMPLES_DIR / "seq2seq.yaml")
+    )
+    from tracebloc_ingestor.cli.run import main
+
+    rc = main()
+
+    assert rc == 0
+    assert mock_runtime["CSVIngestor"].call_count == 1
+    assert mock_runtime["JSONIngestor"].call_count == 0
+    _, kwargs = mock_runtime["CSVIngestor"].call_args
+    assert kwargs["category"] == TaskCategory.SEQ2SEQ
+    assert kwargs["data_format"] == "text"
+    assert kwargs["label_column"] == ""  # self-supervised
+    assert kwargs["file_options"]["extension"] == ".txt"
+    mock_runtime["CSVIngestor"].return_value.ingest.assert_called_once()
+
+
+def test_cli_run_rejects_s2s_with_label(clean_env, mock_runtime, monkeypatch, tmp_path):
+    """Self-supervised: a seq2seq config that sets `label:` must be rejected at
+    the entrypoint (exit 2) before any DB/network call (#213)."""
+    bad = tmp_path / "s2s_with_label.yaml"
+    bad.write_text(
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: seq2seq\n"
+        "table: s2s_test\n"
+        "intent: test\n"
+        "csv: /tmp/ignored.csv\n"
+        "texts: /tmp/ignored/\n"
+        "label: label\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(bad))
+    from tracebloc_ingestor.cli.run import main
+
+    rc = main()
+
+    assert rc == 2
+    mock_runtime["Database"].assert_not_called()
+    mock_runtime["APIClient"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. Validation boundaries (real filesystem)
+# ---------------------------------------------------------------------------
+
+
+def test_s2s_header_only_csv_fails_before_table_creation(clean_env, tmp_path):
+    """A header-only seq2seq manifest is rejected during validation, before the
+    destination table is created — no orphan empty table."""
+    ing, _ = _s2s_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame(columns=["filename"]).to_csv(csv, index=False)
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No data rows found"):
+            ing.ingest(str(csv), batch_size=10)
+    ing.database.create_table.assert_not_called()
+
+
+def test_s2s_all_files_missing_fails_before_table_creation(clean_env, tmp_path):
+    """A populated manifest whose every referenced .txt is missing is rejected
+    before table creation."""
+    ing, _ = _s2s_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["doc1", "doc2"]}).to_csv(csv, index=False)
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No referenced data files"):
+            ing.ingest(str(csv), batch_size=10)
+    ing.database.create_table.assert_not_called()
+
+
+def test_s2s_clean_dataset_validates(clean_env, tmp_path):
+    """A clean dataset — two source<TAB>target pairs — passes validation. The
+    tab is ordinary UTF-8 text."""
+    ing, texts = _s2s_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "pair1.txt").write_text("Translate: Hi\tBonjour\n", encoding="utf-8")
+    (texts / "pair2.txt").write_text("Summarize: a long text\tshort\n", encoding="utf-8")
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["pair1", "pair2"]}).to_csv(csv, index=False)
+
+    assert ing.validate_data(str(csv)) is True
+
+
+def test_s2s_binary_content_rejected(clean_env, tmp_path):
+    """A .txt whose bytes are binary (a NUL byte) is rejected by the shared
+    TextContentValidator — the same content hygiene the other NLP modalities
+    get, here pointed at texts/."""
+    ing, texts = _s2s_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "ok.txt").write_text("fine\ttext\n", encoding="utf-8")
+    (texts / "bad.txt").write_bytes(b"\x00\x01\x02binary")
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["ok", "bad"]}).to_csv(csv, index=False)
+
+    with pytest.raises(ValueError, match="NUL byte"):
+        ing.validate_data(str(csv))
+
+
+# ---------------------------------------------------------------------------
+# 3. Failure accounting
+# ---------------------------------------------------------------------------
+
+
+def test_s2s_api_send_failure_counts_every_record(clean_env):
+    """Every batch POST rejected -> every seq2seq record returns as a failure, so
+    the run exits non-zero (the file-transfer branch runs since seq2seq is
+    file-bearing)."""
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records)
+    ing.api_client.send_batch.return_value = False
+
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+
+    assert len(failed) == 2
+    assert all(f["error"] == "api_send_failed" for f in failed)

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -313,6 +313,34 @@ CASES = [
     ),
 
     # -----------------------------------------------------------------------
+    # seq2seq — self-supervised, no label column. CSV manifest points at .txt
+    # sidecar files holding RAW text (a source<TAB>target pair); the client
+    # builds encoder inputs and decoder targets at train time. Sidecar dir is
+    # ``texts/`` (raw text — same layout as causal language modeling), NOT MLM's
+    # ``sequences/`` (pre-tokenized).
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.SEQ2SEQ,
+            table="seq2seq_train",
+            intent="train",
+            csv="/data/labels.csv",
+            texts="/data/texts/",
+        ),
+        {
+            "category": TaskCategory.SEQ2SEQ,
+            "data_format": DataFormat.TEXT,
+            "intent": Intent.TRAIN,
+            "label_column": "",  # self-supervised — no label
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"extension": FileExtension.TXT},
+        },
+        id="seq2seq",
+    ),
+
+    # -----------------------------------------------------------------------
     # tabular_classification — template label_column="name"
     # -----------------------------------------------------------------------
     pytest.param(

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -128,6 +128,7 @@ def test_classification_categories_include_label_diversity():
         TaskCategory.TIME_TO_EVENT_PREDICTION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
         TaskCategory.CAUSAL_LANGUAGE_MODELING,
+        TaskCategory.SEQ2SEQ,
     ):
         assert LabelDiversityValidator not in _types(
             map_validators(cat, {"schema": {"a": "INT"}})
@@ -352,11 +353,11 @@ def test_map_validators_without_config_falls_back_to_module_global(monkeypatch):
 
 
 def test_nlp_categories_include_content_hygiene_validators():
-    """The text categories (text/token classification, masked & causal LM) gain
-    BOTH the zero-record guard and the (text-only) UTF-8 content validator. The
-    zero-record guard now also covers file-bearing vision categories, but
-    TextContentValidator stays NLP-only (it decodes UTF-8 text, meaningless for
-    images); tabular has neither."""
+    """The text categories (text/token classification, masked & causal LM,
+    seq2seq) gain BOTH the zero-record guard and the (text-only) UTF-8 content
+    validator. The zero-record guard now also covers file-bearing vision
+    categories, but TextContentValidator stays NLP-only (it decodes UTF-8 text,
+    meaningless for images); tabular has neither."""
     from tracebloc_ingestor.validators.ingestable_records_validator import (
         IngestableRecordsValidator,
     )
@@ -369,6 +370,7 @@ def test_nlp_categories_include_content_hygiene_validators():
         TaskCategory.TOKEN_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
         TaskCategory.CAUSAL_LANGUAGE_MODELING,
+        TaskCategory.SEQ2SEQ,
     ):
         types = _types(map_validators(cat, {}))
         # 0-record guard leads (composed centrally); the category's own
@@ -451,6 +453,43 @@ def test_causal_lm_with_schema_adds_data_validator():
     assert DataValidator in _types(v)
 
 
+def test_seq2seq_content_validators_target_texts_subdir():
+    """seq2seq stages RAW text under ``texts/`` (not the pre-tokenized
+    ``sequences/`` MLM uses); the content validators must point there."""
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    v = map_validators(TaskCategory.SEQ2SEQ, {})
+    rec = next(x for x in v if isinstance(x, IngestableRecordsValidator))
+    txt = next(x for x in v if isinstance(x, TextContentValidator))
+    assert rec.file_subdir == "texts"
+    assert txt.texts_path == "texts"
+
+
+def test_seq2seq_excludes_all_label_validators():
+    """seq2seq is self-supervised: only ``filename`` is required, no label
+    column. It must carry none of the label-oriented validators (mirrors causal
+    LM)."""
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+    from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
+
+    types = _types(map_validators(TaskCategory.SEQ2SEQ, {}))
+    assert LabelColumnValidator not in types
+    assert BIOLabelValidator not in types
+    assert LabelDiversityValidator not in types
+
+
+def test_seq2seq_with_schema_adds_data_validator():
+    v = map_validators(TaskCategory.SEQ2SEQ, {"schema": {"a": "INT"}})
+    assert DataValidator in _types(v)
+
+
 def test_text_classification_content_validators_target_texts_subdir():
     from tracebloc_ingestor.validators.ingestable_records_validator import (
         IngestableRecordsValidator,
@@ -500,6 +539,7 @@ ALL_CATEGORIES = (
     TaskCategory.TOKEN_CLASSIFICATION,
     TaskCategory.MASKED_LANGUAGE_MODELING,
     TaskCategory.CAUSAL_LANGUAGE_MODELING,
+    TaskCategory.SEQ2SEQ,
     TaskCategory.TABULAR_CLASSIFICATION,
     TaskCategory.TABULAR_REGRESSION,
     TaskCategory.TIME_SERIES_FORECASTING,

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.4.0"
+__version__ = "0.5.2"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -45,15 +45,16 @@ IMAGE_CATEGORIES: FrozenSet[str] = frozenset(
 )
 
 # Categories that stage raw ``.txt`` files from ``texts/`` and default to the
-# ``.txt`` extension. causal_language_modeling joins text/token classification
-# here (it reads raw text, not the pre-tokenized ``sequences/`` MLM uses); it is
-# self-supervised, but that only governs label handling, not the file_options
-# default this set drives.
+# ``.txt`` extension. causal_language_modeling and seq2seq join text/token
+# classification here (they read raw text, not the pre-tokenized ``sequences/``
+# MLM uses); they are self-supervised, but that only governs label handling, not
+# the file_options default this set drives.
 TEXT_CATEGORIES: FrozenSet[str] = frozenset(
     {
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
         TaskCategory.CAUSAL_LANGUAGE_MODELING,
+        TaskCategory.SEQ2SEQ,
     }
 )
 

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -121,6 +121,24 @@ _SPECS = (
         is_nlp=True,
         file_subdir="texts",
     ),
+    # seq2seq is file-bearing AND self-supervised (no label), exactly like
+    # causal_language_modeling. Each sample is one ``.txt`` of RAW text — a
+    # tab-separated ``source\ttarget`` pair (the same on-disk shape as causal
+    # LM's ``prompt\tcompletion``) — so it stages from ``texts/`` (the raw-text
+    # subdir shared with text/token classification), not ``sequences/`` (which
+    # the framework reserves for pre-tokenized data). It is NLP, so it ships the
+    # #805 data-derived text profile for the contributor-tokenizer-fit check.
+    ModalitySpec(
+        TaskCategory.SEQ2SEQ,
+        is_file_bearing=True,
+        is_tabular_family=False,
+        is_self_supervised=True,
+        data_format=DataFormat.TEXT,
+        build_validators=v.seq2seq,
+        transfer=t.seq2seq,
+        is_nlp=True,
+        file_subdir="texts",
+    ),
     # Tabular family (structured feature tables; no sidecar files -> no transfer).
     ModalitySpec(
         TaskCategory.TABULAR_CLASSIFICATION,

--- a/tracebloc_ingestor/modalities/transfer.py
+++ b/tracebloc_ingestor/modalities/transfer.py
@@ -116,6 +116,16 @@ def causal_language_modeling(
     return text_transfer(record, options, cfg=cfg)
 
 
+def seq2seq(
+    record: Dict[str, Any], options: Dict[str, Any], cfg: Optional[Config] = None
+) -> Optional[Dict[str, Any]]:
+    # Raw text, one .txt per sample in the ``texts`` subdir (same on-disk
+    # layout as causal_language_modeling — the default text_transfer subdir).
+    # Self-supervised: the .txt holds a tab-separated ``source\ttarget`` pair,
+    # never a label.
+    return text_transfer(record, options, cfg=cfg)
+
+
 def semantic_segmentation(
     record: Dict[str, Any], options: Dict[str, Any], cfg: Optional[Config] = None
 ) -> Optional[Dict[str, Any]]:

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -225,6 +225,27 @@ def causal_language_modeling(options: Dict[str, Any]) -> List[BaseValidator]:
     return validators
 
 
+def seq2seq(options: Dict[str, Any]) -> List[BaseValidator]:
+    # Self-supervised, like causal_language_modeling — only a ``filename``
+    # column is required, no label column, so no LabelColumn/BIO/LabelDiversity
+    # validators. Each sample is one ``.txt`` of RAW text: a tab-separated
+    # ``source\ttarget`` pair (same shape as causal LM's ``prompt\tcompletion``).
+    # Both sides are valid UTF-8 text, so the shared TextContentValidator
+    # (binary/non-UTF-8 reject, empty warn) is the whole content check — there
+    # is no extra structural rule to enforce. Stages from ``texts/`` (raw text),
+    # not ``sequences/`` (pre-tokenized).
+    validators: List[BaseValidator] = [
+        FileTypeValidator(
+            allowed_extension=options.get("extension", FileExtension.TXT),
+            path="texts",
+        ),
+        _text_content_validator(options, "texts"),
+    ]
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
 def tabular_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     validators: List[BaseValidator] = []
     if options.get("schema"):

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -37,7 +37,8 @@
         "time_series_forecasting",
         "time_to_event_prediction",
         "masked_language_modeling",
-        "causal_language_modeling"
+        "causal_language_modeling",
+        "seq2seq"
       ],
       "description": "Task category. Drives convention defaults: validators, data_format, default columns, default file extensions, default validator set."
     },
@@ -87,7 +88,7 @@
     "texts": {
       "type": "string",
       "minLength": 1,
-      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification, token_classification, and causal_language_modeling (raw .txt: plain text, or a tab-separated prompt\\tcompletion pair)."
+      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification, token_classification, causal_language_modeling (raw .txt: plain text, or a tab-separated prompt\\tcompletion pair), and seq2seq (raw .txt: a tab-separated source\\ttarget pair)."
     },
 
     "sequences": {
@@ -346,6 +347,14 @@
       "then": { "required": ["texts"] }
     },
     {
+      "description": "seq2seq requires `texts` (raw .txt samples, each a tab-separated source\\ttarget pair). It is self-supervised, so unlike text/token classification it does NOT require `label`.",
+      "if": {
+        "properties": { "category": { "const": "seq2seq" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["texts"] }
+    },
+    {
       "description": "tabular and time-series categories require `schema`.",
       "if": {
         "properties": {
@@ -421,7 +430,8 @@
           "category": {
             "enum": [
               "masked_language_modeling",
-              "causal_language_modeling"
+              "causal_language_modeling",
+              "seq2seq"
             ]
           }
         },

--- a/tracebloc_ingestor/utils/constants.py
+++ b/tracebloc_ingestor/utils/constants.py
@@ -47,6 +47,7 @@ class TaskCategory:
     SEMANTIC_SEGMENTATION = "semantic_segmentation"
     MASKED_LANGUAGE_MODELING = "masked_language_modeling"
     CAUSAL_LANGUAGE_MODELING = "causal_language_modeling"
+    SEQ2SEQ = "seq2seq"
 
     # instance_segmentation is deliberately absent: it briefly shipped here
     # and in the schema enum with no validators and no file transfer, so
@@ -75,6 +76,7 @@ class TaskCategory:
             cls.SEMANTIC_SEGMENTATION,
             cls.MASKED_LANGUAGE_MODELING,
             cls.CAUSAL_LANGUAGE_MODELING,
+            cls.SEQ2SEQ,
         ]
 
     @classmethod

--- a/tracebloc_ingestor/validators/text_content_validator.py
+++ b/tracebloc_ingestor/validators/text_content_validator.py
@@ -1,8 +1,8 @@
 """Text Content Validator Module.
 
 Content-level check for NLP categories (text_classification,
-token_classification, masked_language_modeling, causal_language_modeling).
-``FileTypeValidator`` only
+token_classification, masked_language_modeling, causal_language_modeling,
+seq2seq). ``FileTypeValidator`` only
 checks the file *extension*, so a file named ``doc1.txt`` that actually holds
 binary / non-UTF-8 bytes — or is empty — passed validation and was ingested
 silently; the dataset author only discovered the corruption at training time.
@@ -45,9 +45,9 @@ class TextContentValidator(BaseValidator):
 
     Attributes:
         texts_path: Subdirectory under ``SRC_PATH`` holding the text files
-            (``"texts"`` for text/token classification and causal language
-            modeling, ``"sequences"`` for masked language modeling) — mirrors
-            ``FileTypeValidator(path=...)``.
+            (``"texts"`` for text/token classification, causal language
+            modeling and seq2seq, ``"sequences"`` for masked language
+            modeling) — mirrors ``FileTypeValidator(path=...)``.
         extension: Expected text-file extension (default ``.txt``).
         filename_column: CSV column naming each sample's file (default
             ``"filename"``; resolved case-insensitively).


### PR DESCRIPTION
## What

Adds the `seq2seq` (sequence-to-sequence / encoder-decoder) modality to the ingestor — the data-layer piece of shape #7 (epic tracebloc-client#293). Companions: client tracebloc-client#304 (merged), backend#891, SDK + model-zoo PRs.

## Shape

Each sample is one `.txt` of raw text holding a tab-separated `source\ttarget` pair — the same on-disk layout as `causal_language_modeling`'s `prompt\tcompletion`, staged from `texts/`. Self-supervised: no label column.

## Changes (modeled on `causal_language_modeling`)

- `modalities/registry.py` — `ModalitySpec` for `seq2seq` (file-bearing, self-supervised, NLP, `texts/` subdir, `DataFormat.TEXT`).
- `modalities/validators.py` — `seq2seq` validator (FileType + shared TextContentValidator; no label/BIO validators).
- `modalities/transfer.py` — `seq2seq` raw-text transfer.
- `utils/constants.py`, `cli/conventions.py`, `schema/ingest.v1.json` — register the category; requires `texts`, not `label`.
- `validators/text_content_validator.py` — docstring includes seq2seq.
- Template `templates/seq2seq/` + example `examples/yaml/seq2seq.yaml`; e2e characterization entries.

## Notes

- #805 tokenizer alignment is handled via `is_nlp=True` (data-derived text profile); no ingest-time tokenizer.
- The template does not swallow exceptions (fails loudly).
- The branch carried a redundant `bump version to 0.5.2` commit; develop is already at 0.5.2, so merging develop in collapses it to a no-op (no version change in this PR).

## Tests

Full suite green locally (1273 passed pre-merge; seq2seq + touched slices re-verified post-develop-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive modality registration and tests; behavior mirrors existing causal LM ingestion with no auth or data-model breaking changes.
> 
> **Overview**
> Adds **`seq2seq`** as a supported ingest category for encoder–decoder workloads, following the same self-supervised raw-text path as causal LM.
> 
> **Data contract:** CSV manifest plus per-sample `.txt` files under `texts/`, each holding a tab-separated `source<TAB>target` pair. No `label:` in YAML (schema rejects it like other self-supervised NLP categories) and `texts:` is required.
> 
> **Engine wiring:** New `TaskCategory.SEQ2SEQ`, `ModalitySpec` (file-bearing, self-supervised, NLP, `texts/`), dedicated validators (file type + UTF-8 content, no label validators), and transfer via shared `text_transfer`. CLI `TEXT_CATEGORIES`, `ingest.v1.json`, and NLP/text-profile attachment (#805) are extended to include `seq2seq`.
> 
> **Customer artifacts:** `templates/seq2seq/` (sample data, `seq2seq.py`, README), `examples/yaml/seq2seq.yaml`, and README table update. E2E characterization and ingest suites gain a `seq2seq` case; unit tests cover registry, schema, YAML resolution, CLI routing, validation, and failure accounting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9373f87b005ba312f0ad4438991422f88385bace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->