### PR TITLE
chore(release): bump version to 0.5.7

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.5.6"
+__version__ = "0.5.7"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
## Summary

Bumps `__version__` from `0.5.6` to `0.5.7` on develop to open the next release cycle after [#330](https://github.com/tracebloc/data-ingestors/pull/330) promoted v0.5.6 to master.

`setup.py` reads the literal from `tracebloc_ingestor/__init__.py` ([#175](https://github.com/tracebloc/data-ingestors/pull/175)), so this is the only file to bump.

## Test plan
- [x] `__version__` resolves to `0.5.7` from a Python import.
- [x] No functional code change; existing suite continues to pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version constant change with no behavioral impact.
> 
> **Overview**
> **Version bump only:** `__version__` in `tracebloc_ingestor/__init__.py` changes from `0.5.6` to `0.5.7` to start the next release cycle on develop after v0.5.6 shipped.
> 
> No runtime or API changes. `setup.py` still reads this literal via `_read_version()`, so packaging version stays in sync without editing `setup.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e8bccb429d5c9f68ab40693f4079b35f301b038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->