### PR TITLE
fix: compensating delete — a failed run no longer orphans its rows (#227)

### DIFF
--- a/e2e/test_database_e2e.py
+++ b/e2e/test_database_e2e.py
@@ -116,3 +116,26 @@ def test_get_table_schema_reports_real_mysql_types(db, table):
     assert schema["id"] == "BIGINT"
     assert schema["created_at"] == "DATETIME"
     assert schema["annotation"] == "TEXT"
+
+
+def test_delete_by_ingestor_id_removes_only_that_run(db, table):
+    """#227 compensating delete: removes exactly one run's rows, leaves the
+    other run's rows untouched, and reports the deleted count."""
+    db.create_table(table, {"feature": "FLOAT"})
+    db.insert_batch(
+        table,
+        [
+            _rec("a", feature=1.0, ingestor_id="run-failed"),
+            _rec("b", feature=2.0, ingestor_id="run-failed"),
+            _rec("c", feature=3.0, ingestor_id="run-registered"),
+        ],
+    )
+    assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 3
+
+    deleted = db.delete_by_ingestor_id(table, "run-failed")
+
+    assert deleted == 2
+    rows = _query(f"SELECT data_id, ingestor_id FROM `{table}`")
+    assert rows == [("c", "run-registered")]
+    # idempotent: a second delete is a harmless no-op
+    assert db.delete_by_ingestor_id(table, "run-failed") == 0

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -1241,3 +1241,133 @@ def test_mlm_all_files_missing_fails_before_table_creation(clean_env, tmp_path):
             ing.ingest(str(csv), batch_size=10)
 
     ing.database.create_table.assert_not_called()
+
+
+# ── #227: compensating delete on failed registration ────────────────────────
+# Rows commit per batch during the loop; when the run fails before its dataset
+# registers, the failure path must delete exactly this run's rows (identified
+# by ingestor_id) so the table is clean for a re-run — instead of leaving
+# orphans that trip the stale-table guard (#336).
+
+
+def _ingest_expecting(ing, exc_type):
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(exc_type):
+            ing.ingest("src", batch_size=10)
+
+
+def test_failed_registration_triggers_compensating_delete():
+    """send_ingest_summary fails terminally → the run's rows are deleted by
+    ingestor_id and the original error still propagates."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    ing = make_ingestor(
+        records=[{"a": "1", "filename": "f1"}],
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
+    _ingest_expecting(ing, RuntimeError)
+    ing.database.delete_by_ingestor_id.assert_called_once_with(
+        ing.table_name, ing.ingestor_id
+    )
+
+
+def test_successful_registration_never_deletes():
+    """Happy path: registration succeeds → the compensating delete must not run."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    ing = make_ingestor(
+        records=[{"a": "1", "filename": "f1"}],
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    ing.database.delete_by_ingestor_id.assert_not_called()
+
+
+def test_cleanup_failure_preserves_original_error(caplog):
+    """The delete itself failing must not mask the registration error — the
+    original exception propagates and the orphan state is logged CRITICAL."""
+    import logging
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    ing = make_ingestor(
+        records=[{"a": "1", "filename": "f1"}],
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
+    ing.database.delete_by_ingestor_id.side_effect = Exception("mysql went away")
+    with caplog.at_level(logging.CRITICAL):
+        _ingest_expecting(ing, RuntimeError)  # ORIGINAL error, not the cleanup one
+    assert any("Compensating delete FAILED" in r.message for r in caplog.records)
+
+
+def test_no_rows_inserted_no_delete():
+    """A failure before any row was inserted must not attempt a delete —
+    the table may not even exist yet."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    ing = make_ingestor(
+        records=[],
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    # Force a failure after the commit point but before registration, with
+    # zero inserted rows: get_label_counts blows up on an empty run.
+    ing.database.get_label_counts.side_effect = RuntimeError("boom")
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError):
+            ing.ingest("src", batch_size=10)
+    ing.database.delete_by_ingestor_id.assert_not_called()
+
+
+def test_late_failure_after_registration_never_deletes():
+    """The dataset_registered guard: an exception AFTER send_ingest_summary
+    succeeded (e.g. in summary rendering) must propagate WITHOUT deleting the
+    now-registered dataset's rows. Mutation check: dropping the
+    `and not dataset_registered` condition fails this test."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    ing = make_ingestor(
+        records=[{"a": "1", "filename": "f1"}],
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        ing, "_log_summary", side_effect=RuntimeError("render blew up")
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError):
+            ing.ingest("src", batch_size=10)
+    ing.api_client.send_ingest_summary.assert_called_once()
+    ing.database.delete_by_ingestor_id.assert_not_called()

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -533,6 +533,48 @@ class Database:
             counts[key] = counts.get(key, 0) + cnt
         return counts
 
+    def delete_by_ingestor_id(self, table_name: str, ingestor_id: str) -> int:
+        """
+        Compensating delete (#227): remove every row a single ingest run
+        inserted, identified by its per-process ``ingestor_id``.
+
+        Called from the ingestion failure path when the run will NOT register
+        its dataset with the backend. Rows commit per batch during the ingest
+        loop, so without this a failed run leaves rows that no consumer can
+        reach (training queries are scoped to REGISTERED ingestor_ids) but
+        that inflate the heartbeat's availability report and occupy disk
+        with no remote delete path (the live wound in #336).
+
+        Staged files are deliberately left in place: they are keyed by source
+        filename and idempotently overwritten on re-run.
+
+        Uses ``_execute_with_retry`` so a transient MySQL hiccup does not
+        leave a partial cleanup; a permanent failure propagates to the caller,
+        which logs it loudly while preserving the ORIGINAL ingestion error.
+
+        Args:
+            table_name: Name of the table to clean
+            ingestor_id: UUID of the failed ingest run
+
+        Returns:
+            Number of rows removed
+        """
+        with self.engine.connect() as connection:
+            result = _execute_with_retry(
+                connection,
+                text(
+                    f"DELETE FROM `{table_name.replace('`', '``')}` "
+                    f"WHERE ingestor_id = :ingestor_id"
+                ).bindparams(ingestor_id=ingestor_id),
+            )
+            connection.commit()
+        deleted = result.rowcount if result is not None else 0
+        logger.info(
+            f"Removed {deleted} unregistered row(s) for "
+            f"ingestor_id={ingestor_id!r} from `{table_name}`."
+        )
+        return deleted
+
     def get_samples(
         self, table_name: str, ingestor_id: str, limit: int = 10
     ) -> List[Dict[str, Any]]:

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -449,6 +449,11 @@ class BaseIngestor(ABC):
         total = self._count_records(source)
         stats["total_records"] = total or 0
 
+        # Flipped only after send_ingest_summary returns: gates the #227
+        # compensating delete so a dataset that DID register never has its
+        # rows deleted by a late failure (e.g. in summary rendering).
+        dataset_registered = False
+
         with Session(self.engine) as session:
             try:
                 pbar = tqdm(total=total, desc="Ingesting records", unit="records")
@@ -566,8 +571,9 @@ class BaseIngestor(ABC):
                         f"Inserted {stats['inserted_records']} row(s) but "
                         f"get_label_counts returned nothing for "
                         f"ingestor_id={self.ingestor_id!r}. "
-                        "Rows are committed to MySQL but the dataset was not "
-                        "registered with the backend."
+                        "The dataset was not registered with the backend; "
+                        "this run's rows will be removed by the "
+                        "compensating delete (#227)."
                     )
                 else:
                     samples = self.database.get_samples(
@@ -596,21 +602,64 @@ class BaseIngestor(ABC):
                         samples=samples,
                         meta_data=self.file_options,
                     )
+                    dataset_registered = True
                     stats["api_sent_records"] = stats["inserted_records"]
 
                 summary = IngestionSummary(**stats)
                 self._log_summary(summary)
 
             except Exception as e:
-                # NOTE: rows are already committed above (session.commit()),
-                # so this rollback is a no-op on the inserted data — it only
-                # discards any uncommitted state. If send_ingest_summary
-                # fails for real (a genuine 400/500), the rows remain in
-                # MySQL with no registered dataset; we raise loudly rather
-                # than silently swallow that. A 409 is handled inside the
-                # client as an idempotent success and does not reach here.
-                session.rollback()
+                # Rows commit PER BATCH during the loop, so by the time any
+                # failure lands here — mid-loop, or a genuine 4xx/5xx from
+                # send_ingest_summary — this run's rows are already durable
+                # in MySQL while its dataset will never be registered
+                # (session.rollback() only discards uncommitted state).
+                # Compensate by deleting exactly this run's rows, identified
+                # by the per-process ingestor_id, so a failed run leaves the
+                # table clean for a re-run (#227) instead of leaving orphans
+                # that inflate the heartbeat's availability report and
+                # occupy disk with no delete path (the live wound in #336).
+                # A 409 from the summary call is idempotent success inside
+                # the client and never reaches here; dataset_registered
+                # guards the late-failure case so a REGISTERED dataset's
+                # rows are never deleted. Residual two-generals window: if
+                # the backend registered but the client-side call still
+                # raised (e.g. a 2xx whose body failed to parse, after
+                # retries), this delete removes rows of a backend-registered
+                # dataset — narrow (POST is retried; 409 absorbs re-sends),
+                # and a re-run re-ingests from source. Staged files stay —
+                # they are keyed by filename and idempotently overwritten on
+                # re-run. A cleanup failure must not mask the original
+                # error: log CRITICAL and re-raise the original (the
+                # leftover rows are the pre-#227 status quo, and remain
+                # sweepable by ingestor_id).
+                try:
+                    session.rollback()
+                except Exception as rollback_error:
+                    # A dead connection can make the rollback itself throw —
+                    # exactly the conditions this block fires under. It must
+                    # not mask the original error or skip the cleanup.
+                    logger.warning(f"session.rollback() failed: {rollback_error}")
                 logger.error(f"Error during ingestion: {str(e)}")
+                if stats.get("inserted_records") and not dataset_registered:
+                    try:
+                        deleted = self.database.delete_by_ingestor_id(
+                            self.table_name, self.ingestor_id
+                        )
+                        logger.error(
+                            f"Compensating delete removed {deleted} "
+                            f"unregistered row(s) for "
+                            f"ingestor_id={self.ingestor_id!r} — the table "
+                            "is clean; re-running is safe (#227)."
+                        )
+                    except Exception as cleanup_error:
+                        logger.critical(
+                            f"Compensating delete FAILED for "
+                            f"ingestor_id={self.ingestor_id!r} in table "
+                            f"{self.table_name!r}: {cleanup_error}. "
+                            f"{stats.get('inserted_records', 0)} unregistered "
+                            "row(s) remain orphaned (#227)."
+                        )
                 raise e
 
         return failed_records


### PR DESCRIPTION
## Summary
Rows commit **per batch** during the ingest loop, so any failure after the first batch — mid-loop, or a genuine 4xx/5xx from `send_ingest_summary` — left durable rows whose dataset never registered. Training can't reach them (post-#420 queries are scoped to registered `ingestor_id`s), but they inflate the heartbeat's availability report and occupy disk with no remote delete path — the live wound in #336 (`qa_ic_edge304_train`).

The failure path now deletes exactly this run's rows (`WHERE ingestor_id = <per-process uuid>`) before re-raising, so **a failed run leaves the table clean and re-running is safe**.

## Safety properties (each pinned by a test)
- `dataset_registered` flips only after `send_ingest_summary` returns → a late failure can never delete a **registered** dataset's rows. **Mutation-tested**: dropping the flag condition fails the test suite.
- Cleanup failure logs CRITICAL and preserves the **original** exception (never masked).
- `session.rollback()` hardened — a dead connection can't skip the cleanup or mask the error.
- No rows inserted → no delete attempted (table may not exist yet).
- Residual **two-generals window** documented (backend registered but client raised on an unparseable 2xx after retries — narrow: POST retried, 409 idempotent; re-run re-ingests from source). Crash windows (SIGKILL) remain sweepable by `ingestor_id` — the log-first sweep is the client-runtime follow-up per backend#818.

## Design context
This replaces the June register-then-activate lifecycle from backend#818 — obsoleted by #325's single-call registration + the grounded finding that unregistered rows are unreachable by training. Decisions (Lukas, 2026-07-07) + full refreshed design: [backend#818 comment](https://github.com/tracebloc/backend/issues/818#issuecomment-4901461018).

Closes #227.

## Testing
+5 unit tests (incl. the mutation pin) + 1 e2e against real MySQL (deletes only the failed run's rows, idempotent no-op on repeat). Full suite **1341 passed, 1 xfailed**; `e2e_database` 6/6 on live local MySQL. Adversarially reviewed pre-push; all 4 findings folded (flag coverage, rollback hardening, two-generals doc, comment accuracy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)