### PR TITLE
master-> Fix CSV BOM handling and enhance label column resolution

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -1,0 +1,42 @@
+"""Tests for the shared column-name resolution rule (#340).
+
+``resolve_column`` is the single source of truth for matching a declared
+column name to the actual header, used by BOTH the validators
+(``BaseValidator._match_column`` delegates here) and the ingest read path
+(``BaseIngestor._resolve_label_column``). The two used to diverge — that was
+the #340 silent-null-label bug.
+"""
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.utils.columns import resolve_column
+from tracebloc_ingestor.validators.base import BaseValidator
+
+
+@pytest.mark.parametrize(
+    "cols,name,expected",
+    [
+        (["a", "b"], "a", "a"),                     # exact match wins
+        (["Label", "feat"], "label", "Label"),      # case-insensitive; returns original spelling
+        ([" label ", "n"], "label", " label "),     # whitespace-insensitive; returns raw spelling
+        (["Age", "Income"], "AGE", "Age"),           # fold on both sides
+        (["label"], " label ", "label"),             # whitespace on the query side too
+        (["a", "b"], "missing", None),               # nothing matches
+        ([], "x", None),                             # empty columns
+    ],
+)
+def test_resolve_column(cols, name, expected):
+    assert resolve_column(cols, name) == expected
+
+
+def test_resolve_column_accepts_pandas_columns_and_dict_keys():
+    assert resolve_column(pd.DataFrame({"Label": [1]}).columns, "label") == "Label"
+    assert resolve_column({"Label": 1, "n": 2}.keys(), "label") == "Label"
+
+
+def test_validator_match_column_delegates_to_resolve_column():
+    # Pin the single-source contract: the validator helper must produce the
+    # same answer as the shared rule for the same inputs (#340).
+    for cols, name in ([["Label", "feat"], "label"], [[" id "], "ID"], [["x"], "y"]):
+        assert BaseValidator._match_column(cols, name) == resolve_column(cols, name)

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -82,6 +82,37 @@ def test_read_data_preserves_leading_zeros_with_whitespace_header(tmp_path):
     assert records[1]["code"] == "042"
 
 
+def test_read_data_rejects_bom_masked_duplicate_headers(tmp_path):
+    # Issue #338: with the stdlib csv.reader probe on plain utf-8, a BOM'd
+    # first header (a U+FEFF glued to "a") no longer equals a later "a", so a
+    # duplicate that pandas WILL silently disambiguate ("a","a" -> "a","a.1")
+    # slips past the up-front dup-header guard — the exact invisible
+    # schema-misalignment it exists to prevent. The probe now opens with
+    # utf-8-sig, stripping the BOM so the duplicate is caught before pandas
+    # reads. (Verified: on plain utf-8 the probe sees the BOM'd name as
+    # distinct from "a" and detects no dup.)
+    p = tmp_path / "bom_dups.csv"
+    p.write_text("a,a\n1,2\n3,4\n", encoding="utf-8-sig")
+    assert p.read_bytes().startswith(b"\xef\xbb\xbf")  # sanity: file has a BOM
+    ing = make_csv_ingestor(schema={"a": "INT"})
+    with pytest.raises(ValueError, match="Duplicate column"):
+        list(ing.read_data(str(p)))
+
+
+def test_read_data_bom_guard_covers_utf8_aliases(tmp_path):
+    # Issue #338 follow-up: the BOM upgrade must fire for every UTF-8 spelling,
+    # not just "utf-8"/"utf8". "utf_8" (underscore) is a valid Python codec
+    # that does NOT strip a BOM, so a config using it would have slipped the
+    # BOM'd first header past the dup guard again. _bom_safe_encoding now
+    # canonicalises via codecs.lookup, so the duplicate is still caught.
+    p = tmp_path / "bom_dups_alias.csv"
+    p.write_text("a,a\n1,2\n3,4\n", encoding="utf-8-sig")
+    assert p.read_bytes().startswith(b"\xef\xbb\xbf")  # sanity: file has a BOM
+    ing = make_csv_ingestor(schema={"a": "INT"}, csv_options={"encoding": "utf_8"})
+    with pytest.raises(ValueError, match="Duplicate column"):
+        list(ing.read_data(str(p)))
+
+
 def test_read_data_schema_column_missing_raises(make_csv):
     path = make_csv({"a": [1]})
     ing = make_csv_ingestor(schema={"a": "INT", "missing": "INT"})

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -339,6 +339,25 @@ def test_csv_schema_missing_lists_all_missing_columns(make_csv):
     assert "missing1" in err and "missing2" in err
 
 
+def test_csv_utf8_bom_header_not_falsely_missing(tmp_path):
+    """Issue #338: an Excel "CSV UTF-8" export prepends a byte-order mark, so
+    the stdlib ``csv.reader`` header probe (unlike pandas) reads the first
+    column as a BOM glued to ``age``. The schema-presence check then falsely
+    reports ``age`` missing — a misleading rejection of a file every pandas
+    read path accepts. The probe now opens with utf-8-sig, which strips the
+    BOM; this test also pins that pandas' chunk read strips it too (else the
+    per-column cast would see a BOM'd column and fail).
+    """
+    p = tmp_path / "excel_bom.csv"
+    # write_text with utf-8-sig prepends the BOM, exactly like Excel's export.
+    p.write_text("age,income\n30,50000\n41,72000\n", encoding="utf-8-sig")
+    # sanity: the file really does start with a UTF-8 BOM
+    assert p.read_bytes().startswith(b"\xef\xbb\xbf")
+    result = DataValidator(schema={"age": "INT", "income": "INT"}).validate(str(p))
+    assert result.is_valid, f"BOM'd CSV falsely rejected; errors={result.errors}"
+    assert not any("not present in CSV" in e for e in result.errors)
+
+
 def test_json_sparse_schema_field_still_passes(tmp_path):
     """JSON ingestion is intentionally permissive: JSONIngestor._validate_record
     only WARNS when a schema field is absent from a record and proceeds. A

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -160,6 +160,97 @@ def test_process_record_applies_bucket_label_policy():
     assert rec["label"] != "12345"
 
 
+def test_process_record_reads_label_by_configured_key():
+    """Baseline for #340: RecordProcessor reads the label by EXACT key. With
+    a mismatched key it reads None — this is why the ingestor must resolve the
+    label column to the real header before processing (see the
+    _resolve_label_column + end-to-end tests below)."""
+    ing = make_ingestor(label_column="label", schema={"a": "INT", "label": "VARCHAR(10)"}, category=None)
+    # exact key -> label present
+    assert ing.process_record({"a": "1", "label": "cat", "filename": "f"})["label"] == "cat"
+    # mismatched-case key with the SAME configured name -> None (the bug)
+    assert ing.process_record({"a": "1", "Label": "cat", "filename": "f"})["label"] is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_label_column (#340)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "columns,expected",
+    [
+        (["a", "Label"], "Label"),      # case mismatch -> real header
+        (["a", " label "], " label "),  # whitespace mismatch -> raw header
+        (["a", "label"], "label"),       # exact -> unchanged
+        (["a", "b"], "label"),           # absent -> configured name untouched
+    ],
+)
+def test_resolve_label_column(columns, expected):
+    ing = make_ingestor(label_column="label", schema={"a": "INT", "label": "VARCHAR(10)"})
+    ing._resolve_label_column(columns)
+    assert ing.label_column == expected
+
+
+def test_resolve_label_column_noop_when_unset():
+    ing = make_ingestor(label_column=None)
+    ing._resolve_label_column(["a", "b"])
+    assert ing.label_column is None
+
+
+def test_ingest_label_case_mismatch_survives_to_db():
+    """#340 end-to-end: config ``label: label`` against a header ``Label``.
+    The label column is validated case-insensitively, so the manifest passes
+    preflight; the ingest loop must resolve it to the real header or every
+    label reaches the DB as None (silent all-NULL labels)."""
+    records = [
+        {"a": "1", "Label": "cat", "filename": "f1"},
+        {"a": "2", "Label": "dog", "filename": "f2"},
+    ]
+    ing = make_ingestor(
+        records=records,
+        category=None,
+        label_column="label",
+        schema={"a": "INT", "label": "VARCHAR(10)"},
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    ing.database.insert_batch.assert_called()
+    _table, batch = ing.database.insert_batch.call_args.args
+    assert [r.get("label") for r in batch] == ["cat", "dog"], (
+        f"labels nulled by case mismatch: {[r.get('label') for r in batch]}"
+    )
+
+
+def test_ingest_label_resolves_on_later_record_for_sparse_json():
+    """#340 JSON edge: records may be sparse — a leading object can omit the
+    label. Resolution must retry on later records, not give up after the first,
+    or a mis-cased label on every subsequent row would still null. The first
+    (label-less) record legitimately gets None; the second resolves 'Label'."""
+    records = [
+        {"a": "1", "filename": "f1"},                   # no label key at all
+        {"a": "2", "Label": "dog", "filename": "f2"},   # mis-cased label
+    ]
+    ing = make_ingestor(
+        records=records,
+        category=None,
+        label_column="label",
+        schema={"a": "INT", "label": "VARCHAR(10)"},
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    _table, batch = ing.database.insert_batch.call_args.args
+    assert [r.get("label") for r in batch] == [None, "dog"], (
+        f"expected [None, 'dog']; got {[r.get('label') for r in batch]}"
+    )
+
+
 def test_process_record_strips_whitespace_from_string_label():
     """Issue #261: a raw label value like ``"  A  "`` must be stripped
     before the label policy runs, so MySQL stores ``"A"`` and a CSV

--- a/tests/test_layout_contract.py
+++ b/tests/test_layout_contract.py
@@ -1,0 +1,162 @@
+"""Pins the machine-readable per-task layout contract (data-ingestors#347).
+
+Three guarantees:
+  1. DRIFT — the committed schema/layout.v1.json equals what the registry emits
+     (regenerate with `python -m tracebloc_ingestor.modalities.layout`).
+  2. CONGRUENCE — the contract covers exactly the task taxonomy, and its
+     derived fields agree with each spec's flags (single source, no drift).
+  3. FAITHFULNESS — spot-checks that the two hand-declared pieces (sidecars,
+     record_format) match the ingestor's actual layout truth, so the Go mirror
+     the CLI builds against this JSON can't encode a wrong layout.
+"""
+
+from __future__ import annotations
+
+import json
+
+from tracebloc_ingestor.modalities.layout import (
+    build_layout_contract,
+    contract_path,
+    render_contract,
+)
+from tracebloc_ingestor.modalities.registry import REGISTRY
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+
+def _contract():
+    return build_layout_contract()["tasks"]
+
+
+# 1. DRIFT --------------------------------------------------------------------
+
+
+def test_committed_json_matches_registry():
+    with open(contract_path(), encoding="utf-8") as fh:
+        committed = fh.read()
+    assert committed == render_contract(), (
+        "schema/layout.v1.json is stale — regenerate with "
+        "`python -m tracebloc_ingestor.modalities.layout` and commit the result."
+    )
+
+
+def test_committed_json_is_valid_and_versioned():
+    with open(contract_path(), encoding="utf-8") as fh:
+        doc = json.load(fh)
+    assert doc["version"], "layout contract must carry a version"
+    assert doc["tasks"], "layout contract has no tasks"
+
+
+# 2. CONGRUENCE ---------------------------------------------------------------
+
+
+def test_contract_covers_exactly_the_taxonomy():
+    # Same set as the registry / TaskCategory / schema enum — a category the
+    # customer can submit always has a layout, and none is invented.
+    assert set(_contract()) == set(REGISTRY)
+    assert set(_contract()) == set(TaskCategory.get_all_categories())
+
+
+def test_derived_fields_agree_with_spec_flags():
+    contract = _contract()
+    for cat, spec in REGISTRY.items():
+        layout = contract[cat]
+        assert layout["family"] == spec.data_format, cat
+        assert layout["primary_subdir"] == spec.file_subdir, cat
+        # file-bearing ⇒ a labels CSV listing per-row files; else the data CSV.
+        assert (
+            layout["manifest"]["requires_filename_column"] == spec.is_file_bearing
+        ), cat
+        assert layout["manifest"]["kind"] == (
+            "labels_csv" if spec.is_file_bearing else "data_csv"
+        ), cat
+        # a user label/target column exists iff the task isn't self-supervised.
+        assert layout["manifest"]["has_label_column"] == (
+            not spec.is_self_supervised
+        ), cat
+
+
+def test_sidecars_only_on_file_bearing_tasks():
+    for cat, layout in _contract().items():
+        if layout["sidecars"]:
+            assert REGISTRY[
+                cat
+            ].is_file_bearing, f"{cat} declares sidecars but isn't file-bearing"
+
+
+def test_record_format_only_on_text_tasks():
+    for cat, layout in _contract().items():
+        if layout["record_format"] is not None:
+            assert (
+                REGISTRY[cat].data_format == "text"
+            ), f"{cat} has a record_format but isn't text"
+
+
+# 3. FAITHFULNESS (spot-checks vs the ingestor's real layout) -----------------
+
+
+def test_object_detection_requires_pascal_voc_xml_sidecar():
+    sc = _contract()["object_detection"]["sidecars"]
+    assert sc == [
+        {
+            "subdir": "annotations",
+            "glob": "*.xml",
+            "required": True,
+            "link_column": None,
+        }
+    ]
+
+
+def test_semantic_segmentation_masks_linked_by_mask_id():
+    sc = _contract()["semantic_segmentation"]["sidecars"]
+    assert sc == [
+        {"subdir": "masks", "glob": "*.png", "required": True, "link_column": "mask_id"}
+    ]
+
+
+def test_sentence_pair_is_enforced_tab_pair():
+    rf = _contract()["sentence_pair_classification"]["record_format"]
+    assert rf == {
+        "separator": "\t",
+        "fields": ["text_a", "text_b"],
+        "min_fields": 2,
+        "enforced": True,
+    }
+
+
+def test_embeddings_is_enforced_two_or_three_fields():
+    rf = _contract()["embeddings"]["record_format"]
+    assert rf["fields"] == ["anchor", "positive", "negative"]
+    assert rf["min_fields"] == 2 and rf["enforced"] is True  # 2 (pair) or 3 (triplet)
+
+
+def test_seq2seq_and_causal_lm_are_unenforced_conventions():
+    # Both accept raw free text — a mirror must NOT reject a non-tab file.
+    for cat in ("seq2seq", "causal_language_modeling"):
+        rf = _contract()[cat]["record_format"]
+        assert rf is not None and rf["enforced"] is False, cat
+
+
+def test_mlm_stages_from_sequences_with_no_record_format():
+    mlm = _contract()["masked_language_modeling"]
+    assert mlm["primary_subdir"] == "sequences"
+    assert mlm["record_format"] is None  # pre-tokenized is a convention, not enforced
+    assert mlm["manifest"]["has_label_column"] is False
+
+
+def test_keypoint_has_no_sidecar():
+    # Keypoints ride in the CSV (Annotation/Visibility columns), NOT a sidecar dir.
+    assert _contract()["keypoint_detection"]["sidecars"] == []
+
+
+def test_tabular_family_is_data_csv_without_file_layout():
+    for cat in (
+        "tabular_classification",
+        "tabular_regression",
+        "time_series_forecasting",
+        "time_to_event_prediction",
+    ):
+        layout = _contract()[cat]
+        assert layout["manifest"]["kind"] == "data_csv", cat
+        assert layout["manifest"]["requires_filename_column"] is False, cat
+        assert layout["primary_subdir"] is None, cat
+        assert layout["sidecars"] == [] and layout["record_format"] is None, cat

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.5.7"
+__version__ = "0.6.0"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -17,6 +17,7 @@ from ..utils.constants import (
     CYAN,
 )
 from ..utils import label_policy as label_policy_module
+from ..utils.columns import resolve_column
 from ..utils.validators_mapping import map_validators
 from ..file_transfer import map_file_transfer
 from ..text_profile import compute_text_profile
@@ -268,6 +269,43 @@ class BaseIngestor(ABC):
         """
         return self._record_processor.process(record)
 
+    def _resolve_label_column(self, columns: Any) -> bool:
+        """Pin the configured label column to the actual header spelling (#340).
+
+        The label column is validated case-/whitespace-insensitively
+        (``LabelColumnValidator`` via the shared ``resolve_column`` rule), but
+        the read path pulls it out of each record by exact key — so a manifest
+        ``label: label`` against a header ``Label`` passes preflight and then
+        reads ``None`` for every row (silent all-NULL labels). Resolving the
+        configured name to the real header once, then reading with it, keeps
+        the read path and the validators in agreement.
+
+        Uses the SAME rule as the validators (single source of truth), so a
+        column that passed the label-presence check resolves identically here.
+
+        Returns ``True`` once resolution is settled — the name matched (exactly
+        or after remap) or no column is configured — and ``False`` when the
+        configured name is not present in ``columns`` yet. The caller pins on
+        the first record that *contains* the label: for CSV that's always the
+        first record (a stable full header), and for JSON — whose records may
+        be sparse (a leading object can omit the label) — it retries on later
+        records instead of giving up after the first. A name genuinely absent
+        from every record is left untouched so the existing missing-column
+        handling still fires.
+        """
+        if not self.label_column:
+            return True
+        resolved = resolve_column(columns, self.label_column)
+        if resolved is None:
+            return False
+        if resolved != self.label_column:
+            logger.info(
+                f"Resolved label column {self.label_column!r} to header "
+                f"{resolved!r} (case/whitespace-insensitive match)."
+            )
+            self.label_column = resolved
+        return True
+
     @property
     def _table_lock(self) -> TableLock:
         """The run's table lock (P5b). ``TableLock`` owns the file-lock
@@ -481,8 +519,20 @@ class BaseIngestor(ABC):
             try:
                 pbar = tqdm(total=total, desc="Ingesting records", unit="records")
 
+                _label_resolved = False
                 for record in self.read_data(source):
                     stats["total_records"] += 0 if total else 1
+
+                    # #340: pin the label column to the actual header spelling
+                    # before it is processed. The validators matched the label
+                    # case-/whitespace-insensitively, so a header like ``Label``
+                    # for a config ``label: label`` passed preflight; without
+                    # this the read path (exact key) would then read None for
+                    # every row. Pin on the first record that CONTAINS the label
+                    # — for CSV that's the first record (stable header); for
+                    # sparse JSON a leading object may omit it, so keep trying.
+                    if not _label_resolved:
+                        _label_resolved = self._resolve_label_column(record.keys())
 
                     try:
                         processed_record = self.process_record(record)

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -5,6 +5,7 @@ pandas-based reading and validation capabilities.
 """
 
 from typing import Dict, Any, Generator, Optional, List
+import codecs
 import csv as _csv
 import numpy as np
 import pandas as pd
@@ -21,6 +22,38 @@ from ..utils import coercion
 from ..config import Config
 
 config = Config()
+
+
+def _bom_safe_encoding(encoding: Optional[str]) -> str:
+    """Return a BOM-stripping encoding for the stdlib ``csv.reader`` header
+    probes (#338).
+
+    ``utf-8-sig`` decodes UTF-8 identically to ``utf-8`` but also strips a
+    leading byte-order mark. Excel's "CSV UTF-8" export prepends a BOM;
+    ``open(..., encoding="utf-8")`` leaves it on the first header (a U+FEFF
+    byte-order mark glued to ``age``) and ``str.strip()`` does not remove it
+    — so a probe keyed on that header (the string-dtype pin, the
+    duplicate-header check)
+    silently misreads the first column, while every pandas read path (which
+    strips the BOM) accepts the same file. Only the UTF-8 family is
+    upgraded; an explicit non-UTF-8 encoding is returned unchanged.
+
+    Canonicalise via ``codecs.lookup`` rather than matching a hardcoded alias
+    tuple: Python accepts several spellings for UTF-8 (``utf_8``, ``U8``,
+    ``utf``, ``cp65001``, ...), none of which strip a BOM, so a config that
+    used one of those would silently reintroduce the bug this guards against.
+    """
+    if not encoding:
+        return "utf-8-sig"
+    try:
+        if codecs.lookup(encoding).name == "utf-8":
+            return "utf-8-sig"
+    except LookupError:
+        # Unknown encoding name — leave it untouched so the probe's own
+        # open() raises the real UnicodeDecodeError/LookupError, matching the
+        # main read's behaviour.
+        pass
+    return encoding
 
 
 def _raise_on_overflow(
@@ -420,7 +453,7 @@ class CSVIngestor(BaseIngestor):
                 with open(
                     file_path,
                     "r",
-                    encoding=self.csv_options.get("encoding", "utf-8"),
+                    encoding=_bom_safe_encoding(self.csv_options.get("encoding")),
                     newline="",
                 ) as _fh:
                     _raw = next(_csv.reader(_fh, delimiter=_sep_probe), [])
@@ -478,7 +511,7 @@ class CSVIngestor(BaseIngestor):
                 with open(
                     file_path,
                     "r",
-                    encoding=csv_options.get("encoding", "utf-8"),
+                    encoding=_bom_safe_encoding(csv_options.get("encoding")),
                     newline="",
                 ) as _fh:
                     _row = next(_csv.reader(_fh, delimiter=_sep), [])

--- a/tracebloc_ingestor/modalities/layout.py
+++ b/tracebloc_ingestor/modalities/layout.py
@@ -1,0 +1,151 @@
+"""The per-task local dataset-layout contract (data-ingestors#347).
+
+The ingestor is the source of truth for *what a task's local dataset looks
+like* on disk — the manifest CSV, whether it carries a label column, the
+primary file subdir, extra sidecar dirs (``annotations/``, ``masks/``), and the
+in-``.txt`` record format for the structured text tasks. The CLI used to
+hardcode all of this in Go, which is why the CLI-pending tasks couldn't be
+staged without re-implementing the ingestor's layout rules — a fork
+(RFC-0002 Principle 6).
+
+This module exposes that layout as **machine-readable data** so the CLI's
+discovery/staging becomes a *verified mirror* of the ingestor's truth rather
+than independent logic:
+
+- ``Sidecar`` / ``RecordFormat`` are the two pieces that AREN'T already implied
+  by a category's ``ModalitySpec`` flags; they're declared on the spec
+  (``modalities/registry.py``).
+- ``build_layout_contract()`` composes the full per-task layout by DERIVING the
+  rest from the existing spec flags (``is_file_bearing`` → the manifest lists
+  per-row files; ``not is_self_supervised`` → a label column; ``file_subdir`` →
+  the primary dir; ``data_format`` → the family), so there is a single source
+  and the derived facts can't drift from behaviour.
+- ``tests/test_layout_contract.py`` pins the emitted contract against the
+  committed ``schema/layout.v1.json`` (regenerate on change) and against the
+  spec flags, and the CLI verifies its Go mirror against the same JSON.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+# Bump when the contract's SHAPE changes (fields added/removed/reinterpreted),
+# not when a task's values change — those are caught by the drift test.
+LAYOUT_CONTRACT_VERSION = "1"
+
+
+@dataclass(frozen=True)
+class Sidecar:
+    """An extra per-row directory a file-bearing task needs beyond its primary
+    ``file_subdir`` — e.g. object detection's Pascal-VOC ``annotations/*.xml``
+    or semantic segmentation's ``masks/*.png``.
+
+    ``link_column`` names the manifest CSV column that ties a row to its
+    sidecar file when the link isn't the plain filename stem (semseg's
+    ``mask_id`` — backend#816); ``None`` means the sidecar is paired by the
+    row's ``filename`` stem.
+    """
+
+    subdir: str
+    glob: str
+    required: bool
+    link_column: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class RecordFormat:
+    """The structure INSIDE each ``.txt`` for the structured text tasks.
+
+    ``fields`` are the ordered field names separated by ``separator``;
+    ``min_fields`` is the fewest that must be present (embeddings accepts an
+    optional trailing ``negative``, so ``fields=(anchor,positive,negative)``
+    with ``min_fields=2``). ``enforced`` is True only when a structural
+    validator rejects a malformed file in-cluster (sentence_pair, embeddings);
+    False marks a documented convention the ingestor does NOT reject (seq2seq,
+    causal LM accept raw free text), so a mirror must not reject it either.
+    """
+
+    separator: str
+    fields: Tuple[str, ...]
+    min_fields: int
+    enforced: bool
+
+
+def _sidecar_dict(s: Sidecar) -> Dict[str, Any]:
+    return {
+        "subdir": s.subdir,
+        "glob": s.glob,
+        "required": s.required,
+        "link_column": s.link_column,
+    }
+
+
+def _record_format_dict(rf: RecordFormat) -> Dict[str, Any]:
+    return {
+        "separator": rf.separator,
+        "fields": list(rf.fields),
+        "min_fields": rf.min_fields,
+        "enforced": rf.enforced,
+    }
+
+
+def _task_layout(spec: Any) -> Dict[str, Any]:
+    """Compose one task's layout: the two declared pieces (sidecars,
+    record_format) plus the facts DERIVED from the spec's existing flags."""
+    return {
+        "family": spec.data_format,  # image | text | tabular
+        "manifest": {
+            # File-bearing tasks list per-row files in a labels CSV (required
+            # `filename` column); tabular/time-series have no sidecar files —
+            # the data CSV itself is the manifest, with no `filename` column.
+            "kind": "labels_csv" if spec.is_file_bearing else "data_csv",
+            "requires_filename_column": spec.is_file_bearing,
+            # A user-supplied label/target column. Self-supervised text tasks
+            # (MLM/CLM/seq2seq/embeddings) have none; everything else does.
+            "has_label_column": not spec.is_self_supervised,
+        },
+        "primary_subdir": spec.file_subdir,  # images | texts | sequences | null
+        "sidecars": [_sidecar_dict(s) for s in spec.sidecars],
+        "record_format": (
+            _record_format_dict(spec.record_format) if spec.record_format else None
+        ),
+    }
+
+
+def build_layout_contract() -> Dict[str, Any]:
+    """Serialize the registry's per-task layout to a plain, JSON-ready dict —
+    the machine-readable contract the CLI vendors + mirrors.
+
+    Imported lazily to avoid a circular import (registry.py imports this
+    module's dataclasses)."""
+    from .registry import REGISTRY
+
+    tasks = {cat: _task_layout(spec) for cat, spec in REGISTRY.items()}
+    return {"version": LAYOUT_CONTRACT_VERSION, "tasks": tasks}
+
+
+# Path of the committed, machine-readable contract the CLI vendors + mirrors.
+# Kept next to ingest.v1.json (both are the CLI's contract surface).
+def contract_path() -> "os.PathLike[str]":
+    import os
+
+    return os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "schema", "layout.v1.json"
+    )
+
+
+def render_contract() -> str:
+    """The canonical serialization (sorted, trailing newline) — the exact bytes
+    committed to schema/layout.v1.json and pinned by the drift test."""
+    import json
+
+    return json.dumps(build_layout_contract(), indent=2, sort_keys=True) + "\n"
+
+
+if (
+    __name__ == "__main__"
+):  # `python -m tracebloc_ingestor.modalities.layout` regenerates the JSON
+    with open(contract_path(), "w", encoding="utf-8") as fh:
+        fh.write(render_contract())
+    print(f"wrote {contract_path()}")

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -15,6 +15,7 @@ from typing import Dict
 from ..utils.constants import DataFormat, TaskCategory
 from . import transfer as t
 from . import validators as v
+from .layout import RecordFormat, Sidecar
 from .spec import ModalitySpec
 
 # One entry per supported category — the single source of truth. P3a: the three
@@ -45,6 +46,9 @@ _SPECS = (
         transfer=t.object_detection,
         file_subdir="images",
         is_classification=True,
+        # Pascal-VOC XML, one per image, paired by filename stem (transfer.py
+        # object_detection; xml_validator; file_pairing_validator).
+        sidecars=(Sidecar(subdir="annotations", glob="*.xml", required=True),),
     ),
     ModalitySpec(
         TaskCategory.KEYPOINT_DETECTION,
@@ -67,6 +71,12 @@ _SPECS = (
         transfer=t.semantic_segmentation,
         file_subdir="images",
         is_classification=True,
+        # One mask PNG per image, linked by the CSV `mask_id` column (not the
+        # filename stem), convention `<stem>_mask.png` (transfer.py
+        # semantic_segmentation + backend#816; validators require .png).
+        sidecars=(
+            Sidecar(subdir="masks", glob="*.png", required=True, link_column="mask_id"),
+        ),
     ),
     ModalitySpec(
         TaskCategory.TEXT_CLASSIFICATION,
@@ -111,6 +121,11 @@ _SPECS = (
         is_nlp=True,
         file_subdir="texts",
         is_classification=True,
+        # Each .txt is exactly `text_a\ttext_b` — enforced by
+        # SentencePairValidator (rejects != 2 non-empty tab fields).
+        record_format=RecordFormat(
+            separator="\t", fields=("text_a", "text_b"), min_fields=2, enforced=True
+        ),
     ),
     # masked_language_modeling is file-bearing AND self-supervised (no label).
     ModalitySpec(
@@ -141,6 +156,15 @@ _SPECS = (
         transfer=t.causal_language_modeling,
         is_nlp=True,
         file_subdir="texts",
+        # Raw plain text (pretraining) OR `prompt\tcompletion` (SFT). A
+        # convention only — no structural validator, so a mirror must NOT
+        # reject either shape (enforced=False; min_fields=1 allows raw text).
+        record_format=RecordFormat(
+            separator="\t",
+            fields=("prompt", "completion"),
+            min_fields=1,
+            enforced=False,
+        ),
     ),
     # seq2seq is file-bearing AND self-supervised (no label), exactly like
     # causal_language_modeling. Each sample is one ``.txt`` of RAW text — a
@@ -159,6 +183,11 @@ _SPECS = (
         transfer=t.seq2seq,
         is_nlp=True,
         file_subdir="texts",
+        # `source\ttarget`. A convention — no structural validator (both fields
+        # are free text), so a mirror must not reject a raw file (enforced=False).
+        record_format=RecordFormat(
+            separator="\t", fields=("source", "target"), min_fields=1, enforced=False
+        ),
     ),
     # embeddings is file-bearing AND self-supervised (no label) — the
     # contrastive NLP modality. Each sample is one ``.txt`` of RAW text: a
@@ -180,6 +209,14 @@ _SPECS = (
         transfer=t.embeddings,
         is_nlp=True,
         file_subdir="texts",
+        # `anchor\tpositive` (2) OR `anchor\tpositive\tnegative` (3) — enforced
+        # by ContrastivePairsValidator (rejects anything but 2 or 3 tab fields).
+        record_format=RecordFormat(
+            separator="\t",
+            fields=("anchor", "positive", "negative"),
+            min_fields=2,
+            enforced=True,
+        ),
     ),
     # Tabular family (structured feature tables; no sidecar files -> no transfer).
     ModalitySpec(

--- a/tracebloc_ingestor/modalities/spec.py
+++ b/tracebloc_ingestor/modalities/spec.py
@@ -25,7 +25,10 @@ So the spec is intentionally small here and grows over P3b–P3d.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:  # annotations are strings (future import) — type-only import
+    from .layout import RecordFormat, Sidecar
 
 
 @dataclass(frozen=True)
@@ -90,3 +93,15 @@ class ModalitySpec:
     # regression / self-supervised / token-classification (per-token BIO) and
     # the time families.
     is_classification: bool = False
+    # The two per-task LAYOUT facts not already implied by the flags above
+    # (data-ingestors#347). Everything else about the on-disk layout is derived
+    # from the existing flags by ``modalities.layout.build_layout_contract``.
+    #
+    # sidecars: extra per-row directories beyond ``file_subdir`` —
+    #   object_detection's ``annotations/*.xml``, semantic_segmentation's
+    #   ``masks/*.png``. Empty for every other category.
+    # record_format: the structure inside each ``.txt`` for the structured text
+    #   tasks (sentence_pair / seq2seq / embeddings / causal LM); ``None`` when
+    #   the file is free text with no field structure the CLI must preview.
+    sidecars: Tuple["Sidecar", ...] = ()
+    record_format: Optional["RecordFormat"] = None

--- a/tracebloc_ingestor/schema/layout.v1.json
+++ b/tracebloc_ingestor/schema/layout.v1.json
@@ -1,0 +1,217 @@
+{
+  "tasks": {
+    "causal_language_modeling": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": false,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "texts",
+      "record_format": {
+        "enforced": false,
+        "fields": [
+          "prompt",
+          "completion"
+        ],
+        "min_fields": 1,
+        "separator": "\t"
+      },
+      "sidecars": []
+    },
+    "embeddings": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": false,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "texts",
+      "record_format": {
+        "enforced": true,
+        "fields": [
+          "anchor",
+          "positive",
+          "negative"
+        ],
+        "min_fields": 2,
+        "separator": "\t"
+      },
+      "sidecars": []
+    },
+    "image_classification": {
+      "family": "image",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "images",
+      "record_format": null,
+      "sidecars": []
+    },
+    "keypoint_detection": {
+      "family": "image",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "images",
+      "record_format": null,
+      "sidecars": []
+    },
+    "masked_language_modeling": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": false,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "sequences",
+      "record_format": null,
+      "sidecars": []
+    },
+    "object_detection": {
+      "family": "image",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "images",
+      "record_format": null,
+      "sidecars": [
+        {
+          "glob": "*.xml",
+          "link_column": null,
+          "required": true,
+          "subdir": "annotations"
+        }
+      ]
+    },
+    "semantic_segmentation": {
+      "family": "image",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "images",
+      "record_format": null,
+      "sidecars": [
+        {
+          "glob": "*.png",
+          "link_column": "mask_id",
+          "required": true,
+          "subdir": "masks"
+        }
+      ]
+    },
+    "sentence_pair_classification": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "texts",
+      "record_format": {
+        "enforced": true,
+        "fields": [
+          "text_a",
+          "text_b"
+        ],
+        "min_fields": 2,
+        "separator": "\t"
+      },
+      "sidecars": []
+    },
+    "seq2seq": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": false,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "texts",
+      "record_format": {
+        "enforced": false,
+        "fields": [
+          "source",
+          "target"
+        ],
+        "min_fields": 1,
+        "separator": "\t"
+      },
+      "sidecars": []
+    },
+    "tabular_classification": {
+      "family": "tabular",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "data_csv",
+        "requires_filename_column": false
+      },
+      "primary_subdir": null,
+      "record_format": null,
+      "sidecars": []
+    },
+    "tabular_regression": {
+      "family": "tabular",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "data_csv",
+        "requires_filename_column": false
+      },
+      "primary_subdir": null,
+      "record_format": null,
+      "sidecars": []
+    },
+    "text_classification": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "texts",
+      "record_format": null,
+      "sidecars": []
+    },
+    "time_series_forecasting": {
+      "family": "tabular",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "data_csv",
+        "requires_filename_column": false
+      },
+      "primary_subdir": null,
+      "record_format": null,
+      "sidecars": []
+    },
+    "time_to_event_prediction": {
+      "family": "tabular",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "data_csv",
+        "requires_filename_column": false
+      },
+      "primary_subdir": null,
+      "record_format": null,
+      "sidecars": []
+    },
+    "token_classification": {
+      "family": "text",
+      "manifest": {
+        "has_label_column": true,
+        "kind": "labels_csv",
+        "requires_filename_column": true
+      },
+      "primary_subdir": "texts",
+      "record_format": null,
+      "sidecars": []
+    }
+  },
+  "version": "1"
+}

--- a/tracebloc_ingestor/utils/columns.py
+++ b/tracebloc_ingestor/utils/columns.py
@@ -1,0 +1,41 @@
+"""Shared column-name resolution (#340).
+
+The label / filename columns a dataset author declares in the manifest may not
+match the CSV/JSON header exactly in case or surrounding whitespace. Both the
+validators (which decide accept / reject) and the ingest read path (which pulls
+the value out of each record) must resolve a declared name to the actual header
+the SAME way — otherwise a manifest can pass preflight and then read ``None``
+for every row.
+
+That was the #340 divergence: the validators matched the label column
+case-/whitespace-insensitively (``BaseValidator._match_column``), but
+``RecordProcessor`` read it by exact key, so a config ``label: label`` against a
+header ``Label`` passed both preflights and then silently nulled every label at
+ingest.
+
+This module is that single matching rule. ``BaseValidator._match_column``
+delegates here, and ``BaseIngestor`` calls it to pin the resolved label column
+once per run so the read path and the validators agree.
+"""
+
+from typing import Any, Optional
+
+
+def resolve_column(columns: Any, name: str) -> Optional[str]:
+    """Return the actual column in ``columns`` matching ``name``, case- AND
+    whitespace-insensitively; ``None`` when nothing matches.
+
+    ``columns`` is any iterable of column names (a DataFrame's ``.columns``, an
+    Index, a plain list, a dict's keys). An exact match wins first; otherwise
+    both sides are compared stripped + lower-cased. The ORIGINAL (un-lowercased)
+    column spelling is returned so callers can index the raw frame / record with
+    it. Surrounding whitespace is stripped on both sides because ``CSVIngestor``
+    strips header whitespace on read (``chunk.columns.str.strip()``), so a header
+    ``" label "`` is ingested as ``label`` and must resolve here too.
+    """
+    cols = list(columns)
+    if name in cols:
+        return name
+    target = str(name).strip().lower()
+    normalised = {str(c).strip().lower(): c for c in cols}
+    return normalised.get(target)

--- a/tracebloc_ingestor/validators/base.py
+++ b/tracebloc_ingestor/validators/base.py
@@ -167,13 +167,16 @@ class BaseValidator(ABC):
         ingests fine fails preflight as if the column were missing (matches
         ``LabelDiversityValidator._resolve_column``). The ORIGINAL column name
         is returned so callers can still index the (un-stripped) raw frame.
+
+        The rule is single-sourced in
+        :func:`tracebloc_ingestor.utils.columns.resolve_column` so the ingest
+        read path resolves the label column identically — the two used to
+        diverge (validators case-insensitive, ``RecordProcessor`` exact),
+        silently nulling every label (#340).
         """
-        cols = list(columns)
-        if name in cols:
-            return name
-        target = str(name).strip().lower()
-        normalised = {str(c).strip().lower(): c for c in cols}
-        return normalised.get(target)
+        from ..utils.columns import resolve_column
+
+        return resolve_column(columns, name)
 
     @staticmethod
     def _parse_json(row: Any, column: str) -> Optional[Any]:

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -214,7 +214,12 @@ class DataValidator(BaseValidator):
         #   2. Reject duplicate headers up front so they fail in validation,
         #      not later in the ingestor — same error CSVIngestor raises.
         try:
-            with open(path, "r", encoding="utf-8", newline="") as _fh:
+            # utf-8-sig strips a leading BOM (Excel "CSV UTF-8" export) that
+            # plain utf-8 leaves on the first header — without it the
+            # schema-presence check below falsely reports the first column
+            # missing, while pandas' read path (which strips the BOM) accepts
+            # the same file (#338). Decodes ordinary utf-8 identically.
+            with open(path, "r", encoding="utf-8-sig", newline="") as _fh:
                 _raw_header = next(_csv.reader(_fh), [])
             _stripped = [str(h).strip() for h in _raw_header]
             _dups = sorted({h for h in _stripped if _stripped.count(h) > 1})


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core label extraction and CSV header probing paths where mismatches previously caused silent wrong data or false validation failures; layout JSON is additive but expands the public contract surface.
> 
> **Overview**
> Fixes **silent all-NULL labels** when the manifest’s label name differs from the header only by case or whitespace (#340). A shared **`resolve_column`** rule is introduced; validators delegate through it, and **`BaseIngestor`** pins **`label_column`** to the real header key during the ingest loop (including retry on sparse JSON).
> 
> **Excel UTF-8 BOM** handling is aligned across validation and CSV ingest (#338): header probes use **`utf-8-sig`** (with **`_bom_safe_encoding`** canonicalizing UTF-8 codec aliases like `utf_8`) so BOM-prefixed first columns are not treated as missing or as distinct names that bypass duplicate-header checks.
> 
> Adds a **machine-readable per-task layout contract** (#347): **`build_layout_contract`**, committed **`schema/layout.v1.json`**, **`Sidecar`** / **`RecordFormat`** on modality specs, and tests for drift and congruence with the registry.
> 
> Package version bumps to **0.6.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c73d8c262aeb0414e13caf79f8d0aad62c87d373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->