### PR TITLE
fix(ingest): resolve label column to the real header before read (#340)

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -1,0 +1,42 @@
+"""Tests for the shared column-name resolution rule (#340).
+
+``resolve_column`` is the single source of truth for matching a declared
+column name to the actual header, used by BOTH the validators
+(``BaseValidator._match_column`` delegates here) and the ingest read path
+(``BaseIngestor._resolve_label_column``). The two used to diverge — that was
+the #340 silent-null-label bug.
+"""
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.utils.columns import resolve_column
+from tracebloc_ingestor.validators.base import BaseValidator
+
+
+@pytest.mark.parametrize(
+    "cols,name,expected",
+    [
+        (["a", "b"], "a", "a"),                     # exact match wins
+        (["Label", "feat"], "label", "Label"),      # case-insensitive; returns original spelling
+        ([" label ", "n"], "label", " label "),     # whitespace-insensitive; returns raw spelling
+        (["Age", "Income"], "AGE", "Age"),           # fold on both sides
+        (["label"], " label ", "label"),             # whitespace on the query side too
+        (["a", "b"], "missing", None),               # nothing matches
+        ([], "x", None),                             # empty columns
+    ],
+)
+def test_resolve_column(cols, name, expected):
+    assert resolve_column(cols, name) == expected
+
+
+def test_resolve_column_accepts_pandas_columns_and_dict_keys():
+    assert resolve_column(pd.DataFrame({"Label": [1]}).columns, "label") == "Label"
+    assert resolve_column({"Label": 1, "n": 2}.keys(), "label") == "Label"
+
+
+def test_validator_match_column_delegates_to_resolve_column():
+    # Pin the single-source contract: the validator helper must produce the
+    # same answer as the shared rule for the same inputs (#340).
+    for cols, name in ([["Label", "feat"], "label"], [[" id "], "ID"], [["x"], "y"]):
+        assert BaseValidator._match_column(cols, name) == resolve_column(cols, name)

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -160,6 +160,97 @@ def test_process_record_applies_bucket_label_policy():
     assert rec["label"] != "12345"
 
 
+def test_process_record_reads_label_by_configured_key():
+    """Baseline for #340: RecordProcessor reads the label by EXACT key. With
+    a mismatched key it reads None — this is why the ingestor must resolve the
+    label column to the real header before processing (see the
+    _resolve_label_column + end-to-end tests below)."""
+    ing = make_ingestor(label_column="label", schema={"a": "INT", "label": "VARCHAR(10)"}, category=None)
+    # exact key -> label present
+    assert ing.process_record({"a": "1", "label": "cat", "filename": "f"})["label"] == "cat"
+    # mismatched-case key with the SAME configured name -> None (the bug)
+    assert ing.process_record({"a": "1", "Label": "cat", "filename": "f"})["label"] is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_label_column (#340)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "columns,expected",
+    [
+        (["a", "Label"], "Label"),      # case mismatch -> real header
+        (["a", " label "], " label "),  # whitespace mismatch -> raw header
+        (["a", "label"], "label"),       # exact -> unchanged
+        (["a", "b"], "label"),           # absent -> configured name untouched
+    ],
+)
+def test_resolve_label_column(columns, expected):
+    ing = make_ingestor(label_column="label", schema={"a": "INT", "label": "VARCHAR(10)"})
+    ing._resolve_label_column(columns)
+    assert ing.label_column == expected
+
+
+def test_resolve_label_column_noop_when_unset():
+    ing = make_ingestor(label_column=None)
+    ing._resolve_label_column(["a", "b"])
+    assert ing.label_column is None
+
+
+def test_ingest_label_case_mismatch_survives_to_db():
+    """#340 end-to-end: config ``label: label`` against a header ``Label``.
+    The label column is validated case-insensitively, so the manifest passes
+    preflight; the ingest loop must resolve it to the real header or every
+    label reaches the DB as None (silent all-NULL labels)."""
+    records = [
+        {"a": "1", "Label": "cat", "filename": "f1"},
+        {"a": "2", "Label": "dog", "filename": "f2"},
+    ]
+    ing = make_ingestor(
+        records=records,
+        category=None,
+        label_column="label",
+        schema={"a": "INT", "label": "VARCHAR(10)"},
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    ing.database.insert_batch.assert_called()
+    _table, batch = ing.database.insert_batch.call_args.args
+    assert [r.get("label") for r in batch] == ["cat", "dog"], (
+        f"labels nulled by case mismatch: {[r.get('label') for r in batch]}"
+    )
+
+
+def test_ingest_label_resolves_on_later_record_for_sparse_json():
+    """#340 JSON edge: records may be sparse — a leading object can omit the
+    label. Resolution must retry on later records, not give up after the first,
+    or a mis-cased label on every subsequent row would still null. The first
+    (label-less) record legitimately gets None; the second resolves 'Label'."""
+    records = [
+        {"a": "1", "filename": "f1"},                   # no label key at all
+        {"a": "2", "Label": "dog", "filename": "f2"},   # mis-cased label
+    ]
+    ing = make_ingestor(
+        records=records,
+        category=None,
+        label_column="label",
+        schema={"a": "INT", "label": "VARCHAR(10)"},
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    _table, batch = ing.database.insert_batch.call_args.args
+    assert [r.get("label") for r in batch] == [None, "dog"], (
+        f"expected [None, 'dog']; got {[r.get('label') for r in batch]}"
+    )
+
+
 def test_process_record_strips_whitespace_from_string_label():
     """Issue #261: a raw label value like ``"  A  "`` must be stripped
     before the label policy runs, so MySQL stores ``"A"`` and a CSV

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -17,6 +17,7 @@ from ..utils.constants import (
     CYAN,
 )
 from ..utils import label_policy as label_policy_module
+from ..utils.columns import resolve_column
 from ..utils.validators_mapping import map_validators
 from ..file_transfer import map_file_transfer
 from ..text_profile import compute_text_profile
@@ -268,6 +269,43 @@ class BaseIngestor(ABC):
         """
         return self._record_processor.process(record)
 
+    def _resolve_label_column(self, columns: Any) -> bool:
+        """Pin the configured label column to the actual header spelling (#340).
+
+        The label column is validated case-/whitespace-insensitively
+        (``LabelColumnValidator`` via the shared ``resolve_column`` rule), but
+        the read path pulls it out of each record by exact key — so a manifest
+        ``label: label`` against a header ``Label`` passes preflight and then
+        reads ``None`` for every row (silent all-NULL labels). Resolving the
+        configured name to the real header once, then reading with it, keeps
+        the read path and the validators in agreement.
+
+        Uses the SAME rule as the validators (single source of truth), so a
+        column that passed the label-presence check resolves identically here.
+
+        Returns ``True`` once resolution is settled — the name matched (exactly
+        or after remap) or no column is configured — and ``False`` when the
+        configured name is not present in ``columns`` yet. The caller pins on
+        the first record that *contains* the label: for CSV that's always the
+        first record (a stable full header), and for JSON — whose records may
+        be sparse (a leading object can omit the label) — it retries on later
+        records instead of giving up after the first. A name genuinely absent
+        from every record is left untouched so the existing missing-column
+        handling still fires.
+        """
+        if not self.label_column:
+            return True
+        resolved = resolve_column(columns, self.label_column)
+        if resolved is None:
+            return False
+        if resolved != self.label_column:
+            logger.info(
+                f"Resolved label column {self.label_column!r} to header "
+                f"{resolved!r} (case/whitespace-insensitive match)."
+            )
+            self.label_column = resolved
+        return True
+
     @property
     def _table_lock(self) -> TableLock:
         """The run's table lock (P5b). ``TableLock`` owns the file-lock
@@ -481,8 +519,20 @@ class BaseIngestor(ABC):
             try:
                 pbar = tqdm(total=total, desc="Ingesting records", unit="records")
 
+                _label_resolved = False
                 for record in self.read_data(source):
                     stats["total_records"] += 0 if total else 1
+
+                    # #340: pin the label column to the actual header spelling
+                    # before it is processed. The validators matched the label
+                    # case-/whitespace-insensitively, so a header like ``Label``
+                    # for a config ``label: label`` passed preflight; without
+                    # this the read path (exact key) would then read None for
+                    # every row. Pin on the first record that CONTAINS the label
+                    # — for CSV that's the first record (stable header); for
+                    # sparse JSON a leading object may omit it, so keep trying.
+                    if not _label_resolved:
+                        _label_resolved = self._resolve_label_column(record.keys())
 
                     try:
                         processed_record = self.process_record(record)

--- a/tracebloc_ingestor/utils/columns.py
+++ b/tracebloc_ingestor/utils/columns.py
@@ -1,0 +1,41 @@
+"""Shared column-name resolution (#340).
+
+The label / filename columns a dataset author declares in the manifest may not
+match the CSV/JSON header exactly in case or surrounding whitespace. Both the
+validators (which decide accept / reject) and the ingest read path (which pulls
+the value out of each record) must resolve a declared name to the actual header
+the SAME way — otherwise a manifest can pass preflight and then read ``None``
+for every row.
+
+That was the #340 divergence: the validators matched the label column
+case-/whitespace-insensitively (``BaseValidator._match_column``), but
+``RecordProcessor`` read it by exact key, so a config ``label: label`` against a
+header ``Label`` passed both preflights and then silently nulled every label at
+ingest.
+
+This module is that single matching rule. ``BaseValidator._match_column``
+delegates here, and ``BaseIngestor`` calls it to pin the resolved label column
+once per run so the read path and the validators agree.
+"""
+
+from typing import Any, Optional
+
+
+def resolve_column(columns: Any, name: str) -> Optional[str]:
+    """Return the actual column in ``columns`` matching ``name``, case- AND
+    whitespace-insensitively; ``None`` when nothing matches.
+
+    ``columns`` is any iterable of column names (a DataFrame's ``.columns``, an
+    Index, a plain list, a dict's keys). An exact match wins first; otherwise
+    both sides are compared stripped + lower-cased. The ORIGINAL (un-lowercased)
+    column spelling is returned so callers can index the raw frame / record with
+    it. Surrounding whitespace is stripped on both sides because ``CSVIngestor``
+    strips header whitespace on read (``chunk.columns.str.strip()``), so a header
+    ``" label "`` is ingested as ``label`` and must resolve here too.
+    """
+    cols = list(columns)
+    if name in cols:
+        return name
+    target = str(name).strip().lower()
+    normalised = {str(c).strip().lower(): c for c in cols}
+    return normalised.get(target)

--- a/tracebloc_ingestor/validators/base.py
+++ b/tracebloc_ingestor/validators/base.py
@@ -167,13 +167,16 @@ class BaseValidator(ABC):
         ingests fine fails preflight as if the column were missing (matches
         ``LabelDiversityValidator._resolve_column``). The ORIGINAL column name
         is returned so callers can still index the (un-stripped) raw frame.
+
+        The rule is single-sourced in
+        :func:`tracebloc_ingestor.utils.columns.resolve_column` so the ingest
+        read path resolves the label column identically — the two used to
+        diverge (validators case-insensitive, ``RecordProcessor`` exact),
+        silently nulling every label (#340).
         """
-        cols = list(columns)
-        if name in cols:
-            return name
-        target = str(name).strip().lower()
-        normalised = {str(c).strip().lower(): c for c in cols}
-        return normalised.get(target)
+        from ..utils.columns import resolve_column
+
+        return resolve_column(columns, name)
 
     @staticmethod
     def _parse_json(row: Any, column: str) -> Optional[Any]:


### PR DESCRIPTION
## Summary

The validators resolve the label column **case- and whitespace-insensitively** (`BaseValidator._match_column`), but the read path (`RecordProcessor`) reads it by **exact key** (`record.get(self.label_column)`). So a manifest `label: label` against a CSV header `Label` (or `" label "`):

1. **passes** the in-cluster preflight *and* the CLI preflight (both use the case-insensitive rule), then
2. reads `None` for **every** record's label at ingest.

The result is silent all-NULL labels: a green ingest that quietly destroys the label set. Found during the cli#147 parity work — the parity harness is structurally blind to it (both preflights *accept*; the divergence is in what happens *after* acceptance).

## Fix — single-source the rule, pin it once

- **`tracebloc_ingestor/utils/columns.py::resolve_column`** — the one matching rule (exact wins; else stripped+lowercased compare; returns the original header spelling). `BaseValidator._match_column` now **delegates** to it, so the validators and the read path can no longer drift apart.
- **`BaseIngestor._resolve_label_column`** — resolves the configured label column against the actual header and reassigns `self.label_column`, pinned **once** in the shared ingest loop on the first record that *contains* the label. For CSV that's the first record (stable full header); for JSON — whose records may be **sparse** (a leading object can omit the label) — it retries on later records instead of giving up after the first. No-op on an exact match or an unset column; a name absent from every record is left untouched (existing missing-column handling still fires).

**Scope:** label column only — the reported and verified bug. `unique_id_column` is already guarded by a loud case-sensitive presence check in `CSVIngestor.read_data` (hard error, not a silent null), so it isn't part of this class.

## Tests

- `test_columns.py` — `resolve_column` matrix (exact / case / whitespace / absent / pandas-cols / dict-keys) **and** a delegation-equivalence check pinning that the validator helper returns the same answer as the shared rule.
- `test_ingestor_base.py` — a **baseline** proving the exact-key read nulls a mismatched header (the bug); `_resolve_label_column` remap/exact/absent/unset cases; an **end-to-end** `ing.ingest()` asserting `Label` → `"cat"`/`"dog"` reaches the DB batch, not `None`; and a **sparse-JSON** case asserting resolution retries onto a later record when the first omits the label.

Full suite: **1427 passed, 1 xfailed** (pre-existing leading-zeros INT gap), no regressions.

## Type

Bug fix (correctness / silent data loss) · data-ingestors · RFC-0002 foundation ([backend#1008](https://github.com/tracebloc/backend/issues/1008)); this is the #340 drift-bug class Principle 6 / the value-level parity harness ([backend#1009](https://github.com/tracebloc/backend/issues/1009)) exist to prevent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ingest label extraction on every labeled run; scope is narrow (label column only) but incorrect resolution would still corrupt training labels.
> 
> **Overview**
> Fixes **#340**: manifests could pass label preflight (case-insensitive validators) yet ingest every row with **NULL labels** because `RecordProcessor` reads the label by exact dict key.
> 
> Adds **`resolve_column`** as the shared header-matching rule (exact match first, else stripped + case-folded compare; returns the original header spelling). **`BaseValidator._match_column`** now delegates there instead of duplicating logic.
> 
> **`BaseIngestor._resolve_label_column`** remaps `self.label_column` once per run using that rule. The ingest loop calls it on each record until the label column is found—so CSV pins on the first row and sparse JSON can resolve on a later row—then **`process_record`** uses the real header key.
> 
> New tests cover `resolve_column`, validator delegation parity, resolution edge cases, and end-to-end ingest when config says `label` but data has `Label`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d4d018383bb1b21acb01da8e6b5e86db9938c3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->