### PR TITLE
feat(validators): add a minimum-image-size floor to ImageResolutionValidator (#348)

### DIFF
--- a/tests/test_image_validator_min_size.py
+++ b/tests/test_image_validator_min_size.py
@@ -1,0 +1,195 @@
+"""Tests for the minimum-image-size floor (#348, RFC-0002 §12.9 + Principle 6).
+
+Before this change there was no lower bound on image dimensions: a uniform
+dataset of 8x8 (or 1x1) images sailed through ``ImageResolutionValidator``
+because the only size check was uniformity against ``target_size``. These tests
+pin the absolute floor — rejection below the minimum, a normal image passing,
+the exact boundary, the ``min_size`` override, and that a ``file_options``
+override reaches the validator (the discovery/preview contract cli#183 relies
+on).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from tracebloc_ingestor.utils.validators_mapping import map_validators
+from tracebloc_ingestor.validators.image_validator import (
+    MIN_IMAGE_SIZE,
+    ImageResolutionValidator,
+)
+
+
+@pytest.fixture
+def images_dir(tmp_path):
+    """Return a factory that creates <tmp>/images/<name> at a given size."""
+    d = tmp_path / "images"
+    d.mkdir()
+
+    def _add(name, size, color=(120, 120, 120)):
+        Image.new("RGB", size, color).save(d / name)
+        return d / name
+
+    return tmp_path, _add
+
+
+# --- default floor: reject too-small, pass normal, hold the boundary --------
+
+
+def test_too_small_uniform_dataset_is_rejected(clean_env, images_dir):
+    """The regression this ticket targets: a uniform 8x8 dataset used to pass
+    (auto-detected expected == 8x8, all match). It must now be rejected with an
+    actionable 'too small' message naming the file, its dimensions and the floor."""
+    src, add = images_dir
+    add("tiny.jpg", (8, 8))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+    (msg,) = result.errors
+    assert "below the minimum size" in msg
+    assert "(32, 32)" in msg  # the floor
+    assert "tiny.jpg" in msg  # the offending file
+    assert "(8, 8)" in msg  # its dimensions
+    assert result.metadata["min_size"] == (32, 32)
+    assert result.metadata["too_small"]
+
+
+def test_normal_image_passes(clean_env, images_dir):
+    """A comfortably-above-floor dataset is unaffected by the gate."""
+    src, add = images_dir
+    add("a.jpg", (64, 64))
+    add("b.jpg", (64, 64))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert result.is_valid, result.errors
+    assert result.metadata["min_size"] == (32, 32)
+
+
+def test_boundary_exactly_at_floor_passes(clean_env, images_dir):
+    """An image whose sides equal the floor exactly is accepted (>=, not >)."""
+    src, add = images_dir
+    add("edge.jpg", (32, 32))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert result.is_valid, result.errors
+
+
+@pytest.mark.parametrize("size", [(31, 32), (32, 31)])
+def test_boundary_one_below_floor_on_either_axis_is_rejected(
+    clean_env, images_dir, size
+):
+    """One pixel below the floor on EITHER axis is rejected — the floor is
+    checked per-dimension, independently of target_size uniformity."""
+    src, add = images_dir
+    add("just_under.jpg", size)
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+    assert "below the minimum size" in result.errors[0]
+
+
+# --- override -----------------------------------------------------------------
+
+
+def test_lower_override_admits_smaller_images(clean_env, images_dir):
+    """A per-model override may lower the floor for models that accept smaller
+    inputs — 16x16 images pass once min_size is dropped to (16, 16)."""
+    src, add = images_dir
+    add("a.png", (16, 16))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator(min_size=(16, 16)).validate(None)
+    assert result.is_valid, result.errors
+
+
+def test_higher_override_rejects_below_it(clean_env, images_dir):
+    """A raised floor rejects images that clear the default but not the override."""
+    src, add = images_dir
+    add("a.png", (32, 32))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator(min_size=(64, 64)).validate(None)
+    assert not result.is_valid
+    assert "(64, 64)" in result.errors[0]
+
+
+def test_falsy_override_falls_back_to_default_floor():
+    """A None / empty override never silently disables the gate."""
+    assert ImageResolutionValidator(min_size=None).min_size == MIN_IMAGE_SIZE
+    assert ImageResolutionValidator().min_size == MIN_IMAGE_SIZE
+
+
+# --- floor takes precedence over a uniformity/target mismatch -----------------
+
+
+def test_floor_precedes_uniformity_error(clean_env, images_dir):
+    """When a dataset is both too-small and non-uniform, the floor error wins —
+    it names the more fundamental problem (the images can't be trained on)."""
+    src, add = images_dir
+    add("small.jpg", (8, 8))
+    add("big.jpg", (64, 64))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+    assert "below the minimum size" in result.errors[0]
+    assert "small.jpg" in result.errors[0]
+
+
+# --- _meets_min_size unit ----------------------------------------------------
+
+
+def test_meets_min_size_normalizes_list_override():
+    """A list-typed override (as parsed from JSON/YAML file_options) compares by
+    value, like _resolution_matches — (32, 32) meets a [32, 32] floor."""
+    v = ImageResolutionValidator(min_size=[32, 32])
+    assert v._meets_min_size((32, 32)) is True
+    assert v._meets_min_size((31, 32)) is False
+    assert v._meets_min_size((32, 31)) is False
+    assert v._meets_min_size((1920, 1080)) is True
+
+
+# --- file_options.min_size reaches the validator (cli#183 discovery/preview) --
+
+
+def test_file_options_min_size_reaches_validator():
+    """map_validators must thread ``file_options["min_size"]`` into the image
+    validator so the CLI's preview reads the SAME floor the ingestor enforces."""
+    validators = map_validators(
+        "image_classification",
+        {"target_size": [256, 256], "extension": ".jpg", "min_size": [64, 64]},
+    )
+    image_validators = [
+        v for v in validators if isinstance(v, ImageResolutionValidator)
+    ]
+    assert image_validators, "expected an ImageResolutionValidator in the set"
+    assert all(v.min_size == (64, 64) for v in image_validators)
+
+
+def test_default_when_no_file_option():
+    """Without an override the validator uses the documented default floor."""
+    validators = map_validators(
+        "image_classification",
+        {"target_size": [256, 256], "extension": ".jpg"},
+    )
+    image_validators = [
+        v for v in validators if isinstance(v, ImageResolutionValidator)
+    ]
+    assert image_validators
+    assert all(v.min_size == MIN_IMAGE_SIZE for v in image_validators)
+
+
+# --- schema documents the field (the CLI's discovery surface) -----------------
+
+
+def test_schema_documents_min_size():
+    schema_path = (
+        Path(__file__).resolve().parents[1]
+        / "tracebloc_ingestor"
+        / "schema"
+        / "ingest.v1.json"
+    )
+    schema = json.loads(schema_path.read_text())
+    file_options = schema["properties"]["spec"]["properties"]["file_options"]
+    assert "min_size" in file_options["properties"]

--- a/tests/test_image_validator_min_size.py
+++ b/tests/test_image_validator_min_size.py
@@ -121,6 +121,14 @@ def test_falsy_override_falls_back_to_default_floor():
     assert ImageResolutionValidator().min_size == MIN_IMAGE_SIZE
 
 
+@pytest.mark.parametrize("bad", [32, (16,), (16, 16, 16)])
+def test_malformed_min_size_raises_at_construction(bad):
+    """A non-iterable or non-2-element override is a config error surfaced at
+    construction — not swallowed mid-scan as a per-file image-read error."""
+    with pytest.raises(ValueError, match="min_size must be a"):
+        ImageResolutionValidator(min_size=bad)
+
+
 # --- floor takes precedence over a uniformity/target mismatch -----------------
 
 
@@ -135,6 +143,20 @@ def test_floor_precedes_uniformity_error(clean_env, images_dir):
     assert not result.is_valid
     assert "below the minimum size" in result.errors[0]
     assert "small.jpg" in result.errors[0]
+
+
+def test_too_small_result_still_reports_corrupt_files(clean_env, images_dir):
+    """When a dataset is both too-small and partly corrupt, the floor error
+    wins but the corrupt files are still surfaced in metadata — otherwise they
+    stay hidden until the user fixes the tiny images and re-runs."""
+    src, add = images_dir
+    add("tiny.jpg", (8, 8))
+    (src / "images" / "broken.jpg").write_bytes(b"not a real jpeg")
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+    assert "below the minimum size" in result.errors[0]
+    assert any("broken.jpg" in f for f in result.metadata["invalid_files"])
 
 
 # --- _meets_min_size unit ----------------------------------------------------

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -83,7 +83,10 @@ def _text_content_validator(
 def image_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
-        ImageResolutionValidator(expected_resolution=options["target_size"]),
+        ImageResolutionValidator(
+            expected_resolution=options["target_size"],
+            min_size=options.get("min_size"),
+        ),
         # Fail fast when the configured label column is absent from the CSV
         # (else every record cleans to label=None and the backend rejects each
         # row with HTTP 400 "label: may not be null"). image_classification is
@@ -104,7 +107,10 @@ def object_detection(options: Dict[str, Any]) -> List[BaseValidator]:
             sidecar_path="annotations",
             sidecar_label="annotation",
         ),
-        ImageResolutionValidator(expected_resolution=options["target_size"]),
+        ImageResolutionValidator(
+            expected_resolution=options["target_size"],
+            min_size=options.get("min_size"),
+        ),
     ]
 
 
@@ -122,7 +128,10 @@ def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
             # pairing is plain stem (no suffix) — the default.
             sidecar_suffix="_mask",
         ),
-        ImageResolutionValidator(expected_resolution=options["target_size"]),
+        ImageResolutionValidator(
+            expected_resolution=options["target_size"],
+            min_size=options.get("min_size"),
+        ),
         # Masks are pixel-wise label maps: validate they're readable PNGs and
         # share the images' resolution. The default ImageResolution instance only
         # scans <SRC>/images, so without this a corrupt mask, or a mask whose size
@@ -131,6 +140,7 @@ def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
             expected_resolution=options["target_size"],
             name="Mask Resolution Validator",
             subdir="masks",
+            min_size=options.get("min_size"),
         ),
     ]
 
@@ -143,7 +153,10 @@ def keypoint_detection(options: Dict[str, Any]) -> List[BaseValidator]:
     # rejects datasets whose annotations drift from the declared K.
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
-        ImageResolutionValidator(expected_resolution=options["target_size"]),
+        ImageResolutionValidator(
+            expected_resolution=options["target_size"],
+            min_size=options.get("min_size"),
+        ),
         KeypointAnnotationValidator(
             num_keypoints=options.get("number_of_keypoints"),
             # Bound keypoint coords by the declared image size (images are

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -204,6 +204,13 @@
               "maxItems": 2,
               "description": "[width, height]. Image categories only. Default [512, 512]. The order matches PIL.Image.size and what ImageResolutionValidator expects."
             },
+            "min_size": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1 },
+              "minItems": 2,
+              "maxItems": 2,
+              "description": "[width, height] absolute minimum image size (#348). Images with either side below this are rejected as too small to train on. Image categories only. Defaults to [32, 32] (ImageResolutionValidator.MIN_IMAGE_SIZE) when unset; override per-model to match the model-zoo input requirement."
+            },
             "extension": {
               "type": "string",
               "enum": [".jpg", ".jpeg", ".png", ".txt", ".text", ".xml"],

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -26,6 +26,18 @@ config = Config()
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
+# Absolute lower bound on image dimensions, as (width, height) in pixels
+# (#348, RFC-0002 §12.9 + Principle 6). Images with either side below this are
+# rejected outright — independently of the per-model ``target_size`` uniformity
+# check — because they carry too little spatial structure to train on: standard
+# vision backbones downsample by 2 five times (total /32), so a side below 32px
+# collapses to a sub-pixel feature map, and 32x32 is the canonical small-image
+# benchmark size (CIFAR). A per-model override travels in ``file_options`` as
+# ``min_size`` (schema-plumbed like ``target_size``), so the CLI can discover
+# and preview the same floor (cli#183). Kept conservative on purpose: this is a
+# floor, not the recommended resolution.
+MIN_IMAGE_SIZE: Tuple[int, int] = (32, 32)
+
 
 class ImageResolutionValidator(BaseValidator):
     """Validator for ensuring image resolution uniformity.
@@ -44,6 +56,7 @@ class ImageResolutionValidator(BaseValidator):
         expected_resolution: Optional[Tuple[int, int]] = None,
         name: str = "Image Resolution Validator",
         subdir: str = "images",
+        min_size: Optional[Tuple[int, int]] = None,
     ):
         """Initialize the image resolution validator.
 
@@ -56,10 +69,17 @@ class ImageResolutionValidator(BaseValidator):
                 semantic-segmentation masks — pixel-wise label maps that must be
                 readable and share the images' resolution; the default instance
                 only ever scans ``<SRC_PATH>/images``.
+            min_size: Minimum acceptable image size as (width, height). Images
+                with either side below this are rejected. Defaults to
+                :data:`MIN_IMAGE_SIZE`; a per-model override is plumbed from
+                ``file_options["min_size"]`` (#348).
         """
         super().__init__(name)
         self.expected_resolution = expected_resolution
         self.subdir = subdir
+        # Absolute floor (width, height). A falsy override falls back to the
+        # module default so the gate is always active, never silently disabled.
+        self.min_size = tuple(min_size) if min_size else MIN_IMAGE_SIZE
         self.tolerance = 0  # Whether to enforce strict file type checking . we can later make this configurable
         self.supported_formats = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"}
 
@@ -258,6 +278,7 @@ class ImageResolutionValidator(BaseValidator):
 
         invalid_files = []
         resolution_errors = []
+        too_small = []
         warnings = []
         resolutions_found = set()
 
@@ -277,6 +298,12 @@ class ImageResolutionValidator(BaseValidator):
                         continue
 
                     resolutions_found.add(resolution)
+                    # Absolute minimum-size floor (#348): reject images with
+                    # either side below ``min_size``, independently of the
+                    # target_size uniformity check below — a uniform dataset of
+                    # tiny (e.g. 8x8) images would otherwise pass.
+                    if not self._meets_min_size(resolution):
+                        too_small.append(f"{image_path}: {resolution}")
                     # Check if resolution matches expected (with tolerance)
                     if not self._resolution_matches(
                         resolution, self.expected_resolution
@@ -295,6 +322,27 @@ class ImageResolutionValidator(BaseValidator):
             # Close progress bar
             if progress_bar:
                 progress_bar.close()
+
+        # Enforce the minimum-size floor first: it's the most fundamental,
+        # actionable failure (the images simply can't be trained on), so it
+        # takes precedence over a uniformity / target_size mismatch.
+        if too_small:
+            return self._create_result(
+                is_valid=False,
+                errors=[
+                    f"Images below the minimum size {tuple(self.min_size)} (width, height) "
+                    f"were found — they are too small to train on. Provide larger images or, "
+                    f"if your model accepts smaller inputs, lower the floor via "
+                    f"file_options.min_size. Offending files: {too_small}"
+                ],
+                metadata={
+                    "files_checked": len(image_files),
+                    "min_size": tuple(self.min_size),
+                    "too_small": too_small,
+                    "resolutions_found": sorted(resolutions_found),
+                    "expected_resolution": self.expected_resolution,
+                },
+            )
 
         # Check for uniformity
         if len(resolutions_found) > 1:
@@ -355,9 +403,19 @@ class ImageResolutionValidator(BaseValidator):
                 "files_checked": len(image_files),
                 "uniform_resolution": uniform_resolution,
                 "expected_resolution": self.expected_resolution,
+                "min_size": tuple(self.min_size),
                 "tolerance": self.tolerance,
             },
         )
+
+    def _meets_min_size(self, resolution: Tuple[int, int]) -> bool:
+        """Return True if ``resolution`` (width, height) is at least the floor
+        on BOTH axes. An image exactly at the floor passes; either side below
+        it fails. Normalizes to tuple so a list-typed ``min_size`` (e.g. from a
+        YAML/JSON ``file_options.min_size``) compares by value, mirroring
+        ``_resolution_matches``."""
+        min_w, min_h = tuple(self.min_size)
+        return resolution[0] >= min_w and resolution[1] >= min_h
 
     def _resolution_matches(
         self, actual: Tuple[int, int], expected: Tuple[int, int]

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -38,6 +38,12 @@ logger.setLevel(config.LOG_LEVEL)
 # floor, not the recommended resolution.
 MIN_IMAGE_SIZE: Tuple[int, int] = (32, 32)
 
+# Cap on how many offending files are named inline in a too-small error
+# message (the full list is always kept in result metadata). Keeps the
+# logged / API-bound error string bounded when an entire dataset is below
+# the floor — the common case for this gate.
+_MAX_LISTED_FILES = 20
+
 
 class ImageResolutionValidator(BaseValidator):
     """Validator for ensuring image resolution uniformity.
@@ -77,9 +83,22 @@ class ImageResolutionValidator(BaseValidator):
         super().__init__(name)
         self.expected_resolution = expected_resolution
         self.subdir = subdir
-        # Absolute floor (width, height). A falsy override falls back to the
-        # module default so the gate is always active, never silently disabled.
-        self.min_size = tuple(min_size) if min_size else MIN_IMAGE_SIZE
+        # Absolute floor (width, height), normalized once here so every
+        # downstream read can trust it is a 2-tuple. A falsy override falls
+        # back to the module default so the gate is always active, never
+        # silently disabled. A non-iterable or non-2-element override is a
+        # config error, surfaced at construction rather than swallowed
+        # mid-scan as a per-file image-read error.
+        if min_size:
+            try:
+                min_w, min_h = min_size
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"min_size must be a (width, height) pair; got {min_size!r}"
+                )
+            self.min_size = (min_w, min_h)
+        else:
+            self.min_size = MIN_IMAGE_SIZE
         self.tolerance = 0  # Whether to enforce strict file type checking . we can later make this configurable
         self.supported_formats = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"}
 
@@ -327,18 +346,28 @@ class ImageResolutionValidator(BaseValidator):
         # actionable failure (the images simply can't be trained on), so it
         # takes precedence over a uniformity / target_size mismatch.
         if too_small:
+            # The trigger for this branch is typically a uniformly-tiny
+            # dataset, i.e. EVERY file is offending, so cap the list echoed
+            # into the (logged, API-bound) error string; the full set stays
+            # in metadata. invalid_files is preserved here too — otherwise a
+            # dataset that is both too-small and partly corrupt would hide the
+            # corrupt files until a second run.
+            sample = too_small[:_MAX_LISTED_FILES]
+            more = len(too_small) - len(sample)
+            listed = f"{sample}{f' (and {more} more)' if more else ''}"
             return self._create_result(
                 is_valid=False,
                 errors=[
-                    f"Images below the minimum size {tuple(self.min_size)} (width, height) "
+                    f"Images below the minimum size {self.min_size} (width, height) "
                     f"were found — they are too small to train on. Provide larger images or, "
                     f"if your model accepts smaller inputs, lower the floor via "
-                    f"file_options.min_size. Offending files: {too_small}"
+                    f"file_options.min_size. Offending files: {listed}"
                 ],
                 metadata={
                     "files_checked": len(image_files),
-                    "min_size": tuple(self.min_size),
+                    "min_size": self.min_size,
                     "too_small": too_small,
+                    "invalid_files": invalid_files,
                     "resolutions_found": sorted(resolutions_found),
                     "expected_resolution": self.expected_resolution,
                 },
@@ -403,7 +432,7 @@ class ImageResolutionValidator(BaseValidator):
                 "files_checked": len(image_files),
                 "uniform_resolution": uniform_resolution,
                 "expected_resolution": self.expected_resolution,
-                "min_size": tuple(self.min_size),
+                "min_size": self.min_size,
                 "tolerance": self.tolerance,
             },
         )
@@ -411,10 +440,10 @@ class ImageResolutionValidator(BaseValidator):
     def _meets_min_size(self, resolution: Tuple[int, int]) -> bool:
         """Return True if ``resolution`` (width, height) is at least the floor
         on BOTH axes. An image exactly at the floor passes; either side below
-        it fails. Normalizes to tuple so a list-typed ``min_size`` (e.g. from a
-        YAML/JSON ``file_options.min_size``) compares by value, mirroring
-        ``_resolution_matches``."""
-        min_w, min_h = tuple(self.min_size)
+        it fails. ``self.min_size`` is already normalized to a 2-tuple in
+        ``__init__``, so a list-typed ``file_options.min_size`` compares by
+        value here without re-casting."""
+        min_w, min_h = self.min_size
         return resolution[0] >= min_w and resolution[1] >= min_h
 
     def _resolution_matches(


### PR DESCRIPTION
Closes #348.

## Summary
There is **no minimum-image-size check anywhere today** — a uniform dataset of 8x8 (or 1x1) images passes `ImageResolutionValidator`, because the only size check is *uniformity* against `target_size` (and auto-detection will happily adopt a tiny first image as the expected size). This adds an absolute floor: images below a documented minimum are rejected outright, for every image task. This is a **validation gate only — nothing is resized.**

Lands **here first** (the ingestor is the source of truth per RFC-0002 §12.9 + Principle 6); the CLI only *previews* the same floor under the parity contract — this backs **cli#183**.

## What changed
- **`validators/image_validator.py`**
  - New module-level constant `MIN_IMAGE_SIZE = (32, 32)`.
  - New `min_size` constructor arg (defaults to the constant; a falsy value falls back to it so the gate is never silently disabled).
  - Per-file floor check in `_validate_image_resolutions`, run **independently of** the `target_size` uniformity check, so a uniform tiny dataset can't slip through. On failure it returns an actionable message naming the offending file(s), their dimensions, and the floor, and points at the `file_options.min_size` override. The floor error takes **precedence** over a uniformity/target mismatch (more fundamental). `min_size` is surfaced in result metadata (both success and failure) for CLI discovery/preview parity.
  - Helper `_meets_min_size` (`>=` on both axes; normalizes list→tuple like `_resolution_matches` so a JSON/YAML `min_size` compares by value).
- **`modalities/validators.py`** — thread `min_size=options.get("min_size")` into every image-category `ImageResolutionValidator` (image_classification, object_detection, semantic_segmentation ×2 incl. masks, keypoint_detection), mirroring how `target_size` is plumbed.
- **`schema/ingest.v1.json`** — document `spec.file_options.min_size` (`[width, height]`), next to `target_size`, so the CLI can discover it and configs validate.
- **`tests/test_image_validator_min_size.py`** — new.

## Design decisions for the reviewer to ratify
1. **Default floor = 32×32.** Conservative and justified: standard vision backbones downsample by 2 about five times (total /32), so a side below 32px collapses to a sub-pixel feature map; 32×32 is also the canonical small-image benchmark size (CIFAR). It's a *floor*, not a recommended resolution. Easy to change if the model-zoo team prefers another value.
2. **Constant + `file_options` override, not a hardcoded-only floor.** The ticket asked us to choose. I did both: a named module-level default *and* a per-model `file_options.min_size` override — the schema-field route the ticket flagged, which mirrors `target_size` and is what cli#183 discovers/previews. The constant guarantees the gate is always on even when no override is supplied.
3. **Floor is independent of `target_size`.** It is not derived from `target_size` — a customer could set a tiny `target_size`, and the point of the floor is to catch exactly that. It also fires under auto-detection.

## Test plan
- `.venv/bin/python -m pytest` (python3.12): **1458 passed, 1 xfailed** (the pre-existing leading-zeros INT xfail, unrelated). New file: 14 cases.
- Covered: too-small uniform dataset rejected with the right message (file + dims + floor); normal image passes; exact boundary (32×32 passes, 31×32 / 32×31 rejected on either axis); lower/higher overrides; falsy override falls back to default; floor precedes uniformity error; `file_options.min_size` reaches every image validator via `map_validators`; schema documents the field.
- `black --check` clean on all touched files; schema JSON re-parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stricter preflight on all image-task ingest paths may reject datasets that previously passed; behavior is intentional, well-tested, and limited to validation (no resizing or data mutation).
> 
> **Overview**
> Adds an **absolute minimum image dimension** gate so uniformly tiny datasets (e.g. 8×8) no longer pass ingest when they only matched `target_size` uniformity or auto-detected size.
> 
> `ImageResolutionValidator` now defaults to **`MIN_IMAGE_SIZE` (32×32)** with an optional **`min_size`** override (falsy values fall back to the default so the gate stays on). Each image is checked with **`>=` on both width and height** before the existing uniformity logic; **too-small failures win** over mixed-resolution errors, with bounded error text plus full lists in metadata (including corrupt files when both issues exist). **`spec.file_options.min_size`** is documented in **`ingest.v1.json`** and threaded into every vision-category **`ImageResolutionValidator`** (including mask scans) like **`target_size`**, for CLI discovery/preview parity.
> 
> New **`tests/test_image_validator_min_size.py`** covers boundaries, overrides, precedence, **`map_validators`** wiring, and schema presence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0163cbbff4318e5bdddf503f26c4a5afc3e6aeec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->