### PR TITLE
chore(release): bump version to 0.5.3

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
Lands the `__version__` bump for **v0.5.3** on `develop`: `0.5.2` → `0.5.3`.

v0.5.3 was tagged to ship the **seq2seq** modality (#323), which merged after v0.5.2 — so the released `ghcr.io/tracebloc/ingestor:0.5.3` image is the first to contain seq2seq. The tag carries this bump; this PR reconciles `develop` so `__version__` stops drifting.

No functional change — single-line version literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version bump with no runtime logic changes.
> 
> **Overview**
> Bumps the package version literal in `tracebloc_ingestor/__init__.py` from **0.5.2** to **0.5.3** so `develop` matches the v0.5.3 release tag. `setup.py` still reads this value via `_read_version()` — no other files change.
> 
> No behavioral or API changes; release housekeeping only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d26c99255d2202735c6fafb0ce46a00ed589b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->