### PR TITLE
chore(release): bump version to 0.5.6

### DIFF
--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -255,13 +255,14 @@ def test_emb_binary_content_rejected(clean_env, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_emb_api_send_failure_counts_every_record(clean_env):
-    """Every batch POST rejected -> every embeddings record returns as a
-    failure, so the run exits non-zero (the file-transfer branch runs since
-    embeddings is file-bearing)."""
+def test_emb_ingest_summary_failure_raises_out_of_ingest(clean_env):
+    """The per-batch API publish is gone (#325): a single send_ingest_summary
+    call is made after commit. When it fails, the error raises out of ingest()
+    so the run exits non-zero (the file-transfer branch runs since embeddings is
+    file-bearing)."""
     records = [{"a": "1", "filename": "f1"}, {"a": "2", "filename": "f2"}]
     ing = make_ingestor(records=records)
-    ing.api_client.send_batch.return_value = False
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
 
     with patch.object(base_mod, "Session") as Sess, patch.object(
         ing, "validate_data", return_value=True
@@ -269,9 +270,7 @@ def test_emb_api_send_failure_counts_every_record(clean_env):
         base_mod,
         "map_file_transfer",
         side_effect=lambda c, r, o, cfg=None, source_record=None: r,
-    ):
+    ), patch.object(base_mod, "compute_text_profile", return_value=None):
         Sess.return_value.__enter__.return_value = MagicMock()
-        failed = ing.ingest("src", batch_size=10)
-
-    assert len(failed) == 2
-    assert all(f["error"] == "api_send_failed" for f in failed)
+        with pytest.raises(RuntimeError, match="backend rejected"):
+            ing.ingest("src", batch_size=10)

--- a/tests/test_sentence_pair_classification.py
+++ b/tests/test_sentence_pair_classification.py
@@ -285,16 +285,17 @@ def test_spc_binary_content_rejected(clean_env, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_spc_api_send_failure_counts_every_record(clean_env):
-    """Every batch POST rejected -> every sentence_pair record returns as a
-    failure, so the run exits non-zero (the file-transfer branch runs since
-    sentence_pair is file-bearing)."""
+def test_spc_ingest_summary_failure_raises_out_of_ingest(clean_env):
+    """The per-batch API publish is gone (#325): a single send_ingest_summary
+    call is made after commit. When it fails, the error raises out of ingest()
+    so the run exits non-zero (the file-transfer branch runs since sentence_pair
+    is file-bearing)."""
     records = [
         {"a": "1", "filename": "f1", "label": "entailment"},
         {"a": "2", "filename": "f2", "label": "neutral"},
     ]
     ing = make_ingestor(records=records)
-    ing.api_client.send_batch.return_value = False
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
 
     with patch.object(base_mod, "Session") as Sess, patch.object(
         ing, "validate_data", return_value=True
@@ -302,9 +303,7 @@ def test_spc_api_send_failure_counts_every_record(clean_env):
         base_mod,
         "map_file_transfer",
         side_effect=lambda c, r, o, cfg=None, source_record=None: r,
-    ):
+    ), patch.object(base_mod, "compute_text_profile", return_value=None):
         Sess.return_value.__enter__.return_value = MagicMock()
-        failed = ing.ingest("src", batch_size=10)
-
-    assert len(failed) == 2
-    assert all(f["error"] == "api_send_failed" for f in failed)
+        with pytest.raises(RuntimeError, match="backend rejected"):
+            ing.ingest("src", batch_size=10)

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
Lands the `__version__` bump for **v0.5.6** on develop: `0.5.5` → `0.5.6`.

v0.5.6 ships the global-meta client fix (#325) — `injestor_id`→`ingestor_id` rename + single ingest-summary call — matching the deployed backend #900. v0.5.5 still sends the old param and is rejected (`ingestor_id: This param is required`), breaking all ingestion on dev.

No functional change here beyond the version literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version literal change plus test-only updates; no production logic in this diff.
> 
> **Overview**
> Bumps **`__version__`** from `0.5.5` to **`0.5.6`** in `tracebloc_ingestor/__init__.py` for the release that pairs with the global-meta / ingest-summary client fix (#325).
> 
> **Failure-accounting tests** for embeddings and sentence-pair classification no longer simulate per-batch `send_batch` rejection and `api_send_failed` per-record failures. They now assert that a failed post-commit **`send_ingest_summary`** (`RuntimeError`) **propagates out of `ingest()`**, with an extra mock on **`compute_text_profile`** so the ingest path can run under the updated flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3703818f1a55749e862006b87ed504c81a3f4ac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->