### PR TITLE
feat: add embeddings (self-supervised contrastive) modality

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ Only metadata (schema, statistics, structure) syncs to the web app. Raw data sta
 | Type | Categories |
 |---|---|
 | **Image** | [`image_classification`](templates/image_classification), [`object_detection`](templates/object_detection), [`keypoint_detection`](templates/keypoint_detection), [`semantic_segmentation`](templates/semantic_segmentation) |
-| **Text / NLP** | [`text_classification`](templates/text_classification), [`token_classification`](templates/token_classification), [`masked_language_modeling`](templates/masked_language_modeling), [`causal_language_modeling`](templates/causal_language_modeling), [`seq2seq`](templates/seq2seq) |
+| **Text / NLP** | [`text_classification`](templates/text_classification), [`token_classification`](templates/token_classification), [`masked_language_modeling`](templates/masked_language_modeling), [`causal_language_modeling`](templates/causal_language_modeling), [`seq2seq`](templates/seq2seq), [`embeddings`](templates/embeddings) |
 | **Tabular** | [`tabular_classification`](templates/tabular_classification), [`tabular_regression`](templates/tabular_regression) |
 | **Time series** | [`time_series_forecasting`](templates/time_series_forecasting), [`time_to_event_prediction`](templates/time_to_event_prediction) |
 

--- a/e2e/test_characterization.py
+++ b/e2e/test_characterization.py
@@ -234,6 +234,17 @@ CASES = [
         sidecars=[str(T / "seq2seq/data/texts")],
         roundtrip_col=None,
     ),
+    dict(
+        id="embeddings",
+        cfg=_cfg(
+            table="char_emb",
+            category="embeddings",
+            csv=str(T / "embeddings/data/labels_file_sample.csv"),
+            texts=str(T / "embeddings/data/texts"),
+        ),
+        sidecars=[str(T / "embeddings/data/texts")],
+        roundtrip_col=None,
+    ),
     # semantic_segmentation: the one file-bearing modality the harness never
     # characterized (audit gap). mask_id is DECLARED in schema so it's stored
     # (the training client SELECTs it to locate masks — backend#816); the masks

--- a/e2e/test_ingest_e2e.py
+++ b/e2e/test_ingest_e2e.py
@@ -211,6 +211,19 @@ CASES = [
         ),
         id="seq2seq",
     ),
+    # embeddings: self-supervised contrastive raw text in texts/ (an
+    # anchor<TAB>positive pair or anchor<TAB>positive<TAB>negative triplet). The
+    # structural ContrastivePairsValidator gates malformed files; alignment is
+    # the data-derived text profile (#805), no tokenizer.json at ingest.
+    pytest.param(
+        _cfg(
+            table="e2e_emb",
+            category="embeddings",
+            csv=str(T / "embeddings/data/labels_file_sample.csv"),
+            texts=str(T / "embeddings/data/texts"),
+        ),
+        id="embeddings",
+    ),
     # semantic_segmentation: masks now wire through the declarative path (the P5
     # mask_id work — the transfer resolves the mask via the schema-declared
     # mask_id), so #136's xfail is removed. The full contract (masks land in

--- a/examples/yaml/embeddings.yaml
+++ b/examples/yaml/embeddings.yaml
@@ -1,0 +1,12 @@
+# Embeddings (self-supervised contrastive): CSV manifest + .txt sidecar files
+# (one per sample). Self-supervised — no label column required.
+# `texts:` holds RAW text samples: each .txt is a single tab-separated record,
+# either an `anchor<TAB>positive` pair or an `anchor<TAB>positive<TAB>negative`
+# triplet. The training client builds a contrastive objective from these views.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: stsb_embeddings_train
+intent: train
+category: embeddings
+csv: /data/shared/stsb-embeddings/labels_file.csv
+texts: /data/shared/stsb-embeddings/texts/

--- a/templates/embeddings/README.md
+++ b/templates/embeddings/README.md
@@ -1,0 +1,156 @@
+# Embeddings (Self-Supervised Contrastive) Data Ingestion Template
+
+This template demonstrates how to ingest raw text samples for self-supervised
+contrastive **embedding** training into a database using the
+tracebloc_ingestor framework.
+
+embeddings is **self-supervised** — there is no `label:` field. Each sample is a
+single `.txt` file holding **raw text** as a tab-separated record:
+
+- A **pair** — `anchor<TAB>positive` — two texts that should embed close
+  together (e.g. a sentence and its paraphrase, a question and a matching
+  passage), **or**
+- A **triplet** — `anchor<TAB>positive<TAB>negative` — additionally carrying a
+  hard negative that should embed far from the anchor.
+
+The training client builds a contrastive objective (e.g. InfoNCE / triplet loss)
+from these views on-the-fly.
+
+This is the same raw-text ingestion path as causal language modeling /
+seq2seq — one `.txt` per sample under `texts/` — but the on-disk shape is
+**structured**: a file that is not exactly 2 or 3 non-empty tab-separated fields
+is **rejected** at ingest by `ContrastivePairsValidator` (no plain prose, no
+empty fields, one record per file).
+
+## Quickstart — declarative (recommended)
+
+Ingest with ~8 lines of YAML using the official ingestor image
+(`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage
+> your files on the cluster's shared PVC first — see the
+> [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc)
+> in the chart docs (kubectl cp pattern for small datasets, init-container sync
+> for production).
+
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a
+`texts/` subdirectory holding the per-record `.txt` files.
+
+**2. Write `ingest.yaml`** — note there is **no** `label:` field (self-supervised):
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: embeddings
+table: my_embeddings_train
+intent: train
+csv: /data/shared/my-embeddings/labels_file.csv
+texts: /data/shared/my-embeddings/texts/
+```
+
+**3. Install:**
+
+```bash
+helm install my-embeddings-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+> **If install fails with `'embeddings' is not one of [...]`:** your local Helm
+> chart cache is stale. Refresh it and retry: `helm repo update`.
+
+Canonical example: [`examples/yaml/embeddings.yaml`](../../examples/yaml/embeddings.yaml).
+Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
+
+## Directory Structure
+
+```
+embeddings/
+├── embeddings.py                 # Main ingestion script
+├── README.md                     # This file
+└── data/
+    ├── texts/                    # Text files (.txt), one per sample
+    │   ├── emb_0000001.txt       #   anchor<TAB>positive (pair)
+    │   ├── emb_0000002.txt       #   anchor<TAB>positive (pair)
+    │   ├── emb_0000003.txt       #   anchor<TAB>positive (pair)
+    │   ├── emb_0000004.txt       #   anchor<TAB>positive<TAB>negative (triplet)
+    │   └── emb_0000005.txt       #   anchor<TAB>positive<TAB>negative (triplet)
+    └── labels_file_sample.csv    # CSV manifest mapping filenames to extensions
+```
+
+> The `texts/` subdir is the raw-text convention shared with text/token
+> classification, causal language modeling and seq2seq. (Masked language
+> modeling instead uses `sequences/`, which the framework reserves for
+> *pre-tokenized* data.)
+
+## Data Format
+
+### Text Files
+- Supported extension: `.txt`
+- One sample per file, placed in `data/texts/`
+- A single tab-separated `anchor<TAB>positive` (pair) **or**
+  `anchor<TAB>positive<TAB>negative` (triplet) line. Pairs and triplets may be
+  mixed within one dataset.
+- Files must be decodable UTF-8 (validated at ingest by `TextContentValidator`)
+  **and** structurally valid (validated by `ContrastivePairsValidator`): exactly
+  2 or 3 non-empty tab fields, one record per file. Binary / non-UTF-8 files,
+  plain prose without a tab, empty fields, and multi-line files are rejected.
+
+### CSV Labels File
+embeddings is **self-supervised** — no label column is needed. The CSV contains:
+- `filename`: Base name of the text file, without extension (e.g. `emb_0000001`)
+- `extension`: File extension as a quoted string (e.g. `'.txt'`)
+
+## Tokenizer Alignment
+
+embeddings does **not** ship a tokenizer at ingest. Instead, the ingestor
+computes a data-derived **text profile** (Unicode-script mix + document-length
+distribution — no raw text, no vocabulary, no hash; the FL guardrail) and ships
+it on the global-metadata channel (#805). The backend uses it for a warn-only
+contributor-tokenizer-fit check at dataset linking — the same alignment path as
+the other NLP modalities (text/token classification, MLM, causal LM, seq2seq).
+That check runs on the training-client side.
+
+## Usage
+
+1. Place your `.txt` sample files in `data/texts/`
+2. Update `labels_file_sample.csv` with one row per text file
+3. Configure environment variables (see below)
+4. Run the ingestion script:
+
+```bash
+python embeddings.py
+```
+
+## Configuration
+
+The script uses the following configuration:
+- **Extension**: TXT - Expected text file extension
+- **Chunk Size**: 100 - Batch size for CSV reading
+- **Encoding**: utf-8
+- **Category**: EMBEDDINGS
+- **Data Format**: TEXT
+- **Intent**: TRAIN (change to `Intent.TEST` for evaluation data)
+- **Label column**: None (self-supervised)
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TABLE_NAME` | Target database table | Required |
+| `LABEL_FILE` | Path to CSV manifest | Required |
+| `SRC_PATH` | Path to the parent of the `texts/` directory | Required |
+| `BATCH_SIZE` | Ingestion batch size | 4000 |
+| `BACKEND_TOKEN` | Auth token for API | Required |
+| `CLIENT_ENV` | Environment (local/dev/stg/prod) | prod |
+
+## Notes
+
+- The `filename` column does **not** include the extension — that's supplied
+  separately via the `extension` column.
+- No `label` column is needed because embeddings training is self-supervised
+  (the pairing itself is the supervision signal, derived from the text by the
+  training client).
+- Put exactly one tab between each field. For a pair: everything before the tab
+  is the anchor, everything after is the positive. For a triplet: anchor, then
+  positive, then the hard negative.

--- a/templates/embeddings/data/labels_file_sample.csv
+++ b/templates/embeddings/data/labels_file_sample.csv
@@ -1,0 +1,6 @@
+filename,extension
+emb_0000001,'.txt'
+emb_0000002,'.txt'
+emb_0000003,'.txt'
+emb_0000004,'.txt'
+emb_0000005,'.txt'

--- a/templates/embeddings/data/texts/emb_0000001.txt
+++ b/templates/embeddings/data/texts/emb_0000001.txt
@@ -1,0 +1,1 @@
+A man is playing a guitar.	A person plays an acoustic guitar.

--- a/templates/embeddings/data/texts/emb_0000002.txt
+++ b/templates/embeddings/data/texts/emb_0000002.txt
@@ -1,0 +1,1 @@
+How do I reset my password?	What are the steps to recover my account login?

--- a/templates/embeddings/data/texts/emb_0000003.txt
+++ b/templates/embeddings/data/texts/emb_0000003.txt
@@ -1,0 +1,1 @@
+tracebloc trains models where the data lives.	With tracebloc, models travel to the data instead of the data being moved.

--- a/templates/embeddings/data/texts/emb_0000004.txt
+++ b/templates/embeddings/data/texts/emb_0000004.txt
@@ -1,0 +1,1 @@
+A dog runs across the field.	A puppy sprints through the grass.	A cat sleeps on the sofa.

--- a/templates/embeddings/data/texts/emb_0000005.txt
+++ b/templates/embeddings/data/texts/emb_0000005.txt
@@ -1,0 +1,1 @@
+What is federated learning?	Federated learning trains a shared model without centralizing raw data.	The capital of France is Paris.

--- a/templates/embeddings/embeddings.py
+++ b/templates/embeddings/embeddings.py
@@ -1,0 +1,86 @@
+"""Embeddings (self-supervised contrastive) Data Ingestion Example.
+
+This example demonstrates how to ingest text samples for self-supervised
+contrastive embedding training into a database and optionally send metadata to
+the tracebloc API.
+
+embeddings is self-supervised — no label column is needed. Each row in the CSV
+maps to a ``.txt`` file under ``texts/`` holding RAW text:
+
+- Each file is a single tab-separated record, either a ``anchor\\tpositive``
+  PAIR or an ``anchor\\tpositive\\tnegative`` TRIPLET. The training client pulls
+  the anchor and positive (and optional hard negative) closer / further apart in
+  embedding space via a contrastive objective.
+
+This is the same raw-text ingestion path as seq2seq / causal language modeling
+(one ``.txt`` per sample under ``texts/``), but the on-disk shape is STRUCTURED:
+files that are not exactly 2 or 3 non-empty tab-separated fields are rejected at
+ingest by ``ContrastivePairsValidator``. The contributor's tokenizer alignment
+is checked centrally at dataset linking via the data-derived text profile
+(#805); nothing tokenizer-specific is needed here.
+"""
+
+import logging
+
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
+from tracebloc_ingestor.utils.logging import setup_logging
+from tracebloc_ingestor.utils.constants import (
+    TaskCategory,
+    Intent,
+    DataFormat,
+    FileExtension,
+)
+
+# Initialize config and configure logging
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+
+# Text file options
+text_options = {"extension": FileExtension.TXT}
+
+# CSV specific options
+csv_options = {
+    "chunk_size": 100,
+    "delimiter": ",",
+    "quotechar": '"',
+    "escapechar": "\\",
+    "on_bad_lines": "warn",
+    "encoding": "utf-8",
+}
+
+
+def main():
+    """Run the contrastive embeddings ingestion example."""
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
+
+    # Create ingestor for embeddings data
+    # No label_column — embeddings is self-supervised (contrastive)
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.TEXT,
+        category=TaskCategory.EMBEDDINGS,
+        csv_options=csv_options,
+        file_options=text_options,
+        intent=Intent.TRAIN,
+    )
+
+    # Ingest data with validation
+    logger.info("Starting contrastive embeddings ingestion with data validation...")
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_contrastive_pairs_validator.py
+++ b/tests/test_contrastive_pairs_validator.py
@@ -1,0 +1,172 @@
+"""Tests for ContrastivePairsValidator — the structural check that each
+``embeddings`` ``.txt`` is a tab-separated pair (``anchor\\tpositive``) or
+triplet (``anchor\\tpositive\\tnegative``). FileTypeValidator only checks the
+extension and TextContentValidator only checks UTF-8 decodability — neither sees
+this structure, so this validator is what rejects malformed contrastive rows.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.contrastive_pairs_validator import (
+    ContrastivePairsValidator,
+)
+
+
+@pytest.fixture
+def staged(clean_env, tmp_path):
+    """Return (texts_dir, make_csv) with SRC_PATH pointed at src and a texts/."""
+    src = tmp_path / "src"
+    texts = src / "texts"
+    texts.mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+
+    def make_csv(filenames, column="filename"):
+        path = tmp_path / "data.csv"
+        pd.DataFrame({column: filenames}).to_csv(path, index=False)
+        return path
+
+    return texts, make_csv
+
+
+def _validate(filenames, staged):
+    texts, make_csv = staged
+    path = make_csv(filenames)
+    return ContrastivePairsValidator(texts_path="texts").validate(str(path))
+
+
+def test_valid_pair_and_triplet_pass(staged):
+    texts, make_csv = staged
+    (texts / "pair.txt").write_text("anchor text\tpositive text\n", encoding="utf-8")
+    (texts / "triplet.txt").write_text(
+        "anchor\tpositive\tnegative\n", encoding="utf-8"
+    )
+    result = _validate(["pair", "triplet"], staged)
+    assert result.is_valid, result.errors
+    assert result.metadata["rows_checked"] == 2
+
+
+def test_plain_text_no_tab_rejected(staged):
+    """No tab -> one field. Valid for seq2seq/causal LM, malformed here."""
+    texts, _ = staged
+    (texts / "bad.txt").write_text("just prose, no tab at all\n", encoding="utf-8")
+    result = _validate(["bad"], staged)
+    assert not result.is_valid
+    assert any("tab-separated fields" in e and "found 1" in e for e in result.errors)
+
+
+def test_four_fields_rejected(staged):
+    texts, _ = staged
+    (texts / "bad.txt").write_text("a\tb\tc\td\n", encoding="utf-8")
+    result = _validate(["bad"], staged)
+    assert not result.is_valid
+    assert any("found 4" in e for e in result.errors)
+
+
+def test_empty_field_rejected(staged):
+    texts, _ = staged
+    (texts / "bad.txt").write_text("anchor\t\n", encoding="utf-8")
+    result = _validate(["bad"], staged)
+    assert not result.is_valid
+    assert any("are empty" in e for e in result.errors)
+
+
+def test_whitespace_only_field_rejected(staged):
+    texts, _ = staged
+    (texts / "bad.txt").write_text("anchor\t   \tnegative\n", encoding="utf-8")
+    result = _validate(["bad"], staged)
+    assert not result.is_valid
+    assert any("are empty" in e for e in result.errors)
+
+
+def test_multiline_file_rejected(staged):
+    """The contract is one record per file; a second non-empty line is
+    malformed (several records crammed into one .txt)."""
+    texts, _ = staged
+    (texts / "bad.txt").write_text("a\tb\nc\td\n", encoding="utf-8")
+    result = _validate(["bad"], staged)
+    assert not result.is_valid
+    assert any("multiple lines" in e for e in result.errors)
+
+
+def test_trailing_newline_and_blank_lines_tolerated(staged):
+    """A trailing newline / surrounding blank lines are stripped — the record
+    itself is a single valid pair, so it passes."""
+    texts, _ = staged
+    (texts / "ok.txt").write_text("\nanchor\tpositive\n\n", encoding="utf-8")
+    result = _validate(["ok"], staged)
+    assert result.is_valid, result.errors
+
+
+def test_empty_file_left_to_text_content_validator(staged):
+    """An empty / whitespace-only file is the shared TextContentValidator's
+    warning to raise; the structural validator stays silent (no double-report)."""
+    texts, _ = staged
+    (texts / "empty.txt").write_text("   \n", encoding="utf-8")
+    result = _validate(["empty"], staged)
+    assert result.is_valid, result.errors
+
+
+def test_missing_file_reported(staged):
+    result = _validate(["does_not_exist"], staged)
+    assert not result.is_valid
+    assert any("not found" in e for e in result.errors)
+
+
+def test_missing_filename_column_reported(staged):
+    texts, make_csv = staged
+    path = make_csv(["x"], column="wrongname")
+    result = ContrastivePairsValidator(texts_path="texts").validate(str(path))
+    assert not result.is_valid
+    assert any("filename" in e for e in result.errors)
+
+
+def test_filename_with_explicit_extension_resolved(staged):
+    """A manifest value that already carries the extension is used as-is (mirrors
+    text_transfer's _has_extension rule), not double-suffixed."""
+    texts, make_csv = staged
+    (texts / "pair.txt").write_text("a\tb\n", encoding="utf-8")
+    path = make_csv(["pair.txt"])
+    result = ContrastivePairsValidator(texts_path="texts").validate(str(path))
+    assert result.is_valid, result.errors
+
+
+def test_unreadable_non_utf8_file_reported(staged):
+    """A file the structural reader can't decode as UTF-8 is reported here as
+    unreadable (binary/encoding rejection itself is TextContentValidator's job,
+    but this validator must not crash on it)."""
+    texts, _ = staged
+    # Latin-1 bytes that are not valid UTF-8 (0xE9 = é in latin-1).
+    (texts / "bad.txt").write_bytes("Caf\xe9\tBrasil".encode("latin-1"))
+    result = _validate(["bad"], staged)
+    assert not result.is_valid
+    assert any("could not read text file" in e for e in result.errors)
+
+
+def test_unexpected_error_surfaces_as_validation_error(staged, monkeypatch):
+    """A blow-up in data loading is caught and surfaced as a failed result
+    (mirrors sibling validators) rather than escaping the validator."""
+    v = ContrastivePairsValidator(texts_path="texts")
+    monkeypatch.setattr(
+        v, "_load_data", lambda data: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    result = v.validate("anything")
+    assert not result.is_valid
+    assert any("validation error" in e for e in result.errors)
+
+
+def test_error_cap_summarizes(staged):
+    """A wholly-malformed dataset yields a capped, actionable summary rather
+    than tens of thousands of lines (mirrors BIOLabelValidator)."""
+    texts, _ = staged
+    names = []
+    for i in range(120):
+        name = f"bad{i}"
+        (texts / f"{name}.txt").write_text("no tab here\n", encoding="utf-8")
+        names.append(name)
+    result = _validate(names, staged)
+    assert not result.is_valid
+    assert any("further errors suppressed" in e for e in result.errors)
+    assert len(result.errors) <= 51

--- a/tests/test_contrastive_pairs_validator.py
+++ b/tests/test_contrastive_pairs_validator.py
@@ -115,6 +115,22 @@ def test_missing_file_reported(staged):
     assert any("not found" in e for e in result.errors)
 
 
+def test_path_traversal_manifest_value_skipped(staged):
+    """A manifest value that escapes the dataset dir (``..`` / absolute) is
+    resolved with ``_safe_join`` exactly as the transfer does (#239): the
+    transfer rejects it, so preflight neither reads nor flags a file outside
+    ``texts/`` — it is skipped here (mirrors TextContentValidator), not read
+    from disk."""
+    texts, make_csv = staged
+    # A real readable pair OUTSIDE texts/ — proves we don't read it.
+    outside = texts.parent.parent / "secret.txt"
+    outside.write_text("anchor\tpositive\n", encoding="utf-8")
+    path = make_csv(["../../secret"])
+    result = ContrastivePairsValidator(texts_path="texts").validate(str(path))
+    # Escaping value is skipped (no structural error raised for it).
+    assert result.is_valid, result.errors
+
+
 def test_missing_filename_column_reported(staged):
     texts, make_csv = staged
     path = make_csv(["x"], column="wrongname")

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,277 @@
+"""Embeddings (self-supervised contrastive) — modality wiring, mirroring the
+seq2seq / causal language modeling coverage.
+
+embeddings is the self-supervised, raw-text contrastive modality added
+alongside seq2seq. It shares seq2seq's self-supervised semantics (only a
+``filename`` column, no label) and its raw-text staging — each sample is one
+``.txt`` staged from ``texts/`` (not the pre-tokenized ``sequences/`` MLM uses).
+What makes it distinct is the STRUCTURED on-disk shape: each ``.txt`` is a
+tab-separated ``anchor\\tpositive`` pair OR ``anchor\\tpositive\\tnegative``
+triplet, and the dedicated ``ContrastivePairsValidator`` rejects anything else.
+These tests pin the behaviors the modality must get right:
+
+1. **CLI run** — an embeddings ``ingest.yaml`` routes through ``cli.run.main``
+   to a CSVIngestor with the resolved kwargs; an embeddings config that
+   (wrongly) sets ``label:`` is rejected at the entrypoint (self-supervised,
+   #213).
+2. **Validation boundaries** — header-only / all-files-missing manifests fail
+   fast before table creation; binary content is rejected; a malformed (no-tab)
+   sample is rejected by the structural validator; clean pairs and triplets
+   validate.
+3. **Failure accounting** — a rejected batch POST surfaces every record as a
+   failure so the run exits non-zero.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Generator
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples" / "yaml"
+
+
+# ---------------------------------------------------------------------------
+# Local test doubles (mirror tests/test_seq2seq.py so this file is
+# self-contained).
+# ---------------------------------------------------------------------------
+
+
+class FakeIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source: Any) -> Generator[Dict[str, Any], None, None]:
+        yield from self._records
+
+
+def make_ingestor(records=None, **overrides):
+    db = MagicMock(name="Database")
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = ([1, 2], [])
+    db.get_table_schema.return_value = {"a": "INT"}
+    api = MagicMock(name="APIClient")
+    api.send_batch.return_value = True
+    api.send_generate_edge_label_meta.return_value = True
+    api.send_global_meta_meta.return_value = True
+    api.prepare_dataset.return_value = True
+    api.create_dataset.return_value = {"id": 1}
+
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=TaskCategory.EMBEDDINGS,
+        label_column=None,
+    )
+    kwargs.update(overrides)
+    return FakeIngestor(records or [], **kwargs)
+
+
+def _emb_ingestor_on(tmp_path, clean_env, records):
+    """An embeddings FakeIngestor wired to a real Config rooted at
+    ``tmp_path/src`` with a ``texts/`` subdir, so the path-reading validators
+    run against a real FS."""
+    src = tmp_path / "src"
+    (src / "texts").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    clean_env.setenv("TABLE_NAME", "emb_train")
+    clean_env.setenv("DEST_PATH", str(tmp_path / "dest" / "emb_train"))
+    # Self-supervised embeddings carries no feature schema (the manifest is just
+    # filename/extension), so no DataValidator — match that real shape.
+    ing = make_ingestor(records=records, schema={})
+    ing.database.config = Config()
+    return ing, src / "texts"
+
+
+# ---------------------------------------------------------------------------
+# 1. CLI run
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_runtime():
+    with patch("tracebloc_ingestor.cli.run.Config") as cfg_cls, patch(
+        "tracebloc_ingestor.cli.run.Database"
+    ) as db_cls, patch("tracebloc_ingestor.cli.run.APIClient") as api_cls, patch(
+        "tracebloc_ingestor.cli.run.CSVIngestor"
+    ) as csv_cls, patch(
+        "tracebloc_ingestor.cli.run.JSONIngestor"
+    ) as json_cls, patch(
+        "tracebloc_ingestor.cli.run.setup_logging"
+    ):
+        cfg = MagicMock()
+        cfg.BATCH_SIZE = 4000
+        cfg_cls.return_value = cfg
+        for cls_mock in (csv_cls, json_cls):
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.ingest = MagicMock(return_value=[])
+            cls_mock.return_value = inst
+        yield {"Config": cfg_cls, "Database": db_cls, "APIClient": api_cls,
+               "CSVIngestor": csv_cls, "JSONIngestor": json_cls}
+
+
+def test_cli_run_routes_embeddings_yaml_to_csv_ingestor(
+    clean_env, mock_runtime, monkeypatch
+):
+    """The shipped embeddings example yaml runs end-to-end-but-mocked: a
+    CSVIngestor is built with the resolved embeddings kwargs (TEXT,
+    self-supervised, no label) and ingest() is called once; exit 0."""
+    monkeypatch.setenv("INGEST_CONFIG", str(EXAMPLES_DIR / "embeddings.yaml"))
+    from tracebloc_ingestor.cli.run import main
+
+    rc = main()
+
+    assert rc == 0
+    assert mock_runtime["CSVIngestor"].call_count == 1
+    assert mock_runtime["JSONIngestor"].call_count == 0
+    _, kwargs = mock_runtime["CSVIngestor"].call_args
+    assert kwargs["category"] == TaskCategory.EMBEDDINGS
+    assert kwargs["data_format"] == "text"
+    assert kwargs["label_column"] == ""  # self-supervised
+    assert kwargs["file_options"]["extension"] == ".txt"
+    mock_runtime["CSVIngestor"].return_value.ingest.assert_called_once()
+
+
+def test_cli_run_rejects_embeddings_with_label(
+    clean_env, mock_runtime, monkeypatch, tmp_path
+):
+    """Self-supervised: an embeddings config that sets `label:` must be rejected
+    at the entrypoint (exit 2) before any DB/network call (#213)."""
+    bad = tmp_path / "emb_with_label.yaml"
+    bad.write_text(
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: embeddings\n"
+        "table: emb_test\n"
+        "intent: test\n"
+        "csv: /tmp/ignored.csv\n"
+        "texts: /tmp/ignored/\n"
+        "label: label\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(bad))
+    from tracebloc_ingestor.cli.run import main
+
+    rc = main()
+
+    assert rc == 2
+    mock_runtime["Database"].assert_not_called()
+    mock_runtime["APIClient"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. Validation boundaries (real filesystem)
+# ---------------------------------------------------------------------------
+
+
+def test_emb_header_only_csv_fails_before_table_creation(clean_env, tmp_path):
+    """A header-only embeddings manifest is rejected during validation, before
+    the destination table is created — no orphan empty table."""
+    ing, _ = _emb_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame(columns=["filename"]).to_csv(csv, index=False)
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No data rows found"):
+            ing.ingest(str(csv), batch_size=10)
+    ing.database.create_table.assert_not_called()
+
+
+def test_emb_all_files_missing_fails_before_table_creation(clean_env, tmp_path):
+    """A populated manifest whose every referenced .txt is missing is rejected
+    before table creation."""
+    ing, _ = _emb_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["p1", "p2"]}).to_csv(csv, index=False)
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No referenced data files"):
+            ing.ingest(str(csv), batch_size=10)
+    ing.database.create_table.assert_not_called()
+
+
+def test_emb_clean_pairs_and_triplets_validate(clean_env, tmp_path):
+    """A clean dataset mixing a source<TAB>target pair and an
+    anchor<TAB>positive<TAB>negative triplet passes validation."""
+    ing, texts = _emb_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "pair.txt").write_text("a question\ta matching passage\n", encoding="utf-8")
+    (texts / "triplet.txt").write_text(
+        "an anchor\ta positive\ta hard negative\n", encoding="utf-8"
+    )
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["pair", "triplet"]}).to_csv(csv, index=False)
+
+    assert ing.validate_data(str(csv)) is True
+
+
+def test_emb_malformed_no_tab_rejected(clean_env, tmp_path):
+    """A .txt with no tab (plain prose — valid for seq2seq, NOT for embeddings)
+    is rejected by ContrastivePairsValidator: embeddings needs a pair/triplet."""
+    ing, texts = _emb_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "ok.txt").write_text("anchor\tpositive\n", encoding="utf-8")
+    (texts / "bad.txt").write_text("just one field, no tab here\n", encoding="utf-8")
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["ok", "bad"]}).to_csv(csv, index=False)
+
+    with pytest.raises(ValueError, match="tab-separated fields"):
+        ing.validate_data(str(csv))
+
+
+def test_emb_binary_content_rejected(clean_env, tmp_path):
+    """A .txt whose bytes are binary (a NUL byte) is rejected by the shared
+    TextContentValidator — the same content hygiene the other NLP modalities
+    get, here pointed at texts/."""
+    ing, texts = _emb_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "ok.txt").write_text("anchor\tpositive\n", encoding="utf-8")
+    (texts / "bad.txt").write_bytes(b"\x00\x01\x02binary")
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["ok", "bad"]}).to_csv(csv, index=False)
+
+    with pytest.raises(ValueError, match="NUL byte"):
+        ing.validate_data(str(csv))
+
+
+# ---------------------------------------------------------------------------
+# 3. Failure accounting
+# ---------------------------------------------------------------------------
+
+
+def test_emb_api_send_failure_counts_every_record(clean_env):
+    """Every batch POST rejected -> every embeddings record returns as a
+    failure, so the run exits non-zero (the file-transfer branch runs since
+    embeddings is file-bearing)."""
+    records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
+    ing = make_ingestor(records=records)
+    ing.api_client.send_batch.return_value = False
+
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+
+    assert len(failed) == 2
+    assert all(f["error"] == "api_send_failed" for f in failed)

--- a/tests/test_modality_failure_accounting.py
+++ b/tests/test_modality_failure_accounting.py
@@ -47,13 +47,14 @@ from tracebloc_ingestor.utils.constants import TaskCategory
 # helpers (mirror test_batch_send_failure_accounting.py)
 # ---------------------------------------------------------------------------
 
-# One entry per template directory — the 13 supported modalities.
+# One entry per template directory — the 14 supported modalities.
 _TEMPLATE_CATEGORIES = [
     TaskCategory.IMAGE_CLASSIFICATION,
     TaskCategory.KEYPOINT_DETECTION,
     TaskCategory.MASKED_LANGUAGE_MODELING,
     TaskCategory.CAUSAL_LANGUAGE_MODELING,
     TaskCategory.SEQ2SEQ,
+    TaskCategory.EMBEDDINGS,
     TaskCategory.OBJECT_DETECTION,
     TaskCategory.SEMANTIC_SEGMENTATION,
     TaskCategory.TABULAR_CLASSIFICATION,

--- a/tests/test_modality_registry.py
+++ b/tests/test_modality_registry.py
@@ -60,14 +60,15 @@ def test_derived_sets_match_spec_flags():
 
 def test_nlp_categories_are_exactly_the_text_categories():
     """#805: the NLP set is exactly the text categories (text/token
-    classification + masked & causal language modeling + seq2seq) — never
-    image/tabular."""
+    classification + masked & causal language modeling + seq2seq + embeddings) —
+    never image/tabular."""
     assert NLP_CATEGORIES == {
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
         TaskCategory.CAUSAL_LANGUAGE_MODELING,
         TaskCategory.SEQ2SEQ,
+        TaskCategory.EMBEDDINGS,
     }
 
 
@@ -94,6 +95,14 @@ def test_known_flag_values():
     assert s2s.is_file_bearing and s2s.is_self_supervised and s2s.is_nlp
     assert not s2s.is_tabular_family and not s2s.is_classification
     assert s2s.file_subdir == "texts"
+
+    # embeddings mirrors seq2seq's flags exactly (file-bearing + self-supervised
+    # + NLP, raw text from texts/) — the contrastive modality adds only a
+    # structural validator, not a new flag.
+    emb = spec_for(TaskCategory.EMBEDDINGS)
+    assert emb.is_file_bearing and emb.is_self_supervised and emb.is_nlp
+    assert not emb.is_tabular_family and not emb.is_classification
+    assert emb.file_subdir == "texts"
 
     tab = spec_for(TaskCategory.TABULAR_CLASSIFICATION)
     assert (

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -310,6 +310,34 @@ def test_seq2seq_without_texts_rejected(validator):
         validator.validate(config)
 
 
+def test_embeddings_with_label_rejected(validator):
+    """embeddings is self-supervised (contrastive) like seq2seq (#213): setting
+    `label:` must be rejected at submission. The CSV has no label column and no
+    edge-label metadata is registered for it."""
+    config = _load_example("embeddings.yaml")
+    config["label"] = "some_column"
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_embeddings_without_label_accepted(validator):
+    """The shipped embeddings example omits `label:` by design — it must
+    validate cleanly."""
+    config = _load_example("embeddings.yaml")
+    assert "label" not in config, "test premise: the example yaml has no label"
+    validator.validate(config)  # must not raise
+
+
+def test_embeddings_without_texts_rejected(validator):
+    """embeddings stages raw .txt under `texts:`; omitting it must be rejected
+    (the directory is where the per-sample anchor\\tpositive[\\tnegative] files
+    live)."""
+    config = _load_example("embeddings.yaml")
+    del config["texts"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
 # Regression-class tasks must specify label.policy explicitly; the shorthand
 # string form must be rejected for these categories.
 @pytest.mark.parametrize(

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -341,6 +341,34 @@ CASES = [
     ),
 
     # -----------------------------------------------------------------------
+    # embeddings — self-supervised (contrastive), no label column. CSV manifest
+    # points at .txt sidecar files holding RAW text (an anchor<TAB>positive pair
+    # or anchor<TAB>positive<TAB>negative triplet); the client builds the
+    # contrastive objective at train time. Sidecar dir is ``texts/`` (raw text —
+    # same layout as seq2seq), NOT MLM's ``sequences/`` (pre-tokenized).
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.EMBEDDINGS,
+            table="embeddings_train",
+            intent="train",
+            csv="/data/labels.csv",
+            texts="/data/texts/",
+        ),
+        {
+            "category": TaskCategory.EMBEDDINGS,
+            "data_format": DataFormat.TEXT,
+            "intent": Intent.TRAIN,
+            "label_column": "",  # self-supervised — no label
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"extension": FileExtension.TXT},
+        },
+        id="embeddings",
+    ),
+
+    # -----------------------------------------------------------------------
     # tabular_classification — template label_column="name"
     # -----------------------------------------------------------------------
     pytest.param(

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -129,6 +129,7 @@ def test_classification_categories_include_label_diversity():
         TaskCategory.MASKED_LANGUAGE_MODELING,
         TaskCategory.CAUSAL_LANGUAGE_MODELING,
         TaskCategory.SEQ2SEQ,
+        TaskCategory.EMBEDDINGS,
     ):
         assert LabelDiversityValidator not in _types(
             map_validators(cat, {"schema": {"a": "INT"}})
@@ -354,10 +355,10 @@ def test_map_validators_without_config_falls_back_to_module_global(monkeypatch):
 
 def test_nlp_categories_include_content_hygiene_validators():
     """The text categories (text/token classification, masked & causal LM,
-    seq2seq) gain BOTH the zero-record guard and the (text-only) UTF-8 content
-    validator. The zero-record guard now also covers file-bearing vision
-    categories, but TextContentValidator stays NLP-only (it decodes UTF-8 text,
-    meaningless for images); tabular has neither."""
+    seq2seq, embeddings) gain BOTH the zero-record guard and the (text-only)
+    UTF-8 content validator. The zero-record guard now also covers file-bearing
+    vision categories, but TextContentValidator stays NLP-only (it decodes UTF-8
+    text, meaningless for images); tabular has neither."""
     from tracebloc_ingestor.validators.ingestable_records_validator import (
         IngestableRecordsValidator,
     )
@@ -371,6 +372,7 @@ def test_nlp_categories_include_content_hygiene_validators():
         TaskCategory.MASKED_LANGUAGE_MODELING,
         TaskCategory.CAUSAL_LANGUAGE_MODELING,
         TaskCategory.SEQ2SEQ,
+        TaskCategory.EMBEDDINGS,
     ):
         types = _types(map_validators(cat, {}))
         # 0-record guard leads (composed centrally); the category's own
@@ -490,6 +492,78 @@ def test_seq2seq_with_schema_adds_data_validator():
     assert DataValidator in _types(v)
 
 
+def test_embeddings_content_validators_target_texts_subdir():
+    """embeddings stages RAW text under ``texts/`` (not the pre-tokenized
+    ``sequences/`` MLM uses); the content validators must point there."""
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    v = map_validators(TaskCategory.EMBEDDINGS, {})
+    rec = next(x for x in v if isinstance(x, IngestableRecordsValidator))
+    txt = next(x for x in v if isinstance(x, TextContentValidator))
+    assert rec.file_subdir == "texts"
+    assert txt.texts_path == "texts"
+
+
+def test_embeddings_includes_contrastive_pairs_validator():
+    """embeddings carries the structural ContrastivePairsValidator (the
+    pair/triplet check) ON TOP of the shared content hygiene — that structural
+    check is what distinguishes it from seq2seq / causal LM (free-form text)."""
+    from tracebloc_ingestor.validators.contrastive_pairs_validator import (
+        ContrastivePairsValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    types = _types(map_validators(TaskCategory.EMBEDDINGS, {}))
+    assert ContrastivePairsValidator in types
+    assert TextContentValidator in types
+    # seq2seq / causal LM do NOT structurally constrain their .txt content.
+    assert ContrastivePairsValidator not in _types(
+        map_validators(TaskCategory.SEQ2SEQ, {})
+    )
+    assert ContrastivePairsValidator not in _types(
+        map_validators(TaskCategory.CAUSAL_LANGUAGE_MODELING, {})
+    )
+
+
+def test_embeddings_threads_custom_extension_to_contrastive_validator():
+    """A custom extension reaches both the FileType and the contrastive
+    structural validator so the resolved path matches what text_transfer copies."""
+    from tracebloc_ingestor.validators.contrastive_pairs_validator import (
+        ContrastivePairsValidator,
+    )
+
+    v = map_validators(TaskCategory.EMBEDDINGS, {"extension": ".text"})
+    cp = next(x for x in v if isinstance(x, ContrastivePairsValidator))
+    assert cp.extension == ".text"
+
+
+def test_embeddings_excludes_all_label_validators():
+    """embeddings is self-supervised: only ``filename`` is required, no label
+    column. It must carry none of the label-oriented validators (mirrors
+    seq2seq)."""
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+    from tracebloc_ingestor.validators.bio_label_validator import BIOLabelValidator
+
+    types = _types(map_validators(TaskCategory.EMBEDDINGS, {}))
+    assert LabelColumnValidator not in types
+    assert BIOLabelValidator not in types
+    assert LabelDiversityValidator not in types
+
+
+def test_embeddings_with_schema_adds_data_validator():
+    v = map_validators(TaskCategory.EMBEDDINGS, {"schema": {"a": "INT"}})
+    assert DataValidator in _types(v)
+
+
 def test_text_classification_content_validators_target_texts_subdir():
     from tracebloc_ingestor.validators.ingestable_records_validator import (
         IngestableRecordsValidator,
@@ -540,6 +614,7 @@ ALL_CATEGORIES = (
     TaskCategory.MASKED_LANGUAGE_MODELING,
     TaskCategory.CAUSAL_LANGUAGE_MODELING,
     TaskCategory.SEQ2SEQ,
+    TaskCategory.EMBEDDINGS,
     TaskCategory.TABULAR_CLASSIFICATION,
     TaskCategory.TABULAR_REGRESSION,
     TaskCategory.TIME_SERIES_FORECASTING,

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -45,16 +45,17 @@ IMAGE_CATEGORIES: FrozenSet[str] = frozenset(
 )
 
 # Categories that stage raw ``.txt`` files from ``texts/`` and default to the
-# ``.txt`` extension. causal_language_modeling and seq2seq join text/token
-# classification here (they read raw text, not the pre-tokenized ``sequences/``
-# MLM uses); they are self-supervised, but that only governs label handling, not
-# the file_options default this set drives.
+# ``.txt`` extension. causal_language_modeling, seq2seq and embeddings join
+# text/token classification here (they read raw text, not the pre-tokenized
+# ``sequences/`` MLM uses); they are self-supervised, but that only governs
+# label handling, not the file_options default this set drives.
 TEXT_CATEGORIES: FrozenSet[str] = frozenset(
     {
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
         TaskCategory.CAUSAL_LANGUAGE_MODELING,
         TaskCategory.SEQ2SEQ,
+        TaskCategory.EMBEDDINGS,
     }
 )
 

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -139,6 +139,27 @@ _SPECS = (
         is_nlp=True,
         file_subdir="texts",
     ),
+    # embeddings is file-bearing AND self-supervised (no label) — the
+    # contrastive NLP modality. Each sample is one ``.txt`` of RAW text: a
+    # tab-separated ``anchor\tpositive`` pair OR an ``anchor\tpositive\tnegative``
+    # triplet (no label column). Same raw-text staging as seq2seq / causal LM —
+    # ``texts/``, not the pre-tokenized ``sequences/`` MLM uses. Unlike those two
+    # (which also accept free-form text), the on-disk shape here is STRUCTURED —
+    # exactly 2 or 3 tab-separated fields — so its validator factory adds a
+    # structural ContrastivePairsValidator that rejects malformed rows. It is
+    # NLP, so it ships the #805 data-derived text profile for the
+    # contributor-tokenizer-fit check.
+    ModalitySpec(
+        TaskCategory.EMBEDDINGS,
+        is_file_bearing=True,
+        is_tabular_family=False,
+        is_self_supervised=True,
+        data_format=DataFormat.TEXT,
+        build_validators=v.embeddings,
+        transfer=t.embeddings,
+        is_nlp=True,
+        file_subdir="texts",
+    ),
     # Tabular family (structured feature tables; no sidecar files -> no transfer).
     ModalitySpec(
         TaskCategory.TABULAR_CLASSIFICATION,

--- a/tracebloc_ingestor/modalities/transfer.py
+++ b/tracebloc_ingestor/modalities/transfer.py
@@ -126,6 +126,16 @@ def seq2seq(
     return text_transfer(record, options, cfg=cfg)
 
 
+def embeddings(
+    record: Dict[str, Any], options: Dict[str, Any], cfg: Optional[Config] = None
+) -> Optional[Dict[str, Any]]:
+    # Raw text, one .txt per sample in the ``texts`` subdir (same on-disk
+    # layout as seq2seq — the default text_transfer subdir). Self-supervised
+    # (contrastive): the .txt holds a tab-separated ``anchor\tpositive`` pair or
+    # ``anchor\tpositive\tnegative`` triplet, never a label.
+    return text_transfer(record, options, cfg=cfg)
+
+
 def semantic_segmentation(
     record: Dict[str, Any], options: Dict[str, Any], cfg: Optional[Config] = None
 ) -> Optional[Dict[str, Any]]:

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List
 from ..utils.constants import FileExtension
 from ..validators.base import BaseValidator
 from ..validators.bio_label_validator import BIOLabelValidator
+from ..validators.contrastive_pairs_validator import ContrastivePairsValidator
 from ..validators.data_validator import DataValidator
 from ..validators.file_pairing_validator import FilePairingValidator
 from ..validators.file_validator import FileTypeValidator
@@ -240,6 +241,32 @@ def seq2seq(options: Dict[str, Any]) -> List[BaseValidator]:
             path="texts",
         ),
         _text_content_validator(options, "texts"),
+    ]
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
+def embeddings(options: Dict[str, Any]) -> List[BaseValidator]:
+    # Self-supervised (contrastive), like seq2seq — only a ``filename`` column
+    # is required, no label column, so no LabelColumn/BIO/LabelDiversity
+    # validators. Each sample is one ``.txt`` of RAW text staged from ``texts/``.
+    # UNLIKE seq2seq / causal LM (free-form text), the on-disk shape is
+    # STRUCTURED: a tab-separated ``anchor\tpositive`` pair OR an
+    # ``anchor\tpositive\tnegative`` triplet. So beyond the shared
+    # TextContentValidator (UTF-8 / binary hygiene) it adds a structural
+    # ContrastivePairsValidator that rejects any file that isn't exactly 2 or 3
+    # non-empty tab fields.
+    validators: List[BaseValidator] = [
+        FileTypeValidator(
+            allowed_extension=options.get("extension", FileExtension.TXT),
+            path="texts",
+        ),
+        _text_content_validator(options, "texts"),
+        ContrastivePairsValidator(
+            texts_path="texts",
+            extension=options.get("extension", FileExtension.TXT),
+        ),
     ]
     if options.get("schema"):
         validators.append(DataValidator(schema=options["schema"]))

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -38,7 +38,8 @@
         "time_to_event_prediction",
         "masked_language_modeling",
         "causal_language_modeling",
-        "seq2seq"
+        "seq2seq",
+        "embeddings"
       ],
       "description": "Task category. Drives convention defaults: validators, data_format, default columns, default file extensions, default validator set."
     },
@@ -88,7 +89,7 @@
     "texts": {
       "type": "string",
       "minLength": 1,
-      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification, token_classification, causal_language_modeling (raw .txt: plain text, or a tab-separated prompt\\tcompletion pair), and seq2seq (raw .txt: a tab-separated source\\ttarget pair)."
+      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification, token_classification, causal_language_modeling (raw .txt: plain text, or a tab-separated prompt\\tcompletion pair), seq2seq (raw .txt: a tab-separated source\\ttarget pair), and embeddings (raw .txt: a tab-separated anchor\\tpositive pair, or anchor\\tpositive\\tnegative triplet)."
     },
 
     "sequences": {
@@ -355,6 +356,14 @@
       "then": { "required": ["texts"] }
     },
     {
+      "description": "embeddings requires `texts` (raw .txt samples, each a tab-separated anchor\\tpositive pair or anchor\\tpositive\\tnegative triplet). It is self-supervised (contrastive), so unlike text/token classification it does NOT require `label`.",
+      "if": {
+        "properties": { "category": { "const": "embeddings" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["texts"] }
+    },
+    {
       "description": "tabular and time-series categories require `schema`.",
       "if": {
         "properties": {
@@ -431,7 +440,8 @@
             "enum": [
               "masked_language_modeling",
               "causal_language_modeling",
-              "seq2seq"
+              "seq2seq",
+              "embeddings"
             ]
           }
         },

--- a/tracebloc_ingestor/utils/constants.py
+++ b/tracebloc_ingestor/utils/constants.py
@@ -48,6 +48,7 @@ class TaskCategory:
     MASKED_LANGUAGE_MODELING = "masked_language_modeling"
     CAUSAL_LANGUAGE_MODELING = "causal_language_modeling"
     SEQ2SEQ = "seq2seq"
+    EMBEDDINGS = "embeddings"
 
     # instance_segmentation is deliberately absent: it briefly shipped here
     # and in the schema enum with no validators and no file transfer, so
@@ -77,6 +78,7 @@ class TaskCategory:
             cls.MASKED_LANGUAGE_MODELING,
             cls.CAUSAL_LANGUAGE_MODELING,
             cls.SEQ2SEQ,
+            cls.EMBEDDINGS,
         ]
 
     @classmethod

--- a/tracebloc_ingestor/validators/contrastive_pairs_validator.py
+++ b/tracebloc_ingestor/validators/contrastive_pairs_validator.py
@@ -29,6 +29,7 @@ import os
 from typing import Any, List, Optional, Tuple
 
 from ..config import Config
+from ..file_transfer import _has_extension, _safe_join
 from ..utils.constants import FileExtension
 from .base import BaseValidator, ValidationResult
 
@@ -81,7 +82,7 @@ class ContrastivePairsValidator(BaseValidator):
                     errors=[f"Missing required column: {self.filename_column}"],
                 )
 
-            texts_dir = os.path.join((self._config or config).SRC_PATH, self.texts_path)
+            src_root = (self._config or config).SRC_PATH
             errors: List[str] = []
             checked = 0
             for idx, row in df.iterrows():
@@ -89,7 +90,7 @@ class ContrastivePairsValidator(BaseValidator):
                     errors.append("... further errors suppressed.")
                     break
                 checked += 1
-                error = self._validate_row(row, idx, filename_col, texts_dir)
+                error = self._validate_row(row, idx, filename_col, src_root)
                 if error:
                     errors.append(error)
 
@@ -111,7 +112,7 @@ class ContrastivePairsValidator(BaseValidator):
         row: Any,
         idx: Any,
         filename_col: str,
-        texts_dir: str,
+        src_root: str,
     ) -> Optional[str]:
         row_label = f"Row {idx}"
         filename = str(row[filename_col])
@@ -121,12 +122,18 @@ class ContrastivePairsValidator(BaseValidator):
         # none. Deterministic on purpose — probing the filesystem for
         # alternatives here could validate one file while text_transfer copies a
         # different one.
-        from ..file_transfer import _has_extension
-
         resolved = (
             filename if _has_extension(filename) else f"{filename}{self.extension}"
         )
-        text_path = os.path.join(texts_dir, resolved)
+        # Resolve as the transfer does (``_safe_join`` under SRC_PATH), so
+        # preflight can't disagree with copy behavior: an absolute / ``..``
+        # manifest value is rejected by the transfer (#239), so we neither read
+        # nor flag a file outside the dataset dir — its missing-ness is the
+        # records validator's job. Mirrors TextContentValidator.
+        try:
+            text_path = _safe_join(src_root, self.texts_path, resolved)
+        except ValueError:
+            return None
         if not os.path.isfile(text_path):
             return (
                 f"{row_label}: text file not found at "

--- a/tracebloc_ingestor/validators/contrastive_pairs_validator.py
+++ b/tracebloc_ingestor/validators/contrastive_pairs_validator.py
@@ -1,0 +1,197 @@
+"""Contrastive Pairs Validator Module.
+
+Structural check for the ``embeddings`` (self-supervised contrastive) modality.
+
+Unlike the other raw-text NLP modalities (causal language modeling, seq2seq),
+which also accept free-form text, an embeddings sample has a STRICT on-disk
+shape: each ``.txt`` is a single tab-separated record, either
+
+- a **pair** ``anchor<TAB>positive``                       (2 fields), or
+- a **triplet** ``anchor<TAB>positive<TAB>negative``        (3 fields).
+
+There is no label column — the supervision signal is the pairing itself. A file
+that isn't exactly 2 or 3 non-empty tab fields (e.g. plain prose with no tab, an
+empty field, or several records crammed into one file) is malformed: the
+training client would silently mis-split it into the wrong number of views. So
+we reject it here, against the dataset author, rather than letting it corrupt
+training.
+
+``FileTypeValidator`` only checks the extension and ``TextContentValidator``
+only checks UTF-8 decodability — neither sees this structure — so this is the
+dedicated structural validator, mirroring ``BIOLabelValidator`` for token
+classification. UTF-8 / binary hygiene stays the shared
+``TextContentValidator``'s job; emptiness it already warns about, so an
+empty / whitespace-only file is left untouched here (no double reporting).
+"""
+
+import logging
+import os
+from typing import Any, List, Optional, Tuple
+
+from ..config import Config
+from ..utils.constants import FileExtension
+from .base import BaseValidator, ValidationResult
+
+config = Config()
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+# Cap per-row errors so a wholly-malformed dataset yields an actionable summary
+# rather than tens of thousands of lines (mirrors BIOLabelValidator).
+_MAX_REPORTED_ERRORS = 50
+
+
+class ContrastivePairsValidator(BaseValidator):
+    """Validate that each referenced ``.txt`` is a tab-separated contrastive
+    pair or triplet.
+
+    Attributes:
+        texts_path: Subdirectory under ``SRC_PATH`` holding the ``.txt`` files
+            (``"texts"`` for embeddings; mirrors ``FileTypeValidator(path=...)``).
+        extension: Expected text-file extension (default ``.txt``).
+        filename_column: CSV column naming each sample's file (default
+            ``"filename"``; resolved case-insensitively).
+    """
+
+    def __init__(
+        self,
+        texts_path: str = "texts",
+        extension: str = FileExtension.TXT,
+        filename_column: str = "filename",
+        name: str = "Contrastive Pairs",
+    ):
+        super().__init__(name)
+        self.texts_path = texts_path
+        ext = extension or FileExtension.TXT
+        self.extension = ext if ext.startswith(".") else f".{ext}"
+        self.filename_column = filename_column
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            df = self._load_data(data)
+            if df is None or df.empty:
+                # Nothing to inspect; the empty-CSV case is the
+                # IngestableRecordsValidator's job, not this one.
+                return self._create_result(is_valid=True, metadata={"rows_checked": 0})
+
+            filename_col = self._resolve_column(df, self.filename_column)
+            if filename_col is None:
+                return self._create_result(
+                    is_valid=False,
+                    errors=[f"Missing required column: {self.filename_column}"],
+                )
+
+            texts_dir = os.path.join((self._config or config).SRC_PATH, self.texts_path)
+            errors: List[str] = []
+            checked = 0
+            for idx, row in df.iterrows():
+                if len(errors) >= _MAX_REPORTED_ERRORS:
+                    errors.append("... further errors suppressed.")
+                    break
+                checked += 1
+                error = self._validate_row(row, idx, filename_col, texts_dir)
+                if error:
+                    errors.append(error)
+
+            return self._create_result(
+                is_valid=len(errors) == 0,
+                errors=errors,
+                metadata={"rows_checked": checked},
+            )
+
+        except Exception as e:  # noqa: BLE001 — mirror sibling validators
+            logger.error(f"Error during contrastive pairs validation: {str(e)}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"Contrastive pairs validation error: {str(e)}"],
+            )
+
+    def _validate_row(
+        self,
+        row: Any,
+        idx: Any,
+        filename_col: str,
+        texts_dir: str,
+    ) -> Optional[str]:
+        row_label = f"Row {idx}"
+        filename = str(row[filename_col])
+
+        # Resolve the .txt with text_transfer's exact rule (shared
+        # _has_extension): append the extension only when the CSV filename has
+        # none. Deterministic on purpose — probing the filesystem for
+        # alternatives here could validate one file while text_transfer copies a
+        # different one.
+        from ..file_transfer import _has_extension
+
+        resolved = (
+            filename if _has_extension(filename) else f"{filename}{self.extension}"
+        )
+        text_path = os.path.join(texts_dir, resolved)
+        if not os.path.isfile(text_path):
+            return (
+                f"{row_label}: text file not found at "
+                f"'{self.texts_path}/{resolved}'."
+            )
+
+        try:
+            with open(text_path, "r", encoding="utf-8") as f:
+                content = f.read()
+        except (OSError, UnicodeDecodeError) as e:
+            # Binary / non-UTF-8 content is the shared TextContentValidator's
+            # job to report; here we just can't structurally check it, so skip.
+            return f"{row_label} ('{filename}'): could not read text file: {e}"
+
+        return self._check_structure(content, filename, row_label)
+
+    @staticmethod
+    def _check_structure(
+        content: str, filename: str, row_label: str
+    ) -> Optional[str]:
+        """Return an error message if ``content`` is not a single-line
+        tab-separated pair/triplet, else ``None``.
+
+        An empty / whitespace-only file is left to the shared
+        TextContentValidator (which warns), so it returns ``None`` here.
+        """
+        # Drop only surrounding blank lines / trailing newline — NOT interior
+        # tabs (a leading/trailing empty field must still be caught below).
+        record = content.strip("\r\n")
+        if not record.strip():
+            return None  # empty — TextContentValidator's warning, not ours.
+
+        # The contract is ONE record per file. A surviving interior line break
+        # means several records were crammed into one file (or a field contains
+        # a newline) — ambiguous for the single-sample-per-file contract.
+        if "\n" in record or "\r" in record:
+            return (
+                f"{row_label} ('{filename}'): expected a single tab-separated "
+                f"record but the file spans multiple lines. Put one "
+                f"'anchor<TAB>positive' pair (or "
+                f"'anchor<TAB>positive<TAB>negative' triplet) per .txt."
+            )
+
+        parts = record.split("\t")
+        if len(parts) not in (2, 3):
+            return (
+                f"{row_label} ('{filename}'): expected 2 (anchor<TAB>positive) "
+                f"or 3 (anchor<TAB>positive<TAB>negative) tab-separated fields, "
+                f"found {len(parts)}. Separate each field with exactly one tab."
+            )
+
+        empties = [i + 1 for i, p in enumerate(parts) if not p.strip()]
+        if empties:
+            return (
+                f"{row_label} ('{filename}'): field(s) {empties} are empty — "
+                f"every field (anchor, positive{', negative' if len(parts) == 3 else ''}) "
+                f"must be non-empty."
+            )
+
+        return None
+
+    @staticmethod
+    def _resolve_column(df: Any, name: str) -> Optional[str]:
+        """Return the actual column name matching ``name`` case-insensitively."""
+        if name in df.columns:
+            return name
+        lowered = {c.lower(): c for c in df.columns}
+        return lowered.get(name.lower())

--- a/tracebloc_ingestor/validators/text_content_validator.py
+++ b/tracebloc_ingestor/validators/text_content_validator.py
@@ -2,7 +2,7 @@
 
 Content-level check for NLP categories (text_classification,
 token_classification, masked_language_modeling, causal_language_modeling,
-seq2seq). ``FileTypeValidator`` only
+seq2seq, embeddings). ``FileTypeValidator`` only
 checks the file *extension*, so a file named ``doc1.txt`` that actually holds
 binary / non-UTF-8 bytes — or is empty — passed validation and was ingested
 silently; the dataset author only discovered the corruption at training time.


### PR DESCRIPTION
## What

Enables the NLP **embeddings / contrastive** use case ("shape #5") on the data-ingestors side, mirroring the **seq2seq** wiring (closest sibling). The training container ([tracebloc-engine #302](https://github.com/tracebloc/tracebloc-engine/pull/302)) is already done; this is the ingestor half of the cross-repo wiring. Prerequisite for staging an embeddings dataset.

**On-disk contract:** one `.txt` per sample under `texts/`, each a tab-separated `anchor<TAB>positive` **pair** OR `anchor<TAB>positive<TAB>negative` **triplet**. No label column (self-supervised contrastive).

## Touchpoints (mirrors `seq2seq`)

1. **`utils/constants.py`** — `TaskCategory.EMBEDDINGS`.
2. **`modalities/registry.py`** — `ModalitySpec` (file-bearing, self-supervised, NLP, `texts/`). `is_nlp=True` is the ingestor-side **#805 tokenizer gating**: it ships the data-derived text profile on the global-metadata channel for the contributor-tokenizer-fit check.
3. **`modalities/validators.py` + new `validators/contrastive_pairs_validator.py`** — validates the on-disk format. Beyond the shared `TextContentValidator` (UTF-8/binary hygiene), the new **centralized** `ContrastivePairsValidator` rejects any `.txt` that isn't exactly 2 or 3 non-empty tab fields (plain prose, empty field, 4+ fields, multi-line → rejected).
4. **`schema/ingest.v1.json`** — enum value, `texts` requirement, self-supervised no-label guard (#213).
5. **`modalities/transfer.py` + `cli/conventions.py`** — raw-text staging from `texts/`.
6. **`templates/embeddings/`** — script + README + sample pairs/triplets; **`examples/yaml/embeddings.yaml`**; Readme entry.

## Repo gotchas (verified not reintroduced)

- **Fail loudly:** the template routes through the shared `run_ingestion` helper (no `exit 0` on hard failure) — pinned by `test_modality_failure_accounting` / `test_batch_send_failure_accounting`.
- **No `zip(ids, batch)` mispair:** the send path is untouched; embeddings reuses the existing `text_transfer` + base ingestor.
- **Centralized validation (#317):** the structural check lives in `validators/`, not a per-template copy.

## Tests

- New `tests/test_embeddings.py` (wiring, mirrors `test_seq2seq.py`) and `tests/test_contrastive_pairs_validator.py` (structural unit tests).
- Updated enumerating tests (registry NLP set, validators_mapping, template_equivalence, schema_validation, modality_failure_accounting `_TEMPLATE_CATEGORIES`) and e2e params.
- Full suite green: **1312 passed, 1 xfailed**; total coverage **97%** (≥95 gate), new validator at **100%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the published ingest schema and modality registry (new category must stay in sync everywhere), but behavior reuses existing text transfer and adds validation-only constraints rather than changing core ingest paths.
> 
> **Overview**
> Adds a new **`embeddings`** NLP ingest category for **self-supervised contrastive** training: CSV manifest plus one `.txt` per sample under `texts/`, each file holding either `anchor<TAB>positive` or `anchor<TAB>positive<TAB>negative` (no `label:` — same self-supervised guard as seq2seq/MLM, #213).
> 
> Wiring mirrors **seq2seq** (file-bearing, NLP, `text_transfer` from `texts/`) but adds **`ContrastivePairsValidator`** so ingest rejects malformed shapes (wrong field count, empty fields, multi-line files) that free-form seq2seq/causal LM would allow. **`TaskCategory.EMBEDDINGS`**, modality registry, `ingest.v1.json`, and CLI **`TEXT_CATEGORIES`** are updated; **`templates/embeddings/`**, **`examples/yaml/embeddings.yaml`**, and README docs ship sample data.
> 
> E2E/characterization suites and registry, schema, validator-mapping, template-equivalence, and modality tests are extended so the 14th category stays congruent end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 347e52bf15a66212897b9e40e0c3c8a93753b46b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->