### PR TITLE
feat: salted content-hash data_id — a Job retry re-claims its rows (#225, landed dark)

### DIFF
--- a/e2e/test_database_e2e.py
+++ b/e2e/test_database_e2e.py
@@ -116,3 +116,57 @@ def test_get_table_schema_reports_real_mysql_types(db, table):
     assert schema["id"] == "BIGINT"
     assert schema["created_at"] == "DATETIME"
     assert schema["annotation"] == "TEXT"
+
+
+def test_content_hash_retry_reclaims_rows_instead_of_duplicating(db, table):
+    """#225 end-to-end against real MySQL: a retried run inserting the SAME
+    content under deterministic ids re-claims the prior attempt's rows via
+    the data_id UNIQUE upsert — row count stays constant and ownership moves
+    to the retry's ingestor_id (whose scoped label counts then match)."""
+    from tracebloc_ingestor.ingestors.record_processor import RecordProcessor
+    from tracebloc_ingestor.utils import label_policy as label_policy_module
+
+    db.create_table(table, {"feature": "FLOAT"})
+    salt = db.get_or_create_table_salt(table)
+    assert db.get_or_create_table_salt(table) == salt  # stable across calls
+
+    def run(ingestor_id):
+        rp = RecordProcessor(
+            schema={"feature": "FLOAT"},
+            intent="train",
+            label_column="target",
+            annotation_column=None,
+            unique_id_column=None,
+            label_policy=label_policy_module.PASSTHROUGH,
+            ingestor_id=ingestor_id,
+            data_id_strategy="content_hash",
+            table_salt=salt,
+        )
+        records = []
+        for i, label in [(1, "cat"), (2, "dog")]:
+            rec = rp.process({"feature": float(i), "target": label})
+            rec["ingestor_id"] = ingestor_id
+            records.append(rec)
+        db.insert_batch(table, records)
+
+    run("attempt-1")               # first attempt: rows land
+    assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2
+
+    run("attempt-2-retry")         # k8s Job retry: SAME content, new run id
+    assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2  # no duplication
+    owners = {r[0] for r in _query(f"SELECT ingestor_id FROM `{table}`")}
+    assert owners == {"attempt-2-retry"}  # re-claimed by the retry
+    # the retry's scoped label counts see the full dataset
+    assert db.get_label_counts(table, "attempt-2-retry") == {"cat": 1, "dog": 1}
+
+
+def test_table_salts_are_per_table(db, table):
+    """Identical content in different tables must be unlinkable."""
+    other = table + "_b"
+    try:
+        s1 = db.get_or_create_table_salt(table)
+        s2 = db.get_or_create_table_salt(other)
+        assert s1 != s2
+        assert len(s1) == 64
+    finally:
+        _query(f"DROP TABLE IF EXISTS `{other}`")

--- a/tests/test_content_hash_data_id.py
+++ b/tests/test_content_hash_data_id.py
@@ -1,0 +1,211 @@
+"""#225: deterministic salted content-hash data_id (opt-in, landed dark).
+
+A k8s Job retry re-runs the whole ingest in a fresh pod; with uuid ids every
+row re-inserts. With content_hash, the retry reproduces the same ids and the
+data_id UNIQUE upsert re-claims the prior attempt's rows instead of
+duplicating them. The per-table salt keeps ids unlinkable across tables and
+never leaves the cluster.
+"""
+
+import json
+
+import pytest
+
+from tracebloc_ingestor.cli.conventions import resolve
+from tracebloc_ingestor.ingestors.record_processor import RecordProcessor
+from tracebloc_ingestor.utils import label_policy as label_policy_module
+
+
+SALT_A = "a" * 64
+SALT_B = "b" * 64
+
+
+def make_processor(salt=SALT_A, strategy="content_hash", unique_id_column=None):
+    return RecordProcessor(
+        schema={"feature": "FLOAT", "note": "TEXT"},
+        intent="train",
+        label_column="target",
+        annotation_column=None,
+        unique_id_column=unique_id_column,
+        label_policy=label_policy_module.PASSTHROUGH,
+        ingestor_id="run-1",
+        data_id_strategy=strategy,
+        table_salt=salt,
+    )
+
+
+def _record(**over):
+    base = {"feature": 1.5, "note": "hello", "target": "cat"}
+    base.update(over)
+    return base
+
+
+# ── determinism ──────────────────────────────────────────────────────────────
+
+
+def test_same_record_same_salt_same_id_across_instances():
+    """The whole point: a retried process (fresh instance, fresh ingestor_id)
+    reproduces the identical data_id for identical source content."""
+    a = make_processor().process(_record())
+    retry = RecordProcessor(
+        schema={"feature": "FLOAT", "note": "TEXT"},
+        intent="train",
+        label_column="target",
+        annotation_column=None,
+        unique_id_column=None,
+        label_policy=label_policy_module.PASSTHROUGH,
+        ingestor_id="run-2-after-retry",  # different run
+        data_id_strategy="content_hash",
+        table_salt=SALT_A,
+    ).process(_record())
+    assert a["data_id"] == retry["data_id"]
+    assert len(a["data_id"]) == 64  # sha256 hexdigest
+
+
+def test_different_content_different_id():
+    a = make_processor().process(_record())
+    b = make_processor().process(_record(feature=2.5))
+    assert a["data_id"] != b["data_id"]
+
+
+def test_different_salt_different_id():
+    """Per-table salt: identical content in two tables is unlinkable."""
+    a = make_processor(salt=SALT_A).process(_record())
+    b = make_processor(salt=SALT_B).process(_record())
+    assert a["data_id"] != b["data_id"]
+
+
+def test_label_participates_in_the_hash():
+    """Same features, different label ⇒ different id (a relabeled source row
+    is a different record, not a silent overwrite)."""
+    a = make_processor().process(_record(target="cat"))
+    b = make_processor().process(_record(target="dog"))
+    assert a["data_id"] != b["data_id"]
+
+
+# ── precedence + guards ──────────────────────────────────────────────────────
+
+
+def test_unique_id_column_wins_over_content_hash():
+    """Belt-and-suspenders: an explicit source-id column takes precedence."""
+    p = make_processor(unique_id_column="feature")
+    out = p.process(_record(feature="row-77"))
+    assert out["data_id"] == "row-77"
+
+
+def test_uuid_default_unchanged():
+    """Landed dark: without opting in, ids stay per-process-random."""
+    p = make_processor(strategy="uuid", salt=None)
+    a = p.process(_record())
+    b = p.process(_record())
+    assert a["data_id"] != b["data_id"]  # uuid4 per record
+
+
+def test_content_hash_without_salt_fails_at_construction():
+    with pytest.raises(ValueError, match="table_salt"):
+        make_processor(salt=None)
+
+
+# ── conventions resolution ───────────────────────────────────────────────────
+
+
+def _cfg(strategy=None):
+    cfg = {
+        "apiVersion": "tracebloc.io/v1",
+        "kind": "IngestConfig",
+        "table": "t1",
+        "category": "tabular_classification",
+        "csv": "/data/shared/d.csv",
+        "intent": "train",
+        "label": "target",
+        "schema": {"feature": "FLOAT"},
+    }
+    if strategy:
+        cfg["data_id"] = {"strategy": strategy}
+        if strategy == "column":
+            cfg["data_id"]["column"] = "feature"
+    return cfg
+
+
+def test_resolve_default_is_uuid():
+    r = resolve(_cfg())
+    assert r.data_id_strategy == "uuid"
+    assert r.unique_id_column is None
+
+
+def test_resolve_content_hash():
+    r = resolve(_cfg("content_hash"))
+    assert r.data_id_strategy == "content_hash"
+    assert r.unique_id_column is None
+
+
+def test_resolve_column_still_sets_unique_id_column():
+    r = resolve(_cfg("column"))
+    assert r.unique_id_column == "feature"
+    assert r.data_id_strategy == "uuid"  # column path, not hash
+
+
+# ── schema acceptance ────────────────────────────────────────────────────────
+
+
+def _validator():
+    from jsonschema import Draft7Validator
+    from tracebloc_ingestor.cli.run import _load_schema
+
+    return Draft7Validator(_load_schema())
+
+
+def test_schema_accepts_content_hash_strategy():
+    errors = list(_validator().iter_errors(_cfg("content_hash")))
+    assert errors == []
+
+
+def test_schema_still_requires_column_for_column_strategy():
+    cfg = _cfg("column")
+    del cfg["data_id"]["column"]
+    errors = list(_validator().iter_errors(cfg))
+    assert errors, "strategy=column without column must be rejected"
+
+
+def test_filename_participates_in_the_hash():
+    """File-bearing categories: the schema-filtered record may be nothing but
+    {label, data_intent}, so the source filename must drive the id — two
+    different images with the same label are different records, and the same
+    image re-ingested on retry reproduces its id."""
+    p = make_processor()
+    a = p.process({"filename": "img_001.jpeg", "target": "cat"})
+    b = p.process({"filename": "img_002.jpeg", "target": "cat"})
+    retry = make_processor().process({"filename": "img_001.jpeg", "target": "cat"})
+    assert a["data_id"] != b["data_id"]
+    assert a["data_id"] == retry["data_id"]
+
+
+# ── construction through the real builder (the gap that hid a TypeError) ────
+
+
+def _build(config):
+    from unittest.mock import MagicMock
+
+    from tracebloc_ingestor.cli.run import _build_ingestor
+
+    db = MagicMock()
+    db.get_or_create_table_salt.return_value = SALT_A
+    return _build_ingestor(database=db, api_client=MagicMock(), resolved=resolve(config))
+
+
+@pytest.mark.parametrize("source_key", ["csv", "json"])
+@pytest.mark.parametrize("strategy", [None, "content_hash"])
+def test_build_ingestor_threads_strategy_through_both_subclasses(source_key, strategy):
+    """CSVIngestor and JSONIngestor must accept + forward data_id_strategy —
+    a kwarg passed by _build_ingestor that either subclass drops is a
+    TypeError on EVERY YAML-driven run, even with pure defaults."""
+    cfg = _cfg(strategy)
+    if source_key == "json":
+        cfg.pop("csv")
+        cfg["json"] = "/data/shared/d.json"
+    ing = _build(cfg)
+    expected = strategy or "uuid"
+    assert ing.data_id_strategy == expected
+    # salt is deferred to ingest(); never fetched at construction
+    ing.database.get_or_create_table_salt.assert_not_called()
+    assert ing._table_salt is None

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -190,7 +190,8 @@ class ResolvedConfig:
     label_policy: str = "passthrough"  # "passthrough" | "bucket"
 
     # ----- data_id -----
-    unique_id_column: Optional[str] = None  # None ⇒ UUID generation
+    unique_id_column: Optional[str] = None  # None ⇒ strategy below decides
+    data_id_strategy: str = "uuid"  # uuid | content_hash (column ⇒ unique_id_column)
 
     # ----- Pass-through to ingestors -----
     annotation_column: Optional[str] = None
@@ -267,13 +268,18 @@ def resolve(config: Dict[str, Any]) -> ResolvedConfig:
         resolved.label_column = label["column"]
         resolved.label_policy = label.get("policy", "passthrough")
 
-    # 5. data_id — strategy: uuid (default, no source col leaves the cluster)
-    #    or column (loud, opt-in, captured in unique_id_column for the
-    #    BaseIngestor warning we added in #43).
+    # 5. data_id — strategy: uuid (default, no source col leaves the cluster),
+    #    column (loud, opt-in, captured in unique_id_column for the
+    #    BaseIngestor warning we added in #43), or content_hash (#225:
+    #    deterministic salted hash — a Job retry re-claims its previous rows
+    #    via the data_id UNIQUE upsert instead of duplicating them; landed
+    #    dark, default stays uuid until a release of soak).
     data_id = config.get("data_id") or {}
     if data_id.get("strategy") == "column":
         resolved.unique_id_column = data_id["column"]
-    # else: leave unique_id_column = None ⇒ UUID generation
+    elif data_id.get("strategy") == "content_hash":
+        resolved.data_id_strategy = "content_hash"
+    # else: leave defaults ⇒ UUID generation
 
     # 6. csv_options — merge customer overrides over defaults.
     csv_overrides = (config.get("spec") or {}).get("csv_options") or {}

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -313,6 +313,7 @@ def _build_ingestor(
         table_name=resolved.table_name,
         schema=resolved.schema,
         unique_id_column=resolved.unique_id_column,
+        data_id_strategy=resolved.data_id_strategy,
         label_column=resolved.label_column,
         intent=resolved.intent,
         annotation_column=resolved.annotation_column,

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -23,6 +23,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.dialects.mysql import insert, LONGBLOB, BLOB
 from sqlalchemy.exc import OperationalError, InterfaceError, DBAPIError
 import logging
+import secrets
 from urllib.parse import quote
 from typing import List, Dict, Any, Optional
 from datetime import datetime
@@ -216,6 +217,11 @@ class Database:
                 column (e.g. a user CSV with its own ``id``), which would
                 otherwise surface as a cryptic SQLAlchemy DuplicateColumnError.
         """
+        if table_name == self.SALT_TABLE:
+            raise ValueError(
+                f"{table_name!r} is reserved for the content-hash salt store "
+                "(#225) and cannot be used as a dataset table."
+            )
         # Fail fast on reserved-column collisions before any DB I/O. `label`
         # is intentionally excluded — it's the user-facing label column the
         # framework maps onto the standard `label` column.
@@ -501,6 +507,56 @@ class Database:
             )
 
         return result["success_ids"], result["failures"]
+
+    SALT_TABLE = "tracebloc_ingest_meta"
+
+    def get_or_create_table_salt(self, table_name: str) -> str:
+        """
+        Return the per-table salt for content-hash ``data_id`` derivation
+        (#225), creating it atomically on first use.
+
+        The salt is 32 random bytes (hex) stored ONLY in the cluster's MySQL
+        — it never appears in any payload that leaves the cluster. Salting
+        per table means identical content in two tables (or two clusters)
+        yields unrelated ids, so the opaque sample ids in the ingest summary
+        can't be correlated across datasets, while a retried run on the SAME
+        table reproduces its ids exactly (the point of #225).
+
+        Concurrency-safe without the table lock: ``INSERT IGNORE`` makes the
+        create atomic — the loser of a race simply reads the winner's salt.
+        """
+        with self.engine.connect() as connection:
+            _execute_with_retry(
+                connection,
+                text(
+                    f"CREATE TABLE IF NOT EXISTS `{self.SALT_TABLE}` ("
+                    "  table_name VARCHAR(64) NOT NULL PRIMARY KEY,"
+                    "  salt CHAR(64) NOT NULL,"
+                    "  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+                    ")"
+                ),
+            )
+            _execute_with_retry(
+                connection,
+                text(
+                    f"INSERT IGNORE INTO `{self.SALT_TABLE}` (table_name, salt) "
+                    "VALUES (:table_name, :salt)"
+                ).bindparams(table_name=table_name, salt=secrets.token_hex(32)),
+            )
+            connection.commit()
+            row = _execute_with_retry(
+                connection,
+                text(
+                    f"SELECT salt FROM `{self.SALT_TABLE}` "
+                    "WHERE table_name = :table_name"
+                ).bindparams(table_name=table_name),
+            ).fetchone()
+        if row is None:  # pragma: no cover — insert+select on one connection
+            raise RuntimeError(
+                f"Could not create or read the content-hash salt for "
+                f"table {table_name!r}."
+            )
+        return row[0]
 
     def get_label_counts(self, table_name: str, ingestor_id: str) -> Dict[str, int]:
         """

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -146,6 +146,7 @@ class BaseIngestor(ABC):
         data_format: Optional[str] = None,
         file_options: Optional[Dict[str, Any]] = None,
         label_policy: str = label_policy_module.PASSTHROUGH,
+        data_id_strategy: str = "uuid",
     ):
         """Initialize the base ingestor.
 
@@ -172,6 +173,14 @@ class BaseIngestor(ABC):
             ValueError: If unique_id_column is not provided
         """
         self.ingestor_id = str(uuid.uuid4())
+        # #225: deterministic content-hash data_id (opt-in, landed dark).
+        # unique_id_column wins if both are set (schema can't express both;
+        # belt-and-suspenders). The salt fetch is DEFERRED to ingest() —
+        # mirroring #260's deferred create_table — so a validator-rejected
+        # run leaves no salt row behind. get_or_create is atomic
+        # (INSERT IGNORE), so it needs no table lock even then.
+        self.data_id_strategy = data_id_strategy
+        self._table_salt: Optional[str] = None
         self.database = database
         self.engine: Engine = database.engine
         self.api_client = api_client
@@ -246,6 +255,8 @@ class BaseIngestor(ABC):
             unique_id_column=self.unique_id_column,
             label_policy=self.label_policy,
             ingestor_id=self.ingestor_id,
+            data_id_strategy=self.data_id_strategy,
+            table_salt=self._table_salt,
         )
 
     def process_record(self, record: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -427,6 +438,18 @@ class BaseIngestor(ABC):
         # input (#260). Deferring to here ensures a validator-rejected ingest
         # leaves no orphaned empty table behind that the next retry's
         # stale-table guard would trip on.
+        # #225: fetch the per-table salt only now — the run survived
+        # validation, so it will actually write rows (mirrors the deferred
+        # create_table below, #260); a rejected run leaves no salt row.
+        if (
+            self.data_id_strategy == "content_hash"
+            and not self.unique_id_column
+            and self._table_salt is None
+        ):
+            self._table_salt = self.database.get_or_create_table_salt(
+                self.table_name
+            )
+
         if self.table is None:
             self.table = self.database.create_table(self.table_name, self._table_schema)
 

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -128,6 +128,7 @@ class CSVIngestor(BaseIngestor):
         category: Optional[str] = None,
         data_format: Optional[str] = None,
         label_policy: str = label_policy_module.PASSTHROUGH,
+        data_id_strategy: str = "uuid",
     ):
         """Initialize CSV Ingestor.
 
@@ -162,6 +163,7 @@ class CSVIngestor(BaseIngestor):
             data_format,
             file_options,
             label_policy=label_policy,
+            data_id_strategy=data_id_strategy,
         )
         self.csv_options = csv_options or {}
 

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -216,6 +216,7 @@ class JSONIngestor(BaseIngestor):
         file_options: Optional[Dict[str, Any]] = None,
         log_level: Optional[int] = None,
         label_policy: str = label_policy_module.PASSTHROUGH,
+        data_id_strategy: str = "uuid",
     ):
         """Initialize JSON Ingestor.
 
@@ -253,6 +254,7 @@ class JSONIngestor(BaseIngestor):
             data_format,
             file_options,
             label_policy=label_policy,
+            data_id_strategy=data_id_strategy,
         )
         self.json_options = json_options or {}
         if log_level is not None:

--- a/tracebloc_ingestor/ingestors/record_processor.py
+++ b/tracebloc_ingestor/ingestors/record_processor.py
@@ -23,6 +23,8 @@ former blanket ``mask_id`` pop (#212) — the cleaned record carries only the
 columns the schema declares.
 """
 
+import hashlib
+import json
 import logging
 import uuid
 from typing import Any, Dict, Optional
@@ -49,12 +51,22 @@ class RecordProcessor:
         unique_id_column: Optional[str],
         label_policy: Any,
         ingestor_id: str,
+        data_id_strategy: str = "uuid",
+        table_salt: Optional[str] = None,
     ):
         self.schema = schema
         self.intent = intent
         self.label_column = label_column
         self.annotation_column = annotation_column
         self.unique_id_column = unique_id_column
+        # #225: content-hash strategy needs the per-table salt; failing at
+        # construction beats minting unsalted (correlatable) ids at row time.
+        if data_id_strategy == "content_hash" and not unique_id_column and not table_salt:
+            raise ValueError(
+                "data_id_strategy='content_hash' requires a table_salt"
+            )
+        self.data_id_strategy = data_id_strategy
+        self.table_salt = table_salt
         self.label_policy = label_policy
         self.ingestor_id = ingestor_id
 
@@ -148,8 +160,21 @@ class RecordProcessor:
             cleaned_record["annotation"] = record.get(self.annotation_column)
 
         if not self.unique_id_column:
-            # logger.warning("No unique ID column specified, generating unique ID mapping")
-            cleaned_record["data_id"] = str(uuid.uuid4())
+            if self.data_id_strategy == "content_hash":
+                # #225: deterministic id — a retried k8s Job reproduces the
+                # same ids, so the data_id UNIQUE upsert re-claims the prior
+                # attempt's rows instead of duplicating them. The source
+                # filename MUST participate: for file-bearing categories the
+                # schema-filtered dict is just {label, data_intent, ...}, so
+                # without it two different images with the same label would
+                # collide and the upsert would collapse the dataset. It is
+                # merged here (not read from cleaned_record) because process()
+                # attaches filename only AFTER this method returns.
+                cleaned_record["data_id"] = self._content_hash(
+                    {**cleaned_record, "filename": record.get("filename")}
+                )
+            else:
+                cleaned_record["data_id"] = str(uuid.uuid4())
             return cleaned_record
 
         unique_id = record.get(self.unique_id_column)
@@ -159,6 +184,33 @@ class RecordProcessor:
         else:
             logger.warning(f"Missing or invalid unique ID for record: {record}")
             return None
+
+    def _content_hash(self, cleaned_record: Dict[str, Any]) -> str:
+        """
+        Deterministic ``data_id`` from the record's cleaned content (#225).
+
+        SHA-256 over the per-table salt + a canonical JSON serialization of
+        every cleaned field (sorted keys, ASCII, compact separators,
+        ``default=str`` so dates/decimals serialize stably post-cast). The
+        record is hashed AFTER schema cleaning and label policy, so the
+        digest reflects exactly what will be stored — identical source
+        records produce identical ids across process restarts.
+
+        Privacy: the salt (random per table, cluster-MySQL-only) makes the
+        digest unlinkable across tables/clusters and defeats dictionary
+        attacks on low-cardinality records; only 10 opaque ``{data_id,
+        label}`` samples ever leave the cluster in the ingest summary.
+        """
+        canonical = json.dumps(
+            cleaned_record,
+            sort_keys=True,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return hashlib.sha256(
+            (self.table_salt + canonical).encode("utf-8")
+        ).hexdigest()
 
     def process(self, record: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Process a single record"""

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -163,9 +163,9 @@
       "properties": {
         "strategy": {
           "type": "string",
-          "enum": ["uuid", "column"],
+          "enum": ["uuid", "column", "content_hash"],
           "default": "uuid",
-          "description": "How `data_id` is generated. `uuid` (default) generates a fresh UUID per record — no source column leaves the cluster. `column` maps a source column's value, which is louder (logged warning) and only safe when the column doesn't carry PII."
+          "description": "How `data_id` is generated. `uuid` (default) generates a fresh UUID per record — no source column leaves the cluster, but a retried run re-inserts every row under new ids. `column` maps a source column's value, which is louder (logged warning) and only safe when the column doesn't carry PII. `content_hash` derives a deterministic id from the record's content (features + label + source filename), salted with a random per-table value that never leaves the cluster — a retried run re-claims its previous rows instead of duplicating them. Note: genuinely identical source rows therefore collapse into one stored row (content-level dedup)."
         },
         "column": {
           "type": "string",


### PR DESCRIPTION
## Summary
With uuid ids, a retried k8s Job re-inserts every row under fresh ids — the 3×-duplication bug. `content_hash` derives `data_id = sha256(per-table salt + canonical JSON of the cleaned record + source filename)`, so a retry reproduces its ids exactly and the `data_id` UNIQUE upsert **re-claims** the prior attempt's rows: ownership moves to the new `ingestor_id` (whose scoped label counts then cover the full dataset) and the drained old dataset auto-retires via the existing heartbeat reaper. One change cures retry duplication, the retry-orphan flavor of #227, and the double-registration vector.

**Landed dark**: default stays `uuid`; opt-in via `data_id: {strategy: content_hash}`. Flip after one release of soak. Decisions + privacy sign-off (salted hash approved): [backend#818, 2026-07-07](https://github.com/tracebloc/backend/issues/818#issuecomment-4901461018).

## Privacy
Salt = 32 random bytes, created atomically (`INSERT IGNORE`) in cluster-MySQL `tracebloc_ingest_meta` (name now reserved against dataset use) — **never leaves the cluster**. Per-table salting makes ids unlinkable across tables/clusters and defeats dictionary attacks; only 10 opaque `{data_id,label}` samples ever egress. Salt fetch deferred to `ingest()` post-validation (mirrors #260), so a rejected run leaves no salt row.

## Two catches worth reading
- **Self-review**: for file-bearing categories the schema-filtered record is just `{label, data_intent}` — without folding the source **filename** into the hash, all same-label images would collide and the upsert would collapse the dataset. Fixed + pinned by test.
- **Adversarial review (HIGH)**: `CSVIngestor`/`JSONIngestor` have explicit param lists and dropped the new kwarg → **TypeError on every YAML-driven run, even defaults** — invisible to the unit suite because nothing constructed through `_build_ingestor`. Fixed + pinned by a 4-way construction-matrix test; the full-engine e2e (`run.main` over all 15 templates on real MySQL) now guards this class.

Documented semantic: genuinely identical source rows collapse into one stored row (content-level dedup — noted in the schema description); a per-run collapsed-duplicates counter is a follow-up for un-darkening.

**Note for tracebloc/cli**: vendored `ingest.v1.json` gains an enum value — re-vendor with the pending category sync when this promotes to master.

## Testing
+17 unit (determinism across instances/salts, filename+label participation, precedence, dark-default byte-identical, construction matrix csv×json × default×content_hash, schema, conventions) + 2 e2e on **real MySQL** (retry re-claim: count constant, ownership flips, scoped counts correct; per-table salt isolation). Suite **1353 passed, 1 xfailed**; full e2e **36/36** incl. all 15 modality templates.

Refs #225 · sibling PR #337 (#227 compensating delete) · design backend#818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)