### PR TITLE
chore(release): bump version to 0.5.4

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
Lands the `__version__` bump for **v0.5.4** on `develop`: `0.5.3` → `0.5.4`.

v0.5.4 was tagged to ship the **embeddings** (self-supervised contrastive) modality (#327), which merged after v0.5.3 — so `ghcr.io/tracebloc/ingestor:0.5.4` is the first image to contain embeddings. The tag carries this bump; this PR reconciles `develop`.

No functional change — single-line version literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only; no runtime or behavioral code changes.
> 
> **Overview**
> Bumps the package **`__version__`** in `tracebloc_ingestor/__init__.py` from **0.5.3** to **0.5.4**, aligning `develop` with the v0.5.4 release tag (embeddings modality shipped in that image).
> 
> `setup.py` continues to read this literal via `_read_version()`, so no other files need updating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca8e39f20ff8174cccca319b764d65718195d820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->