### PR TITLE
feat(layout): publish a machine-readable per-task dataset-layout contract (#347)

### DIFF
--- a/tests/test_layout_contract.py
+++ b/tests/test_layout_contract.py
@@ -1,0 +1,162 @@
+"""Pins the machine-readable per-task layout contract (data-ingestors#347).
+
+Three guarantees:
+  1. DRIFT — the committed schema/layout.v1.json equals what the registry emits
+     (regenerate with `python -m tracebloc_ingestor.modalities.layout`).
+  2. CONGRUENCE — the contract covers exactly the task taxonomy, and its
+     derived fields agree with each spec's flags (single source, no drift).
+  3. FAITHFULNESS — spot-checks that the two hand-declared pieces (sidecars,
+     record_format) match the ingestor's actual layout truth, so the Go mirror
+     the CLI builds against this JSON can't encode a wrong layout.
+"""
+
+from __future__ import annotations
+
+import json
+
+from tracebloc_ingestor.modalities.layout import (
+    build_layout_contract,
+    contract_path,
+    render_contract,
+)
+from tracebloc_ingestor.modalities.registry import REGISTRY
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+def _contract():
+    return build_layout_contract()["tasks"]
+
+
+# 1. DRIFT --------------------------------------------------------------------
+
+
+def test_committed_json_matches_registry():
+    with open(contract_path(), encoding="utf-8") as fh:
+        committed = fh.read()
+    assert committed == render_contract(), (
+        "schema/layout.v1.json is stale — regenerate with "
+        "`python -m tracebloc_ingestor.modalities.layout` and commit the result."
+    )
+
+
+def test_committed_json_is_valid_and_versioned():
+    with open(contract_path(), encoding="utf-8") as fh:
+        doc = json.load(fh)
+    assert doc["version"], "layout contract must carry a version"
+    assert doc["tasks"], "layout contract has no tasks"
+
+
+# 2. CONGRUENCE ---------------------------------------------------------------
+
+
+def test_contract_covers_exactly_the_taxonomy():
+    # Same set as the registry / TaskCategory / schema enum — a category the
+    # customer can submit always has a layout, and none is invented.
+    assert set(_contract()) == set(REGISTRY)
+    assert set(_contract()) == set(TaskCategory.get_all_categories())
+
+
+def test_derived_fields_agree_with_spec_flags():
+    contract = _contract()
+    for cat, spec in REGISTRY.items():
+        layout = contract[cat]
+        assert layout["family"] == spec.data_format, cat
+        assert layout["primary_subdir"] == spec.file_subdir, cat
+        # file-bearing ⇒ a labels CSV listing per-row files; else the data CSV.
+        assert (
+            layout["manifest"]["requires_filename_column"] == spec.is_file_bearing
+        ), cat
+        assert layout["manifest"]["kind"] == (
+            "labels_csv" if spec.is_file_bearing else "data_csv"
+        ), cat
+        # a user label/target column exists iff the task isn't self-supervised.
+        assert layout["manifest"]["has_label_column"] == (
+            not spec.is_self_supervised
+        ), cat
+
+
+def test_sidecars_only_on_file_bearing_tasks():
+    for cat, layout in _contract().items():
+        if layout["sidecars"]:
+            assert REGISTRY[
+                cat
+            ].is_file_bearing, f"{cat} declares sidecars but isn't file-bearing"
+
+
+def test_record_format_only_on_text_tasks():
+    for cat, layout in _contract().items():
+        if layout["record_format"] is not None:
+            assert (
+                REGISTRY[cat].data_format == "text"
+            ), f"{cat} has a record_format but isn't text"
+
+
+# 3. FAITHFULNESS (spot-checks vs the ingestor's real layout) -----------------
+
+
+def test_object_detection_requires_pascal_voc_xml_sidecar():
+    sc = _contract()["object_detection"]["sidecars"]
+    assert sc == [
+        {
+            "subdir": "annotations",
+            "glob": "*.xml",
+            "required": True,
+            "link_column": None,
+        }
+    ]
+
+
+def test_semantic_segmentation_masks_linked_by_mask_id():
+    sc = _contract()["semantic_segmentation"]["sidecars"]
+    assert sc == [
+        {"subdir": "masks", "glob": "*.png", "required": True, "link_column": "mask_id"}
+    ]
+
+
+def test_sentence_pair_is_enforced_tab_pair():
+    rf = _contract()["sentence_pair_classification"]["record_format"]
+    assert rf == {
+        "separator": "\t",
+        "fields": ["text_a", "text_b"],
+        "min_fields": 2,
+        "enforced": True,
+    }
+
+
+def test_embeddings_is_enforced_two_or_three_fields():
+    rf = _contract()["embeddings"]["record_format"]
+    assert rf["fields"] == ["anchor", "positive", "negative"]
+    assert rf["min_fields"] == 2 and rf["enforced"] is True  # 2 (pair) or 3 (triplet)
+
+
+def test_seq2seq_and_causal_lm_are_unenforced_conventions():
+    # Both accept raw free text — a mirror must NOT reject a non-tab file.
+    for cat in ("seq2seq", "causal_language_modeling"):
+        rf = _contract()[cat]["record_format"]
+        assert rf is not None and rf["enforced"] is False, cat
+
+
+def test_mlm_stages_from_sequences_with_no_record_format():
+    mlm = _contract()["masked_language_modeling"]
+    assert mlm["primary_subdir"] == "sequences"
+    assert mlm["record_format"] is None  # pre-tokenized is a convention, not enforced
+    assert mlm["manifest"]["has_label_column"] is False
+
+
+def test_keypoint_has_no_sidecar():
+    # Keypoints ride in the CSV (Annotation/Visibility columns), NOT a sidecar dir.
+    assert _contract()["keypoint_detection"]["sidecars"] == []
+
+
+def test_tabular_family_is_data_csv_without_file_layout():
+    for cat in (
+        "tabular_classification",
+        "tabular_regression",
+        "time_series_forecasting",
+        "time_to_event_prediction",
+    ):
+        layout = _contract()[cat]
+        assert layout["manifest"]["kind"] == "data_csv", cat
+        assert layout["manifest"]["requires_filename_column"] is False, cat
+        assert layout["primary_subdir"] is None, cat
+        assert layout["sidecars"] == [] and layout["record_format"] is None, cat

--- a/tracebloc_ingestor/modalities/layout.py
+++ b/tracebloc_ingestor/modalities/layout.py
@@ -1,0 +1,151 @@
+"""The per-task local dataset-layout contract (data-ingestors#347).
+
+The ingestor is the source of truth for *what a task's local dataset looks
+like* on disk — the manifest CSV, whether it carries a label column, the
+primary file subdir, extra sidecar dirs (``annotations/``, ``masks/``), and the
+in-``.txt`` record format for the structured text tasks. The CLI used to
+hardcode all of this in Go, which is why the CLI-pending tasks couldn't be
+staged without re-implementing the ingestor's layout rules — a fork
+(RFC-0002 Principle 6).
+
+This module exposes that layout as **machine-readable data** so the CLI's
+discovery/staging becomes a *verified mirror* of the ingestor's truth rather
+than independent logic:
+
+- ``Sidecar`` / ``RecordFormat`` are the two pieces that AREN'T already implied
+  by a category's ``ModalitySpec`` flags; they're declared on the spec
+  (``modalities/registry.py``).
+- ``build_layout_contract()`` composes the full per-task layout by DERIVING the
+  rest from the existing spec flags (``is_file_bearing`` → the manifest lists
+  per-row files; ``not is_self_supervised`` → a label column; ``file_subdir`` →
+  the primary dir; ``data_format`` → the family), so there is a single source
+  and the derived facts can't drift from behaviour.
+- ``tests/test_layout_contract.py`` pins the emitted contract against the
+  committed ``schema/layout.v1.json`` (regenerate on change) and against the
+  spec flags, and the CLI verifies its Go mirror against the same JSON.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+# Bump when the contract's SHAPE changes (fields added/removed/reinterpreted),
+# not when a task's values change — those are caught by the drift test.
+LAYOUT_CONTRACT_VERSION = "1"
+
+
+@dataclass(frozen=True)
+class Sidecar:
+    """An extra per-row directory a file-bearing task needs beyond its primary
+    ``file_subdir`` — e.g. object detection's Pascal-VOC ``annotations/*.xml``
+    or semantic segmentation's ``masks/*.png``.
+
+    ``link_column`` names the manifest CSV column that ties a row to its
+    sidecar file when the link isn't the plain filename stem (semseg's
+    ``mask_id`` — backend#816); ``None`` means the sidecar is paired by the
+    row's ``filename`` stem.
+    """
+
+    subdir: str
+    glob: str
+    required: bool
+    link_column: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class RecordFormat:
+    """The structure INSIDE each ``.txt`` for the structured text tasks.
+
+    ``fields`` are the ordered field names separated by ``separator``;
+    ``min_fields`` is the fewest that must be present (embeddings accepts an
+    optional trailing ``negative``, so ``fields=(anchor,positive,negative)``
+    with ``min_fields=2``). ``enforced`` is True only when a structural
+    validator rejects a malformed file in-cluster (sentence_pair, embeddings);
+    False marks a documented convention the ingestor does NOT reject (seq2seq,
+    causal LM accept raw free text), so a mirror must not reject it either.
+    """
+
+    separator: str
+    fields: Tuple[str, ...]
+    min_fields: int
+    enforced: bool
+
+
+def _sidecar_dict(s: Sidecar) -> Dict[str, Any]:
+    return {
+        "subdir": s.subdir,
+        "glob": s.glob,
+        "required": s.required,
+        "link_column": s.link_column,
+    }
+
+
+def _record_format_dict(rf: RecordFormat) -> Dict[str, Any]:
+    return {
+        "separator": rf.separator,
+        "fields": list(rf.fields),
+        "min_fields": rf.min_fields,
+        "enforced": rf.enforced,
+    }
+
+
+def _task_layout(spec: Any) -> Dict[str, Any]:
+    """Compose one task's layout: the two declared pieces (sidecars,
+    record_format) plus the facts DERIVED from the spec's existing flags."""
+    return {
+        "family": spec.data_format,  # image | text | tabular
+        "manifest": {
+            # File-bearing tasks list per-row files in a labels CSV (required
+            # `filename` column); tabular/time-series have no sidecar files —
+            # the data CSV itself is the manifest, with no `filename` column.
+            "kind": "labels_csv" if spec.is_file_bearing else "data_csv",
+            "requires_filename_column": spec.is_file_bearing,
+            # A user-supplied label/target column. Self-supervised text tasks
+            # (MLM/CLM/seq2seq/embeddings) have none; everything else does.
+            "has_label_column": not spec.is_self_supervised,
+        },
+        "primary_subdir": spec.file_subdir,  # images | texts | sequences | null
+        "sidecars": [_sidecar_dict(s) for s in spec.sidecars],
+        "record_format": (
+            _record_format_dict(spec.record_format) if spec.record_format else None
+        ),
+    }
+
+
+def build_layout_contract() -> Dict[str, Any]:
+    """Serialize the registry's per-task layout to a plain, JSON-ready dict —
+    the machine-readable contract the CLI vendors + mirrors.
+
+    Imported lazily to avoid a circular import (registry.py imports this
+    module's dataclasses)."""
+    from .registry import REGISTRY
+
+    tasks = {cat: _task_layout(spec) for cat, spec in REGISTRY.items()}
+    return {"version": LAYOUT_CONTRACT_VERSION, "tasks": tasks}
+
+
+# Path of the committed, machine-readable contract the CLI vendors + mirrors.
+# Kept next to ingest.v1.json (both are the CLI's contract surface).
+def contract_path() -> "os.PathLike[str]":
+    import os
+
+    return os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "schema", "layout.v1.json"
+    )
+
+
+def render_contract() -> str:
+    """The canonical serialization (sorted, trailing newline) — the exact bytes
+    committed to schema/layout.v1.json and pinned by the drift test."""
+    import json
+
+    return json.dumps(build_layout_contract(), indent=2, sort_keys=True) + "\n"
+
+
+if (
+    __name__ == "__main__"
+):  # `python -m tracebloc_ingestor.modalities.layout` regenerates the JSON
+    with open(contract_path(), "w", encoding="utf-8") as fh:
+        fh.write(render_contract())
+    print(f"wrote {contract_path()}")

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -15,6 +15,7 @@ from typing import Dict
 from ..utils.constants import DataFormat, TaskCategory
 from . import transfer as t
 from . import validators as v
+from .layout import RecordFormat, Sidecar
 from .spec import ModalitySpec
 
 # One entry per supported category — the single source of truth. P3a: the three
@@ -45,6 +46,9 @@ _SPECS = (
         transfer=t.object_detection,
         file_subdir="images",
         is_classification=True,
+        # Pascal-VOC XML, one per image, paired by filename stem (transfer.py
+        # object_detection; xml_validator; file_pairing_validator).
+        sidecars=(Sidecar(subdir="annotations", glob="*.xml", required=True),),
     ),
     ModalitySpec(
         TaskCategory.KEYPOINT_DETECTION,
@@ -67,6 +71,12 @@ _SPECS = (
         transfer=t.semantic_segmentation,
         file_subdir="images",
         is_classification=True,
+        # One mask PNG per image, linked by the CSV `mask_id` column (not the
+        # filename stem), convention `<stem>_mask.png` (transfer.py
+        # semantic_segmentation + backend#816; validators require .png).
+        sidecars=(
+            Sidecar(subdir="masks", glob="*.png", required=True, link_column="mask_id"),
+        ),
     ),
     ModalitySpec(
         TaskCategory.TEXT_CLASSIFICATION,
@@ -111,6 +121,11 @@ _SPECS = (
         is_nlp=True,
         file_subdir="texts",
         is_classification=True,
+        # Each .txt is exactly `text_a\ttext_b` — enforced by
+        # SentencePairValidator (rejects != 2 non-empty tab fields).
+        record_format=RecordFormat(
+            separator="\t", fields=("text_a", "text_b"), min_fields=2, enforced=True
+        ),
     ),
     # masked_language_modeling is file-bearing AND self-supervised (no label).
     ModalitySpec(
@@ -141,6 +156,15 @@ _SPECS = (
         transfer=t.causal_language_modeling,
         is_nlp=True,
         file_subdir="texts",
+        # Raw plain text (pretraining) OR `prompt\tcompletion` (SFT). A
+        # convention only — no structural validator, so a mirror must NOT
+        # reject either shape (enforced=False; min_fields=1 allows raw text).
+        record_format=RecordFormat(
+            separator="\t",
+            fields=("prompt", "completion"),
+            min_fields=1,
+            enforced=False,
+        ),
     ),
     # seq2seq is file-bearing AND self-supervised (no label), exactly like
     # causal_language_modeling. Each sample is one ``.txt`` of RAW text — a
@@ -159,6 +183,11 @@ _SPECS = (
         transfer=t.seq2seq,
         is_nlp=True,
         file_subdir="texts",
+        # `source\ttarget`. A convention — no structural validator (both fields
+        # are free text), so a mirror must not reject a raw file (enforced=False).
+        record_format=RecordFormat(
+            separator="\t", fields=("source", "target"), min_fields=1, enforced=False
+        ),
     ),
     # embeddings is file-bearing AND self-supervised (no label) — the
     # contrastive NLP modality. Each sample is one ``.txt`` of RAW text: a
@@ -180,6 +209,14 @@ _SPECS = (
         transfer=t.embeddings,
         is_nlp=True,
         file_subdir="texts",
+        # `anchor\tpositive` (2) OR `anchor\tpositive\tnegative` (3) — enforced
+        # by ContrastivePairsValidator (rejects anything but 2 or 3 tab fields).
+        record_format=RecordFormat(
+            separator="\t",
+            fields=("anchor", "positive", "negative"),
+            min_fields=2,
+            enforced=True,
+        ),
     ),
     # Tabular family (structured feature tables; no sidecar files -> no transfer).
     ModalitySpec(

--- a/tracebloc_ingestor/modalities/spec.py
+++ b/tracebloc_ingestor/modalities/spec.py
@@ -25,7 +25,10 @@ So the spec is intentionally small here and grows over P3b–P3d.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:  # annotations are strings (future import) — type-only import
+    from .layout import RecordFormat, Sidecar
 
 
 @dataclass(frozen=True)
@@ -90,3 +93,15 @@ class ModalitySpec:
     # regression / self-supervised / token-classification (per-token BIO) and
     # the time families.
     is_classification: bool = False
+    # The two per-task LAYOUT facts not already implied by the flags above
+    # (data-ingestors#347). Everything else about the on-disk layout is derived
+    # from the existing flags by ``modalities.layout.build_layout_contract``.
+    #
+    # sidecars: extra per-row directories beyond ``file_subdir`` —
+    #   object_detection's ``annotations/*.xml``, semantic_segmentation's
+    #   ``masks/*.png``. Empty for every other category.
+    # record_format: the structure inside each ``.txt`` for the structured text
+    #   tasks (sentence_pair / seq2seq / embeddings / causal LM); ``None`` when
+    #   the file is free text with no field structure the CLI must preview.
+    sidecars: Tuple["Sidecar", ...] = ()
+    record_format: Optional["RecordFormat"] = None

--- a/tracebloc_ingestor/schema/layout.v1.json
+++ b/tracebloc_ingestor/schema/layout.v1.json
@@ -1,0 +1,217 @@
+{
+  "tasks": {
+    "causal_language_modeling": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": false,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "texts",
+      "record_format": {
+        "enforced": false,
+        "fields": [
+          "prompt",
+          "completion"
+        ],
+        "min_fields": 1,
+        "separator": "\t"
+      },
+      "sidecars": []
+    },
+    "embeddings": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": false,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "texts",
+      "record_format": {
+        "enforced": true,
+        "fields": [
+          "anchor",
+          "positive",
+          "negative"
+        ],
+        "min_fields": 2,
+        "separator": "\t"
+      },
+      "sidecars": []
+    },
+    "image_classification": {
+      "family": "image",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "images",
+      "record_format": null,
+      "sidecars": []
+    },
+    "keypoint_detection": {
+      "family": "image",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "images",
+      "record_format": null,
+      "sidecars": []
+    },
+    "masked_language_modeling": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": false,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "sequences",
+      "record_format": null,
+      "sidecars": []
+    },
+    "object_detection": {
+      "family": "image",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "images",
+      "record_format": null,
+      "sidecars": [
+        {
+          "glob": "*.xml",
+          "link_column": null,
+          "required": true,
+          "subdir": "annotations"
+        }
+      ]
+    },
+    "semantic_segmentation": {
+      "family": "image",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "images",
+      "record_format": null,
+      "sidecars": [
+        {
+          "glob": "*.png",
+          "link_column": "mask_id",
+          "required": true,
+          "subdir": "masks"
+        }
+      ]
+    },
+    "sentence_pair_classification": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "texts",
+      "record_format": {
+        "enforced": true,
+        "fields": [
+          "text_a",
+          "text_b"
+        ],
+        "min_fields": 2,
+        "separator": "\t"
+      },
+      "sidecars": []
+    },
+    "seq2seq": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": false,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "texts",
+      "record_format": {
+        "enforced": false,
+        "fields": [
+          "source",
+          "target"
+        ],
+        "min_fields": 1,
+        "separator": "\t"
+      },
+      "sidecars": []
+    },
+    "tabular_classification": {
+      "family": "tabular",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "data_csv",
+        "requires_filename_column": false
+      },
+      "primary_subdir": null,
+      "record_format": null,
+      "sidecars": []
+    },
+    "tabular_regression": {
+      "family": "tabular",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "data_csv",
+        "requires_filename_column": false
+      },
+      "primary_subdir": null,
+      "record_format": null,
+      "sidecars": []
+    },
+    "text_classification": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "texts",
+      "record_format": null,
+      "sidecars": []
+    },
+    "time_series_forecasting": {
+      "family": "tabular",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "data_csv",
+        "requires_filename_column": false
+      },
+      "primary_subdir": null,
+      "record_format": null,
+      "sidecars": []
+    },
+    "time_to_event_prediction": {
+      "family": "tabular",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "data_csv",
+        "requires_filename_column": false
+      },
+      "primary_subdir": null,
+      "record_format": null,
+      "sidecars": []
+    },
+    "token_classification": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "texts",
+      "record_format": null,
+      "sidecars": []
+    }
+  },
+  "version": "1"
+}


### PR DESCRIPTION
## Summary

The ingestor is the source of truth for **what a task's local dataset looks like** on disk — manifest CSV, label column, primary subdir, sidecar dirs, in-`.txt` record format — but the CLI **hardcodes it per task in Go**, which is why the CLI-pending text tasks + semantic segmentation can't be staged without re-implementing the ingestor's layout rules (a fork; RFC-0002 Principle 6). This exposes that layout as **machine-readable data** so the CLI's discovery/staging becomes a *verified mirror*, not independent logic.

## Design — minimal, single-source

Most layout facts are already **implied by a category's `ModalitySpec` flags**, so only the two *non-derivable* pieces are declared on the spec:
- **`sidecars`** — object_detection's `annotations/*.xml`; semantic_segmentation's `masks/*.png` linked by the CSV `mask_id` (backend#816). Empty for every other task.
- **`record_format`** — the in-`.txt` structure for the structured text tasks.

`build_layout_contract()` composes the full per-task contract by **deriving** the rest from existing flags (`is_file_bearing`→manifest-lists-files, `not is_self_supervised`→has-label, `file_subdir`→primary dir, `data_format`→family). One source ⇒ the derived facts can't drift from behaviour.

## What's here

- **`modalities/layout.py`** — `Sidecar` + `RecordFormat` dataclasses, the emitter, and a `python -m tracebloc_ingestor.modalities.layout` entrypoint that (re)writes the JSON.
- **`modalities/spec.py` / `registry.py`** — the two new declared fields, populated for the 2 sidecar tasks + 4 structured text tasks, faithful to the transfer/validator truth: **sentence_pair + embeddings ENFORCED**; **seq2seq + causal LM are unenforced conventions** (accept raw text, so a mirror must not reject it).
- **`schema/layout.v1.json`** — the committed contract the CLI vendors + mirrors (next to `ingest.v1.json`).
- **`tests/test_layout_contract.py`** — pins **drift** (committed JSON == registry emit; *mutation-verified it bites*), **congruence** (contract == the taxonomy; derived fields agree with spec flags), and **faithfulness** (spot-checks: OD xml sidecar, semseg `mask_id` link, sentence_pair/embeddings enforced, seq2seq/causal-LM unenforced, MLM `sequences/`+no-format, **keypoint has no sidecar** — keypoints ride in the CSV, tabular data-csv/no-file-layout).

Faithful per-task truth extracted from `modalities/transfer.py` + the validators + `templates/`. Full suite green (**1445 passed, 1 xfailed** — the pre-existing leading-zeros gap).

## Type

Feature / contract · data-ingestors · RFC-0002 §14 (Principle 6 / Option A). **Closes [#347](https://github.com/tracebloc/data-ingestors/issues/347).** Unblocks the re-scoped **cli#182** ("consume the layout contract to stage the pending tasks"). Part of the data-ingest epic [backend#1008](https://github.com/tracebloc/backend/issues/1008).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract emission and registry metadata only; behavior is guarded by tests and does not change ingest validation or transfer paths at runtime.
> 
> **Overview**
> Introduces a **machine-readable per-task dataset layout contract** so CLI discovery/staging can mirror the ingestor instead of re-implementing layout rules in Go.
> 
> **`modalities/layout.py`** defines `Sidecar` and `RecordFormat`, and **`build_layout_contract()`** composes each task’s layout from registry `ModalitySpec` flags (manifest kind, label column, family, primary subdir) plus the two explicitly declared pieces on each spec. **`schema/layout.v1.json`** is the committed v1 artifact, regenerable via `python -m tracebloc_ingestor.modalities.layout`.
> 
> **`ModalitySpec`** gains optional **`sidecars`** and **`record_format`**; **`registry.py`** sets them for object detection (Pascal-VOC `annotations/*.xml`), semantic segmentation (`masks/*.png` via `mask_id`), and structured text tasks (enforced tab formats for sentence-pair/embeddings; unenforced conventions for seq2seq/causal LM).
> 
> **`tests/test_layout_contract.py`** pins drift (committed JSON equals emit), congruence with the full taxonomy and derived fields, and faithfulness spot-checks (sidecars, record formats, tabular `data_csv` layout, keypoint has no sidecar).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd88bf02ce0714d4248f7f6614c1e70c0a2eb258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->