### PR TITLE
feat: add sentence_pair_classification modality

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ Only metadata (schema, statistics, structure) syncs to the web app. Raw data sta
 | Type | Categories |
 |---|---|
 | **Image** | [`image_classification`](templates/image_classification), [`object_detection`](templates/object_detection), [`keypoint_detection`](templates/keypoint_detection), [`semantic_segmentation`](templates/semantic_segmentation) |
-| **Text / NLP** | [`text_classification`](templates/text_classification), [`token_classification`](templates/token_classification), [`masked_language_modeling`](templates/masked_language_modeling), [`causal_language_modeling`](templates/causal_language_modeling), [`seq2seq`](templates/seq2seq), [`embeddings`](templates/embeddings) |
+| **Text / NLP** | [`text_classification`](templates/text_classification), [`token_classification`](templates/token_classification), [`sentence_pair_classification`](templates/sentence_pair_classification), [`masked_language_modeling`](templates/masked_language_modeling), [`causal_language_modeling`](templates/causal_language_modeling), [`seq2seq`](templates/seq2seq), [`embeddings`](templates/embeddings) |
 | **Tabular** | [`tabular_classification`](templates/tabular_classification), [`tabular_regression`](templates/tabular_regression) |
 | **Time series** | [`time_series_forecasting`](templates/time_series_forecasting), [`time_to_event_prediction`](templates/time_to_event_prediction) |
 

--- a/e2e/test_characterization.py
+++ b/e2e/test_characterization.py
@@ -118,6 +118,18 @@ CASES = [
         roundtrip_col=None,
     ),
     dict(
+        id="sentence_pair_classification",
+        cfg=_cfg(
+            table="char_spc",
+            category="sentence_pair_classification",
+            csv=str(T / "sentence_pair_classification/data/labels_file_sample.csv"),
+            texts=str(T / "sentence_pair_classification/data/texts"),
+            label="label",
+        ),
+        sidecars=[str(T / "sentence_pair_classification/data/texts")],
+        roundtrip_col=None,
+    ),
+    dict(
         id="time_to_event_prediction",
         cfg=_cfg(
             table="char_tte",

--- a/e2e/test_ingest_e2e.py
+++ b/e2e/test_ingest_e2e.py
@@ -41,6 +41,20 @@ CASES = [
         ),
         id="text_classification",
     ),
+    # sentence_pair_classification: SUPERVISED text classification (label in the
+    # CSV, like text_classification) but each .txt is a tab-separated
+    # text_a<TAB>text_b pair. The structural SentencePairValidator gates
+    # malformed files; alignment is the data-derived text profile (#805).
+    pytest.param(
+        _cfg(
+            table="e2e_spc",
+            category="sentence_pair_classification",
+            csv=str(T / "sentence_pair_classification/data/labels_file_sample.csv"),
+            texts=str(T / "sentence_pair_classification/data/texts"),
+            label="label",
+        ),
+        id="sentence_pair_classification",
+    ),
     # token_classification was uncovered by any e2e test (audit gap). Same
     # on-disk layout as text classification (one .txt per sample under texts/);
     # the BIO tags travel in the `label` column. The template CSV quotes the

--- a/examples/yaml/sentence_pair_classification.yaml
+++ b/examples/yaml/sentence_pair_classification.yaml
@@ -1,0 +1,14 @@
+# Sentence-pair classification: CSV manifest + .txt sidecar files (one per
+# sample) + a label column. Supervised — the class label lives in the CSV.
+# `texts:` holds RAW text samples: each .txt is a single tab-separated
+# `text_a<TAB>text_b` sentence pair (the text_classification layout with a tab
+# separating the pair). The class (e.g. entailment / contradiction / neutral for
+# NLI, or paraphrase / not_paraphrase) is the `label` column in the CSV.
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+table: mnli_sentence_pairs_train
+intent: train
+category: sentence_pair_classification
+csv: /data/shared/mnli-pairs/labels_file.csv
+texts: /data/shared/mnli-pairs/texts/
+label: label

--- a/templates/sentence_pair_classification/README.md
+++ b/templates/sentence_pair_classification/README.md
@@ -1,0 +1,103 @@
+# Sentence-Pair Classification Data Ingestion Template
+
+This template demonstrates how to ingest **sentence-pair classification** data
+into a database using the tracebloc_ingestor framework.
+
+sentence_pair_classification is **supervised** — every sample carries a class
+`label` in the labels CSV, exactly like `text_classification`. Each sample is a
+single `.txt` file under `texts/` holding **raw text** as a tab-separated pair:
+
+- `text_a<TAB>text_b` — two sentences the model encodes together and classifies
+  (e.g. a premise and a hypothesis for NLI → `entailment` / `contradiction` /
+  `neutral`, or two sentences for a paraphrase / duplicate-question task →
+  `paraphrase` / `not_paraphrase`).
+
+This is the same on-disk layout as `text_classification` (one `.txt` per sample
+under `texts/`, class label in the CSV) with **one difference**: the `.txt` holds
+**two** sentences separated by a single tab. The on-disk shape is therefore
+**structured** — a file that is not exactly 2 non-empty tab-separated fields is
+**rejected** at ingest by `SentencePairValidator` (no plain prose with no tab, no
+empty side, one record per file).
+
+## Quickstart — declarative (recommended)
+
+Ingest with ~9 lines of YAML using the official ingestor image
+(`ghcr.io/tracebloc/ingestor`). No Python edits, no Dockerfile to build.
+
+> **Prerequisite:** the chart doesn't transport data into the cluster. Stage
+> your files on the cluster's shared PVC first — see the
+> [data-staging recipe](https://github.com/tracebloc/client/blob/develop/ingestor/README.md#stage-your-data-on-the-shared-pvc)
+> in the chart docs (kubectl cp pattern for small datasets, init-container sync
+> for production).
+
+**1. Stage the data** on the shared PVC at `/data/shared/<your-prefix>/` with a
+`texts/` subdirectory holding the per-record `.txt` files.
+
+**2. Write `ingest.yaml`** — note the `label:` field (supervised):
+
+```yaml
+apiVersion: tracebloc.io/v1
+kind: IngestConfig
+category: sentence_pair_classification
+table: my_sentence_pairs_train
+intent: train
+csv: /data/shared/my-pairs/labels_file.csv
+texts: /data/shared/my-pairs/texts/
+label: label
+```
+
+**3. Install:**
+
+```bash
+helm install my-sentence-pairs-dataset tracebloc/ingestor \
+  --namespace tracebloc \
+  --set-file ingestConfig=./ingest.yaml
+```
+
+> **If install fails with `'sentence_pair_classification' is not one of [...]`:**
+> your local Helm chart cache is stale. Refresh it and retry: `helm repo update`.
+
+## Data layout
+
+```
+data/
+├── labels_file_sample.csv    # filename, extension, label (one row per sample)
+└── texts/
+    ├── pair1.txt             # text_a<TAB>text_b
+    ├── pair2.txt
+    └── ...
+```
+
+The labels CSV maps each `filename` to its class `label`:
+
+```csv
+filename,extension,label
+pair1,'.txt',entailment
+pair2,'.txt',contradiction
+pair3,'.txt',neutral
+```
+
+Each referenced `.txt` is a single tab-separated sentence pair, e.g. `pair1.txt`:
+
+```
+A man is playing a guitar.<TAB>A person is making music.
+```
+
+## Validation
+
+At ingest the framework rejects, before any row reaches the database:
+
+- **Non-UTF-8 / binary content** (shared `TextContentValidator`).
+- **A `.txt` that isn't exactly 2 non-empty tab-separated fields** — plain prose
+  with no tab, an empty side, or several records crammed into one file
+  (`SentencePairValidator`).
+- **A missing / absent `label` column**, or a dataset with fewer than 2 distinct
+  labels (`LabelColumnValidator` + `LabelDiversityValidator`).
+
+## Script alternative
+
+To run from Python instead of the declarative YAML, see
+[`sentence_pair_classification.py`](sentence_pair_classification.py) — it builds a
+`CSVIngestor` with `category=TaskCategory.SENTENCE_PAIR_CLASSIFICATION` and
+`label_column="label"`, then calls the shared `run_ingestion` helper (which exits
+non-zero on any hard failure — no silent `exit 0`).

--- a/templates/sentence_pair_classification/data/labels_file_sample.csv
+++ b/templates/sentence_pair_classification/data/labels_file_sample.csv
@@ -1,0 +1,6 @@
+filename,extension,label
+pair1,'.txt',entailment
+pair2,'.txt',contradiction
+pair3,'.txt',neutral
+pair4,'.txt',entailment
+pair5,'.txt',contradiction

--- a/templates/sentence_pair_classification/data/texts/pair1.txt
+++ b/templates/sentence_pair_classification/data/texts/pair1.txt
@@ -1,0 +1,1 @@
+A man is playing a guitar.	A person is making music.

--- a/templates/sentence_pair_classification/data/texts/pair2.txt
+++ b/templates/sentence_pair_classification/data/texts/pair2.txt
@@ -1,0 +1,1 @@
+A man is playing a guitar.	The man is asleep and completely silent.

--- a/templates/sentence_pair_classification/data/texts/pair3.txt
+++ b/templates/sentence_pair_classification/data/texts/pair3.txt
@@ -1,0 +1,1 @@
+A man is playing a guitar.	The man is a professional musician.

--- a/templates/sentence_pair_classification/data/texts/pair4.txt
+++ b/templates/sentence_pair_classification/data/texts/pair4.txt
@@ -1,0 +1,1 @@
+Two dogs are running through the park.	Animals are moving around outdoors.

--- a/templates/sentence_pair_classification/data/texts/pair5.txt
+++ b/templates/sentence_pair_classification/data/texts/pair5.txt
@@ -1,0 +1,1 @@
+Two dogs are running through the park.	There are no animals anywhere in sight.

--- a/templates/sentence_pair_classification/sentence_pair_classification.py
+++ b/templates/sentence_pair_classification/sentence_pair_classification.py
@@ -1,0 +1,90 @@
+"""Sentence-Pair Classification Data Ingestion Example.
+
+This example demonstrates how to ingest sentence-pair classification data — text
+files holding a tab-separated ``text_a<TAB>text_b`` pair plus a class label — into
+a database and optionally send metadata to the tracebloc API.
+
+sentence_pair_classification is SUPERVISED: the class label travels in the labels
+CSV, exactly like text_classification. Each row maps to a ``.txt`` file under
+``texts/`` holding RAW text:
+
+- Each file is a single tab-separated ``text_a<TAB>text_b`` sentence pair (e.g. a
+  premise and a hypothesis for NLI, or two sentences for a paraphrase / STS
+  task). The training client encodes the two sentences as a pair and predicts
+  the CSV ``label``.
+
+This is the same raw-text ingestion path as text_classification (one ``.txt`` per
+sample under ``texts/``), but the on-disk shape is STRUCTURED: files that are not
+exactly 2 non-empty tab-separated fields are rejected at ingest by
+``SentencePairValidator``. The contributor's tokenizer alignment is checked
+centrally at dataset linking via the data-derived text profile (#805); nothing
+tokenizer-specific is needed here.
+"""
+
+import logging
+
+from tracebloc_ingestor import (
+    Config,
+    Database,
+    APIClient,
+    CSVIngestor,
+    run_ingestion,
+)
+from tracebloc_ingestor.utils.logging import setup_logging
+from tracebloc_ingestor.utils.constants import (
+    TaskCategory,
+    Intent,
+    DataFormat,
+    FileExtension,
+)
+
+# Initialize config and configure logging
+config = Config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+
+# Text file options
+text_options = {"extension": FileExtension.TXT}
+
+# CSV specific options
+csv_options = {
+    "chunk_size": 100,
+    "delimiter": ",",
+    "quotechar": '"',
+    "escapechar": "\\",
+    "on_bad_lines": "warn",
+    "encoding": "utf-8",
+}
+
+
+def main():
+    """Run the sentence-pair classification ingestion example."""
+    # Initialize components
+    database = Database(config)
+    api_client = APIClient(config)
+
+    # Create ingestor for sentence-pair classification data
+    # Supervised — the class label lives in the CSV `label` column.
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=config.TABLE_NAME,
+        data_format=DataFormat.TEXT,
+        category=TaskCategory.SENTENCE_PAIR_CLASSIFICATION,
+        csv_options=csv_options,
+        file_options=text_options,
+        label_column="label",
+        intent=Intent.TRAIN,
+    )
+
+    # Ingest data with validation
+    logger.info(
+        "Starting sentence-pair classification ingestion with data validation..."
+    )
+    run_ingestion(
+        ingestor, config.LABEL_FILE, batch_size=config.BATCH_SIZE, logger=logger
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_modality_failure_accounting.py
+++ b/tests/test_modality_failure_accounting.py
@@ -47,7 +47,7 @@ from tracebloc_ingestor.utils.constants import TaskCategory
 # helpers (mirror test_batch_send_failure_accounting.py)
 # ---------------------------------------------------------------------------
 
-# One entry per template directory — the 14 supported modalities.
+# One entry per template directory — the 15 supported modalities.
 _TEMPLATE_CATEGORIES = [
     TaskCategory.IMAGE_CLASSIFICATION,
     TaskCategory.KEYPOINT_DETECTION,
@@ -60,6 +60,7 @@ _TEMPLATE_CATEGORIES = [
     TaskCategory.TABULAR_CLASSIFICATION,
     TaskCategory.TABULAR_REGRESSION,
     TaskCategory.TEXT_CLASSIFICATION,
+    TaskCategory.SENTENCE_PAIR_CLASSIFICATION,
     TaskCategory.TIME_SERIES_FORECASTING,
     TaskCategory.TIME_TO_EVENT_PREDICTION,
     TaskCategory.TOKEN_CLASSIFICATION,

--- a/tests/test_modality_registry.py
+++ b/tests/test_modality_registry.py
@@ -59,12 +59,13 @@ def test_derived_sets_match_spec_flags():
 
 
 def test_nlp_categories_are_exactly_the_text_categories():
-    """#805: the NLP set is exactly the text categories (text/token
+    """#805: the NLP set is exactly the text categories (text/token/sentence-pair
     classification + masked & causal language modeling + seq2seq + embeddings) —
     never image/tabular."""
     assert NLP_CATEGORIES == {
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
+        TaskCategory.SENTENCE_PAIR_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
         TaskCategory.CAUSAL_LANGUAGE_MODELING,
         TaskCategory.SEQ2SEQ,
@@ -103,6 +104,15 @@ def test_known_flag_values():
     assert emb.is_file_bearing and emb.is_self_supervised and emb.is_nlp
     assert not emb.is_tabular_family and not emb.is_classification
     assert emb.file_subdir == "texts"
+
+    # sentence_pair_classification is SUPERVISED text classification: NLP +
+    # file-bearing + is_classification, raw text from texts/, but (unlike the
+    # self-supervised text categories) NOT self-supervised — the class label
+    # travels in the labels CSV, mirroring text_classification.
+    spc = spec_for(TaskCategory.SENTENCE_PAIR_CLASSIFICATION)
+    assert spc.is_file_bearing and spc.is_nlp and spc.is_classification
+    assert not spc.is_self_supervised and not spc.is_tabular_family
+    assert spc.file_subdir == "texts"
 
     tab = spec_for(TaskCategory.TABULAR_CLASSIFICATION)
     assert (

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -28,7 +28,6 @@ import pytest
 import yaml
 from jsonschema import Draft7Validator, ValidationError
 
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCHEMA_PATH = REPO_ROOT / "tracebloc_ingestor" / "schema" / "ingest.v1.json"
 EXAMPLES_DIR = REPO_ROOT / "examples" / "yaml"
@@ -60,9 +59,8 @@ EXAMPLES = sorted(p.name for p in EXAMPLES_DIR.glob("*.yaml"))
 def test_example_validates(validator: Draft7Validator, example_name: str):
     config = _load_example(example_name)
     errors = sorted(validator.iter_errors(config), key=lambda e: e.path)
-    assert not errors, (
-        f"{example_name} failed schema validation:\n  "
-        + "\n  ".join(f"{list(e.absolute_path) or '<root>'}: {e.message}" for e in errors)
+    assert not errors, f"{example_name} failed schema validation:\n  " + "\n  ".join(
+        f"{list(e.absolute_path) or '<root>'}: {e.message}" for e in errors
     )
 
 
@@ -70,7 +68,8 @@ def test_image_classification_is_eight_lines():
     """The dominant case has to fit in ~8 lines, per #44 design constraint."""
     body = (EXAMPLES_DIR / "image_classification.yaml").read_text(encoding="utf-8")
     non_blank_non_comment = [
-        line for line in body.splitlines()
+        line
+        for line in body.splitlines()
         if line.strip() and not line.lstrip().startswith("#")
     ]
     assert len(non_blank_non_comment) == 8, (
@@ -94,7 +93,8 @@ def test_all_task_categories_covered():
     covered = {
         yaml.safe_load((EXAMPLES_DIR / name).read_text(encoding="utf-8"))["category"]
         for name in EXAMPLES
-        if name != "custom_processor.yaml"  # uses tabular_classification, already covered
+        if name
+        != "custom_processor.yaml"  # uses tabular_classification, already covered
     }
 
     missing = enum_values - covered
@@ -135,6 +135,7 @@ def test_schema_category_enum_matches_engine_categories():
 # ---------------------------------------------------------------------------
 # Negative coverage: each rejection path the schema is supposed to enforce.
 # ---------------------------------------------------------------------------
+
 
 def _ic_base() -> dict:
     """A known-good image_classification config to mutate per test."""
@@ -223,6 +224,22 @@ def test_token_classification_without_texts_rejected(validator):
 
 def test_token_classification_without_label_rejected(validator):
     config = _load_example("token_classification.yaml")
+    del config["label"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_sentence_pair_classification_without_texts_rejected(validator):
+    config = _load_example("sentence_pair_classification.yaml")
+    del config["texts"]
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_sentence_pair_classification_without_label_rejected(validator):
+    """sentence_pair_classification is SUPERVISED (like text/token
+    classification): omitting `label` must be rejected at submission."""
+    config = _load_example("sentence_pair_classification.yaml")
     del config["label"]
     with pytest.raises(ValidationError):
         validator.validate(config)

--- a/tests/test_sentence_pair_classification.py
+++ b/tests/test_sentence_pair_classification.py
@@ -1,0 +1,310 @@
+"""Sentence-pair classification — modality wiring, mirroring the
+text_classification / embeddings coverage.
+
+sentence_pair_classification is the SUPERVISED text-classification modality whose
+``.txt`` holds a STRUCTURED tab-separated ``text_a\\ttext_b`` pair. It shares
+text_classification's supervised semantics (a ``label`` column in the CSV, so it
+carries LabelColumn + LabelDiversity validators) and its raw-text staging — each
+sample is one ``.txt`` staged from ``texts/``. What makes it distinct is the
+STRUCTURED on-disk shape: the dedicated ``SentencePairValidator`` rejects any
+``.txt`` that isn't exactly 2 non-empty tab-separated fields. These tests pin the
+behaviors the modality must get right:
+
+1. **CLI run** — a sentence_pair ``ingest.yaml`` routes through ``cli.run.main``
+   to a CSVIngestor with the resolved kwargs (TEXT, label_column="label"); a
+   config that (wrongly) OMITS ``label`` is rejected at the entrypoint
+   (supervised — the opposite of the self-supervised modalities).
+2. **Validation boundaries** — header-only / all-files-missing manifests fail
+   fast before table creation; binary content is rejected; a malformed sample
+   (no tab, or a 3-field triplet) is rejected by the structural validator; clean
+   pairs validate.
+3. **Failure accounting** — a rejected batch POST surfaces every record as a
+   failure so the run exits non-zero.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Generator
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples" / "yaml"
+
+
+# ---------------------------------------------------------------------------
+# Local test doubles (mirror tests/test_embeddings.py so this file is
+# self-contained).
+# ---------------------------------------------------------------------------
+
+
+class FakeIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source: Any) -> Generator[Dict[str, Any], None, None]:
+        yield from self._records
+
+
+def make_ingestor(records=None, **overrides):
+    db = MagicMock(name="Database")
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = ([1, 2], [])
+    db.get_table_schema.return_value = {"a": "INT"}
+    api = MagicMock(name="APIClient")
+    api.send_batch.return_value = True
+    api.send_generate_edge_label_meta.return_value = True
+    api.send_global_meta_meta.return_value = True
+    api.prepare_dataset.return_value = True
+    api.create_dataset.return_value = {"id": 1}
+
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=TaskCategory.SENTENCE_PAIR_CLASSIFICATION,
+        label_column="label",
+    )
+    kwargs.update(overrides)
+    return FakeIngestor(records or [], **kwargs)
+
+
+def _spc_ingestor_on(tmp_path, clean_env, records):
+    """A sentence_pair FakeIngestor wired to a real Config rooted at
+    ``tmp_path/src`` with a ``texts/`` subdir, so the path-reading validators
+    run against a real FS. Supervised — carries label_column="label"."""
+    src = tmp_path / "src"
+    (src / "texts").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    clean_env.setenv("TABLE_NAME", "spc_train")
+    clean_env.setenv("DEST_PATH", str(tmp_path / "dest" / "spc_train"))
+    ing = make_ingestor(records=records, schema={})
+    ing.database.config = Config()
+    return ing, src / "texts"
+
+
+# ---------------------------------------------------------------------------
+# 1. CLI run
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_runtime():
+    with patch("tracebloc_ingestor.cli.run.Config") as cfg_cls, patch(
+        "tracebloc_ingestor.cli.run.Database"
+    ) as db_cls, patch("tracebloc_ingestor.cli.run.APIClient") as api_cls, patch(
+        "tracebloc_ingestor.cli.run.CSVIngestor"
+    ) as csv_cls, patch(
+        "tracebloc_ingestor.cli.run.JSONIngestor"
+    ) as json_cls, patch(
+        "tracebloc_ingestor.cli.run.setup_logging"
+    ):
+        cfg = MagicMock()
+        cfg.BATCH_SIZE = 4000
+        cfg_cls.return_value = cfg
+        for cls_mock in (csv_cls, json_cls):
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.ingest = MagicMock(return_value=[])
+            cls_mock.return_value = inst
+        yield {
+            "Config": cfg_cls,
+            "Database": db_cls,
+            "APIClient": api_cls,
+            "CSVIngestor": csv_cls,
+            "JSONIngestor": json_cls,
+        }
+
+
+def test_cli_run_routes_sentence_pair_yaml_to_csv_ingestor(
+    clean_env, mock_runtime, monkeypatch
+):
+    """The shipped sentence_pair example yaml runs end-to-end-but-mocked: a
+    CSVIngestor is built with the resolved sentence_pair kwargs (TEXT, supervised
+    with label_column="label") and ingest() is called once; exit 0."""
+    monkeypatch.setenv(
+        "INGEST_CONFIG", str(EXAMPLES_DIR / "sentence_pair_classification.yaml")
+    )
+    from tracebloc_ingestor.cli.run import main
+
+    rc = main()
+
+    assert rc == 0
+    assert mock_runtime["CSVIngestor"].call_count == 1
+    assert mock_runtime["JSONIngestor"].call_count == 0
+    _, kwargs = mock_runtime["CSVIngestor"].call_args
+    assert kwargs["category"] == TaskCategory.SENTENCE_PAIR_CLASSIFICATION
+    assert kwargs["data_format"] == "text"
+    assert kwargs["label_column"] == "label"  # supervised
+    assert kwargs["file_options"]["extension"] == ".txt"
+    mock_runtime["CSVIngestor"].return_value.ingest.assert_called_once()
+
+
+def test_cli_run_rejects_sentence_pair_without_label(
+    clean_env, mock_runtime, monkeypatch, tmp_path
+):
+    """Supervised: a sentence_pair config that OMITS `label:` must be rejected at
+    the entrypoint (exit 2) before any DB/network call — the opposite of the
+    self-supervised modalities, which reject a config that SETS label."""
+    bad = tmp_path / "spc_no_label.yaml"
+    bad.write_text(
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: sentence_pair_classification\n"
+        "table: spc_test\n"
+        "intent: test\n"
+        "csv: /tmp/ignored.csv\n"
+        "texts: /tmp/ignored/\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(bad))
+    from tracebloc_ingestor.cli.run import main
+
+    rc = main()
+
+    assert rc == 2
+    mock_runtime["Database"].assert_not_called()
+    mock_runtime["APIClient"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. Validation boundaries (real filesystem)
+# ---------------------------------------------------------------------------
+
+
+def test_spc_header_only_csv_fails_before_table_creation(clean_env, tmp_path):
+    """A header-only sentence_pair manifest is rejected during validation, before
+    the destination table is created — no orphan empty table."""
+    ing, _ = _spc_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame(columns=["filename", "label"]).to_csv(csv, index=False)
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No data rows found"):
+            ing.ingest(str(csv), batch_size=10)
+    ing.database.create_table.assert_not_called()
+
+
+def test_spc_all_files_missing_fails_before_table_creation(clean_env, tmp_path):
+    """A populated manifest whose every referenced .txt is missing is rejected
+    before table creation."""
+    ing, _ = _spc_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame({"filename": ["p1", "p2"], "label": ["entailment", "neutral"]}).to_csv(
+        csv, index=False
+    )
+
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No referenced data files"):
+            ing.ingest(str(csv), batch_size=10)
+    ing.database.create_table.assert_not_called()
+
+
+def test_spc_clean_pairs_validate(clean_env, tmp_path):
+    """A clean dataset of tab-separated text_a<TAB>text_b pairs with >=2 distinct
+    labels passes validation."""
+    ing, texts = _spc_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "pair1.txt").write_text(
+        "A man plays guitar.\tSomeone makes music.\n", encoding="utf-8"
+    )
+    (texts / "pair2.txt").write_text(
+        "A man plays guitar.\tThe man is silent.\n", encoding="utf-8"
+    )
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame(
+        {"filename": ["pair1", "pair2"], "label": ["entailment", "contradiction"]}
+    ).to_csv(csv, index=False)
+
+    assert ing.validate_data(str(csv)) is True
+
+
+def test_spc_malformed_no_tab_rejected(clean_env, tmp_path):
+    """A .txt with no tab (a single sentence — valid for text_classification, NOT
+    for sentence pairs) is rejected by SentencePairValidator."""
+    ing, texts = _spc_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "ok.txt").write_text("text_a\ttext_b\n", encoding="utf-8")
+    (texts / "bad.txt").write_text("just one sentence, no tab here\n", encoding="utf-8")
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame(
+        {"filename": ["ok", "bad"], "label": ["entailment", "neutral"]}
+    ).to_csv(csv, index=False)
+
+    with pytest.raises(ValueError, match="tab-separated fields"):
+        ing.validate_data(str(csv))
+
+
+def test_spc_triplet_rejected(clean_env, tmp_path):
+    """A 3-field triplet is valid for embeddings but malformed for a sentence
+    pair — exactly 2 tab-separated fields are required."""
+    ing, texts = _spc_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "ok.txt").write_text("text_a\ttext_b\n", encoding="utf-8")
+    (texts / "bad.txt").write_text("a\tb\tc\n", encoding="utf-8")
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame(
+        {"filename": ["ok", "bad"], "label": ["entailment", "neutral"]}
+    ).to_csv(csv, index=False)
+
+    with pytest.raises(ValueError, match="tab-separated fields"):
+        ing.validate_data(str(csv))
+
+
+def test_spc_binary_content_rejected(clean_env, tmp_path):
+    """A .txt whose bytes are binary (a NUL byte) is rejected by the shared
+    TextContentValidator — the same content hygiene the other NLP modalities
+    get, here pointed at texts/."""
+    ing, texts = _spc_ingestor_on(clean_env=clean_env, tmp_path=tmp_path, records=[])
+    (texts / "ok.txt").write_text("text_a\ttext_b\n", encoding="utf-8")
+    (texts / "bad.txt").write_bytes(b"\x00\x01\x02binary")
+    csv = tmp_path / "manifest.csv"
+    pd.DataFrame(
+        {"filename": ["ok", "bad"], "label": ["entailment", "neutral"]}
+    ).to_csv(csv, index=False)
+
+    with pytest.raises(ValueError, match="NUL byte"):
+        ing.validate_data(str(csv))
+
+
+# ---------------------------------------------------------------------------
+# 3. Failure accounting
+# ---------------------------------------------------------------------------
+
+
+def test_spc_api_send_failure_counts_every_record(clean_env):
+    """Every batch POST rejected -> every sentence_pair record returns as a
+    failure, so the run exits non-zero (the file-transfer branch runs since
+    sentence_pair is file-bearing)."""
+    records = [
+        {"a": "1", "filename": "f1", "label": "entailment"},
+        {"a": "2", "filename": "f2", "label": "neutral"},
+    ]
+    ing = make_ingestor(records=records)
+    ing.api_client.send_batch.return_value = False
+
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+
+    assert len(failed) == 2
+    assert all(f["error"] == "api_send_failed" for f in failed)

--- a/tests/test_sentence_pair_validator.py
+++ b/tests/test_sentence_pair_validator.py
@@ -1,0 +1,190 @@
+"""Tests for SentencePairValidator — the structural check that each
+``sentence_pair_classification`` ``.txt`` is a tab-separated sentence pair
+(``text_a\\ttext_b``, exactly 2 non-empty fields). FileTypeValidator only checks
+the extension and TextContentValidator only checks UTF-8 decodability — neither
+sees this structure, so this validator is what rejects malformed pairs.
+
+Mirrors tests/test_contrastive_pairs_validator.py; the difference is the field
+contract: sentence pairs are EXACTLY 2 fields (a 3-field triplet, valid for
+embeddings, is malformed here).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.validators.sentence_pair_validator import (
+    SentencePairValidator,
+)
+
+
+@pytest.fixture
+def staged(clean_env, tmp_path):
+    """Return (texts_dir, make_csv) with SRC_PATH pointed at src and a texts/."""
+    src = tmp_path / "src"
+    texts = src / "texts"
+    texts.mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+
+    def make_csv(filenames, column="filename"):
+        path = tmp_path / "data.csv"
+        pd.DataFrame({column: filenames}).to_csv(path, index=False)
+        return path
+
+    return texts, make_csv
+
+
+def _validate(filenames, staged):
+    texts, make_csv = staged
+    path = make_csv(filenames)
+    return SentencePairValidator(texts_path="texts").validate(str(path))
+
+
+def test_valid_pair_passes(staged):
+    texts, make_csv = staged
+    (texts / "pair.txt").write_text(
+        "A man plays guitar.\tSomeone makes music.\n", encoding="utf-8"
+    )
+    result = _validate(["pair"], staged)
+    assert result.is_valid, result.errors
+    assert result.metadata["rows_checked"] == 1
+
+
+def test_plain_text_no_tab_rejected(staged):
+    """No tab -> one field. Valid for seq2seq/causal LM, malformed here."""
+    texts, _ = staged
+    (texts / "bad.txt").write_text("just prose, no tab at all\n", encoding="utf-8")
+    result = _validate(["bad"], staged)
+    assert not result.is_valid
+    assert any("tab-separated fields" in e and "found 1" in e for e in result.errors)
+
+
+def test_triplet_three_fields_rejected(staged):
+    """A 3-field triplet is valid for embeddings but malformed for sentence
+    pairs — exactly 2 fields are required."""
+    texts, _ = staged
+    (texts / "bad.txt").write_text("a\tb\tc\n", encoding="utf-8")
+    result = _validate(["bad"], staged)
+    assert not result.is_valid
+    assert any("found 3" in e for e in result.errors)
+
+
+def test_empty_field_rejected(staged):
+    texts, _ = staged
+    (texts / "bad.txt").write_text("text_a\t\n", encoding="utf-8")
+    result = _validate(["bad"], staged)
+    assert not result.is_valid
+    assert any("are empty" in e for e in result.errors)
+
+
+def test_whitespace_only_field_rejected(staged):
+    texts, _ = staged
+    (texts / "bad.txt").write_text("   \ttext_b\n", encoding="utf-8")
+    result = _validate(["bad"], staged)
+    assert not result.is_valid
+    assert any("are empty" in e for e in result.errors)
+
+
+def test_multiline_file_rejected(staged):
+    """The contract is one record per file; a second non-empty line is
+    malformed (several records crammed into one .txt)."""
+    texts, _ = staged
+    (texts / "bad.txt").write_text("a\tb\nc\td\n", encoding="utf-8")
+    result = _validate(["bad"], staged)
+    assert not result.is_valid
+    assert any("multiple lines" in e for e in result.errors)
+
+
+def test_trailing_newline_and_blank_lines_tolerated(staged):
+    """A trailing newline / surrounding blank lines are stripped — the record
+    itself is a single valid pair, so it passes."""
+    texts, _ = staged
+    (texts / "ok.txt").write_text("\ntext_a\ttext_b\n\n", encoding="utf-8")
+    result = _validate(["ok"], staged)
+    assert result.is_valid, result.errors
+
+
+def test_empty_file_left_to_text_content_validator(staged):
+    """An empty / whitespace-only file is the shared TextContentValidator's
+    warning to raise; the structural validator stays silent (no double-report)."""
+    texts, _ = staged
+    (texts / "empty.txt").write_text("   \n", encoding="utf-8")
+    result = _validate(["empty"], staged)
+    assert result.is_valid, result.errors
+
+
+def test_missing_file_reported(staged):
+    result = _validate(["does_not_exist"], staged)
+    assert not result.is_valid
+    assert any("not found" in e for e in result.errors)
+
+
+def test_path_traversal_manifest_value_skipped(staged):
+    """A manifest value that escapes the dataset dir (``..`` / absolute) is
+    resolved with ``_safe_join`` exactly as the transfer does (#239): the
+    transfer rejects it, so preflight neither reads nor flags a file outside
+    ``texts/`` — it is skipped here (mirrors TextContentValidator), not read
+    from disk."""
+    texts, make_csv = staged
+    outside = texts.parent.parent / "secret.txt"
+    outside.write_text("text_a\ttext_b\n", encoding="utf-8")
+    path = make_csv(["../../secret"])
+    result = SentencePairValidator(texts_path="texts").validate(str(path))
+    assert result.is_valid, result.errors
+
+
+def test_missing_filename_column_reported(staged):
+    texts, make_csv = staged
+    path = make_csv(["x"], column="wrongname")
+    result = SentencePairValidator(texts_path="texts").validate(str(path))
+    assert not result.is_valid
+    assert any("filename" in e for e in result.errors)
+
+
+def test_filename_with_explicit_extension_resolved(staged):
+    """A manifest value that already carries the extension is used as-is (mirrors
+    text_transfer's _has_extension rule), not double-suffixed."""
+    texts, make_csv = staged
+    (texts / "pair.txt").write_text("a\tb\n", encoding="utf-8")
+    path = make_csv(["pair.txt"])
+    result = SentencePairValidator(texts_path="texts").validate(str(path))
+    assert result.is_valid, result.errors
+
+
+def test_unreadable_non_utf8_file_reported(staged):
+    """A file the structural reader can't decode as UTF-8 is reported here as
+    unreadable (binary/encoding rejection itself is TextContentValidator's job,
+    but this validator must not crash on it)."""
+    texts, _ = staged
+    (texts / "bad.txt").write_bytes("Caf\xe9\tBrasil".encode("latin-1"))
+    result = _validate(["bad"], staged)
+    assert not result.is_valid
+    assert any("could not read text file" in e for e in result.errors)
+
+
+def test_unexpected_error_surfaces_as_validation_error(staged, monkeypatch):
+    """A blow-up in data loading is caught and surfaced as a failed result
+    (mirrors sibling validators) rather than escaping the validator."""
+    v = SentencePairValidator(texts_path="texts")
+    monkeypatch.setattr(
+        v, "_load_data", lambda data: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    result = v.validate("anything")
+    assert not result.is_valid
+    assert any("validation error" in e for e in result.errors)
+
+
+def test_error_cap_summarizes(staged):
+    """A wholly-malformed dataset yields a capped, actionable summary rather
+    than tens of thousands of lines (mirrors BIOLabelValidator)."""
+    texts, _ = staged
+    names = []
+    for i in range(120):
+        name = f"bad{i}"
+        (texts / f"{name}.txt").write_text("no tab here\n", encoding="utf-8")
+        names.append(name)
+    result = _validate(names, staged)
+    assert not result.is_valid
+    assert any("further errors suppressed" in e for e in result.errors)
+    assert len(result.errors) <= 51

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -58,7 +58,6 @@ from tracebloc_ingestor.utils.constants import (
 )
 from tracebloc_ingestor.utils.label_policy import BUCKET, PASSTHROUGH
 
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES_DIR = REPO_ROOT / "examples" / "yaml"
 
@@ -70,6 +69,7 @@ EXAMPLES_DIR = REPO_ROOT / "examples" / "yaml"
 # so we can control intent / label_column / data_id strategy to match the
 # template exactly.
 # ---------------------------------------------------------------------------
+
 
 def _yaml(**fields) -> Dict[str, Any]:
     """Helper: build a YAML config dict with apiVersion/kind boilerplate."""
@@ -103,11 +103,13 @@ CASES = [
             "label_policy": PASSTHROUGH,
             "unique_id_column": None,
             "annotation_column": None,
-            "file_options": {"target_size": [256, 256], "extension": FileExtension.JPEG},
+            "file_options": {
+                "target_size": [256, 256],
+                "extension": FileExtension.JPEG,
+            },
         },
         id="image_classification",
     ),
-
     # -----------------------------------------------------------------------
     # object_detection — template + convention default now align with the
     # bundled VisDrone aerial sample (1920×1080, #199). The sample is kept at
@@ -132,11 +134,13 @@ CASES = [
             "label_policy": PASSTHROUGH,
             "unique_id_column": None,
             "annotation_column": None,
-            "file_options": {"target_size": [1920, 1080], "extension": FileExtension.JPG},
+            "file_options": {
+                "target_size": [1920, 1080],
+                "extension": FileExtension.JPG,
+            },
         },
         id="object_detection",
     ),
-
     # -----------------------------------------------------------------------
     # keypoint_detection — template uses 256×256 with 9 keypoints. No
     # convention defaults for these (both dataset-specific); schema requires
@@ -171,7 +175,6 @@ CASES = [
         },
         id="keypoint_detection",
     ),
-
     # -----------------------------------------------------------------------
     # semantic_segmentation — template uses 512×512, label_column="image_label",
     # unique_id_column="filename" (opt-in).
@@ -199,7 +202,6 @@ CASES = [
         },
         id="semantic_segmentation",
     ),
-
     # -----------------------------------------------------------------------
     # text_classification — template uses extension=.txt, label_column="label"
     # -----------------------------------------------------------------------
@@ -228,7 +230,34 @@ CASES = [
         },
         id="text_classification",
     ),
-
+    # -----------------------------------------------------------------------
+    # sentence_pair_classification — SUPERVISED, like text_classification
+    # (.txt in texts/, label_column="label", extension .txt). The only on-disk
+    # difference is that each .txt holds a tab-separated text_a<TAB>text_b pair;
+    # the resolved ingestor kwargs are identical to text_classification.
+    # -----------------------------------------------------------------------
+    pytest.param(
+        _yaml(
+            category=TaskCategory.SENTENCE_PAIR_CLASSIFICATION,
+            table="sentence_pair_classification_train",
+            intent="train",
+            csv="/data/labels.csv",
+            texts="/data/texts/",
+            schema={"extra_feature": "VARCHAR(255)"},
+            label="label",
+        ),
+        {
+            "category": TaskCategory.SENTENCE_PAIR_CLASSIFICATION,
+            "data_format": DataFormat.TEXT,
+            "intent": Intent.TRAIN,
+            "label_column": "label",
+            "label_policy": PASSTHROUGH,
+            "unique_id_column": None,
+            "annotation_column": None,
+            "file_options": {"extension": FileExtension.TXT},
+        },
+        id="sentence_pair_classification",
+    ),
     # -----------------------------------------------------------------------
     # token_classification — same on-disk layout as text_classification
     # (.txt in texts/, label_column="label"); the label is a space-separated
@@ -256,7 +285,6 @@ CASES = [
         },
         id="token_classification",
     ),
-
     # -----------------------------------------------------------------------
     # masked_language_modeling — self-supervised, no label column. CSV manifest
     # points at .txt sidecar files containing space-separated token sequences;
@@ -283,7 +311,6 @@ CASES = [
         },
         id="masked_language_modeling",
     ),
-
     # -----------------------------------------------------------------------
     # causal_language_modeling — self-supervised, no label column. CSV manifest
     # points at .txt sidecar files holding RAW text (plain text or a
@@ -311,7 +338,6 @@ CASES = [
         },
         id="causal_language_modeling",
     ),
-
     # -----------------------------------------------------------------------
     # seq2seq — self-supervised, no label column. CSV manifest points at .txt
     # sidecar files holding RAW text (a source<TAB>target pair); the client
@@ -339,7 +365,6 @@ CASES = [
         },
         id="seq2seq",
     ),
-
     # -----------------------------------------------------------------------
     # embeddings — self-supervised (contrastive), no label column. CSV manifest
     # points at .txt sidecar files holding RAW text (an anchor<TAB>positive pair
@@ -367,7 +392,6 @@ CASES = [
         },
         id="embeddings",
     ),
-
     # -----------------------------------------------------------------------
     # tabular_classification — template label_column="name"
     # -----------------------------------------------------------------------
@@ -394,7 +418,6 @@ CASES = [
         },
         id="tabular_classification",
     ),
-
     # -----------------------------------------------------------------------
     # tabular_regression — regression-class, label_policy MUST be bucket
     # (#44 deliberate behavior change vs template's raw passthrough).
@@ -424,7 +447,6 @@ CASES = [
         },
         id="tabular_regression",
     ),
-
     # -----------------------------------------------------------------------
     # time_series_forecasting — regression-class, label_policy=bucket.
     # Template label_column="max_magnitude".
@@ -454,7 +476,6 @@ CASES = [
         },
         id="time_series_forecasting",
     ),
-
     # -----------------------------------------------------------------------
     # time_to_event_prediction — regression-class, label_policy=bucket,
     # plus time_column="time" (template's value).
@@ -509,15 +530,17 @@ def test_yaml_resolves_to_template_equivalent_kwargs(yaml_config, expected):
 # All existing templates have a YAML equivalent that's exercisable here.
 # ---------------------------------------------------------------------------
 
+
 def test_every_existing_template_has_a_case():
     """The acceptance criterion enumerates 'seven existing templates plus
     segmentation' (= 8). The repo also added keypoint_detection (+1 = 9).
     Every template directory under templates/ must have a parametrized
     case in this file."""
-    template_dirs = sorted(p.name for p in (REPO_ROOT / "templates").iterdir() if p.is_dir())
+    template_dirs = sorted(
+        p.name for p in (REPO_ROOT / "templates").iterdir() if p.is_dir()
+    )
     template_categories = {
-        d for d in template_dirs
-        if d != "example_data"  # the only non-template dir
+        d for d in template_dirs if d != "example_data"  # the only non-template dir
     }
 
     case_categories = {c.values[0]["category"] for c in CASES}
@@ -534,6 +557,7 @@ def test_every_existing_template_has_a_case():
 # and the same kwargs land on the ingestor constructor.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize("yaml_config,expected", CASES)
 def test_yaml_config_reaches_ingestor_via_entrypoint(
     yaml_config, expected, tmp_path, monkeypatch
@@ -544,12 +568,15 @@ def test_yaml_config_reaches_ingestor_via_entrypoint(
     cfg_file.write_text(yaml.safe_dump(yaml_config), encoding="utf-8")
     monkeypatch.setenv("INGEST_CONFIG", str(cfg_file))
 
-    with patch("tracebloc_ingestor.cli.run.Config") as mock_config_cls, \
-         patch("tracebloc_ingestor.cli.run.Database"), \
-         patch("tracebloc_ingestor.cli.run.APIClient"), \
-         patch("tracebloc_ingestor.cli.run.CSVIngestor") as mock_csv_cls, \
-         patch("tracebloc_ingestor.cli.run.JSONIngestor") as mock_json_cls, \
-         patch("tracebloc_ingestor.cli.run.setup_logging"):
+    with patch("tracebloc_ingestor.cli.run.Config") as mock_config_cls, patch(
+        "tracebloc_ingestor.cli.run.Database"
+    ), patch("tracebloc_ingestor.cli.run.APIClient"), patch(
+        "tracebloc_ingestor.cli.run.CSVIngestor"
+    ) as mock_csv_cls, patch(
+        "tracebloc_ingestor.cli.run.JSONIngestor"
+    ) as mock_json_cls, patch(
+        "tracebloc_ingestor.cli.run.setup_logging"
+    ):
         mock_config = MagicMock()
         mock_config.BATCH_SIZE = 4000
         mock_config_cls.return_value = mock_config
@@ -561,13 +588,14 @@ def test_yaml_config_reaches_ingestor_via_entrypoint(
             cls_mock.return_value = inst
 
         from tracebloc_ingestor.cli.run import main
+
         rc = main()
 
     assert rc == 0
     # All current cases use csv source; assert CSV path was taken.
-    assert mock_csv_cls.call_count == 1, (
-        f"expected CSVIngestor for {yaml_config['category']}, got {mock_csv_cls.call_count} call(s)"
-    )
+    assert (
+        mock_csv_cls.call_count == 1
+    ), f"expected CSVIngestor for {yaml_config['category']}, got {mock_csv_cls.call_count} call(s)"
 
     _, kwargs = mock_csv_cls.call_args
     for key, want in expected.items():

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -118,6 +118,7 @@ def test_classification_categories_include_label_diversity():
         TaskCategory.KEYPOINT_DETECTION,
         TaskCategory.TABULAR_CLASSIFICATION,
         TaskCategory.TEXT_CLASSIFICATION,
+        TaskCategory.SENTENCE_PAIR_CLASSIFICATION,
     ):
         assert LabelDiversityValidator in _types(map_validators(cat, IMAGE_OPTS)), cat
 
@@ -369,6 +370,7 @@ def test_nlp_categories_include_content_hygiene_validators():
     for cat in (
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
+        TaskCategory.SENTENCE_PAIR_CLASSIFICATION,
         TaskCategory.MASKED_LANGUAGE_MODELING,
         TaskCategory.CAUSAL_LANGUAGE_MODELING,
         TaskCategory.SEQ2SEQ,
@@ -449,9 +451,7 @@ def test_causal_lm_excludes_all_label_validators():
 
 
 def test_causal_lm_with_schema_adds_data_validator():
-    v = map_validators(
-        TaskCategory.CAUSAL_LANGUAGE_MODELING, {"schema": {"a": "INT"}}
-    )
+    v = map_validators(TaskCategory.CAUSAL_LANGUAGE_MODELING, {"schema": {"a": "INT"}})
     assert DataValidator in _types(v)
 
 
@@ -561,6 +561,83 @@ def test_embeddings_excludes_all_label_validators():
 
 def test_embeddings_with_schema_adds_data_validator():
     v = map_validators(TaskCategory.EMBEDDINGS, {"schema": {"a": "INT"}})
+    assert DataValidator in _types(v)
+
+
+def test_sentence_pair_content_validators_target_texts_subdir():
+    """sentence_pair_classification stages RAW text under ``texts/`` (the same
+    layout as text_classification); the content validators must point there."""
+    from tracebloc_ingestor.validators.ingestable_records_validator import (
+        IngestableRecordsValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    v = map_validators(TaskCategory.SENTENCE_PAIR_CLASSIFICATION, {})
+    rec = next(x for x in v if isinstance(x, IngestableRecordsValidator))
+    txt = next(x for x in v if isinstance(x, TextContentValidator))
+    assert rec.file_subdir == "texts"
+    assert txt.texts_path == "texts"
+
+
+def test_sentence_pair_includes_structural_and_label_validators():
+    """sentence_pair carries the structural SentencePairValidator (the exactly-2
+    tab-fields check) ON TOP of the shared content hygiene — that structural
+    check is what distinguishes it from text_classification (free-form text). As
+    a SUPERVISED category it also keeps LabelColumnValidator, which must run
+    BEFORE the (centrally-composed) LabelDiversityValidator."""
+    from tracebloc_ingestor.validators.sentence_pair_validator import (
+        SentencePairValidator,
+    )
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+    from tracebloc_ingestor.validators.text_content_validator import (
+        TextContentValidator,
+    )
+
+    types = _types(map_validators(TaskCategory.SENTENCE_PAIR_CLASSIFICATION, {}))
+    assert SentencePairValidator in types
+    assert TextContentValidator in types
+    assert LabelColumnValidator in types
+    assert types.index(LabelColumnValidator) < types.index(LabelDiversityValidator)
+    # text_classification does NOT structurally constrain its .txt content.
+    assert SentencePairValidator not in _types(
+        map_validators(TaskCategory.TEXT_CLASSIFICATION, {})
+    )
+
+
+def test_sentence_pair_threads_custom_extension_to_structural_validator():
+    """A custom extension reaches the structural validator so the resolved path
+    matches what text_transfer copies."""
+    from tracebloc_ingestor.validators.sentence_pair_validator import (
+        SentencePairValidator,
+    )
+
+    v = map_validators(
+        TaskCategory.SENTENCE_PAIR_CLASSIFICATION, {"extension": ".text"}
+    )
+    sp = next(x for x in v if isinstance(x, SentencePairValidator))
+    assert sp.extension == ".text"
+
+
+def test_sentence_pair_threads_custom_label_column():
+    from tracebloc_ingestor.validators.label_column_validator import (
+        LabelColumnValidator,
+    )
+
+    v = map_validators(
+        TaskCategory.SENTENCE_PAIR_CLASSIFICATION, {"label_column": "relation"}
+    )
+    lc = next(x for x in v if isinstance(x, LabelColumnValidator))
+    assert lc.label_column == "relation"
+
+
+def test_sentence_pair_with_schema_adds_data_validator():
+    v = map_validators(
+        TaskCategory.SENTENCE_PAIR_CLASSIFICATION, {"schema": {"a": "INT"}}
+    )
     assert DataValidator in _types(v)
 
 

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -49,10 +49,13 @@ IMAGE_CATEGORIES: FrozenSet[str] = frozenset(
 # text/token classification here (they read raw text, not the pre-tokenized
 # ``sequences/`` MLM uses); they are self-supervised, but that only governs
 # label handling, not the file_options default this set drives.
+# sentence_pair_classification also belongs here — supervised, but its .txt is
+# still raw text (a tab-separated ``text_a\ttext_b`` pair) staged from ``texts/``.
 TEXT_CATEGORIES: FrozenSet[str] = frozenset(
     {
         TaskCategory.TEXT_CLASSIFICATION,
         TaskCategory.TOKEN_CLASSIFICATION,
+        TaskCategory.SENTENCE_PAIR_CLASSIFICATION,
         TaskCategory.CAUSAL_LANGUAGE_MODELING,
         TaskCategory.SEQ2SEQ,
         TaskCategory.EMBEDDINGS,

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -91,6 +91,27 @@ _SPECS = (
         is_nlp=True,
         file_subdir="texts",
     ),
+    # sentence_pair_classification is SUPERVISED text classification — the class
+    # label travels in the labels CSV, exactly like text_classification (so
+    # is_classification=True, is_self_supervised=False, staged from ``texts/``).
+    # What's distinct is the on-disk shape: each ``.txt`` is a STRUCTURED
+    # tab-separated ``text_a\ttext_b`` sentence pair (the text_classification
+    # layout with a tab separating the pair), so its validator factory adds a
+    # structural SentencePairValidator that rejects malformed files. It is NLP,
+    # so it ships the #805 data-derived text profile for the
+    # contributor-tokenizer-fit check.
+    ModalitySpec(
+        TaskCategory.SENTENCE_PAIR_CLASSIFICATION,
+        is_file_bearing=True,
+        is_tabular_family=False,
+        is_self_supervised=False,
+        data_format=DataFormat.TEXT,
+        build_validators=v.sentence_pair_classification,
+        transfer=t.sentence_pair_classification,
+        is_nlp=True,
+        file_subdir="texts",
+        is_classification=True,
+    ),
     # masked_language_modeling is file-bearing AND self-supervised (no label).
     ModalitySpec(
         TaskCategory.MASKED_LANGUAGE_MODELING,

--- a/tracebloc_ingestor/modalities/transfer.py
+++ b/tracebloc_ingestor/modalities/transfer.py
@@ -100,6 +100,16 @@ def token_classification(
     return text_transfer(record, options, cfg=cfg)
 
 
+def sentence_pair_classification(
+    record: Dict[str, Any], options: Dict[str, Any], cfg: Optional[Config] = None
+) -> Optional[Dict[str, Any]]:
+    # Same on-disk layout as text classification: one .txt per sample in the
+    # ``texts`` subdir. Supervised — the class label travels in the labels CSV,
+    # not on disk; the .txt holds a tab-separated ``text_a\ttext_b`` sentence
+    # pair (the default text_transfer subdir).
+    return text_transfer(record, options, cfg=cfg)
+
+
 def masked_language_modeling(
     record: Dict[str, Any], options: Dict[str, Any], cfg: Optional[Config] = None
 ) -> Optional[Dict[str, Any]]:

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -34,6 +34,7 @@ from ..validators.keypoint_visibility_validator import KeypointVisibilityValidat
 from ..validators.label_column_validator import LabelColumnValidator
 from ..validators.label_diversity_validator import LabelDiversityValidator
 from ..validators.numeric_columns_validator import NumericColumnsValidator
+from ..validators.sentence_pair_validator import SentencePairValidator
 from ..validators.text_content_validator import TextContentValidator
 from ..validators.time_before_today_validator import TimeBeforeTodayValidator
 from ..validators.time_format_validator import TimeFormatValidator
@@ -187,6 +188,36 @@ def token_classification(options: Dict[str, Any]) -> List[BaseValidator]:
             extension=options.get("extension", FileExtension.TXT),
             label_column=options.get("label_column") or "label",
         ),
+    ]
+    if options.get("schema"):
+        validators.append(DataValidator(schema=options["schema"]))
+    return validators
+
+
+def sentence_pair_classification(options: Dict[str, Any]) -> List[BaseValidator]:
+    # SUPERVISED text classification (the class label travels in the labels CSV,
+    # exactly like text_classification) — so it carries the same FileType +
+    # content + LabelColumn validators, and map_validators adds LabelDiversity
+    # (is_classification) + DataValidator (with a schema) around them. What's
+    # DISTINCT: each .txt is a STRUCTURED tab-separated ``text_a\ttext_b`` pair,
+    # so beyond the shared TextContentValidator (UTF-8/binary hygiene) it adds a
+    # centralized SentencePairValidator that rejects any file that isn't exactly
+    # 2 non-empty tab fields (no plain prose, no empty side, one record/file).
+    validators: List[BaseValidator] = [
+        FileTypeValidator(
+            allowed_extension=options.get("extension", FileExtension.TXT),
+            path="texts",
+        ),
+        _text_content_validator(options, "texts"),
+        SentencePairValidator(
+            texts_path="texts",
+            extension=options.get("extension", FileExtension.TXT),
+        ),
+        # Fail fast when the configured label column is absent from the CSV
+        # header (otherwise every record cleans to label=None and the backend
+        # rejects each row with HTTP 400 "label: may not be null") — same as
+        # text_classification.
+        LabelColumnValidator(label_column=options.get("label_column") or "label"),
     ]
     if options.get("schema"):
         validators.append(DataValidator(schema=options["schema"]))

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -32,6 +32,7 @@
         "semantic_segmentation",
         "text_classification",
         "token_classification",
+        "sentence_pair_classification",
         "tabular_classification",
         "tabular_regression",
         "time_series_forecasting",
@@ -89,7 +90,7 @@
     "texts": {
       "type": "string",
       "minLength": 1,
-      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification, token_classification, causal_language_modeling (raw .txt: plain text, or a tab-separated prompt\\tcompletion pair), seq2seq (raw .txt: a tab-separated source\\ttarget pair), and embeddings (raw .txt: a tab-separated anchor\\tpositive pair, or anchor\\tpositive\\tnegative triplet)."
+      "description": "Directory holding text files referenced by the labels CSV. Required for text_classification, token_classification, sentence_pair_classification (raw .txt: a tab-separated text_a\\ttext_b sentence pair), causal_language_modeling (raw .txt: plain text, or a tab-separated prompt\\tcompletion pair), seq2seq (raw .txt: a tab-separated source\\ttarget pair), and embeddings (raw .txt: a tab-separated anchor\\tpositive pair, or anchor\\tpositive\\tnegative triplet)."
     },
 
     "sequences": {
@@ -332,6 +333,14 @@
       "then": { "required": ["texts"] }
     },
     {
+      "description": "sentence_pair_classification requires `texts` (raw .txt samples, each a tab-separated text_a\\ttext_b sentence pair). It is supervised, so it also requires `label` (see the label rule below).",
+      "if": {
+        "properties": { "category": { "const": "sentence_pair_classification" } },
+        "required": ["category"]
+      },
+      "then": { "required": ["texts"] }
+    },
+    {
       "description": "masked_language_modeling requires `sequences`.",
       "if": {
         "properties": { "category": { "const": "masked_language_modeling" } },
@@ -424,6 +433,7 @@
               "semantic_segmentation",
               "text_classification",
               "token_classification",
+              "sentence_pair_classification",
               "tabular_classification"
             ]
           }

--- a/tracebloc_ingestor/utils/constants.py
+++ b/tracebloc_ingestor/utils/constants.py
@@ -40,6 +40,7 @@ class TaskCategory:
     KEYPOINT_DETECTION = "keypoint_detection"
     TEXT_CLASSIFICATION = "text_classification"
     TOKEN_CLASSIFICATION = "token_classification"
+    SENTENCE_PAIR_CLASSIFICATION = "sentence_pair_classification"
     TABULAR_CLASSIFICATION = "tabular_classification"
     TABULAR_REGRESSION = "tabular_regression"
     TIME_SERIES_FORECASTING = "time_series_forecasting"
@@ -70,6 +71,7 @@ class TaskCategory:
             cls.KEYPOINT_DETECTION,
             cls.TEXT_CLASSIFICATION,
             cls.TOKEN_CLASSIFICATION,
+            cls.SENTENCE_PAIR_CLASSIFICATION,
             cls.TABULAR_CLASSIFICATION,
             cls.TABULAR_REGRESSION,
             cls.TIME_SERIES_FORECASTING,

--- a/tracebloc_ingestor/validators/contrastive_pairs_validator.py
+++ b/tracebloc_ingestor/validators/contrastive_pairs_validator.py
@@ -16,43 +16,28 @@ training client would silently mis-split it into the wrong number of views. So
 we reject it here, against the dataset author, rather than letting it corrupt
 training.
 
-``FileTypeValidator`` only checks the extension and ``TextContentValidator``
-only checks UTF-8 decodability — neither sees this structure — so this is the
-dedicated structural validator, mirroring ``BIOLabelValidator`` for token
-classification. UTF-8 / binary hygiene stays the shared
-``TextContentValidator``'s job; emptiness it already warns about, so an
-empty / whitespace-only file is left untouched here (no double reporting).
+The manifest walk, path resolution and record-level checks live in the shared
+:class:`~tracebloc_ingestor.validators.tab_separated_record_validator.TabSeparatedRecordValidator`
+base (also used by ``sentence_pair_classification``); this subclass only pins
+the pair-or-triplet field contract and its phrasing. UTF-8 / binary hygiene
+stays the shared ``TextContentValidator``'s job; emptiness it already warns
+about, so an empty / whitespace-only file is left untouched here (no double
+reporting).
 """
 
-import logging
-import os
-from typing import Any, List, Optional, Tuple
+from typing import Tuple
 
-from ..config import Config
-from ..file_transfer import _has_extension, _safe_join
 from ..utils.constants import FileExtension
-from .base import BaseValidator, ValidationResult
-
-config = Config()
-logger = logging.getLogger(__name__)
-logger.setLevel(config.LOG_LEVEL)
-
-# Cap per-row errors so a wholly-malformed dataset yields an actionable summary
-# rather than tens of thousands of lines (mirrors BIOLabelValidator).
-_MAX_REPORTED_ERRORS = 50
+from .tab_separated_record_validator import TabSeparatedRecordValidator
 
 
-class ContrastivePairsValidator(BaseValidator):
-    """Validate that each referenced ``.txt`` is a tab-separated contrastive
-    pair or triplet.
-
-    Attributes:
-        texts_path: Subdirectory under ``SRC_PATH`` holding the ``.txt`` files
-            (``"texts"`` for embeddings; mirrors ``FileTypeValidator(path=...)``).
-        extension: Expected text-file extension (default ``.txt``).
-        filename_column: CSV column naming each sample's file (default
-            ``"filename"``; resolved case-insensitively).
+class ContrastivePairsValidator(TabSeparatedRecordValidator):
+    """Validate that each referenced ``embeddings`` ``.txt`` is a tab-separated
+    pair (``anchor<TAB>positive``) or triplet (``anchor<TAB>positive<TAB>negative``).
     """
+
+    ALLOWED_FIELD_COUNTS: Tuple[int, ...] = (2, 3)
+    _ERROR_NOUN = "contrastive pairs"
 
     def __init__(
         self,
@@ -61,144 +46,21 @@ class ContrastivePairsValidator(BaseValidator):
         filename_column: str = "filename",
         name: str = "Contrastive Pairs",
     ):
-        super().__init__(name)
-        self.texts_path = texts_path
-        ext = extension or FileExtension.TXT
-        self.extension = ext if ext.startswith(".") else f".{ext}"
-        self.filename_column = filename_column
-
-    def validate(self, data: Any, **kwargs) -> ValidationResult:
-        try:
-            df = self._load_data(data)
-            if df is None or df.empty:
-                # Nothing to inspect; the empty-CSV case is the
-                # IngestableRecordsValidator's job, not this one.
-                return self._create_result(is_valid=True, metadata={"rows_checked": 0})
-
-            filename_col = self._resolve_column(df, self.filename_column)
-            if filename_col is None:
-                return self._create_result(
-                    is_valid=False,
-                    errors=[f"Missing required column: {self.filename_column}"],
-                )
-
-            src_root = (self._config or config).SRC_PATH
-            errors: List[str] = []
-            checked = 0
-            for idx, row in df.iterrows():
-                if len(errors) >= _MAX_REPORTED_ERRORS:
-                    errors.append("... further errors suppressed.")
-                    break
-                checked += 1
-                error = self._validate_row(row, idx, filename_col, src_root)
-                if error:
-                    errors.append(error)
-
-            return self._create_result(
-                is_valid=len(errors) == 0,
-                errors=errors,
-                metadata={"rows_checked": checked},
-            )
-
-        except Exception as e:  # noqa: BLE001 — mirror sibling validators
-            logger.error(f"Error during contrastive pairs validation: {str(e)}")
-            return self._create_result(
-                is_valid=False,
-                errors=[f"Contrastive pairs validation error: {str(e)}"],
-            )
-
-    def _validate_row(
-        self,
-        row: Any,
-        idx: Any,
-        filename_col: str,
-        src_root: str,
-    ) -> Optional[str]:
-        row_label = f"Row {idx}"
-        filename = str(row[filename_col])
-
-        # Resolve the .txt with text_transfer's exact rule (shared
-        # _has_extension): append the extension only when the CSV filename has
-        # none. Deterministic on purpose — probing the filesystem for
-        # alternatives here could validate one file while text_transfer copies a
-        # different one.
-        resolved = (
-            filename if _has_extension(filename) else f"{filename}{self.extension}"
+        super().__init__(
+            texts_path=texts_path,
+            extension=extension,
+            filename_column=filename_column,
+            name=name,
         )
-        # Resolve as the transfer does (``_safe_join`` under SRC_PATH), so
-        # preflight can't disagree with copy behavior: an absolute / ``..``
-        # manifest value is rejected by the transfer (#239), so we neither read
-        # nor flag a file outside the dataset dir — its missing-ness is the
-        # records validator's job. Mirrors TextContentValidator.
-        try:
-            text_path = _safe_join(src_root, self.texts_path, resolved)
-        except ValueError:
-            return None
-        if not os.path.isfile(text_path):
-            return (
-                f"{row_label}: text file not found at "
-                f"'{self.texts_path}/{resolved}'."
-            )
 
-        try:
-            with open(text_path, "r", encoding="utf-8") as f:
-                content = f.read()
-        except (OSError, UnicodeDecodeError) as e:
-            # Binary / non-UTF-8 content is the shared TextContentValidator's
-            # job to report; here we just can't structurally check it, so skip.
-            return f"{row_label} ('{filename}'): could not read text file: {e}"
+    def _expected_fields_phrase(self) -> str:
+        return "2 (anchor<TAB>positive) or 3 (anchor<TAB>positive<TAB>negative)"
 
-        return self._check_structure(content, filename, row_label)
+    def _multiline_hint(self) -> str:
+        return (
+            "Put one 'anchor<TAB>positive' pair (or "
+            "'anchor<TAB>positive<TAB>negative' triplet) per .txt."
+        )
 
-    @staticmethod
-    def _check_structure(
-        content: str, filename: str, row_label: str
-    ) -> Optional[str]:
-        """Return an error message if ``content`` is not a single-line
-        tab-separated pair/triplet, else ``None``.
-
-        An empty / whitespace-only file is left to the shared
-        TextContentValidator (which warns), so it returns ``None`` here.
-        """
-        # Drop only surrounding blank lines / trailing newline — NOT interior
-        # tabs (a leading/trailing empty field must still be caught below).
-        record = content.strip("\r\n")
-        if not record.strip():
-            return None  # empty — TextContentValidator's warning, not ours.
-
-        # The contract is ONE record per file. A surviving interior line break
-        # means several records were crammed into one file (or a field contains
-        # a newline) — ambiguous for the single-sample-per-file contract.
-        if "\n" in record or "\r" in record:
-            return (
-                f"{row_label} ('{filename}'): expected a single tab-separated "
-                f"record but the file spans multiple lines. Put one "
-                f"'anchor<TAB>positive' pair (or "
-                f"'anchor<TAB>positive<TAB>negative' triplet) per .txt."
-            )
-
-        parts = record.split("\t")
-        if len(parts) not in (2, 3):
-            return (
-                f"{row_label} ('{filename}'): expected 2 (anchor<TAB>positive) "
-                f"or 3 (anchor<TAB>positive<TAB>negative) tab-separated fields, "
-                f"found {len(parts)}. Separate each field with exactly one tab."
-            )
-
-        empties = [i + 1 for i, p in enumerate(parts) if not p.strip()]
-        if empties:
-            return (
-                f"{row_label} ('{filename}'): field(s) {empties} are empty — "
-                f"every field (anchor, positive{', negative' if len(parts) == 3 else ''}) "
-                f"must be non-empty."
-            )
-
-        return None
-
-    @staticmethod
-    def _resolve_column(df: Any, name: str) -> Optional[str]:
-        """Return the actual column name matching ``name`` case-insensitively."""
-        if name in df.columns:
-            return name
-        lowered = {c.lower(): c for c in df.columns}
-        return lowered.get(name.lower())
+    def _field_names(self, count: int) -> str:
+        return f"anchor, positive{', negative' if count == 3 else ''}"

--- a/tracebloc_ingestor/validators/sentence_pair_validator.py
+++ b/tracebloc_ingestor/validators/sentence_pair_validator.py
@@ -1,0 +1,60 @@
+"""Sentence-Pair Validator Module.
+
+Structural check for the ``sentence_pair_classification`` modality.
+
+sentence_pair_classification is SUPERVISED text classification (the class label
+travels in the labels CSV, exactly like ``text_classification``), but each
+``.txt`` holds a STRICT on-disk shape: a single tab-separated pair of sentences
+
+    text_a<TAB>text_b                                   (exactly 2 fields).
+
+This is the ``text_classification`` layout with a tab separating the two
+sentences of the pair. A file that isn't exactly 2 non-empty tab fields (e.g.
+plain prose with no tab, an empty side, or several records crammed into one
+file) is malformed: the training client would fail to split it into the two
+sentences the model encodes as a pair. So we reject it here, against the dataset
+author, rather than letting it corrupt training.
+
+The manifest walk, path resolution and record-level checks live in the shared
+:class:`~tracebloc_ingestor.validators.tab_separated_record_validator.TabSeparatedRecordValidator`
+base (also used by ``embeddings``); this subclass only pins the exactly-a-pair
+field contract and its phrasing. UTF-8 / binary hygiene stays the shared
+``TextContentValidator``'s job; emptiness it already warns about, so an empty /
+whitespace-only file is left untouched here (no double reporting).
+"""
+
+from typing import Tuple
+
+from ..utils.constants import FileExtension
+from .tab_separated_record_validator import TabSeparatedRecordValidator
+
+
+class SentencePairValidator(TabSeparatedRecordValidator):
+    """Validate that each referenced ``sentence_pair_classification`` ``.txt`` is
+    a tab-separated sentence pair (``text_a<TAB>text_b``)."""
+
+    ALLOWED_FIELD_COUNTS: Tuple[int, ...] = (2,)
+    _ERROR_NOUN = "sentence pair"
+
+    def __init__(
+        self,
+        texts_path: str = "texts",
+        extension: str = FileExtension.TXT,
+        filename_column: str = "filename",
+        name: str = "Sentence Pair",
+    ):
+        super().__init__(
+            texts_path=texts_path,
+            extension=extension,
+            filename_column=filename_column,
+            name=name,
+        )
+
+    def _expected_fields_phrase(self) -> str:
+        return "exactly 2 (text_a<TAB>text_b)"
+
+    def _multiline_hint(self) -> str:
+        return "Put one 'text_a<TAB>text_b' sentence pair per .txt."
+
+    def _field_names(self, count: int) -> str:
+        return "text_a, text_b"

--- a/tracebloc_ingestor/validators/tab_separated_record_validator.py
+++ b/tracebloc_ingestor/validators/tab_separated_record_validator.py
@@ -1,0 +1,229 @@
+"""Tab-Separated Record Validator base.
+
+Shared structural check for the NLP modalities whose ``.txt`` samples are a
+single tab-separated record with a fixed number of non-empty fields:
+
+- ``embeddings`` — a ``anchor<TAB>positive`` pair OR
+  ``anchor<TAB>positive<TAB>negative`` triplet (2 or 3 fields), via
+  :class:`~tracebloc_ingestor.validators.contrastive_pairs_validator.ContrastivePairsValidator`.
+- ``sentence_pair_classification`` — a ``text_a<TAB>text_b`` pair (exactly 2
+  fields), via
+  :class:`~tracebloc_ingestor.validators.sentence_pair_validator.SentencePairValidator`.
+
+``FileTypeValidator`` only checks the extension and ``TextContentValidator``
+only checks UTF-8 decodability — neither sees this structure. This base does the
+manifest walk, path resolution (shared ``_safe_join`` — so preflight can't
+disagree with what the transfer copies, #239), reading and the record-level
+checks (single line, allowed field count, non-empty fields). Subclasses supply
+only the modality-specific field contract (allowed counts + the phrasing used in
+error messages), so the scaffold lives once instead of being copy-pasted per
+modality.
+
+UTF-8 / binary hygiene stays ``TextContentValidator``'s job; emptiness it
+already warns about, so an empty / whitespace-only file is left untouched here
+(no double reporting), exactly like the per-modality subclasses used to do.
+"""
+
+import logging
+import os
+from typing import Any, List, Optional, Tuple
+
+from ..config import Config
+from ..file_transfer import _has_extension, _safe_join
+from ..utils.constants import FileExtension
+from .base import BaseValidator, ValidationResult
+
+config = Config()
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+# Cap per-row errors so a wholly-malformed dataset yields an actionable summary
+# rather than tens of thousands of lines (mirrors BIOLabelValidator).
+_MAX_REPORTED_ERRORS = 50
+
+
+class TabSeparatedRecordValidator(BaseValidator):
+    """Validate that each referenced ``.txt`` is a single tab-separated record
+    with an allowed number of non-empty fields.
+
+    Template-method base: the manifest walk, path resolution, reading and the
+    record-level checks live here; subclasses configure the field contract via
+    :attr:`ALLOWED_FIELD_COUNTS` and the three phrasing hooks below.
+
+    Attributes:
+        texts_path: Subdirectory under ``SRC_PATH`` holding the ``.txt`` files
+            (``"texts"``; mirrors ``FileTypeValidator(path=...)``).
+        extension: Expected text-file extension (default ``.txt``).
+        filename_column: CSV column naming each sample's file (default
+            ``"filename"``; resolved case-insensitively).
+    """
+
+    #: Field counts a valid record may have. Subclasses override (e.g. ``(2, 3)``
+    #: for pair-or-triplet, ``(2,)`` for exactly-a-pair).
+    ALLOWED_FIELD_COUNTS: Tuple[int, ...] = ()
+    #: Noun used in the "…" validation-error / log messages (lower-case).
+    _ERROR_NOUN: str = "tab-separated record"
+
+    def __init__(
+        self,
+        texts_path: str = "texts",
+        extension: str = FileExtension.TXT,
+        filename_column: str = "filename",
+        name: str = "Tab-Separated Record",
+    ):
+        super().__init__(name)
+        self.texts_path = texts_path
+        ext = extension or FileExtension.TXT
+        self.extension = ext if ext.startswith(".") else f".{ext}"
+        self.filename_column = filename_column
+
+    # -- modality-specific phrasing hooks --------------------------------------
+
+    def _expected_fields_phrase(self) -> str:
+        """The field-count clause used in the wrong-count error, e.g.
+        ``"2 (anchor<TAB>positive) or 3 (anchor<TAB>positive<TAB>negative)"``."""
+        raise NotImplementedError
+
+    def _multiline_hint(self) -> str:
+        """The one-record-per-file remediation hint used in the multi-line
+        error, e.g. ``"Put one 'anchor<TAB>positive' pair … per .txt."``."""
+        raise NotImplementedError
+
+    def _field_names(self, count: int) -> str:
+        """Comma-joined field names for a record of ``count`` fields, used in
+        the empty-field error, e.g. ``"anchor, positive"``."""
+        raise NotImplementedError
+
+    # -- shared scaffold -------------------------------------------------------
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            df = self._load_data(data)
+            if df is None or df.empty:
+                # Nothing to inspect; the empty-CSV case is the
+                # IngestableRecordsValidator's job, not this one.
+                return self._create_result(is_valid=True, metadata={"rows_checked": 0})
+
+            filename_col = self._resolve_column(df, self.filename_column)
+            if filename_col is None:
+                return self._create_result(
+                    is_valid=False,
+                    errors=[f"Missing required column: {self.filename_column}"],
+                )
+
+            src_root = (self._config or config).SRC_PATH
+            errors: List[str] = []
+            checked = 0
+            for idx, row in df.iterrows():
+                if len(errors) >= _MAX_REPORTED_ERRORS:
+                    errors.append("... further errors suppressed.")
+                    break
+                checked += 1
+                error = self._validate_row(row, idx, filename_col, src_root)
+                if error:
+                    errors.append(error)
+
+            return self._create_result(
+                is_valid=len(errors) == 0,
+                errors=errors,
+                metadata={"rows_checked": checked},
+            )
+
+        except Exception as e:  # noqa: BLE001 — mirror sibling validators
+            logger.error(f"Error during {self._ERROR_NOUN} validation: {str(e)}")
+            return self._create_result(
+                is_valid=False,
+                errors=[f"{self._ERROR_NOUN.capitalize()} validation error: {str(e)}"],
+            )
+
+    def _validate_row(
+        self,
+        row: Any,
+        idx: Any,
+        filename_col: str,
+        src_root: str,
+    ) -> Optional[str]:
+        row_label = f"Row {idx}"
+        filename = str(row[filename_col])
+
+        # Resolve the .txt with text_transfer's exact rule (shared
+        # _has_extension): append the extension only when the CSV filename has
+        # none. Deterministic on purpose — probing the filesystem for
+        # alternatives here could validate one file while text_transfer copies a
+        # different one.
+        resolved = (
+            filename if _has_extension(filename) else f"{filename}{self.extension}"
+        )
+        # Resolve as the transfer does (``_safe_join`` under SRC_PATH), so
+        # preflight can't disagree with copy behavior: an absolute / ``..``
+        # manifest value is rejected by the transfer (#239), so we neither read
+        # nor flag a file outside the dataset dir — its missing-ness is the
+        # records validator's job. Mirrors TextContentValidator.
+        try:
+            text_path = _safe_join(src_root, self.texts_path, resolved)
+        except ValueError:
+            return None
+        if not os.path.isfile(text_path):
+            return (
+                f"{row_label}: text file not found at "
+                f"'{self.texts_path}/{resolved}'."
+            )
+
+        try:
+            with open(text_path, "r", encoding="utf-8") as f:
+                content = f.read()
+        except (OSError, UnicodeDecodeError) as e:
+            # Binary / non-UTF-8 content is the shared TextContentValidator's
+            # job to report; here we just can't structurally check it, so skip.
+            return f"{row_label} ('{filename}'): could not read text file: {e}"
+
+        return self._check_structure(content, filename, row_label)
+
+    def _check_structure(
+        self, content: str, filename: str, row_label: str
+    ) -> Optional[str]:
+        """Return an error message if ``content`` is not a single-line
+        tab-separated record with an allowed field count, else ``None``.
+
+        An empty / whitespace-only file is left to the shared
+        TextContentValidator (which warns), so it returns ``None`` here.
+        """
+        # Drop only surrounding blank lines / trailing newline — NOT interior
+        # tabs (a leading/trailing empty field must still be caught below).
+        record = content.strip("\r\n")
+        if not record.strip():
+            return None  # empty — TextContentValidator's warning, not ours.
+
+        # The contract is ONE record per file. A surviving interior line break
+        # means several records were crammed into one file (or a field contains
+        # a newline) — ambiguous for the single-sample-per-file contract.
+        if "\n" in record or "\r" in record:
+            return (
+                f"{row_label} ('{filename}'): expected a single tab-separated "
+                f"record but the file spans multiple lines. {self._multiline_hint()}"
+            )
+
+        parts = record.split("\t")
+        if len(parts) not in self.ALLOWED_FIELD_COUNTS:
+            return (
+                f"{row_label} ('{filename}'): expected {self._expected_fields_phrase()} "
+                f"tab-separated fields, found {len(parts)}. Separate each field "
+                f"with exactly one tab."
+            )
+
+        empties = [i + 1 for i, p in enumerate(parts) if not p.strip()]
+        if empties:
+            return (
+                f"{row_label} ('{filename}'): field(s) {empties} are empty — "
+                f"every field ({self._field_names(len(parts))}) must be non-empty."
+            )
+
+        return None
+
+    @staticmethod
+    def _resolve_column(df: Any, name: str) -> Optional[str]:
+        """Return the actual column name matching ``name`` case-insensitively."""
+        if name in df.columns:
+            return name
+        lowered = {c.lower(): c for c in df.columns}
+        return lowered.get(name.lower())

--- a/tracebloc_ingestor/validators/text_content_validator.py
+++ b/tracebloc_ingestor/validators/text_content_validator.py
@@ -1,8 +1,8 @@
 """Text Content Validator Module.
 
 Content-level check for NLP categories (text_classification,
-token_classification, masked_language_modeling, causal_language_modeling,
-seq2seq, embeddings). ``FileTypeValidator`` only
+token_classification, sentence_pair_classification, masked_language_modeling,
+causal_language_modeling, seq2seq, embeddings). ``FileTypeValidator`` only
 checks the file *extension*, so a file named ``doc1.txt`` that actually holds
 binary / non-UTF-8 bytes — or is empty — passed validation and was ingested
 silently; the dataset author only discovered the corruption at training time.


### PR DESCRIPTION
## What

Enable the NLP **sentence-pair classification** use case end-to-end on the ingestor side — Phase-4 cross-repo wiring for engine [tracebloc-engine#301](https://github.com/tracebloc/tracebloc-engine/pull/301).

The on-disk contract: one `.txt` per sample under `texts/`, each a tab-separated **`text_a<TAB>text_b`** sentence pair, plus a class `label` in the labels CSV.

`sentence_pair_classification` is **supervised** text classification — the label travels in the CSV exactly like `text_classification` (`is_classification=True`, `is_self_supervised=False`, staged from `texts/`) — but the `.txt` has a **structured** shape (the `text_classification` layout with a tab separating the pair).

## Wiring (mirrors `text_classification`; structural check mirrors `embeddings`)

- **`utils/constants.py`** — `TaskCategory.SENTENCE_PAIR_CLASSIFICATION`.
- **`schema/ingest.v1.json`** — enum value, `texts` requirement + description, and added to the **"requires `label`"** rule (supervised — deliberately *not* the self-supervised no-label guard).
- **`modalities/registry.py`** — `ModalitySpec` (file-bearing, classification, NLP, `texts/`). `is_nlp` gates the **#805** data-derived text profile (the ingestor side of the federated tokenizer-alignment check — there is no `check_same_tokenizer` in this repo; that lives in backend/SDK).
- **`modalities/validators.py` + `transfer.py` + `cli/conventions.py`** — same validator set + raw-text staging from `texts/` as `text_classification`.

## What's distinct from `text_classification`

The on-disk shape is **structured**, so beyond the shared `TextContentValidator` (UTF-8/binary hygiene) it adds a structural check that rejects any `.txt` that isn't exactly **2 non-empty tab fields** (no plain prose, no empty side, one record per file).

Rather than clone `ContrastivePairsValidator`, this extracts the shared scaffold into a new **`TabSeparatedRecordValidator`** base (centralized validators, #317). `ContrastivePairsValidator` (2-or-3 fields) subclasses it with **byte-identical messages** — its existing tests pass unchanged — and **`SentencePairValidator`** (exactly-2) is a thin subclass.

Template fails loudly via the shared `run_ingestion` helper (no `exit 0` on hard failure); `zip(ids, batch)` send path untouched.

## Tests

- New `templates/sentence_pair_classification/` (script + README + labels CSV + 5 sample pairs), `examples/yaml/sentence_pair_classification.yaml`.
- New `tests/test_sentence_pair_validator.py` + `tests/test_sentence_pair_classification.py` (supervised — incl. rejecting a config that *omits* `label`).
- Updated the enumerating/contract tests (registry, validators_mapping, schema_validation, template_equivalence, modality_failure_accounting) + e2e params.
- Unit suite green locally (`1353 passed, 1 xfailed`); black-clean. e2e runs on CI (MySQL service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New modality touches schema, registry, validators, and ingestion paths used by all YAML submissions; behavior is well-tested but expands the supported category surface customers rely on.
> 
> **Overview**
> Adds **supervised** `sentence_pair_classification` end-to-end: CSV manifest + `texts/` sidecars where each `.txt` is exactly **`text_a<TAB>text_b`**, with class labels in the CSV like `text_classification`.
> 
> Wires the new category through **`TaskCategory`**, **`ingest.v1.json`** (enum, required `texts` + `label`), modality **registry** (NLP, file-bearing, classification), **conventions**, **transfer** (`text_transfer` from `texts/`), and a validator stack that adds **`SentencePairValidator`** on top of the usual text hygiene and label checks.
> 
> Introduces shared **`TabSeparatedRecordValidator`** and refactors **`ContrastivePairsValidator`** to subclass it (embeddings pair/triplet vs sentence-pair exactly-2 fields). Ships template, example YAML, docs, e2e/characterization cases, and broad test coverage; bumps package version to **0.5.5**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc356b18435de36237e0ee3247a2312a6ec0cb29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->