### PR TITLE
feat: replace per-row GlobalMeta flow with single ingest summary call

### DIFF
--- a/e2e/test_characterization.py
+++ b/e2e/test_characterization.py
@@ -290,29 +290,17 @@ def _fetch_rows(table):
 
 @pytest.fixture
 def capture_api(monkeypatch):
-    """Record the args every APIClient backend method is called with, then
-    delegate to the original (which returns the local-mode value). Captures the
-    engine's INTENT to send even though local mode skips the actual POST."""
-    calls = {
-        n: []
-        for n in (
-            "send_batch",
-            "send_global_meta_meta",
-            "prepare_dataset",
-            "create_dataset",
-        )
-    }
-    for name in calls:
-        orig = getattr(client_mod.APIClient, name)
+    """Record the kwargs send_ingest_summary is called with, then delegate to
+    the original (which returns the local-mode value without making an HTTP
+    call). Captures the engine's intent to send the summary payload."""
+    calls = {"send_ingest_summary": []}
+    orig = client_mod.APIClient.send_ingest_summary
 
-        def make(name, orig):
-            def wrapper(self, *args, **kwargs):
-                calls[name].append({"args": args, "kwargs": kwargs})
-                return orig(self, *args, **kwargs)
+    def wrapper(self, *args, **kwargs):
+        calls["send_ingest_summary"].append({"args": args, "kwargs": kwargs})
+        return orig(self, *args, **kwargs)
 
-            return wrapper
-
-        monkeypatch.setattr(client_mod.APIClient, name, make(name, orig))
+    monkeypatch.setattr(client_mod.APIClient, "send_ingest_summary", wrapper)
     return calls
 
 
@@ -377,29 +365,35 @@ def test_characterization(case, tmp_path, monkeypatch, capture_api):
             ], f"{case['id']}: tabular ingest copied unexpected files"
 
     # ── Dimension 3: backend payloads ────────────────────────────────────
-    # send_batch(records, table_name, ingestor_id) — records is [(id, dict)].
-    sent = [rec for c in capture_api["send_batch"] for (_id, rec) in c["args"][0]]
-    assert (
-        len(sent) == expected_rows
-    ), f"{case['id']}: {len(sent)} records sent to API, {expected_rows} expected"
-    for rec in sent:
-        assert rec.get("data_id"), "sent record missing data_id"
-        assert rec.get("data_intent") == cfg["intent"]
-    # The dataset-registration trio each fires exactly once.
-    assert len(capture_api["send_global_meta_meta"]) == 1
-    assert len(capture_api["prepare_dataset"]) == 1
-    assert len(capture_api["create_dataset"]) == 1
-    # global_meta carries the table name + a schema whose columns are a
-    # superset of the user schema (plus the framework's standard columns).
-    meta_args = capture_api["send_global_meta_meta"][0]["args"]
-    assert meta_args[0] == table
-    schema_sent = meta_args[1]
-    # The label column is mapped onto the framework's standard `label` column,
-    # not stored under its own name (e.g. regression's `price` -> `label`), so
-    # exclude it: the remaining FEATURE columns must all be in the payload.
+    # send_ingest_summary fires exactly once, carrying the full ingest summary.
+    assert len(capture_api["send_ingest_summary"]) == 1, (
+        f"{case['id']}: send_ingest_summary called "
+        f"{len(capture_api['send_ingest_summary'])} times"
+    )
+    summary_kw = capture_api["send_ingest_summary"][0]["kwargs"]
+    # Table name must be passed through.
+    assert summary_kw.get("table_name") == table, (
+        f"{case['id']}: table_name in summary payload is "
+        f"{summary_kw.get('table_name')!r}, expected {table!r}"
+    )
+    # Intent must match the configured intent.
+    assert summary_kw.get("data_intent") == cfg["intent"], (
+        f"{case['id']}: data_intent {summary_kw.get('data_intent')!r} != "
+        f"{cfg['intent']!r}"
+    )
+    # Label counts: the sum of all label bucket counts must equal the total
+    # inserted rows (every row lands in exactly one bucket).
+    total_labelled = sum(summary_kw.get("labels", {}).values())
+    assert total_labelled == expected_rows, (
+        f"{case['id']}: labels total {total_labelled} != {expected_rows} expected rows"
+    )
+    # Schema: the user-declared feature columns must all be present in the
+    # schema payload sent to the backend. The label column maps to the
+    # framework's standard `label` column and is excluded from the check.
     label = cfg.get("label")
     label_col = label.get("column") if isinstance(label, dict) else label
     feature_cols = set(cfg.get("schema", {})) - {label_col}
+    schema_sent = summary_kw.get("schema", {})
     assert feature_cols <= set(schema_sent), (
         f"{case['id']}: schema payload missing feature columns "
         f"{feature_cols - set(schema_sent)}"

--- a/tests/test_api_client_failure_modes.py
+++ b/tests/test_api_client_failure_modes.py
@@ -15,6 +15,7 @@ import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
+import requests
 
 from tracebloc_ingestor.api import client as client_mod
 from tracebloc_ingestor.api.client import APIClient
@@ -88,57 +89,62 @@ def _client(**overrides):
     return client
 
 
+def _summary_call(client):
+    return client.send_ingest_summary(
+        table_name="tbl", ingestor_id="ing", labels={"cat": 1},
+        dataset_title="T", data_format="image", data_intent="train",
+        category="image_classification", schema={}, samples=[],
+    )
+
+
 # --- retry on transient 5xx (proves the adapter retry actually fires) -------
 
-def test_send_batch_retries_transient_5xx_then_succeeds(mock_api):
-    mock_api.queue = [{"status": 503}, {"status": 503}, {"status": 200, "body": "{}"}]
+def test_send_ingest_summary_retries_transient_5xx_then_succeeds(mock_api):
+    body = '{"dataset_id": 1, "dataset_key": "k"}'
+    mock_api.queue = [{"status": 503}, {"status": 503}, {"status": 200, "body": body}]
     client = _client()
-    assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is True
+    result = _summary_call(client)
+    assert result.get("dataset_id") == 1
     assert mock_api.requests == 3  # 2 retries + the success
 
 
-def test_send_batch_persistent_5xx_returns_false(mock_api):
+def test_send_ingest_summary_persistent_5xx_raises(mock_api):
     mock_api.default = {"status": 503, "body": "down"}
     client = _client()
-    assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+    with pytest.raises(requests.exceptions.RequestException):
+        _summary_call(client)
     assert mock_api.requests > 1  # it retried before giving up
 
 
 # --- non-retryable status ---------------------------------------------------
 
-def test_send_batch_401_returns_false_without_retry(mock_api):
+def test_send_ingest_summary_401_raises_without_retry(mock_api):
     mock_api.default = {"status": 401, "body": "unauthorized"}
     client = _client()
-    assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+    with pytest.raises(requests.exceptions.HTTPError):
+        _summary_call(client)
     assert mock_api.requests == 1  # 401 isn't in the 5xx retry list
 
 
 # --- timeout (a hanging backend must not hang the ingest) -------------------
 
-def test_send_batch_timeout_is_handled(mock_api, monkeypatch):
+def test_send_ingest_summary_timeout_raises(mock_api, monkeypatch):
     monkeypatch.setattr(client_mod, "API_TIMEOUT", 0.5)
     mock_api.default = {"status": 200, "body": "{}", "delay": 2.0}
     client = _client()
     for adapter in client.session.adapters.values():
         adapter.max_retries.total = 0  # 1 attempt (~0.5s), no retry-on-timeout
-    assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+    with pytest.raises(requests.exceptions.RequestException):
+        _summary_call(client)
 
 
 # --- non-JSON 200 body (regression for the JSONDecodeError fix) -------------
 
-def test_send_global_meta_non_json_200_still_succeeds(mock_api):
-    # A 200 whose body isn't JSON used to flip a successful send to False (the
-    # .json() in the log line raised). It must now warn + still report success.
-    mock_api.default = {"status": 200, "body": "OK", "content_type": "text/plain"}
-    client = _client()
-    assert client.send_global_meta_meta("tbl", {"a": "INT"}, {}) is True
-
-
-def test_create_dataset_non_json_200_raises_clear_error(mock_api):
+def test_send_ingest_summary_non_json_200_raises_clear_error(mock_api):
     mock_api.default = {"status": 200, "body": "<html>oops</html>", "content_type": "text/html"}
     client = _client()
     with pytest.raises(ValueError, match="non-JSON"):
-        client.create_dataset(ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION)
+        _summary_call(client)
 
 
 def test_authenticate_non_json_200_raises_clear_error(mock_api):

--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -1,13 +1,12 @@
-"""Tests for APIClient request methods (send_batch, metadata, prepare, create).
+"""Tests for APIClient request methods (send_ingest_summary).
 
 Auth boot paths are covered in test_api_client_auth.py. Here we build a client
 with BACKEND_TOKEN set (so __init__ does no network call) and patch the
-session's get/post to exercise each method's success / error / local-mode path.
+session's post to exercise each method's success / error / local-mode path.
 """
 
 from __future__ import annotations
 
-import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,12 +14,9 @@ import requests
 
 from tracebloc_ingestor.config import Config
 from tracebloc_ingestor.api.client import APIClient
-from tracebloc_ingestor.utils.constants import TaskCategory
 
 
 def _client(**overrides):
-    # TITLE=None by default so create_dataset's title-generation path is
-    # deterministic regardless of any TITLE exported in the host/CI env.
     defaults = dict(
         BACKEND_TOKEN="tok",
         CLIENT_USERNAME=None,
@@ -58,235 +54,69 @@ def test_authenticate_http_error_raises():
 
 
 # ---------------------------------------------------------------------------
-# send_batch
+# send_ingest_summary
 # ---------------------------------------------------------------------------
 
 
-def test_send_batch_success():
+def _summary_call(client):
+    return client.send_ingest_summary(
+        table_name="tbl", ingestor_id="ing", labels={"cat": 1},
+        dataset_title="T", data_format="image", data_intent="train",
+        category="image_classification", schema={}, samples=[],
+    )
+
+
+def test_send_ingest_summary_success():
     client = _client()
-    records = [(1, {"data_id": "a", "label": "cat"}), (2, {"data_id": "b"})]
-    with patch.object(client.session, "post", return_value=_resp(200)) as post:
-        assert client.send_batch(records, "tbl", ingestor_id="ing") is True
-    post.assert_called_once()
-    assert "/global_meta/tbl/" in post.call_args[0][0]
+    with patch.object(
+        client.session, "post",
+        return_value=_resp(200, {"dataset_id": 1, "dataset_key": "key"}),
+    ):
+        result = _summary_call(client)
+    assert result == {"dataset_id": 1, "dataset_key": "key"}
 
 
-def test_send_batch_http_error_returns_false():
+def test_send_ingest_summary_http_error_raises():
     client = _client()
     with patch.object(client.session, "post", return_value=_resp(500, text="boom")):
-        assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
-
-
-def test_send_batch_local_mode_skips_network():
-    client = _client(EDGE_ENV="local")
-    with patch.object(client.session, "post") as post:
-        assert client.send_batch([(1, {})], "tbl", "ing") is True
-    post.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# send_global_meta_meta
-# ---------------------------------------------------------------------------
-
-
-def test_send_global_meta_success():
-    client = _client()
-    with patch.object(client.session, "post", return_value=_resp(200, {"ok": 1})):
-        assert client.send_global_meta_meta("tbl", {"a": "INT"}, {"k": "v"}) is True
-
-
-def test_send_global_meta_error_returns_false():
-    client = _client()
-    with patch.object(client.session, "post", return_value=_resp(400, text="bad")):
-        assert client.send_global_meta_meta("tbl", {}, {}) is False
-
-
-def test_send_global_meta_local_mode():
-    client = _client(EDGE_ENV="local")
-    with patch.object(client.session, "post") as post:
-        assert client.send_global_meta_meta("tbl", {}, {}) is True
-    post.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# send_generate_edge_label_meta
-# ---------------------------------------------------------------------------
-
-
-def test_generate_edge_label_success():
-    client = _client()
-    with patch.object(client.session, "get", return_value=_resp(200)) as get:
-        assert client.send_generate_edge_label_meta("tbl", "ing", "train") is True
-    assert "generate-edge-labels-meta" in get.call_args[0][0]
-
-
-def test_generate_edge_label_error_returns_false():
-    client = _client()
-    with patch.object(client.session, "get", return_value=_resp(503, text="down")):
-        assert client.send_generate_edge_label_meta("tbl", "ing", "train") is False
-
-
-def test_generate_edge_label_local_mode():
-    client = _client(EDGE_ENV="local")
-    with patch.object(client.session, "get") as get:
-        assert client.send_generate_edge_label_meta("tbl", "ing", "train") is True
-    get.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# prepare_dataset
-# ---------------------------------------------------------------------------
-
-
-def test_prepare_dataset_success():
-    client = _client()
-    with patch.object(client.session, "get", return_value=_resp(200, {"ok": 1})):
-        assert (
-            client.prepare_dataset(
-                TaskCategory.IMAGE_CLASSIFICATION, "ing", "image", "train"
-            )
-            is True
-        )
-
-
-def test_prepare_dataset_invalid_category_returns_false():
-    client = _client()
-    with patch.object(client.session, "get") as get:
-        assert client.prepare_dataset("nonsense", "ing", "image", "train") is False
-    get.assert_not_called()
-
-
-def test_prepare_dataset_error_returns_false():
-    client = _client()
-    with patch.object(client.session, "get", return_value=_resp(500, text="x")):
-        assert (
-            client.prepare_dataset(
-                TaskCategory.IMAGE_CLASSIFICATION, "ing", "image", "train"
-            )
-            is False
-        )
-
-
-def test_prepare_dataset_local_mode():
-    client = _client(EDGE_ENV="local")
-    with patch.object(client.session, "get") as get:
-        assert client.prepare_dataset("anything", "ing", "image", "train") is True
-    get.assert_not_called()
-
-
-def test_prepare_dataset_error_captures_response_body():
-    """On HTTP error, `prepare_dataset` must stash the backend response body
-    on `self.last_prepare_error` so callers can surface the actual reason
-    in their user-visible error — instead of pointing at "the logged API
-    error above". Issue #251.
-
-    The body retained must include the status code and the response text
-    (capped) so a downstream RuntimeError can include both.
-    """
-    client = _client()
-    body = '{"message":"Please provide atleast 2 labels."}'
-    with patch.object(client.session, "get", return_value=_resp(400, text=body)):
-        ok = client.prepare_dataset(
-            TaskCategory.TABULAR_CLASSIFICATION, "ing", "tabular", "train"
-        )
-    assert ok is False
-    assert client.last_prepare_error is not None
-    # Status code + body both surface so the user sees the backend reason.
-    assert "HTTP 400" in client.last_prepare_error
-    assert "Please provide" in client.last_prepare_error
-
-
-def test_prepare_dataset_last_error_starts_unset():
-    """On a clean ingestor with no prior failure, `last_prepare_error`
-    is None — base.py falls back to its generic 'see logged API error
-    above' message only when this attribute is truly absent."""
-    client = _client()
-    assert client.last_prepare_error is None
-
-
-def test_prepare_dataset_network_error_captures_string():
-    """When `e.response` is None (DNS / connection refused / timeout),
-    last_prepare_error should still be populated with the stringified
-    exception — never silently fall through to None."""
-    import requests as _req
-
-    client = _client()
-    err = _req.exceptions.ConnectionError("name resolution failed")
-    with patch.object(client.session, "get", side_effect=err):
-        ok = client.prepare_dataset(
-            TaskCategory.TABULAR_CLASSIFICATION, "ing", "tabular", "train"
-        )
-    assert ok is False
-    assert client.last_prepare_error is not None
-    assert "name resolution failed" in client.last_prepare_error
-
-
-# ---------------------------------------------------------------------------
-# create_dataset
-# ---------------------------------------------------------------------------
-
-
-def test_create_dataset_success_generates_title():
-    client = _client()
-    captured = {}
-
-    def fake_post(url, data=None, headers=None, timeout=None):
-        captured["data"] = data
-        return _resp(200, {"id": 7})
-
-    with patch.object(client.session, "post", side_effect=fake_post):
-        result = client.create_dataset(
-            ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
-        )
-    assert result == {"id": 7}
-    assert "image_classification_ing" in captured["data"]
-
-
-def test_create_dataset_tabular_allows_feature_modification():
-    client = _client()
-    captured = {}
-    with patch.object(
-        client.session,
-        "post",
-        side_effect=lambda url, data=None, **k: captured.update(data=data)
-        or _resp(200, {"id": 1}),
-    ):
-        client.create_dataset(
-            ingestor_id="ing", category=TaskCategory.TABULAR_CLASSIFICATION
-        )
-    assert '"allow_feature_modification": true' in captured["data"]
-
-
-def test_create_dataset_uses_config_title():
-    client = _client(TITLE="My Title")
-    captured = {}
-    with patch.object(
-        client.session,
-        "post",
-        side_effect=lambda url, data=None, **k: captured.update(data=data)
-        or _resp(200, {"id": 1}),
-    ):
-        client.create_dataset(
-            ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
-        )
-    assert "My Title" in captured["data"]
-
-
-def test_create_dataset_error_raises():
-    client = _client()
-    with patch.object(client.session, "post", return_value=_resp(500, text="err")):
         with pytest.raises(requests.exceptions.RequestException):
-            client.create_dataset(
-                ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
-            )
+            _summary_call(client)
 
 
-def test_create_dataset_local_mode():
+def test_send_ingest_summary_local_mode():
     client = _client(EDGE_ENV="local")
     with patch.object(client.session, "post") as post:
-        result = client.create_dataset(ingestor_id="ing", category="x")
-    assert result["id"] == "mock_dataset_id"
+        result = _summary_call(client)
     post.assert_not_called()
+    assert result["dataset_id"] == "mock_dataset_id"
+
+
+def test_send_ingest_summary_payload_shape():
+    import json as _json
+
+    client = _client()
+    with patch.object(
+        client.session, "post",
+        return_value=_resp(200, {"dataset_id": 42, "dataset_key": "k"}),
+    ) as post:
+        client.send_ingest_summary(
+            table_name="tbl",
+            ingestor_id="ing-42",
+            labels={"cat": 5, "dog": 3},
+            dataset_title="My Dataset",
+            data_format="image",
+            data_intent="train",
+            category="image_classification",
+            schema={"col": "INT"},
+            samples=[{"data_id": "a"}],
+            meta_data={"source": "test"},
+        )
+
+    sent = _json.loads(post.call_args.kwargs["data"])
+    for key in ("ingestor_id", "labels", "dataset_title", "data_format",
+                "data_intent", "category", "schema", "samples", "meta_data"):
+        assert key in sent, f"missing key: {key}"
+    assert sent["meta_data"] == {"source": "test"}
 
 
 # ---------------------------------------------------------------------------
@@ -297,7 +127,7 @@ def test_create_dataset_local_mode():
 def test_authed_request_refreshes_token_on_401():
     """A 401 on an authenticated call triggers ONE refresh + retry. The
     refresh path rotates the token to a fresh value; the second call
-    succeeds with the new token. The terminal create_dataset / metadata
+    succeeds with the new token. The terminal send_ingest_summary
     callback used to fail outright on multi-hour runs when the token
     aged out — now it transparently re-mints."""
     client = _client(BACKEND_TOKEN="old_token")
@@ -308,7 +138,7 @@ def test_authed_request_refreshes_token_on_401():
         calls.append(headers["Authorization"])
         if len(calls) == 1:
             return _resp(401, text='{"detail":"Invalid token."}')
-        return _resp(200, {"id": 7})
+        return _resp(200, {"dataset_id": 7, "dataset_key": "k"})
 
     # Stub _refresh_token to simulate a successful rotation.
     def fake_refresh():
@@ -318,9 +148,7 @@ def test_authed_request_refreshes_token_on_401():
     with patch.object(client.session, "post", side_effect=fake_post), patch.object(
         client, "_refresh_token", side_effect=fake_refresh
     ):
-        client.create_dataset(
-            ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
-        )
+        _summary_call(client)
 
     assert len(calls) == 2, "expected one 401 + one retry"
     assert calls[0] == "TOKEN old_token"
@@ -342,9 +170,7 @@ def test_authed_request_gives_up_after_one_retry(monkeypatch):
 
     with patch.object(client.session, "post", side_effect=fake_post):
         with pytest.raises(requests.exceptions.RequestException):
-            client.create_dataset(
-                ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
-            )
+            _summary_call(client)
 
     # One attempt only — refresh saw no change so no retry.
     assert len(calls) == 1
@@ -356,11 +182,10 @@ def test_authed_request_passes_through_non_401_unchanged():
     failure — the per-call error handling already covers those."""
     client = _client()
     with patch.object(
-        client.session, "post", return_value=_resp(200, {"id": 1})
+        client.session, "post",
+        return_value=_resp(200, {"dataset_id": 1, "dataset_key": "k"}),
     ) as post:
-        client.create_dataset(
-            ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
-        )
+        _summary_call(client)
     # Exactly one call — no refresh, no retry on the happy path.
     assert post.call_count == 1
 
@@ -424,39 +249,3 @@ def test_refresh_token_false_when_reauth_raises():
     client.token = "old_token"
     with patch.object(client, "authenticate", side_effect=RuntimeError("auth down")):
         assert client._refresh_token() is False
-
-
-# ---------------------------------------------------------------------------
-# send_batch payload contract — the per-record body the backend depends on,
-# including defaults and the misspelled-but-load-bearing `injestor_id` key. A
-# typo/default drift here would silently break registration with green tests.
-# ---------------------------------------------------------------------------
-
-
-def test_send_batch_payload_shape():
-    import json as _json
-
-    client = _client()
-    records = [
-        (1, {"data_id": "a", "data_intent": "test", "label": "cat"}),
-        (2, {"data_id": "b"}),  # exercises the data_intent / label defaults
-    ]
-    with patch.object(client.session, "post", return_value=_resp(200)) as post:
-        assert client.send_batch(records, "tbl", ingestor_id="ing-42") is True
-
-    sent = _json.loads(post.call_args.kwargs["data"])
-    assert sent[0] == {
-        "data_id": "a",
-        "data_intent": "test",
-        "label": "cat",
-        "is_sample": False,
-        "injestor_id": "ing-42",
-    }
-    # Defaults: data_intent -> "train", label -> "".
-    assert sent[1] == {
-        "data_id": "b",
-        "data_intent": "train",
-        "label": "",
-        "is_sample": False,
-        "injestor_id": "ing-42",
-    }

--- a/tests/test_batch_send_failure_accounting.py
+++ b/tests/test_batch_send_failure_accounting.py
@@ -71,12 +71,10 @@ def make_ingestor(records=None, **overrides):
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
     db.get_table_schema.return_value = {"a": "INT"}
+    db.get_label_counts.return_value = {"cat": 2}
+    db.get_samples.return_value = []
     api = MagicMock(name="APIClient")
-    api.send_batch.return_value = True
-    api.send_generate_edge_label_meta.return_value = True
-    api.send_global_meta_meta.return_value = True
-    api.prepare_dataset.return_value = True
-    api.create_dataset.return_value = {"id": 1}
+    api.send_ingest_summary.return_value = {"dataset_id": 1, "dataset_key": "key"}
 
     kwargs = dict(
         database=db,
@@ -91,11 +89,10 @@ def make_ingestor(records=None, **overrides):
 
 
 # ---------------------------------------------------------------------------
-# 1. send_batch logs the actual backend error, not a 100-char stub
+# 1. send_ingest_summary logs the actual backend error, not a 100-char stub
 # ---------------------------------------------------------------------------
 
-# A realistic DRF batch-rejection body: well past the old 100-char cutoff
-# (str(e) started with "HTTP 400: ", leaving ~90 chars of body).
+# A realistic DRF batch-rejection body: well past the old 100-char cutoff.
 _DRF_400_BODY = (
     '[{"data_id": ["This field may not be blank."], '
     '"label": ["Object with label=tok_cls_O does not exist. '
@@ -104,45 +101,54 @@ _DRF_400_BODY = (
 )
 
 
-def test_send_batch_400_logs_status_and_full_field_error(caplog):
+def _summary_call(client):
+    return client.send_ingest_summary(
+        table_name="tbl", ingestor_id="ing", labels={"cat": 1},
+        dataset_title="T", data_format="image", data_intent="train",
+        category="image_classification", schema={}, samples=[],
+    )
+
+
+def test_send_ingest_summary_400_logs_status_and_full_error(caplog):
     client = _client()
     with patch.object(client.session, "post", return_value=_resp(400, text=_DRF_400_BODY)):
         with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
-            assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+            with pytest.raises(requests.exceptions.HTTPError):
+                _summary_call(client)
     joined = "\n".join(r.getMessage() for r in caplog.records)
-    assert "Error sending batch to API" in joined
+    assert "Error sending ingest summary" in joined
     assert "HTTP 400" in joined
-    # The tail of the DRF body — beyond the old [:100] truncation — must be
-    # visible so the operator can see WHY the backend rejected the batch.
     assert "well past the first hundred characters" in joined
 
 
-def test_send_batch_400_body_capped_at_2000_chars(caplog):
+def test_send_ingest_summary_400_body_capped_at_2000_chars(caplog):
     client = _client()
     huge = "x" * 5000
     with patch.object(client.session, "post", return_value=_resp(400, text=huge)):
         with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
-            client.send_batch([(1, {"data_id": "a"})], "tbl", "ing")
+            with pytest.raises(requests.exceptions.HTTPError):
+                _summary_call(client)
     joined = "\n".join(r.getMessage() for r in caplog.records)
     assert "x" * 2000 in joined
     assert "x" * 2001 not in joined
 
 
-def test_send_batch_connection_error_still_logged(caplog):
+def test_send_ingest_summary_connection_error_still_logged(caplog):
     client = _client()
     with patch.object(
         client.session, "post",
         side_effect=requests.exceptions.ConnectionError("conn refused"),
     ):
         with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
-            assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
+            with pytest.raises(requests.exceptions.ConnectionError):
+                _summary_call(client)
     joined = "\n".join(r.getMessage() for r in caplog.records)
-    assert "Error sending batch to API" in joined
+    assert "Error sending ingest summary" in joined
     assert "conn refused" in joined
 
 
 # ---------------------------------------------------------------------------
-# 2. ingest() surfaces API-send failures: returned, counted, summarized
+# 2. ingest() surfaces summary failures: raise propagates, DB failures counted
 # ---------------------------------------------------------------------------
 
 def _run_ingest(ing, batch_size=10):
@@ -161,38 +167,34 @@ def _run_ingest(ing, batch_size=10):
     return failed, captured.get("summary")
 
 
-def test_ingest_api_send_failure_returns_failed_records():
+def test_ingest_summary_failure_raises_out_of_ingest():
+    """send_ingest_summary failing raises out of ingest() so cli.run.main
+    returns 1 and the template scripts exit non-zero."""
     records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
     ing = make_ingestor(records=records, category=None)
-    ing.api_client.send_batch.return_value = False  # every batch POST rejected
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
 
-    failed, summary = _run_ingest(ing)
-
-    # Every inserted-but-unsent record comes back as a failed record, so
-    # cli.run.main returns 1 and the template scripts sys.exit(1).
-    assert len(failed) == 2
-    assert all(f["error"] == "api_send_failed" for f in failed)
-
-    # The summary must not claim the records shipped.
-    assert summary.inserted_records == 2
-    assert summary.api_sent_records == 0
-    assert summary.has_failures is True
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(ing, "validate_data", return_value=True):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError, match="backend rejected"):
+            ing.ingest("src", batch_size=10)
 
 
-def test_ingest_api_send_failure_on_final_partial_batch():
-    # 3 records with batch_size=2 exercises BOTH flush sites (in-loop and
-    # final partial batch).
+def test_ingest_summary_failure_on_partial_batch():
+    """Same guard with 3 records split across 2 batches (exercises both flush
+    sites — in-loop and final partial batch)."""
     records = [{"a": str(i), "filename": f"f{i}"} for i in range(3)]
     ing = make_ingestor(records=records, category=None)
-    ing.api_client.send_batch.return_value = False
-    # insert_batch must echo the actual batch size, not the fixture's [1, 2]
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
     ing.database.insert_batch.side_effect = lambda t, b: (list(range(len(b))), [])
+    ing.database.get_label_counts.return_value = {"cat": 3}
 
-    failed, summary = _run_ingest(ing, batch_size=2)
-
-    assert len(failed) == 3
-    assert summary.inserted_records == 3
-    assert summary.api_sent_records == 0
+    with patch.object(base_mod, "Session") as Sess, \
+         patch.object(ing, "validate_data", return_value=True):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError, match="backend rejected"):
+            ing.ingest("src", batch_size=2)
 
 
 def test_ingest_api_success_keeps_failed_records_empty():
@@ -239,20 +241,15 @@ def test_ingest_partial_db_failure_not_double_counted():
     assert summary.failed_records == 1
 
 
-def test_ingest_mid_batch_db_failure_plus_api_failure_tags_right_records():
-    # Bugbot regression guard: insert_batch's per-record fallback appends
-    # successes in scan order, so after a MID-batch DB failure the inserted
-    # records are NOT the first len(ids) entries. The api_send_failed tag
-    # must land on the records that actually inserted (here: #0 and #2),
-    # not on a batch[:len(ids)] prefix that would include the DB-failed #1
-    # and omit #2.
+def test_ingest_mid_batch_db_failure_only_db_failure_in_failed():
+    # Mid-batch DB failure: 2 of 3 records insert, 1 fails. send_ingest_summary
+    # is still called (some records inserted), and only the DB failure appears
+    # in failed — no api_send_failed entries since the summary call succeeded.
     records = [{"a": str(i), "filename": f"f{i}"} for i in range(3)]
     ing = make_ingestor(records=records, category=None)
-    ing.api_client.send_batch.return_value = False
+    ing.database.get_label_counts.return_value = {"a": 2}
 
     def fake_insert(table_name, batch):
-        # Middle record fails; failure carries a COPY of the record (the
-        # real insert_batch builds processed_record = {**record, ...}).
         failed_copy = {**batch[1], "updated_at": "now"}
         return [10, 12], [{"record": failed_copy, "error": "dup key"}]
 
@@ -260,12 +257,11 @@ def test_ingest_mid_batch_db_failure_plus_api_failure_tags_right_records():
 
     failed, summary = _run_ingest(ing)
 
-    api_failed = [f for f in failed if f["error"] == "api_send_failed"]
-    assert {f["record"]["a"] for f in api_failed} == {"0", "2"}
-    assert [f["error"] for f in failed if f["error"] != "api_send_failed"] == ["dup key"]
+    assert [f["error"] for f in failed] == ["dup key"]
     assert summary.inserted_records == 2
-    assert summary.api_sent_records == 0
+    assert summary.api_sent_records == 2
     assert summary.failed_records == 1
+    ing.api_client.send_ingest_summary.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_causal_language_modeling.py
+++ b/tests/test_causal_language_modeling.py
@@ -57,12 +57,10 @@ def make_ingestor(records=None, **overrides):
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.return_value = ([1, 2], [])
     db.get_table_schema.return_value = {"a": "INT"}
+    db.get_label_counts.return_value = {"cat": 2}
+    db.get_samples.return_value = []
     api = MagicMock(name="APIClient")
-    api.send_batch.return_value = True
-    api.send_generate_edge_label_meta.return_value = True
-    api.send_global_meta_meta.return_value = True
-    api.prepare_dataset.return_value = True
-    api.create_dataset.return_value = {"id": 1}
+    api.send_ingest_summary.return_value = {"dataset_id": 1, "dataset_key": "key"}
 
     kwargs = dict(
         database=db,
@@ -232,13 +230,12 @@ def test_clm_binary_content_rejected(clean_env, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_clm_api_send_failure_counts_every_record(clean_env):
-    """Every batch POST rejected -> every CLM record returns as a failure, so
-    the run exits non-zero (the file-transfer branch runs since CLM is
-    file-bearing)."""
+def test_clm_api_send_failure_propagates(clean_env):
+    """send_ingest_summary failing raises out of ingest() for CLM, so the run
+    exits non-zero (file-bearing modality still exercises the file-transfer branch)."""
     records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
     ing = make_ingestor(records=records)
-    ing.api_client.send_batch.return_value = False
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
 
     with patch.object(base_mod, "Session") as Sess, patch.object(
         ing, "validate_data", return_value=True
@@ -248,7 +245,5 @@ def test_clm_api_send_failure_counts_every_record(clean_env):
         side_effect=lambda c, r, o, cfg=None, source_record=None: r,
     ):
         Sess.return_value.__enter__.return_value = MagicMock()
-        failed = ing.ingest("src", batch_size=10)
-
-    assert len(failed) == 2
-    assert all(f["error"] == "api_send_failed" for f in failed)
+        with pytest.raises(RuntimeError, match="backend rejected"):
+            ing.ingest("src", batch_size=10)

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -417,41 +417,15 @@ def test_authenticate_error_with_response_text():
             APIClient(cfg)
 
 
-def test_send_batch_error_with_response_text():
+def test_send_ingest_summary_error_with_response_text():
     client = _client()
     with patch.object(client.session, "post", side_effect=_err_with_response()):
-        assert client.send_batch([(1, {"data_id": "a"})], "tbl", "ing") is False
-
-
-def test_send_global_meta_error_with_response_text():
-    client = _client()
-    with patch.object(client.session, "post", side_effect=_err_with_response()):
-        assert client.send_global_meta_meta("tbl", {}, {}) is False
-
-
-def test_generate_edge_label_error_with_response_text():
-    client = _client()
-    with patch.object(client.session, "get", side_effect=_err_with_response()):
-        assert client.send_generate_edge_label_meta("tbl", "ing", "train") is False
-
-
-def test_prepare_dataset_error_with_response_text():
-    client = _client()
-    with patch.object(client.session, "get", side_effect=_err_with_response()):
-        assert (
-            client.prepare_dataset(
-                TaskCategory.IMAGE_CLASSIFICATION, "ing", "image", "train"
-            )
-            is False
-        )
-
-
-def test_create_dataset_error_with_response_text():
-    client = _client()
-    with patch.object(client.session, "post", side_effect=_err_with_response()):
-        with pytest.raises(requests.exceptions.RequestException):
-            client.create_dataset(
-                ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
+        with pytest.raises(requests.exceptions.HTTPError):
+            client.send_ingest_summary(
+                table_name="tbl", ingestor_id="ing", labels={"cat": 1},
+                dataset_title="T", data_format="image", data_intent="train",
+                category=TaskCategory.IMAGE_CLASSIFICATION,
+                schema={}, samples=[],
             )
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -729,3 +729,36 @@ def test_upsert_doubles_embedded_backticks_in_column_name():
     assert "VALUES(`ev``il`)" in sql
     # Unescaped form would close the identifier early — must not appear.
     assert "VALUES(`ev`il`)" not in sql
+
+
+# ---------------------------------------------------------------------------
+# get_samples / get_label_counts: SQL NULL label normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_get_samples_null_label_normalised_to_empty_string(db, mock_engine_factory):
+    """SQL NULL labels in sample rows must be normalised to '' so the JSON
+    payload matches get_label_counts, which already maps NULL → '' (the same
+    convention the old per-row API always sent when no label was present)."""
+    _, _, conn = mock_engine_factory
+    conn.execute.return_value.fetchall.return_value = [
+        ("id-1", None),   # self-supervised / no label column → SQL NULL
+        ("id-2", "cat"),
+    ]
+    result = db.get_samples("tbl", "ing-uuid")
+    assert result == [
+        {"data_id": "id-1", "label": ""},
+        {"data_id": "id-2", "label": "cat"},
+    ]
+
+
+def test_get_label_counts_null_label_normalised_to_empty_string(db, mock_engine_factory):
+    """SQL NULL and '' both map to '' so they merge into a single count."""
+    _, _, conn = mock_engine_factory
+    conn.execute.return_value.fetchall.return_value = [
+        (None, 3),
+        ("",   2),
+        ("cat", 5),
+    ]
+    result = db.get_label_counts("tbl", "ing-uuid")
+    assert result == {"": 5, "cat": 5}

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -34,12 +34,10 @@ def make_ingestor(records=None, **overrides):
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
     db.get_table_schema.return_value = {"a": "INT"}
+    db.get_label_counts.return_value = {"cat": 2}
+    db.get_samples.return_value = []
     api = MagicMock(name="APIClient")
-    api.send_batch.return_value = True
-    api.send_generate_edge_label_meta.return_value = True
-    api.send_global_meta_meta.return_value = True
-    api.prepare_dataset.return_value = True
-    api.create_dataset.return_value = {"id": 1}
+    api.send_ingest_summary.return_value = {"dataset_id": 1, "dataset_key": "key"}
 
     kwargs = dict(
         database=db,
@@ -358,11 +356,10 @@ def test_process_record_omits_mask_id_for_non_semseg_categories():
 def test_process_batch_success():
     ing = make_ingestor()
     session = MagicMock()
-    ids, api_success, db_failures = ing._batch_writer._process(
+    ids, db_failures = ing._batch_writer._process(
         [{"data_id": "a"}], session
     )
     assert ids == [1, 2]
-    assert api_success is True
     assert db_failures == []
 
 
@@ -370,12 +367,11 @@ def test_process_batch_no_ids_skips_api():
     ing = make_ingestor()
     ing.database.insert_batch.return_value = ([], [{"err": "x"}])
     session = MagicMock()
-    ids, api_success, db_failures = ing._batch_writer._process(
+    ids, db_failures = ing._batch_writer._process(
         [{"data_id": "a"}], session
     )
     assert ids == []
-    assert api_success is False
-    ing.api_client.send_batch.assert_not_called()
+    assert db_failures == [{"err": "x"}]
 
 
 def test_process_batch_reraises_on_insert_error():
@@ -507,49 +503,25 @@ def test_ingest_happy_path():
         failed = ing.ingest("src", batch_size=10)
     assert failed == []
     ing.database.insert_batch.assert_called()
-    ing.api_client.create_dataset.assert_called_once()
+    ing.api_client.send_ingest_summary.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    "failing_step",
-    [
-        "send_generate_edge_label_meta",
-        "send_global_meta_meta",
-        "prepare_dataset",
-    ],
-)
-def test_ingest_fails_loud_when_backend_registration_step_fails(failing_step):
-    # REGRESSION GUARD: a False return from ANY backend registration step leaves
-    # the dataset half-created — rows are committed to MySQL but the dataset is
-    # not registered. The old nested-if cascade silently skipped the remaining
-    # steps (including create_dataset) and the run STILL returned cleanly (exit
-    # 0), so the user saw a "success" over an unregistered dataset. Each step
-    # must now RAISE so the run exits non-zero and the failure is visible.
+def test_ingest_fails_loud_when_backend_registration_fails():
+    # REGRESSION GUARD: if send_ingest_summary raises, rows are committed to
+    # MySQL but the dataset is not registered. The exception must propagate so
+    # the run exits non-zero and the failure is visible.
     records = [{"a": "1", "filename": "f1"}]
     ing = make_ingestor(records=records, category=None)
-    getattr(ing.api_client, failing_step).return_value = False
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
     with patch.object(base_mod, "Session") as Sess:
         Sess.return_value.__enter__.return_value = MagicMock()
-        with pytest.raises(RuntimeError, match="NOT registered"):
+        with pytest.raises(RuntimeError):
             ing.ingest("src", batch_size=10)
-    # The chain must stop — create_dataset is never reached on a failed step.
-    ing.api_client.create_dataset.assert_not_called()
 
 
-def test_ingest_calls_edge_label_for_self_supervised_categories():
-    """Self-supervised categories (MLM, …) MUST call the edge-label endpoint
-    like every other category.
-
-    Originally (#213) the call was SKIPPED for self-supervised categories
-    because they carry no `label` and the old backend rejected blank labels,
-    returning a misleading HTTP 400. Backend PR #683 ('allow blank label for
-    self-supervised categories') fixed that: GenerateEdgeLabelsMeta now buckets
-    the single '' label into ``edge_labels_meta = {"": N}`` (HTTP 200). The
-    skip was the only thing left blocking self-supervised registration —
-    without an ``edge_labels_meta`` document the backend's get_edges finds no
-    candidate edges and ``prepare`` returns 'No edges found', so the dataset
-    never registers and stays invisible in the app. The call must now run for
-    self-supervised too; the remaining registration steps still run."""
+def test_ingest_calls_summary_for_self_supervised_categories():
+    """Self-supervised categories (MLM, …) MUST call send_ingest_summary like
+    every other category — the single-call flow handles all categories uniformly."""
     from tracebloc_ingestor.utils.constants import TaskCategory
 
     records = [{"a": "1", "filename": "f1"}]
@@ -558,8 +530,6 @@ def test_ingest_calls_edge_label_for_self_supervised_categories():
         category=TaskCategory.MASKED_LANGUAGE_MODELING,
         label_column=None,
     )
-    # Patch validate_data + map_file_transfer to skip real-filesystem checks;
-    # the behaviour we're testing lives at the registration block AFTER ingest.
     with patch.object(base_mod, "Session") as Sess, patch.object(
         ing, "validate_data", return_value=True
     ), patch.object(
@@ -569,17 +539,12 @@ def test_ingest_calls_edge_label_for_self_supervised_categories():
     ):
         Sess.return_value.__enter__.return_value = MagicMock()
         ing.ingest("src", batch_size=10)
-    ing.api_client.send_generate_edge_label_meta.assert_called_once()
-    ing.api_client.send_global_meta_meta.assert_called_once()
-    ing.api_client.prepare_dataset.assert_called_once()
-    ing.api_client.create_dataset.assert_called_once()
+    ing.api_client.send_ingest_summary.assert_called_once()
 
 
-def test_ingest_fails_loud_when_edge_label_fails_for_self_supervised():
-    """A False return from the edge-label call for a self-supervised category
-    must RAISE (it is no longer skipped — see the test above), leaving the
-    dataset unregistered rather than silently exiting 0. Mirrors the
-    label-carrying fail-loud guard for the self-supervised path."""
+def test_ingest_fails_loud_when_summary_fails_for_self_supervised():
+    """If send_ingest_summary raises for a self-supervised category, the ingest
+    must fail loudly — not silently exit 0 with an unregistered dataset."""
     from tracebloc_ingestor.utils.constants import TaskCategory
 
     records = [{"a": "1", "filename": "f1"}]
@@ -588,7 +553,7 @@ def test_ingest_fails_loud_when_edge_label_fails_for_self_supervised():
         category=TaskCategory.MASKED_LANGUAGE_MODELING,
         label_column=None,
     )
-    ing.api_client.send_generate_edge_label_meta.return_value = False
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
     with patch.object(base_mod, "Session") as Sess, patch.object(
         ing, "validate_data", return_value=True
     ), patch.object(
@@ -597,16 +562,12 @@ def test_ingest_fails_loud_when_edge_label_fails_for_self_supervised():
         side_effect=lambda c, r, o, cfg=None, source_record=None: r,
     ):
         Sess.return_value.__enter__.return_value = MagicMock()
-        with pytest.raises(RuntimeError, match="NOT registered"):
+        with pytest.raises(RuntimeError):
             ing.ingest("src", batch_size=10)
-    ing.api_client.send_generate_edge_label_meta.assert_called_once()
-    # The chain must stop — create_dataset is never reached on a failed step.
-    ing.api_client.create_dataset.assert_not_called()
 
 
-def test_ingest_still_calls_edge_label_for_label_carrying_categories():
-    """Regression guard for the gate above: a non-self-supervised category
-    still calls the edge-label endpoint."""
+def test_ingest_calls_summary_for_label_carrying_categories():
+    """Non-self-supervised categories also call send_ingest_summary."""
     from tracebloc_ingestor.utils.constants import TaskCategory
 
     records = [{"a": "1", "filename": "f1"}]
@@ -624,7 +585,7 @@ def test_ingest_still_calls_edge_label_for_label_carrying_categories():
     ):
         Sess.return_value.__enter__.return_value = MagicMock()
         ing.ingest("src", batch_size=10)
-    ing.api_client.send_generate_edge_label_meta.assert_called_once()
+    ing.api_client.send_ingest_summary.assert_called_once()
 
 
 def test_ingest_fails_fast_on_invalid_intent():
@@ -1032,7 +993,7 @@ _TEXT_PROFILE = {
 )
 def test_ingest_attaches_text_profile_for_nlp(category):
     """For every NLP category, the data-derived text profile is attached to
-    file_options so it rides the existing global-metadata channel."""
+    file_options and sent as meta_data in the ingest summary."""
     from tracebloc_ingestor.utils.constants import TaskCategory
 
     cat = getattr(TaskCategory, category)
@@ -1049,8 +1010,8 @@ def test_ingest_attaches_text_profile_for_nlp(category):
     ):
         Sess.return_value.__enter__.return_value = MagicMock()
         ing.ingest("src", batch_size=10)
-    args, _ = ing.api_client.send_global_meta_meta.call_args
-    assert args[2].get("text_profile") == _TEXT_PROFILE
+    call_kwargs = ing.api_client.send_ingest_summary.call_args[1]
+    assert call_kwargs["meta_data"].get("text_profile") == _TEXT_PROFILE
 
 
 def test_ingest_omits_text_profile_when_none_for_nlp():
@@ -1075,8 +1036,8 @@ def test_ingest_omits_text_profile_when_none_for_nlp():
     ):
         Sess.return_value.__enter__.return_value = MagicMock()
         ing.ingest("src", batch_size=10)
-    args, _ = ing.api_client.send_global_meta_meta.call_args
-    assert "text_profile" not in args[2]
+    call_kwargs = ing.api_client.send_ingest_summary.call_args[1]
+    assert "text_profile" not in call_kwargs["meta_data"]
 
 
 def test_ingest_does_not_profile_non_nlp():
@@ -1101,8 +1062,84 @@ def test_ingest_does_not_profile_non_nlp():
         Sess.return_value.__enter__.return_value = MagicMock()
         ing.ingest("src", batch_size=10)
     profile.assert_not_called()
-    args, _ = ing.api_client.send_global_meta_meta.call_args
-    assert "text_profile" not in args[2]
+    call_kwargs = ing.api_client.send_ingest_summary.call_args[1]
+    assert "text_profile" not in call_kwargs["meta_data"]
+
+
+# --- meta_data forwarding: file_options reach send_ingest_summary -----------
+
+
+def test_ingest_forwards_file_options_as_meta_data():
+    """Caller-supplied file_options (e.g. extension, target_size) must appear
+    verbatim in the meta_data kwarg of send_ingest_summary."""
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(
+        records=records,
+        category=None,
+        file_options={"extension": ".jpeg", "target_size": [256, 256]},
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    call_kwargs = ing.api_client.send_ingest_summary.call_args[1]
+    assert call_kwargs["meta_data"]["extension"] == ".jpeg"
+    assert call_kwargs["meta_data"]["target_size"] == [256, 256]
+
+
+def test_ingest_includes_number_of_columns_in_meta_data_for_tabular():
+    """For tabular-family categories, number_of_columns is injected into
+    file_options and must therefore appear in meta_data."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    records = [{"a": "1", "b": "2", "filename": "f1"}]
+    ing = make_ingestor(
+        records=records,
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+        schema={"a": "INT", "b": "FLOAT"},
+    )
+    ing.database.get_table_schema.return_value = {"a": "INT", "b": "FLOAT"}
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    call_kwargs = ing.api_client.send_ingest_summary.call_args[1]
+    assert call_kwargs["meta_data"]["number_of_columns"] == 2
+
+
+def test_ingest_does_not_inject_number_of_columns_for_non_tabular():
+    """Non-tabular categories (e.g. image_classification) must NOT get
+    number_of_columns in meta_data — the count would be meaningless there."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    records = [{"a": "1", "filename": "f1"}]
+    ing = make_ingestor(
+        records=records,
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        schema={"a": "INT"},
+    )
+    ing.database.get_table_schema.return_value = {"a": "INT"}
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    call_kwargs = ing.api_client.send_ingest_summary.call_args[1]
+    assert "number_of_columns" not in call_kwargs["meta_data"]
 
 
 # --- Truthful registration-failure message about row state (0-record case) ---
@@ -1118,21 +1155,31 @@ def test_rows_state_clause_phrasing():
     assert "3 already-ingested row(s)" in base_mod._rows_state_clause(3)
 
 
-def test_zero_inserted_registration_failure_message_is_truthful():
-    """A registration failure with 0 inserted rows must NOT say rows are already
-    in the database (the misleading message the adversarial run surfaced)."""
-    # insert_batch reports 0 inserted ids -> inserted_records stays 0.
+def test_zero_inserted_skips_registration():
+    """stats['inserted_records'] == 0 → send_ingest_summary is skipped and
+    ingest completes without error. The guard is on inserted_records, not on
+    the return value of get_label_counts."""
     ing = make_ingestor(records=[{"a": "1", "filename": "f1"}], category=None)
-    ing.database.insert_batch.return_value = ([], [])  # no ids inserted
-    ing.api_client.send_generate_edge_label_meta.return_value = False
+    ing.database.insert_batch.return_value = ([], [])  # nothing committed
     with patch.object(base_mod, "Session") as Sess:
         Sess.return_value.__enter__.return_value = MagicMock()
-        with pytest.raises(RuntimeError) as exc:
+        ing.ingest("src", batch_size=10)  # must NOT raise
+    ing.api_client.send_ingest_summary.assert_not_called()
+
+
+def test_label_counts_empty_despite_inserts_raises():
+    """If rows were inserted (inserted_records > 0) but get_label_counts returns
+    {} — a DB accounting mismatch — ingest must raise RuntimeError rather than
+    silently skip registration and leave committed MySQL rows unregistered."""
+    ing = make_ingestor(records=[{"a": "1", "filename": "f1"}], category=None)
+    # insert_batch reports 1 row committed, but the DB query returns nothing.
+    ing.database.insert_batch.return_value = ([42], [])
+    ing.database.get_label_counts.return_value = {}
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError, match="get_label_counts returned nothing"):
             ing.ingest("src", batch_size=10)
-    msg = str(exc.value)
-    assert "NOT registered" in msg
-    assert "already in the database" not in msg
-    assert "no rows were ingested" in msg
+    ing.api_client.send_ingest_summary.assert_not_called()
 
 
 def test_mlm_header_only_csv_fails_before_table_creation(clean_env, tmp_path):

--- a/tests/test_modality_failure_accounting.py
+++ b/tests/test_modality_failure_accounting.py
@@ -101,12 +101,10 @@ def make_ingestor(records=None, **overrides):
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
     db.get_table_schema.return_value = {"a": "INT"}
+    db.get_label_counts.return_value = {"cat": 2}
+    db.get_samples.return_value = []
     api = MagicMock(name="APIClient")
-    api.send_batch.return_value = True
-    api.send_generate_edge_label_meta.return_value = True
-    api.send_global_meta_meta.return_value = True
-    api.prepare_dataset.return_value = True
-    api.create_dataset.return_value = {"id": 1}
+    api.send_ingest_summary.return_value = {"dataset_id": 1, "dataset_key": "key"}
 
     kwargs = dict(
         database=db,
@@ -149,22 +147,24 @@ def _run_ingest(ing, batch_size=10):
 
 
 @pytest.mark.parametrize("category", _TEMPLATE_CATEGORIES)
-def test_api_send_failure_counted_for_every_category(category):
-    """Every batch POST rejected -> every record comes back as a failed
-    record for EVERY modality, so the caller exits non-zero. Covers the
-    file-transfer branch in _ingest_with_lock that ``category=None``
-    (the #223 tests) skips."""
+def test_api_send_failure_propagates_for_every_category(category):
+    """send_ingest_summary failing raises out of ingest() for EVERY modality,
+    so the caller exits non-zero. Covers the file-transfer branch that
+    ``category=None`` skips."""
     records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
     ing = make_ingestor(records=records, category=category)
-    ing.api_client.send_batch.return_value = False  # every batch POST rejected
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
 
-    failed, summary = _run_ingest(ing)
-
-    assert len(failed) == 2, f"{category}: api-send failures not surfaced"
-    assert all(f["error"] == "api_send_failed" for f in failed)
-    assert summary.inserted_records == 2
-    assert summary.api_sent_records == 0
-    assert summary.has_failures is True
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError, match="backend rejected"):
+            ing.ingest("src", batch_size=10)
 
 
 @pytest.mark.parametrize("category", _TEMPLATE_CATEGORIES)
@@ -258,20 +258,15 @@ def test_template_except_handler_reraises(template):
 # ---------------------------------------------------------------------------
 
 
-def test_mid_batch_db_failure_sends_only_inserted_records():
-    """3-record batch, middle record fails DB insert. The API send must
-    carry exactly the two records that inserted (#0 and #2) — not a
-    positional ``batch[:len(ids)]`` prefix that would send the DB-failed
-    #1 (phantom backend record with no MySQL row) and drop the inserted
-    #2 (committed row the platform never sees)."""
+def test_mid_batch_db_failure_summary_still_called():
+    """3-record batch, middle record fails DB insert. send_ingest_summary is
+    still called (2 records DID insert), and only the DB failure appears in
+    failed — no phantom api_send_failed entries."""
     records = [{"a": str(i), "filename": f"f{i}"} for i in range(3)]
     ing = make_ingestor(records=records, category=None)
-    seen = {}
+    ing.database.get_label_counts.return_value = {"a": 2}
 
     def fake_insert(table_name, batch):
-        seen["batch"] = list(batch)
-        # Middle record fails; failure carries a COPY of the record (the
-        # real insert_batch builds processed_record = {**record, ...}).
         failed_copy = {**batch[1], "updated_at": "now"}
         return [10, 12], [{"record": failed_copy, "error": "dup key"}]
 
@@ -279,15 +274,7 @@ def test_mid_batch_db_failure_sends_only_inserted_records():
 
     failed, summary = _run_ingest(ing)
 
-    sent = ing.api_client.send_batch.call_args[0][0]
-    sent_data_ids = {record["data_id"] for _, record in sent}
-    batch = seen["batch"]
-    assert sent_data_ids == {
-        batch[0]["data_id"],
-        batch[2]["data_id"],
-    }, "API send must carry the records that actually inserted"
-    assert len(sent) == 2
-    # Accounting unchanged: the DB failure is the only failed record.
+    ing.api_client.send_ingest_summary.assert_called_once()
     assert [f["error"] for f in failed] == ["dup key"]
     assert summary.inserted_records == 2
     assert summary.api_sent_records == 2
@@ -307,62 +294,32 @@ _DRF_400_BODY = (
 )
 
 
-@pytest.mark.parametrize(
-    "call",
-    [
-        pytest.param(
-            lambda c: c.send_global_meta_meta("tbl", {"a": "INT"}, {}),
-            id="send_global_meta_meta",
-        ),
-        pytest.param(
-            lambda c: c.send_generate_edge_label_meta("tbl", "ing", "train"),
-            id="send_generate_edge_label_meta",
-        ),
-        pytest.param(
-            lambda c: c.prepare_dataset(
-                TaskCategory.IMAGE_CLASSIFICATION, "ing", "image", "train"
-            ),
-            id="prepare_dataset",
-        ),
-    ],
-)
-def test_registration_call_400_logs_status_and_full_error(call, caplog):
-    client = _client()
-    with patch.object(
-        client.session, "post", return_value=_resp(400, text=_DRF_400_BODY)
-    ), patch.object(client.session, "get", return_value=_resp(400, text=_DRF_400_BODY)):
-        with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
-            assert call(client) is False
-    joined = "\n".join(r.getMessage() for r in caplog.records)
-    assert "HTTP 400" in joined
-    # The tail of the body — beyond the old [:100] truncation — must be
-    # visible so the operator can see WHY the backend rejected the call.
-    assert "well past the first hundred characters" in joined
-
-
-def test_create_dataset_400_logs_full_error_and_raises(caplog):
+def test_send_ingest_summary_400_logs_status_and_full_error(caplog):
+    """send_ingest_summary rejection (400) must log the full body — not a
+    100-char stub — so operators can see WHY the backend rejected the call."""
     client = _client()
     with patch.object(
         client.session, "post", return_value=_resp(400, text=_DRF_400_BODY)
     ):
         with caplog.at_level(logging.ERROR, logger="tracebloc_ingestor.api.client"):
             with pytest.raises(requests.exceptions.HTTPError):
-                client.create_dataset(
-                    ingestor_id="ing", category=TaskCategory.IMAGE_CLASSIFICATION
+                client.send_ingest_summary(
+                    table_name="tbl", ingestor_id="ing", labels={"cat": 1},
+                    dataset_title="T", data_format="image", data_intent="train",
+                    category=TaskCategory.IMAGE_CLASSIFICATION,
+                    schema={}, samples=[],
                 )
     joined = "\n".join(r.getMessage() for r in caplog.records)
     assert "HTTP 400" in joined
     assert "well past the first hundred characters" in joined
 
 
-def test_create_dataset_exception_propagates_out_of_ingest():
-    """create_dataset is the one registration call whose return value
-    isn't checked in _ingest_with_lock — it signals failure by raising.
-    Guard that the raise actually escapes ingest() (with the template
-    re-raise fix, that now fails the run in every modality)."""
+def test_send_ingest_summary_exception_propagates_out_of_ingest():
+    """send_ingest_summary is the one registration call that signals failure by
+    raising. Guard that the raise escapes ingest() so the run exits non-zero."""
     records = [{"a": "1", "filename": "f1"}]
     ing = make_ingestor(records=records, category=None)
-    ing.api_client.create_dataset.side_effect = requests.exceptions.HTTPError(
+    ing.api_client.send_ingest_summary.side_effect = requests.exceptions.HTTPError(
         "HTTP 401: token expired"
     )
 

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -59,12 +59,10 @@ def make_ingestor(records=None, **overrides):
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.return_value = ([1, 2], [])
     db.get_table_schema.return_value = {"a": "INT"}
+    db.get_label_counts.return_value = {"cat": 2}
+    db.get_samples.return_value = []
     api = MagicMock(name="APIClient")
-    api.send_batch.return_value = True
-    api.send_generate_edge_label_meta.return_value = True
-    api.send_global_meta_meta.return_value = True
-    api.prepare_dataset.return_value = True
-    api.create_dataset.return_value = {"id": 1}
+    api.send_ingest_summary.return_value = {"dataset_id": 1, "dataset_key": "key"}
 
     kwargs = dict(
         database=db,
@@ -235,13 +233,12 @@ def test_s2s_binary_content_rejected(clean_env, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_s2s_api_send_failure_counts_every_record(clean_env):
-    """Every batch POST rejected -> every seq2seq record returns as a failure, so
-    the run exits non-zero (the file-transfer branch runs since seq2seq is
-    file-bearing)."""
+def test_s2s_api_send_failure_propagates(clean_env):
+    """send_ingest_summary failing raises out of ingest() for seq2seq, so the
+    run exits non-zero (file-bearing modality still exercises file-transfer branch)."""
     records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
     ing = make_ingestor(records=records)
-    ing.api_client.send_batch.return_value = False
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
 
     with patch.object(base_mod, "Session") as Sess, patch.object(
         ing, "validate_data", return_value=True
@@ -251,7 +248,5 @@ def test_s2s_api_send_failure_counts_every_record(clean_env):
         side_effect=lambda c, r, o, cfg=None, source_record=None: r,
     ):
         Sess.return_value.__enter__.return_value = MagicMock()
-        failed = ing.ingest("src", batch_size=10)
-
-    assert len(failed) == 2
-    assert all(f["error"] == "api_send_failed" for f in failed)
+        with pytest.raises(RuntimeError, match="backend rejected"):
+            ing.ingest("src", batch_size=10)

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Dict, Any, Optional
+from typing import List, Dict, Any, Optional
 import os
 import requests, json
 import logging
@@ -6,15 +6,12 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from ..config import Config
 from ..utils.constants import (
-    TaskCategory,
     API_TIMEOUT,
     RESET,
     BOLD,
     GREEN,
     RED,
     YELLOW,
-    BLUE,
-    CYAN,
 )
 
 # Logger for this module. Level is set by `setup_logging()` on the root
@@ -40,13 +37,6 @@ class APIClient:
 
         self.config = config
         self.session = self._create_session()
-
-        # Last `prepare_dataset` HTTP-error body, retained so callers
-        # can include the actual backend reason in the user-visible
-        # RuntimeError instead of just pointing at "the logged API
-        # error above" (issue #251). Set by `prepare_dataset`'s error
-        # handler; remains None on a clean run.
-        self.last_prepare_error: Optional[str] = None
 
         # Auth resolution order:
         #   1. local mode  → mock token, no network call
@@ -221,343 +211,99 @@ class APIClient:
         headers["Authorization"] = f"TOKEN {self.token}"
         return send(url, headers=headers, **kwargs)
 
-    def send_batch(
+    def send_ingest_summary(
         self,
-        records: List[Tuple[int, Dict[str, Any]]],
         table_name: str,
         ingestor_id: str,
-    ) -> bool:
+        labels: Dict[str, int],
+        dataset_title: str,
+        data_format: str,
+        data_intent: str,
+        category: str,
+        schema: Dict[str, str],
+        samples: List[Dict[str, Any]],
+        meta_data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """
-        Send a batch of records to the remote API.
+        Send a single ingest summary to the backend, creating the UserDataSet in one
+        call. Replaces the legacy per-row POST → generate_edge_labels_meta →
+        send_global_meta_meta → prepare_dataset → create_dataset flow.
 
         Args:
-            records: List of tuples containing (id, record) pairs
-            table_name: Name of the table to send data to
-            ingestor_id: Unique ID for the ingestor
+            table_name: Dataset table name (used as the URL path segment)
+            ingestor_id: UUID identifying this ingest run
+            labels: ``{label: row_count}`` — computed locally after DB insert
+            dataset_title: Human-readable name for the new dataset
+            data_format: One of "image", "tabular", "text", "audio", "video"
+            data_intent: "train" or "test"
+            category: TaskCategory value, e.g. "image_classification"
+            schema: Column schema written to GlobalMetaData
+            samples: Small list of representative records shown in the UI
+
         Returns:
-            bool: True if successful, False otherwise
+            ``{"dataset_id": ..., "dataset_key": ...}``
+
+        Raises:
+            requests.exceptions.RequestException: If the API call fails after retries
         """
-        # Skip API calls in local mode
         if self.config.EDGE_ENV == "local":
-            logger.info(f"Mock: Would send {len(records)} records to API")
-            return True
+            logger.info(
+                f"Mock: Would send ingest summary for {table_name} "
+                f"({sum(labels.values())} rows across {len(labels)} label(s))"
+            )
+            return {"dataset_id": "mock_dataset_id", "dataset_key": "mock_dataset_key"}
 
         try:
             payload = json.dumps(
-                [
-                    {
-                        "data_id": record_data.get("data_id"),
-                        "data_intent": record_data.get("data_intent", "train"),
-                        "label": record_data.get("label", ""),
-                        "is_sample": False,
-                        "injestor_id": ingestor_id,
-                    }
-                    for _, record_data in records
-                ]
+                {
+                    "ingestor_id": ingestor_id,
+                    "labels": labels,
+                    "dataset_title": dataset_title,
+                    "data_format": data_format,
+                    "data_intent": data_intent,
+                    "category": category,
+                    "schema": schema,
+                    "samples": samples,
+                    "meta_data": meta_data or {},
+                }
             )
-
-            logger.info(f"Data to send: {payload}")
-
+            logger.info(
+                f"Sending ingest summary for {table_name}: "
+                f"{len(labels)} label(s), {sum(labels.values())} total rows"
+            )
             response = self._authed_request(
                 "POST",
-                f"{self.config.API_ENDPOINT}/global_meta/{table_name}/",
-                data=payload,
+                f"{self.config.API_ENDPOINT}/global_meta/summary/{table_name}/",
                 extra_headers={"Content-Type": "application/json"},
+                data=payload,
                 timeout=API_TIMEOUT,
             )
 
             # Check status after retries are exhausted. Attach the response
             # so the handler below can log the status and body — a bare
-            # HTTPError has e.response = None, which used to route a DRF 400
-            # into the str(e)[:100] branch, truncating the message right
-            # after "HTTP 400: " and hiding the field error that explains
-            # why every batch was rejected.
+            # HTTPError has e.response = None, which would hide the field
+            # error that explains why the call was rejected.
             if response.status_code >= 400:
                 raise requests.exceptions.HTTPError(
                     f"HTTP {response.status_code}: {response.text}",
                     response=response,
                 )
-            return True
+            result = self._parse_json(response, required=True)
+            logger.info(
+                f"{GREEN}Dataset created: key={result.get('dataset_key')} "
+                f"id={result.get('dataset_id')}{RESET}"
+            )
+            return result
 
         except requests.exceptions.RequestException as e:
             if e.response is not None:
                 body = (e.response.text or "")[:2000]
                 logger.error(
-                    f"{RED}Error sending batch to API: "
+                    f"{RED}Error sending ingest summary: "
                     f"HTTP {e.response.status_code}: {body}{RESET}"
                 )
             else:
-                logger.error(f"{RED}Error sending batch to API: {str(e)[:500]}{RESET}")
-            return False
-
-    def send_global_meta_meta(
-        self, table_name: str, schema: Dict[str, str], add_info
-    ) -> bool:
-        """
-        Sends global metadata, including the schema, to the remote server.
-
-        Args:
-            table_name: The type of the dataset
-            schema: A dictionary representing the schema
-
-        Returns:
-            bool: True if successful, False otherwise
-        """
-        # Skip API calls in local mode
-        if self.config.EDGE_ENV == "local":
-            logger.info(f"Mock: Would send schema for {table_name}")
-            return True
-
-        try:
-            payload = json.dumps(
-                {
-                    "table_name": table_name,
-                    "schema": schema,
-                    "meta_data": add_info,
-                }
-            )
-
-            logger.info(f"Global metadata to send: {(payload)}")
-
-            response = self._authed_request(
-                "POST",
-                f"{self.config.API_ENDPOINT}/global_meta/global_metadata/",
-                data=payload,
-                extra_headers={"Content-Type": "application/json"},
-                timeout=API_TIMEOUT,
-            )
-
-            # Check status after retries are exhausted. Attach the response
-            # so the handler below can log the status and the full body —
-            # a bare HTTPError has e.response = None, which routed a DRF 400
-            # into a str(e)[:100] branch that truncated the message right
-            # after "HTTP 400: ", hiding the field error (same swallow point
-            # send_batch had — fixed in #223).
-            if response.status_code >= 400:
-                raise requests.exceptions.HTTPError(
-                    f"HTTP {response.status_code}: {response.text}",
-                    response=response,
-                )
-            logger.info(
-                f"{GREEN}Successfully sent global metadata. "
-                f"Response: {self._parse_json(response, required=False)}{RESET}"
-            )
-            return True
-
-        except requests.exceptions.RequestException as e:
-            if e.response is not None:
-                body = (e.response.text or "")[:2000]
-                logger.error(
-                    f"{RED}Error sending global metadata to API: "
-                    f"HTTP {e.response.status_code}: {body}{RESET}"
-                )
-            else:
-                logger.error(
-                    f"{RED}Error sending global metadata to API: {str(e)[:500]}{RESET}"
-                )
-            return False
-
-    def send_generate_edge_label_meta(
-        self, table_name: str, ingestor_id: str, intent: str
-    ) -> bool:
-        """
-        Send a request to generate edge label metadata for the specified dataset type.
-
-        Args:
-            table_name: The type of the dataset
-
-        Returns:
-            bool: True if successful, False otherwise
-        """
-        # Skip API calls in local mode
-        if self.config.EDGE_ENV == "local":
-            logger.info(f"Mock: Would generate edge labels for {table_name}")
-            return True
-
-        try:
-            url = f"{self.config.API_ENDPOINT}/global_meta/generate-edge-labels-meta/?table_name={table_name}&injestor_id={ingestor_id}&data_intent={intent}"
-
-            logger.info(
-                f"Sending request to generate edge label metadata for dataset type: {table_name}"
-            )
-            response = self._authed_request("GET", url, timeout=API_TIMEOUT)
-
-            # Check status after retries are exhausted. Response attached so
-            # the handler logs the full backend error (see send_batch / #223).
-            if response.status_code >= 400:
-                raise requests.exceptions.HTTPError(
-                    f"HTTP {response.status_code}: {response.text}",
-                    response=response,
-                )
-            logger.info(
-                f"{GREEN}Successfully generated edge label metadata. Response{RESET}"
-            )
-            return True
-
-        except requests.exceptions.RequestException as e:
-            if e.response is not None:
-                body = (e.response.text or "")[:2000]
-                logger.error(
-                    f"{RED}Error generating edge label metadata: "
-                    f"HTTP {e.response.status_code}: {body}{RESET}"
-                )
-            else:
-                logger.error(
-                    f"{RED}Error generating edge label metadata: {str(e)[:500]}{RESET}"
-                )
-            return False
-
-    def prepare_dataset(
-        self, category: str, ingestor_id: str, data_format: str, intent: str
-    ) -> bool:
-        """
-        Prepare data for a specific category and ingestor.
-
-        Args:
-            category: The category of data (must be one of TaskCategory values)
-            injester_id: The unique identifier for the injester
-            data_format: The format of the data
-
-        Returns:
-            bool: True if successful, False otherwise
-        """
-        # Clear any error stashed by a previous prepare_dataset call up front,
-        # so an early `return False` below (local mode, invalid category)
-        # can't leave a stale message that base.py then attaches to an
-        # unrelated failure (bugbot #252). Only the exception handler in THIS
-        # call should ever populate it.
-        self.last_prepare_error = None
-
-        # Skip API calls in local mode
-        if self.config.EDGE_ENV == "local":
-            logger.info(f"Mock: Would prepare dataset {category}")
-            return True
-
-        if not TaskCategory.is_valid_category(category):
-            print(
-                f"return {TaskCategory.is_valid_category(category)} for input : {category}"
-            )
-            logger.error(f"Invalid category: {category}")
-            return False
-
-        try:
-            url = f"{self.config.API_ENDPOINT}/global_meta/prepare/?category={category}&injestor_id={ingestor_id}&data_format={data_format}&data_intent={intent}"
-
-            logger.info(
-                f"Sending prepare request for category: {category}, injester_id: {ingestor_id}, data_format: {data_format} , data_intent: {intent}"
-            )
-            response = self._authed_request("GET", url, timeout=API_TIMEOUT)
-
-            # Check status after retries are exhausted. Response attached so
-            # the handler logs the full backend error (see send_batch / #223).
-            if response.status_code >= 400:
-                raise requests.exceptions.HTTPError(
-                    f"HTTP {response.status_code}: {response.text}",
-                    response=response,
-                )
-            logger.info(
-                f"{GREEN}Successfully prepared data. "
-                f"Response: {self._parse_json(response, required=False)}{RESET}"
-            )
-            return True
-
-        except requests.exceptions.RequestException as e:
-            if e.response is not None:
-                body = (e.response.text or "")[:2000]
-                logger.error(
-                    f"{RED}Error preparing data: "
-                    f"HTTP {e.response.status_code}: {body}{RESET}"
-                )
-                # Stash the backend's response so callers can surface the
-                # actual reason (e.g. "Please provide atleast 2 labels.")
-                # in the user-visible error — instead of pointing at "the
-                # logged API error above" which the user has to grep for.
-                # Issue #251: misleading "Backend failed to prepare the
-                # dataset" message that buried a clear backend reason.
-                self.last_prepare_error = (
-                    f"HTTP {e.response.status_code}: {body}"
-                )
-            else:
-                logger.error(f"{RED}Error preparing data: {str(e)[:500]}{RESET}")
-                self.last_prepare_error = str(e)[:500]
-            return False
-
-    def create_dataset(
-        self,
-        allow_feature_modification: bool = False,
-        ingestor_id: str = None,
-        category: str = None,
-    ) -> Dict[str, Any]:
-        """
-        Create a new dataset with the specified parameters.
-
-        Args:
-            title: The title of the dataset (if None, will be generated from category and ingestor_id)
-            allow_feature_modification: Whether feature modification is allowed
-            ingestor_id: The unique identifier for the ingestor
-
-        Returns:
-            Dict[str, Any]: The created dataset information if successful
-
-        Raises:
-            requests.exceptions.RequestException: If the API request fails
-        """
-        # Skip API calls in local mode
-        if self.config.EDGE_ENV == "local":
-            logger.info(f"Mock: Would create dataset {category}")
-            return {"id": "mock_dataset_id", "title": "Mock Dataset"}
-
-        try:
-            # Generate title from category and ingestor_id if not provided
-            if self.config.TITLE is None:
-                title = f"{category}_{ingestor_id}"
-            else:
-                title = self.config.TITLE  # Fallback to config title if no ingestor_id
-
-            if category == TaskCategory.TABULAR_CLASSIFICATION:
-                allow_feature_modification = True
-            else:
-                allow_feature_modification = False
-
-            payload = json.dumps(
-                {
-                    "title": title,
-                    "allow_feature_modification": allow_feature_modification,
-                }
-            )
-
-            logger.info(f"{GREEN}Creating dataset with payload: {payload}{RESET}")
-
-            response = self._authed_request(
-                "POST",
-                f"{self.config.API_ENDPOINT}/dataset/",
-                data=payload,
-                extra_headers={"Content-Type": "application/json"},
-                timeout=API_TIMEOUT,
-            )
-
-            # Check status after retries are exhausted. Response attached so
-            # the handler logs the full backend error (see send_batch / #223).
-            if response.status_code >= 400:
-                raise requests.exceptions.HTTPError(
-                    f"HTTP {response.status_code}: {response.text}",
-                    response=response,
-                )
-            dataset = self._parse_json(response, required=True)
-            logger.info(
-                f"{GREEN}Successfully created dataset. Response: {dataset}{RESET}"
-            )
-            return dataset
-
-        except requests.exceptions.RequestException as e:
-            if e.response is not None:
-                body = (e.response.text or "")[:2000]
-                logger.error(
-                    f"{RED}Error creating dataset: "
-                    f"HTTP {e.response.status_code}: {body}{RESET}"
-                )
-            else:
-                logger.error(f"{RED}Error creating dataset: {str(e)[:500]}{RESET}")
+                logger.error(f"{RED}Error sending ingest summary: {str(e)[:500]}{RESET}")
             raise
 
     def __del__(self):

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -502,6 +502,66 @@ class Database:
 
         return result["success_ids"], result["failures"]
 
+    def get_label_counts(self, table_name: str, ingestor_id: str) -> Dict[str, int]:
+        """
+        Return ``{label: row_count}`` for every label inserted by *ingestor_id*.
+
+        Used to build the summary payload sent to the backend after all records
+        have been committed, giving an accurate count that excludes any rows
+        that failed DB insertion.
+
+        Args:
+            table_name: Name of the table to query
+            ingestor_id: UUID of the current ingest run
+
+        Returns:
+            Dict mapping label string to integer row count
+        """
+        with self.engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    f"SELECT label, COUNT(*) AS cnt "
+                    f"FROM `{table_name}` "
+                    f"WHERE ingestor_id = :ingestor_id "
+                    f"GROUP BY label"
+                ),
+                {"ingestor_id": ingestor_id},
+            ).fetchall()
+        counts: Dict[str, int] = {}
+        for label, cnt in rows:
+            key = label if label is not None else ""
+            counts[key] = counts.get(key, 0) + cnt
+        return counts
+
+    def get_samples(
+        self, table_name: str, ingestor_id: str, limit: int = 10
+    ) -> List[Dict[str, Any]]:
+        """
+        Return a small sample of records for the given ingest run.
+
+        These are stored on the backend as ``UserDataSet.data_samples`` and
+        displayed in the dataset preview UI.
+
+        Args:
+            table_name: Name of the table to query
+            ingestor_id: UUID of the current ingest run
+            limit: Maximum number of sample rows to return (default 10)
+
+        Returns:
+            List of ``{"data_id": ..., "label": ...}`` dicts
+        """
+        with self.engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    f"SELECT data_id, label "
+                    f"FROM `{table_name}` "
+                    f"WHERE ingestor_id = :ingestor_id "
+                    f"LIMIT :limit"
+                ),
+                {"ingestor_id": ingestor_id, "limit": limit},
+            ).fetchall()
+        return [{"data_id": row[0], "label": row[1] if row[1] is not None else ""} for row in rows]
+
     def get_table_schema(self, table_name: str) -> Dict[str, str]:
         """
         Returns the schema of a table as a dictionary mapping column names to their MySQL types.

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -550,99 +550,54 @@ class BaseIngestor(ABC):
                 session.commit()
                 pbar.close()
 
-                # Register the dataset with the backend. Every step here is
-                # REQUIRED: the rows are already committed to MySQL above, so if
-                # any step fails the dataset is half-created — rows present but
-                # not registered. The previous code nested these as
-                # `if A: if B: if C: create()`, so a False return at ANY step
-                # silently skipped the rest (including create_dataset AND the
-                # summary) and the run STILL exited 0 — leaving committed rows
-                # with no registered dataset and no error the user could see.
-                # Fail loudly instead: raise so the process exits non-zero and
-                # the failure surfaces (the CLI streams these logs live and marks
-                # the Job failed). The api_client has already logged the
-                # underlying HTTP detail before returning False.
-                # Generate edge-label metadata for EVERY category, including
-                # self-supervised ones (MLM / text / token). The backend's
-                # get_edges discovers candidate edges only via the
-                # `edge_labels_meta` collection, so a dataset with no
-                # edge_labels_meta document can never be prepared/registered —
-                # it stays invisible in the app even though its rows are in
-                # MySQL.
-                #
-                # History: this call used to be skipped for self-supervised
-                # categories (#213) because those rows carry no `label` and the
-                # old backend rejected blank labels — the edge-label endpoint
-                # returned a misleading HTTP 400 ("No data found for table X"),
-                # which combined with PR #187's fail-loud behaviour to surface a
-                # registration crash unrelated to the real cause. Backend
-                # PR #683 ("allow blank label for self-supervised categories")
-                # fixed that: blank `label` is accepted, GenerateEdgeLabelsMeta
-                # buckets the single "" label into `edge_labels_meta = {"": N}`
-                # (truthy → inserted → HTTP 200), and PrepareDatasetMeta uses
-                # min_labels=0 for these categories. So the skip is now the only
-                # thing blocking self-supervised registration — remove it and
-                # let generate run for all categories, still failing loud (the
-                # RuntimeError below) on a False return.
-                if not self.api_client.send_generate_edge_label_meta(
-                    self.table_name, self.ingestor_id, self.intent
-                ):
-                    raise RuntimeError(
-                        f"Backend rejected edge-label metadata; the dataset was "
-                        f"NOT registered "
-                        f"({_rows_state_clause(stats['inserted_records'])}). "
-                        f"See the logged API error above."
-                    )
-
-                # Ship a data-derived text profile for NLP datasets (#805):
-                # Unicode-script mix + length distribution, computed from the
-                # staged text with NO tokenizer. The backend uses it for a
-                # warn-only tokenizer-fit check at linking. Only aggregate
-                # statistics cross the boundary — never raw text or vocabulary.
-                if self.category in _NLP_CATEGORIES:
-                    text_profile = compute_text_profile(self.database.config)
-                    if text_profile:
-                        self.file_options["text_profile"] = text_profile
-
-                schema_dict = self.database.get_table_schema(self.table_name)
-                if not self.api_client.send_global_meta_meta(
-                    self.table_name, schema_dict, self.file_options
-                ):
-                    raise RuntimeError(
-                        f"Backend rejected the dataset schema/metadata; the "
-                        f"dataset was NOT registered "
-                        f"({_rows_state_clause(stats['inserted_records'])}). "
-                        f"See the logged API error above."
-                    )
-
-                if not self.api_client.prepare_dataset(
-                    self.category,
-                    self.ingestor_id,
-                    self.data_format,
-                    self.intent,
-                ):
-                    # Surface the BACKEND'S actual reason in the user-visible
-                    # error — not just "see the logged API error above" which
-                    # forces the user to grep the log for the real cause.
-                    # Issue #251: a misleading "Backend failed to prepare the
-                    # dataset" message buried the real reason (e.g. "Please
-                    # provide atleast 2 labels.") in a preceding ERROR line.
-                    detail = (
-                        getattr(self.api_client, "last_prepare_error", None)
-                        or "see the logged API error above"
-                    )
-                    raise RuntimeError(
-                        f"Backend failed to prepare the dataset; it was NOT "
-                        f"registered "
-                        f"({_rows_state_clause(stats['inserted_records'])}). "
-                        f"Backend response: {detail}"
-                    )
-
-                self.api_client.create_dataset(
-                    category=self.category, ingestor_id=self.ingestor_id
+                # Query accurate label counts from the DB (excludes any rows that
+                # failed insertion) and collect a small preview sample.
+                label_counts = self.database.get_label_counts(
+                    self.table_name, self.ingestor_id
                 )
 
-                # Create and log summary — only after successful registration.
+                if not stats["inserted_records"]:
+                    logger.warning(
+                        "No records were inserted for this ingestor run; "
+                        "skipping ingest summary."
+                    )
+                elif not label_counts:
+                    raise RuntimeError(
+                        f"Inserted {stats['inserted_records']} row(s) but "
+                        f"get_label_counts returned nothing for "
+                        f"ingestor_id={self.ingestor_id!r}. "
+                        "Rows are committed to MySQL but the dataset was not "
+                        "registered with the backend."
+                    )
+                else:
+                    samples = self.database.get_samples(
+                        self.table_name, self.ingestor_id
+                    )
+                    dataset_title = (
+                        self.api_client.config.TITLE
+                        or f"{self.table_name} - {self.ingestor_id[:8]}"
+                    )
+                    schema_dict = self.database.get_table_schema(self.table_name)
+
+                    if self.category in _NLP_CATEGORIES:
+                        text_profile = compute_text_profile(self.database.config)
+                        if text_profile:
+                            self.file_options["text_profile"] = text_profile
+
+                    self.api_client.send_ingest_summary(
+                        table_name=self.table_name,
+                        ingestor_id=self.ingestor_id,
+                        labels=label_counts,
+                        dataset_title=dataset_title,
+                        data_format=self.data_format,
+                        data_intent=self.intent,
+                        category=self.category,
+                        schema=schema_dict,
+                        samples=samples,
+                        meta_data=self.file_options,
+                    )
+                    stats["api_sent_records"] = stats["inserted_records"]
+
                 summary = IngestionSummary(**stats)
                 self._log_summary(summary)
 
@@ -663,9 +618,8 @@ class BaseIngestor(ABC):
     @property
     def _batch_writer(self) -> BatchWriter:
         """The ingestor's batch write-path collaborator (P5d). Owns DB insert +
-        API publish + failure accounting; built from the run's database /
-        api_client / table. A fresh instance per access is fine — it just holds
-        those refs."""
+        failure accounting; built from the run's database / table. A fresh
+        instance per access is fine — it just holds those refs."""
         return BatchWriter(
             self.database, self.api_client, self.table_name, self.ingestor_id
         )

--- a/tracebloc_ingestor/ingestors/batch_writer.py
+++ b/tracebloc_ingestor/ingestors/batch_writer.py
@@ -1,13 +1,13 @@
-"""Batch write path — DB insert + API publish + failure accounting
+"""Batch write path — DB insert + failure accounting
 (structural refactor — backend#796, P5d).
 
-Owns what happens to one batch of cleaned records: insert to MySQL, publish the
-inserted rows to the backend, and fold the outcome (inserted / api-sent /
-failed) into the run's ``stats`` and ``failed_records``. Extracted verbatim from ``BaseIngestor._flush_batch`` /
-``_process_batch`` — the subtle mid-batch-DB-failure accounting (match by
-``data_id``, not position) and the #99 / api_send_failed surfacing are
-byte-for-byte unchanged. ``BaseIngestor`` composes it via the ``_batch_writer``
-property; the attribute names match the ingestor's so the bodies are identical.
+Owns what happens to one batch of cleaned records: insert to MySQL and fold the
+outcome (inserted / failed) into the run's ``stats`` and ``failed_records``.
+Extracted from ``BaseIngestor._process_batch``. ``BaseIngestor`` composes it
+via the ``_batch_writer`` property.
+
+The per-batch API publish step has been removed: a single ``send_ingest_summary``
+call is made after all records are committed (see ``BaseIngestor._ingest_with_lock``).
 
 ``session`` is threaded through unchanged for signature/behaviour parity even
 though the insert goes through ``database.insert_batch`` (which manages its own
@@ -26,8 +26,13 @@ logger = logging.getLogger(__name__)
 
 
 class BatchWriter:
-    """Inserts a batch to MySQL, publishes it to the backend, and records the
-    outcome. One instance per ingest (built by ``BaseIngestor._batch_writer``)."""
+    """Inserts a batch to MySQL and records the outcome. One instance per
+    ingest (built by ``BaseIngestor._batch_writer``).
+
+    The per-batch API publish step is gone: a single ``send_ingest_summary``
+    call is made after all records are committed (see
+    ``BaseIngestor._ingest_with_lock``).
+    """
 
     def __init__(
         self, database: Any, api_client: Any, table_name: str, ingestor_id: str
@@ -44,55 +49,14 @@ class BatchWriter:
         stats: Dict[str, int],
         failed_records: List[Dict[str, Any]],
     ) -> None:
-        """Process one batch and fold its outcome into ``stats`` /
-        ``failed_records``. Shared by the in-loop and final-batch flush
-        sites in ``_ingest_with_lock``.
-
-        Failure accounting is the point of this helper. A run where every
-        batch POST was rejected with HTTP 400 used to finish with
-        "All records processed successfully" and exit 0 — the rows were
-        in MySQL but the backend had zero records, and the next platform
-        call failed with "No data found for table name". Two swallow
-        points caused that:
-
-        - ``api_success=False`` only skipped the ``api_sent_records``
-          increment; the records never reached ``failed_records``, so
-          ``ingest()`` returned ``[]`` and the caller exited 0. Now each
-          inserted-but-unsent record is returned as a failed record with
-          ``error="api_send_failed"`` (the rows stay committed — they're
-          in MySQL but invisible to the platform until re-sent).
-        - an exception from ``_process`` was logged and dropped,
-          leaving the whole batch out of every counter. Now the batch is
-          counted and returned as failed.
-
-        The summary needs no extra field: "Failed to Send to API" is
-        derived from ``inserted_records - api_sent_records``, and
-        ``IngestionSummary.has_failures`` already trips on that gap.
+        """Insert one batch to MySQL and fold its outcome into ``stats`` /
+        ``failed_records``. Shared by the in-loop and final-batch flush sites
+        in ``_ingest_with_lock``.
         """
         try:
-            inserted_ids, api_success, db_failures = self._process(batch, session)
-            # Only count records that were successfully inserted
+            inserted_ids, db_failures = self._process(batch, session)
             if inserted_ids:
                 stats["inserted_records"] += len(inserted_ids)
-                if api_success:
-                    stats["api_sent_records"] += len(inserted_ids)
-                else:
-                    # The inserted-but-unsent records are the batch minus
-                    # the DB failures. Don't assume they're the first
-                    # len(ids) entries: insert_batch's per-record fallback
-                    # appends successes in scan order, so a mid-batch DB
-                    # failure shifts which records were inserted. Failure
-                    # entries carry a *copy* of the record (processed_record
-                    # adds updated_at), so match by data_id — set on every
-                    # processed record by _map_unique_id — not by identity.
-                    db_failed_data_ids = {
-                        f.get("record", {}).get("data_id") for f in db_failures
-                    }
-                    failed_records.extend(
-                        {"record": record, "error": "api_send_failed"}
-                        for record in batch
-                        if record.get("data_id") not in db_failed_data_ids
-                    )
             if db_failures:
                 stats["failed_records"] += len(db_failures)
                 failed_records.extend(db_failures)
@@ -103,16 +67,17 @@ class BatchWriter:
                 {"record": record, "error": str(e)} for record in batch
             )
 
-    def _process(self, batch: List[Dict[str, Any]], session: Session) -> List[int]:
-        """
-        Process and insert a batch of records
+    def _process(
+        self, batch: List[Dict[str, Any]], session: Session
+    ) -> tuple:
+        """Insert a batch of records into the database.
 
         Args:
-            batch: List of records to process
-            session: Database session
+            batch: List of records to insert
+            session: Database session (unused — inserts commit internally)
 
         Returns:
-            List of record IDs
+            Tuple of (inserted_ids, db_failures)
 
         Raises:
             Exception: If batch processing fails
@@ -125,40 +90,8 @@ class BatchWriter:
             # reaches here (RecordProcessor drops it; map_file_transfer strips
             # its lend). So the former blanket ``mask_id`` pop (#212) is gone
             # with its cause; there's nothing framework-internal to drop.
-            # Insert batch and get IDs
             ids, db_failures = self.database.insert_batch(self.table_name, batch)
-            api_success = False
-            # Send to API with ingestor_id
-            if ids:  # Only send to API if we have valid IDs
-                # Send only the records that actually inserted.
-                # ``zip(ids, batch)`` pairs positionally and truncates to
-                # ``len(ids)``; after a MID-batch DB failure (insert_batch's
-                # per-record fallback appends successes in scan order) that
-                # would send the DB-failed record to the API and drop the
-                # last inserted one — a phantom backend record pointing at
-                # no MySQL row, plus a committed row the platform never
-                # sees. Match by data_id, same as flush.
-                if db_failures:
-                    db_failed_data_ids = {
-                        f.get("record", {}).get("data_id") for f in db_failures
-                    }
-                    records_to_send = [
-                        record
-                        for record in batch
-                        if record.get("data_id") not in db_failed_data_ids
-                    ]
-                else:
-                    records_to_send = batch
-                api_success = self.api_client.send_batch(
-                    [(id, record) for id, record in zip(ids, records_to_send)],
-                    self.table_name,
-                    ingestor_id=self.ingestor_id,  # Include ingestor_id in API requests
-                )
-            return (
-                ids if ids else [],
-                api_success,
-                db_failures,
-            )  # Ensure we always return a list
+            return ids if ids else [], db_failures
 
         except Exception as e:
             logger.error(f"{RED}Error processing batch: {str(e)}{RESET}")


### PR DESCRIPTION
## Summary

- **Removes** the 4-step per-ingest API flow (`send_batch` → `generate_edge_labels_meta` → `send_global_meta_meta` → `prepare_dataset` → `create_dataset`) from every ingestor
- **Adds** `send_ingest_summary` — a single `POST /global_meta/summary/<table_name>/` that creates the `UserDataSet` in one backend call
- **Adds** `database.get_label_counts` and `database.get_samples` — post-commit DB queries that compute exact label counts and collect a preview sample, eliminating the in-memory tracking that could drift on DB failures
- **Simplifies** `BatchWriter._process` / `flush` to DB-only (no per-batch API publish); `api_sent_records` is set in bulk after all batches commit
- Uses `_authed_request` + `_parse_json` for the new endpoint (401-refresh retry, proper non-JSON-body handling)

## Motivation

Aligns with backend PR #900 (`global-meta` branch) which replaced per-row `GlobalMeta` rows with a single `POST /global_meta/summary/<table_name>/` endpoint. The old flow required 5 sequential API calls after every ingest; any step failing silently left rows committed but the dataset unregistered. The new flow is one call that either succeeds or raises, with a clear error surfaced to the operator.

## Test plan

- [ ] Local mode (`EDGE_ENV=local`) logs mock summary and returns without making any network calls
- [ ] Standard ingest run: rows inserted → `get_label_counts` returns non-empty dict → `send_ingest_summary` POSTs to `/global_meta/summary/<table>/` → dataset created in backend
- [ ] Zero-row run (all records fail insertion): `get_label_counts` returns `{}` → warning logged, `send_ingest_summary` skipped, no error
- [ ] 401 on `send_ingest_summary`: token refresh attempted, request retried once
- [ ] HTTP 4xx from backend: `RequestException` raised with full response body logged, ingest exits non-zero

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core post-ingest registration and failure semantics (exceptions vs silent partial registration); misaligned label counts or summary failures leave committed MySQL rows without a registered dataset.
> 
> **Overview**
> **Replaces** the old ingest-time API sequence (`send_batch`, edge labels, global metadata, `prepare_dataset`, `create_dataset`) with a **single** `POST /global_meta/summary/<table_name>/` via **`send_ingest_summary`**, which returns `dataset_id` / `dataset_key` or **raises** (no more boolean false-and-continue registration).
> 
> **`BatchWriter`** is **DB-only** during batching: per-batch `send_batch` and `api_send_failed` accounting are **removed**; **`api_sent_records`** is set **once** after a successful summary when rows were inserted.
> 
> **After commit**, **`BaseIngestor`** loads **`get_label_counts`** and **`get_samples`** from MySQL (NULL labels → `''`), skips the summary when nothing inserted, and **raises** if rows were inserted but label counts are empty. NLP **`text_profile`** and **`file_options`** (e.g. tabular **`number_of_columns`**) go in summary **`meta_data`**.
> 
> **`Database`** adds **`get_label_counts`** / **`get_samples`**; **`APIClient`** drops **`last_prepare_error`** and the legacy methods. Tests and e2e characterization now assert the **one-shot summary payload** and **exception propagation** instead of per-row batch sends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54e98786d67f677344e242b16974299fa6515f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->