### PR TITLE
fix(csv): strip UTF-8 BOM in stdlib csv.reader header probes (#338)

### DIFF
--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -82,6 +82,23 @@ def test_read_data_preserves_leading_zeros_with_whitespace_header(tmp_path):
     assert records[1]["code"] == "042"
 
 
+def test_read_data_rejects_bom_masked_duplicate_headers(tmp_path):
+    # Issue #338: with the stdlib csv.reader probe on plain utf-8, a BOM'd
+    # first header (a U+FEFF glued to "a") no longer equals a later "a", so a
+    # duplicate that pandas WILL silently disambiguate ("a","a" -> "a","a.1")
+    # slips past the up-front dup-header guard — the exact invisible
+    # schema-misalignment it exists to prevent. The probe now opens with
+    # utf-8-sig, stripping the BOM so the duplicate is caught before pandas
+    # reads. (Verified: on plain utf-8 the probe sees the BOM'd name as
+    # distinct from "a" and detects no dup.)
+    p = tmp_path / "bom_dups.csv"
+    p.write_text("a,a\n1,2\n3,4\n", encoding="utf-8-sig")
+    assert p.read_bytes().startswith(b"\xef\xbb\xbf")  # sanity: file has a BOM
+    ing = make_csv_ingestor(schema={"a": "INT"})
+    with pytest.raises(ValueError, match="Duplicate column"):
+        list(ing.read_data(str(p)))
+
+
 def test_read_data_schema_column_missing_raises(make_csv):
     path = make_csv({"a": [1]})
     ing = make_csv_ingestor(schema={"a": "INT", "missing": "INT"})

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -99,6 +99,20 @@ def test_read_data_rejects_bom_masked_duplicate_headers(tmp_path):
         list(ing.read_data(str(p)))
 
 
+def test_read_data_bom_guard_covers_utf8_aliases(tmp_path):
+    # Issue #338 follow-up: the BOM upgrade must fire for every UTF-8 spelling,
+    # not just "utf-8"/"utf8". "utf_8" (underscore) is a valid Python codec
+    # that does NOT strip a BOM, so a config using it would have slipped the
+    # BOM'd first header past the dup guard again. _bom_safe_encoding now
+    # canonicalises via codecs.lookup, so the duplicate is still caught.
+    p = tmp_path / "bom_dups_alias.csv"
+    p.write_text("a,a\n1,2\n3,4\n", encoding="utf-8-sig")
+    assert p.read_bytes().startswith(b"\xef\xbb\xbf")  # sanity: file has a BOM
+    ing = make_csv_ingestor(schema={"a": "INT"}, csv_options={"encoding": "utf_8"})
+    with pytest.raises(ValueError, match="Duplicate column"):
+        list(ing.read_data(str(p)))
+
+
 def test_read_data_schema_column_missing_raises(make_csv):
     path = make_csv({"a": [1]})
     ing = make_csv_ingestor(schema={"a": "INT", "missing": "INT"})

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -339,6 +339,25 @@ def test_csv_schema_missing_lists_all_missing_columns(make_csv):
     assert "missing1" in err and "missing2" in err
 
 
+def test_csv_utf8_bom_header_not_falsely_missing(tmp_path):
+    """Issue #338: an Excel "CSV UTF-8" export prepends a byte-order mark, so
+    the stdlib ``csv.reader`` header probe (unlike pandas) reads the first
+    column as a BOM glued to ``age``. The schema-presence check then falsely
+    reports ``age`` missing — a misleading rejection of a file every pandas
+    read path accepts. The probe now opens with utf-8-sig, which strips the
+    BOM; this test also pins that pandas' chunk read strips it too (else the
+    per-column cast would see a BOM'd column and fail).
+    """
+    p = tmp_path / "excel_bom.csv"
+    # write_text with utf-8-sig prepends the BOM, exactly like Excel's export.
+    p.write_text("age,income\n30,50000\n41,72000\n", encoding="utf-8-sig")
+    # sanity: the file really does start with a UTF-8 BOM
+    assert p.read_bytes().startswith(b"\xef\xbb\xbf")
+    result = DataValidator(schema={"age": "INT", "income": "INT"}).validate(str(p))
+    assert result.is_valid, f"BOM'd CSV falsely rejected; errors={result.errors}"
+    assert not any("not present in CSV" in e for e in result.errors)
+
+
 def test_json_sparse_schema_field_still_passes(tmp_path):
     """JSON ingestion is intentionally permissive: JSONIngestor._validate_record
     only WARNS when a schema field is absent from a record and proceeds. A

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -23,6 +23,25 @@ from ..config import Config
 config = Config()
 
 
+def _bom_safe_encoding(encoding: Optional[str]) -> str:
+    """Return a BOM-stripping encoding for the stdlib ``csv.reader`` header
+    probes (#338).
+
+    ``utf-8-sig`` decodes UTF-8 identically to ``utf-8`` but also strips a
+    leading byte-order mark. Excel's "CSV UTF-8" export prepends a BOM;
+    ``open(..., encoding="utf-8")`` leaves it on the first header (a U+FEFF
+    byte-order mark glued to ``age``) and ``str.strip()`` does not remove it
+    — so a probe keyed on that header (the string-dtype pin, the
+    duplicate-header check)
+    silently misreads the first column, while every pandas read path (which
+    strips the BOM) accepts the same file. Only the UTF-8 family is
+    upgraded; an explicit non-UTF-8 encoding is returned unchanged.
+    """
+    if not encoding or encoding.lower() in ("utf-8", "utf8"):
+        return "utf-8-sig"
+    return encoding
+
+
 def _raise_on_overflow(
     column: str, original: pd.Series, converted: pd.Series, dtype: str
 ) -> None:
@@ -420,7 +439,7 @@ class CSVIngestor(BaseIngestor):
                 with open(
                     file_path,
                     "r",
-                    encoding=self.csv_options.get("encoding", "utf-8"),
+                    encoding=_bom_safe_encoding(self.csv_options.get("encoding")),
                     newline="",
                 ) as _fh:
                     _raw = next(_csv.reader(_fh, delimiter=_sep_probe), [])
@@ -478,7 +497,7 @@ class CSVIngestor(BaseIngestor):
                 with open(
                     file_path,
                     "r",
-                    encoding=csv_options.get("encoding", "utf-8"),
+                    encoding=_bom_safe_encoding(csv_options.get("encoding")),
                     newline="",
                 ) as _fh:
                     _row = next(_csv.reader(_fh, delimiter=_sep), [])

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -5,6 +5,7 @@ pandas-based reading and validation capabilities.
 """
 
 from typing import Dict, Any, Generator, Optional, List
+import codecs
 import csv as _csv
 import numpy as np
 import pandas as pd
@@ -36,9 +37,22 @@ def _bom_safe_encoding(encoding: Optional[str]) -> str:
     silently misreads the first column, while every pandas read path (which
     strips the BOM) accepts the same file. Only the UTF-8 family is
     upgraded; an explicit non-UTF-8 encoding is returned unchanged.
+
+    Canonicalise via ``codecs.lookup`` rather than matching a hardcoded alias
+    tuple: Python accepts several spellings for UTF-8 (``utf_8``, ``U8``,
+    ``utf``, ``cp65001``, ...), none of which strip a BOM, so a config that
+    used one of those would silently reintroduce the bug this guards against.
     """
-    if not encoding or encoding.lower() in ("utf-8", "utf8"):
+    if not encoding:
         return "utf-8-sig"
+    try:
+        if codecs.lookup(encoding).name == "utf-8":
+            return "utf-8-sig"
+    except LookupError:
+        # Unknown encoding name — leave it untouched so the probe's own
+        # open() raises the real UnicodeDecodeError/LookupError, matching the
+        # main read's behaviour.
+        pass
     return encoding
 
 

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -214,7 +214,12 @@ class DataValidator(BaseValidator):
         #   2. Reject duplicate headers up front so they fail in validation,
         #      not later in the ingestor — same error CSVIngestor raises.
         try:
-            with open(path, "r", encoding="utf-8", newline="") as _fh:
+            # utf-8-sig strips a leading BOM (Excel "CSV UTF-8" export) that
+            # plain utf-8 leaves on the first header — without it the
+            # schema-presence check below falsely reports the first column
+            # missing, while pandas' read path (which strips the BOM) accepts
+            # the same file (#338). Decodes ordinary utf-8 identically.
+            with open(path, "r", encoding="utf-8-sig", newline="") as _fh:
                 _raw_header = next(_csv.reader(_fh), [])
             _stripped = [str(h).strip() for h in _raw_header]
             _dups = sorted({h for h in _stripped if _stripped.count(h) > 1})


### PR DESCRIPTION
## Summary

Excel's "CSV UTF-8" export prepends a UTF-8 BOM. The stdlib `csv.reader` header probes read it over `open(encoding="utf-8")`, which does **not** strip the BOM (and `str.strip()` doesn't remove `U+FEFF`) — unlike every pandas read path in the codebase, which strips it fine. So a BOM'd export:

- **DataValidator** — the schema-presence check `set(schema) - set(header)` sees `<BOM>age` as the first column and falsely reports `age` missing. The file is **rejected in-cluster after the full upload**, with a misleading error naming a column that IS present. *(the user-visible bug)*
- **CSVIngestor** — the up-front duplicate-header guard sees a BOM'd first column as distinct from a later identically-named one, so a real duplicate slips past and pandas silently disambiguates it to `a`/`a.1`, mapping the schema onto the wrong physical column.

## Fix

Open the stdlib probe streams with `utf-8-sig` — strips a leading BOM, decodes ordinary utf-8 identically.
- `data_validator.py`: literal `utf-8-sig` on the streaming header probe.
- `csv_ingestor.py`: a `_bom_safe_encoding()` helper routes the configurable encoding — only the utf-8 family is upgraded; an explicit non-utf-8 encoding is left untouched.

The main pandas reads already strip the BOM (verified on pandas 3.0.3) and are unchanged.

## Tests

- `test_data_validator.py::test_csv_utf8_bom_header_not_falsely_missing` — a BOM'd CSV now validates; also pins that pandas' chunk read strips the BOM.
- `test_csv_ingestor.py::test_read_data_rejects_bom_masked_duplicate_headers` — a BOM-masked duplicate header is now caught (empirically verified it slips past on plain utf-8).

Full suite: **1413 passed, 1 xfailed** (pre-existing leading-zeros INT gap), no regressions.

## Type

Bug fix (correctness) · data-ingestors · RFC-0002 foundation ([backend#1008](https://github.com/tracebloc/backend/issues/1008))

## Follow-up (CLI, not this PR)

Once this ships in deployed ingestor images, the CLI's local preflight (which currently pre-rejects BOM'd tabular CSVs to match the *old* in-cluster behaviour) can relax to strip-and-continue; regenerate the validator goldens (`scripts/gen-validator-goldens.py`) so the parity test flags the change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to how header rows are opened for probes; pandas ingest paths are unchanged and behavior for non–UTF-8 encodings is preserved.
> 
> **Overview**
> Fixes **#338**: Excel “CSV UTF-8” files start with a BOM. Stdlib `csv.reader` header probes used plain `utf-8`, so the first column name kept `U+FEFF` and no longer matched the schema or duplicate checks, while pandas reads already strip the BOM.
> 
> **DataValidator** opens the streaming header probe with **`utf-8-sig`**, so schema-presence checks no longer falsely report the first column missing.
> 
> **CSVIngestor** adds **`_bom_safe_encoding()`** and uses it on both header probes (string-dtype pin and duplicate-column guard). UTF-8 family encodings are normalized via `codecs.lookup` (e.g. `utf_8` → `utf-8-sig`); non–UTF-8 encodings are unchanged.
> 
> New tests cover BOM’d valid CSVs, BOM-masked duplicate headers, and the `utf_8` encoding alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dbad79f6e2a5b009029cc49f2c7fa06ad62d316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->