### PR TITLE
chore(release): bump version to 0.7.0

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
## What / Why

Releases the changes accumulated on `develop` since 0.6.0.

**MINOR bump (0.6.0 → 0.7.0)** — additive public surface:

- **feat(tsc): `time_series_classification` category (#359)** — new task category end to end: grouped validators (`SequenceGroupValidator`, `LabelConstantWithinGroupValidator`, `PerGroupTimeOrderedValidator`), sequence-unit label counts, composite `(sequence_id, timestamp)` index, post-insert group-integrity pass, new `ModalitySpec.grouping` trait, and **layout contract v2** (`LAYOUT_CONTRACT_VERSION` `1 → 2`, additive `grouping` block).
- **feat(schema): own tabular type-inference rules; fix leading-zeros to VARCHAR (#357)** — additive public inference surface.
- **fix(semseg): always store the masks sidecar's `mask_id` link column (#358)**.

Version is single-sourced in `tracebloc_ingestor/__init__.py` (`setup.py` parses the literal, #175) — this PR bumps only that line.

## Test plan

- No code change beyond the version literal; CI (unit + e2e matrix) runs the full suite accumulated on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the version string changes; no behavioral or security-sensitive code paths are modified in this diff.
> 
> **Overview**
> Releases **0.7.0** by updating `__version__` in `tracebloc_ingestor/__init__.py` from `"0.6.0"` to `"0.7.0"`. **`setup.py`** continues to read that literal via `_read_version()`, so the published package version stays aligned without a second edit.
> 
> This PR does not change runtime logic; it tags the **MINOR** release that bundles features and fixes already on `develop` (e.g. time series classification, schema inference, semseg mask link column).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa74cd50d091a42826a9194b15387b3db9b65c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->