### PR TITLE
fix: treat backend 409 as idempotent success in send_ingest_summary (#332)

### DIFF
--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -83,6 +83,20 @@ def test_send_ingest_summary_http_error_raises():
             _summary_call(client)
 
 
+def test_send_ingest_summary_409_returns_existing_dataset():
+    """Backend #900 returns 409 + {dataset_id, dataset_key} when the
+    (owner, ingestor_id) dataset already exists (e.g. a transport-level POST
+    retry after a dropped 201). That 409 is a success signal for the retry —
+    the client must return the existing dataset, not raise (issue #332)."""
+    client = _client()
+    with patch.object(
+        client.session, "post",
+        return_value=_resp(409, {"dataset_id": 7, "dataset_key": "existing"}),
+    ):
+        result = _summary_call(client)
+    assert result == {"dataset_id": 7, "dataset_key": "existing"}
+
+
 def test_send_ingest_summary_local_mode():
     client = _client(EDGE_ENV="local")
     with patch.object(client.session, "post") as post:

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -279,6 +279,22 @@ class APIClient:
                 timeout=API_TIMEOUT,
             )
 
+            # 409 = backend idempotency guard (backend #900): the
+            # (owner, ingestor_id) dataset already exists — e.g. urllib3
+            # re-sent this POST after a dropped/timed-out 201 on a long
+            # ingest (POST is in the retry adapter's allowed_methods). The
+            # body carries the existing {dataset_id, dataset_key}. This is a
+            # success signal for the retry, not a failure — parse and return
+            # it rather than crashing an ingest whose dataset was created.
+            if response.status_code == 409:
+                result = self._parse_json(response, required=True)
+                logger.info(
+                    f"{GREEN}Dataset already registered (idempotent retry): "
+                    f"key={result.get('dataset_key')} "
+                    f"id={result.get('dataset_id')}{RESET}"
+                )
+                return result
+
             # Check status after retries are exhausted. Attach the response
             # so the handler below can log the status and body — a bare
             # HTTPError has e.response = None, which would hide the field

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -602,6 +602,13 @@ class BaseIngestor(ABC):
                 self._log_summary(summary)
 
             except Exception as e:
+                # NOTE: rows are already committed above (session.commit()),
+                # so this rollback is a no-op on the inserted data — it only
+                # discards any uncommitted state. If send_ingest_summary
+                # fails for real (a genuine 400/500), the rows remain in
+                # MySQL with no registered dataset; we raise loudly rather
+                # than silently swallow that. A 409 is handled inside the
+                # client as an idempotent success and does not reach here.
                 session.rollback()
                 logger.error(f"Error during ingestion: {str(e)}")
                 raise e


### PR DESCRIPTION
Fixes #332.

## Problem

`send_ingest_summary` (introduced in #325) raised on **any** `status >= 400`. But backend #900 deliberately returns **`409 CONFLICT` + `{dataset_id, dataset_key}`** on a duplicate `(owner, ingestor_id)` — a *success signal for a retry*, not an error.

The retry adapter (`_create_session`) lists `POST` in `allowed_methods`, so urllib3 re-sends the summary POST on a dropped/timed-out connection. If the backend already committed the dataset (201 server-side) but the response never reached the client, the re-sent POST hits the idempotency guard → `409` → the client raised → the Job exited non-zero for a dataset that **was actually created**. A manual re-run then generates a fresh `ingestor_id`, so the backend dedupe never matches and a **duplicate dataset** is created.

## Fix

Special-case `409` *before* the `>= 400` check in `send_ingest_summary`: parse and return the existing `{dataset_id, dataset_key}` body, logging it as an idempotent retry.

## Changes

- `tracebloc_ingestor/api/client.py` — handle 409 as idempotent success.
- `tests/test_api_client_methods.py` — regression test asserting 409 returns the existing dataset and does not raise.
- `tracebloc_ingestor/ingestors/base.py` — clarifying comment on the post-commit `rollback()` no-op (issue's secondary note).

## Testing

API-client, ingestor-base, and failure-mode suites pass (99 passed), including the new test. The 4 CSV float-overflow failures in the full suite are pre-existing (fail on clean `develop` too — local numpy/pandas quirk), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-ingest registration behavior on a retried summary POST; scope is narrow (409 only) but affects whether long ingests exit cleanly vs. leaving committed rows unregistered.
> 
> **Overview**
> **`send_ingest_summary`** no longer treats every `status >= 400` as failure. When the backend returns **409** with `{dataset_id, dataset_key}` (duplicate `(owner, ingestor_id)` after a transport-level POST retry), the client parses that body and returns it as success instead of raising—so jobs don’t fail after the dataset was already created and operators aren’t pushed into re-runs with a new `ingestor_id` that bypass dedupe.
> 
> A regression test covers the 409 path; **`base.py`** only documents that post-commit `rollback()` doesn’t undo rows and that real 4xx/5xx on summary still fail loudly while 409 is handled in the client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f669665680795537098dc840631f7ed05e7fbff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->