### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.5.7"
+__version__ = "0.6.0"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
## Summary

Bumps `__version__` `0.5.7 → 0.6.0` (single-sourced in `tracebloc_ingestor/__init__.py`; `setup.py` reads it). This is the version the develop→master release sync (#354) ships.

**MINOR bump** — the release batch since 0.5.7 contains a new additive feature alongside two fixes:
- feat(layout): machine-readable per-task dataset-layout contract — `modalities/layout.py`, `schema/layout.v1.json`, new `ModalitySpec` fields (#347)
- fix(ingest): resolve label column to the real header before read (#340)
- fix(csv): strip UTF-8 BOM in stdlib `csv.reader` header probes (#338)

## Related

Feeds the release-sync PR #354 (develop → master).

## Type of change
- [x] Tech-debt / refactor (release chore)

## Test plan
- `python -c` parse check: `_read_version` resolves `0.6.0`.
- No behavior change — version literal only.

## Deployment notes
A MINOR bump does not auto-roll to prod — prod pins the ingestor image tag in the `client` chart (`images.ingestor.tag`), so deploying 0.6.0 needs a separate client-chart tag bump after publish.

## Checklist
- [x] No secrets / credentials in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version literal only; no logic, security, or data-handling changes.
> 
> **Overview**
> Bumps the package **`__version__`** from `0.5.7` to **`0.6.0`** in `tracebloc_ingestor/__init__.py`, the single source of truth that `setup.py` reads via `_read_version()`.
> 
> This is a **MINOR** release marker for the develop→master sync; it does not change runtime behavior. Deploying **0.6.0** in prod still requires updating the pinned ingestor image tag in the client chart after publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 826bb5afe150c410525ea2da25ed9b493fd2b788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->