### PR TITLE
Release 0.7.0: sync develop→master (TSC #359 deferred)

### DIFF
--- a/e2e/test_semseg_client_contract_e2e.py
+++ b/e2e/test_semseg_client_contract_e2e.py
@@ -1,0 +1,228 @@
+"""backend#816 — the semseg ingestor→client mask_id contract, end-to-end.
+
+Ingests a real ``semantic_segmentation`` dataset into a real MySQL (the e2e
+harness DB) and asserts the ingestor produces EXACTLY what the training client
+resolves masks from — checked against the CLIENT'S OWN derivation rule. This is
+the boundary the develop regression slipped through: the ingestor's own e2e only
+asserted "sidecar files copied", and the client's tests mock the metadata
+DataFrame, so nothing proved the ingested table + files satisfy the client.
+
+The client (tracebloc-client/core/datasets/segmentation_dataset_pytorch.py,
+``__getitem__``) does, per row::
+
+    mask_id   = str(row["mask_id"]).strip()
+    mask_name = mask_id.split(".")[0] if "." in mask_id else mask_id
+    detected  = find_image_extn(self.path, mask_name)   # .jpg/.jpeg/.png, any case
+    if not detected: raise FileNotFoundError(...)        # NO naming fallback
+
+Two halves, matching di#358's REQUIRED-contract decision:
+
+- DECLARED case (the template path): the manifest declares + populates
+  ``mask_id``, so the ingest succeeds and the stored table satisfies the client
+  exactly — (1) ``row["mask_id"]`` is populated (never NULL), and (2) a mask
+  file exists at ``DEST/<mask_name><ext>`` (what ``find_image_extn`` resolves).
+- MISSING-COLUMN case: ``mask_id`` is now REQUIRED — a manifest lacking the
+  column is REJECTED at preflight by ``MaskIdColumnValidator`` (no silent schema
+  mutation), so the ingest FAILS (rc != 0) and creates no table.
+
+Skipped by conftest's ``collect_ignore_glob`` unless a MySQL is reachable.
+"""
+
+import os
+from pathlib import Path
+
+import mysql.connector
+import pandas as pd
+import pytest
+import yaml
+
+from tracebloc_ingestor.cli import run
+from tracebloc_ingestor.config import Config
+
+REPO = Path(__file__).resolve().parents[1]
+SEG = REPO / "templates" / "semantic_segmentation" / "semantic_data"
+
+# The extensions + any-case matching the client's find_image_extn tries.
+_IMG_EXTS = (".jpg", ".jpeg", ".png")
+
+
+def _cfg(**kw):
+    base = {"apiVersion": "tracebloc.io/v1", "kind": "IngestConfig", "intent": "train"}
+    base.update(kw)
+    return base
+
+
+def _connect():
+    return mysql.connector.connect(
+        host=os.environ["MYSQL_HOST"],
+        port=int(os.environ["MYSQL_PORT"]),
+        user=os.environ["DB_USER"],
+        password=os.environ["DB_PASSWORD"],
+        database=os.environ["DB_NAME"],
+    )
+
+
+def _drop(table):
+    conn = _connect()
+    conn.cursor().execute(f"DROP TABLE IF EXISTS `{table}`")
+    conn.commit()
+    conn.close()
+
+
+def _rows(table):
+    conn = _connect()
+    cur = conn.cursor(dictionary=True)
+    cur.execute(f"SELECT * FROM `{table}`")
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+def _table_exists(table) -> bool:
+    conn = _connect()
+    cur = conn.cursor()
+    cur.execute("SHOW TABLES LIKE %s", (table,))
+    exists = cur.fetchone() is not None
+    conn.close()
+    return exists
+
+
+def _client_would_resolve_mask(data_dir: Path, mask_id: str) -> bool:
+    """Mirror the client's resolution: mask_name = mask_id sans extension, then
+    look for mask_name + a known image extension (any case) in data_dir.
+    Returns True iff a file exists — i.e. the client would NOT FileNotFoundError.
+    """
+    mask_name = mask_id.split(".")[0] if "." in mask_id else mask_id
+    for ext in _IMG_EXTS:
+        for cand in (ext, ext.upper()):
+            if (data_dir / f"{mask_name}{cand}").exists():
+                return True
+    return False
+
+
+def test_semseg_declared_ingest_satisfies_client_mask_contract(tmp_path, monkeypatch):
+    # DECLARED case: the template manifest declares + populates mask_id, so the
+    # ingest succeeds and the stored table satisfies the client's derivation.
+    table = "e2e_seg_declared"
+    _drop(table)  # deterministic on re-run
+    cfg = _cfg(
+        table=table,
+        category="semantic_segmentation",
+        csv=str(SEG / "labels_file_sample.csv"),
+        images=str(SEG / "images"),
+        masks=str(SEG / "masks"),
+        label="image_label",
+        schema={"mask_id": "VARCHAR(255)"},
+    )
+    config_path = tmp_path / "ingest.yaml"
+    config_path.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("INGEST_CONFIG", str(config_path))
+
+    rc = run.main()
+    assert rc == 0, f"semseg ingest ({table}) exited {rc}"
+
+    rows = _rows(table)
+    src = pd.read_csv(cfg["csv"])
+    assert len(rows) == len(src), f"{table}: {len(rows)} rows, expected {len(src)}"
+
+    # (1) The ingested table MUST carry a populated mask_id column (declared in
+    # the manifest, backend#816). The client SELECTs it; a NULL/absent value
+    # makes it derive a garbage filename + crash.
+    assert all("mask_id" in r for r in rows), (
+        f"{table}: ingested rows have no mask_id column (client SELECTs it); "
+        f"columns = {list(rows[0].keys()) if rows else 'no rows'}"
+    )
+    src_mask_ids = set(src["mask_id"].astype(str))
+    dest = Path(Config.STORAGE_PATH) / table
+    for r in rows:
+        mask_id = r["mask_id"]
+        assert mask_id, (
+            f"{table}: NULL/empty mask_id on data_id={r.get('data_id')!r} — the "
+            f"client would derive a garbage mask filename and raise FileNotFoundError"
+        )
+        assert str(mask_id) in src_mask_ids, (
+            f"{table}: stored mask_id {mask_id!r} not one of the source values "
+            f"{src_mask_ids}"
+        )
+        # (2) The mask file is at exactly the path the client derives. This is
+        # the cross-repo assertion: it fails if the ingestor stored mask_id but
+        # didn't copy the mask, or copied it under a name the client can't find.
+        assert _client_would_resolve_mask(dest, str(mask_id)), (
+            f"{table}: no mask file for mask_id={mask_id!r} at the client-derived "
+            f"path under {dest} — PyTorchSegmentationDataset would raise "
+            f"FileNotFoundError at train time"
+        )
+
+
+def test_semseg_missing_mask_id_column_is_rejected(tmp_path, monkeypatch):
+    # MISSING-COLUMN case: mask_id is REQUIRED (di#358 — no silent schema
+    # mutation). The template CSV always ships a mask_id header, so build a copy
+    # WITHOUT that column to exercise the rejection. MaskIdColumnValidator must
+    # fail this at preflight → the ingest exits non-zero and creates no table.
+    table = "e2e_seg_no_mask_id"
+    _drop(table)  # deterministic on re-run
+
+    src = pd.read_csv(SEG / "labels_file_sample.csv")
+    assert "mask_id" in src.columns, "template CSV should ship a mask_id header"
+    no_mask = src.drop(columns=["mask_id"])
+    csv_no_mask = tmp_path / "labels_no_mask_id.csv"
+    no_mask.to_csv(csv_no_mask, index=False)
+
+    cfg = _cfg(
+        table=table,
+        category="semantic_segmentation",
+        csv=str(csv_no_mask),
+        images=str(SEG / "images"),
+        masks=str(SEG / "masks"),
+        label="image_label",
+        schema={"mask_id": "VARCHAR(255)"},
+    )
+    config_path = tmp_path / "ingest.yaml"
+    config_path.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("INGEST_CONFIG", str(config_path))
+
+    rc = run.main()
+    assert rc != 0, (
+        f"semseg ingest with a manifest lacking mask_id should be REJECTED at "
+        f"preflight (mask_id is required, backend#816), but exited {rc}"
+    )
+    # Rejection happens before the destination table is created — no orphan table.
+    assert not _table_exists(
+        table
+    ), f"{table}: a validator-rejected ingest must not create a table"
+
+
+def test_semseg_undeclared_mask_id_is_rejected(tmp_path, monkeypatch):
+    # ORIGINAL #816 SHAPE: the manifest CSV HAS mask_id (populated), but the
+    # config omits `schema`, so mask_id is never a declared -> stored column.
+    # RecordProcessor would silently drop it (the develop regression). The
+    # declaration half of MaskIdColumnValidator must reject this at preflight —
+    # a CSV-only check would wave it straight through to a broken table.
+    table = "e2e_seg_undeclared_mask_id"
+    _drop(table)  # deterministic on re-run
+
+    src = pd.read_csv(SEG / "labels_file_sample.csv")
+    assert "mask_id" in src.columns, "template CSV should ship a populated mask_id"
+
+    cfg = _cfg(
+        table=table,
+        category="semantic_segmentation",
+        csv=str(SEG / "labels_file_sample.csv"),  # HAS mask_id
+        images=str(SEG / "images"),
+        masks=str(SEG / "masks"),
+        label="image_label",
+        # NB: no `schema` key -> mask_id is not declared, so it would be dropped.
+    )
+    config_path = tmp_path / "ingest.yaml"
+    config_path.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("INGEST_CONFIG", str(config_path))
+
+    rc = run.main()
+    assert rc != 0, (
+        f"semseg ingest that doesn't DECLARE mask_id in the schema should be "
+        f"REJECTED at preflight (mask_id would be dropped -> client crash, "
+        f"backend#816), but exited {rc}"
+    )
+    assert not _table_exists(
+        table
+    ), f"{table}: a validator-rejected ingest must not create a table"

--- a/examples/yaml/semantic_segmentation.yaml
+++ b/examples/yaml/semantic_segmentation.yaml
@@ -1,6 +1,10 @@
 # Semantic segmentation: image + per-image PNG mask.
 # `masks:` directory is convention-mapped one-mask-per-image; the mask file
 # extension is forced to .png by the default validator set.
+# `mask_id` is REQUIRED: the training client reads this column to locate each
+# mask file, so the manifest CSV must carry a populated `mask_id` column and the
+# schema must declare it. An ingest whose manifest lacks it is rejected at
+# preflight (there is no schema-less semantic segmentation).
 apiVersion: tracebloc.io/v1
 kind: IngestConfig
 table: tumors_train
@@ -10,3 +14,5 @@ csv: /data/shared/tumors/labels.csv
 images: /data/shared/tumors/images/
 masks: /data/shared/tumors/masks/
 label: image_label
+schema:
+  mask_id: VARCHAR(255)

--- a/templates/semantic_segmentation/README.md
+++ b/templates/semantic_segmentation/README.md
@@ -22,7 +22,16 @@ csv: /data/shared/tumors/labels.csv
 images: /data/shared/tumors/images/
 masks: /data/shared/tumors/masks/
 label: image_label
+schema:
+  mask_id: VARCHAR(255) # REQUIRED — the client reads this column to find each mask
 ```
+
+> **`mask_id` is required.** The training client locates each mask file from the
+> `mask_id` column (no naming-convention fallback), so your manifest CSV must
+> include a `mask_id` column, populated on every row, and the schema must declare
+> it as above. There is no schema-less semantic segmentation: an ingest whose
+> manifest lacks `mask_id` (or leaves it blank on any row) is rejected at
+> preflight with a clear error, before any table is created.
 
 **3. Install:**
 
@@ -72,7 +81,7 @@ semantic_segmentation/
 ### CSV Labels File
 The CSV file contains the following columns:
 - `filename`: Image filename (with or without extension — the configured extension is appended if missing)
-- `mask_id`: Corresponding mask filename (with or without extension — `.png` is appended if missing)
+- `mask_id` **(required)**: Corresponding mask filename (with or without extension — `.png` is appended if missing). The training client reads this column to locate each mask file, so it must be present and populated on every row, and declared in the schema as `mask_id: VARCHAR(255)` (see `semantic_segmentation.py`). A manifest missing this column, or with a blank value on any row, is rejected at preflight.
 - `image_label`: Class label present in the image (one row per class per image)
 
 Example:

--- a/tests/fixtures/schema_inference_parity.json
+++ b/tests/fixtures/schema_inference_parity.json
@@ -1,0 +1,27 @@
+{
+  "description": "Value-level parity contract for tabular schema inference (RFC-0002 §8.1). The data-ingestors `schema_inference.infer_column_type` is the source of truth; the Go CLI `InferSchema` (cli#185) must return the SAME type for each case. Backs the parity harness backend#1009. Each case: raw string column values -> expected SQL type. First-match-wins precedence: leading-zero-code -> bool -> int/bigint -> float -> date/datetime -> varchar. UNITS/CHARSET (must match on the Go side): VARCHAR(n) counts CHARACTERS (Unicode code points, = MySQL VARCHAR semantics) so Go must use utf8.RuneCountInString, NOT len(string) (bytes); integer/float matching is ASCII-only ([0-9]) so Unicode-digit and underscore-grouped tokens are text, not numbers.",
+  "sample_cap": 5000,
+  "cases": [
+    {"name": "int", "values": ["1", "2", "3", "-4"], "expected": "INT"},
+    {"name": "int_with_blank", "values": ["1", "", "3"], "expected": "INT"},
+    {"name": "bigint_over_int32", "values": ["3000000000", "1"], "expected": "BIGINT"},
+    {"name": "int64_overflow_is_text", "values": ["99999999999999999999999999", "1"], "expected": "VARCHAR(26)"},
+    {"name": "float", "values": ["3.14", "2.0", "-0.5"], "expected": "FLOAT"},
+    {"name": "float_scientific", "values": ["1e9", "2.5"], "expected": "FLOAT"},
+    {"name": "float_and_int_mixed", "values": ["1", "2.5", "3"], "expected": "FLOAT"},
+    {"name": "bool_yes_no", "values": ["yes", "no", "yes"], "expected": "BOOLEAN"},
+    {"name": "bool_true_false", "values": ["true", "false", "TRUE"], "expected": "BOOLEAN"},
+    {"name": "zero_one_is_int_not_bool", "values": ["0", "1", "1", "0"], "expected": "INT"},
+    {"name": "zip_leading_zero", "values": ["007", "0012"], "expected": "VARCHAR(4)"},
+    {"name": "zip_mixed_padded_and_unpadded", "values": ["00501", "90210", "12345"], "expected": "VARCHAR(5)"},
+    {"name": "single_zero_is_int", "values": ["0", "1", "0"], "expected": "INT"},
+    {"name": "date", "values": ["2024-01-02", "2024-03-15"], "expected": "DATE"},
+    {"name": "datetime", "values": ["2024-01-02 13:45:00", "2024-01-03 08:00:00"], "expected": "DATETIME"},
+    {"name": "numeric_id_is_int_not_date", "values": ["20240101", "20240102"], "expected": "INT"},
+    {"name": "varchar_text", "values": ["apple", "banana"], "expected": "VARCHAR(6)"},
+    {"name": "underscore_grouped_is_text", "values": ["1_000", "2_000"], "expected": "VARCHAR(5)"},
+    {"name": "unicode_digits_are_text", "values": ["١٢٣", "٤٥٦"], "expected": "VARCHAR(3)"},
+    {"name": "multibyte_varchar_is_char_count", "values": ["café", "naïve"], "expected": "VARCHAR(5)"},
+    {"name": "all_missing_is_varchar1", "values": ["", "NA", "null"], "expected": "VARCHAR(1)"}
+  ]
+}

--- a/tests/test_adversarial_ingestion_harness.py
+++ b/tests/test_adversarial_ingestion_harness.py
@@ -54,6 +54,7 @@ from sqlalchemy.schema import CreateTable
 from tracebloc_ingestor import database as db_mod
 from tracebloc_ingestor.database import Database
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.schema_inference import infer_column_type
 from tracebloc_ingestor.utils.constants import TaskCategory
 from tracebloc_ingestor.validators.data_validator import DataValidator
 
@@ -249,14 +250,40 @@ def test_varchar_leading_zero_codes_preserved():
     assert [r["code"] for r in rows] == ["007", "0012"]
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "Same root cause as the VARCHAR case: a code column typed INT loses leading "
-    "zeros (007 -> '7') because pandas infers int at read. A raw dumper who types "
-    "a zip/accession/gene code as INT silently corrupts it."
-))
 def test_int_typed_codes_keep_zeros():
-    rows = _ingest({"code": "INT"}, "code\n007\n0012\n")
+    # FIXED (#349): a zero-padded code column is no longer TYPED INT. The owned
+    # inference rules (schema_inference.infer_column_type) are now the source of
+    # truth for the column type, and they classify a leading-zero numeric token
+    # as VARCHAR — so the code survives verbatim instead of "007" -> 7. This
+    # pins the fix at the layer that owns the decision; the CLI mirrors these
+    # rules under parity (cli#185). (A hand-declared INT still can't hold "007"
+    # — the point is that nothing INFERS INT for such a column anymore, so the
+    # corruption can't originate.)
+    inferred = infer_column_type(["007", "0012"])
+    assert inferred.startswith("VARCHAR"), f"expected VARCHAR, inferred {inferred!r}"
+    rows = _ingest({"code": inferred}, "code\n007\n0012\n")
     assert [r["code"] for r in rows] == ["007", "0012"]
+
+
+@pytest.mark.xfail(strict=True, reason=(
+    "Residual gap (#349): the OWNED inference never assigns INT to a leading-zero "
+    "code column, so the corruption can no longer ORIGINATE there. But a "
+    "HAND-DECLARED INT column (schema supplied upstream, not inferred) still "
+    "silently corrupts '007' -> 7 — the INT cast strips the zeros with no error. "
+    "The harness contract is preserve-or-fail-loudly; on this path the pipeline "
+    "does NEITHER. This pins the real-ingest behaviour the rewritten "
+    "test_int_typed_codes_keep_zeros no longer covers (it exercises the inference "
+    "helper, not a declared-INT ingest). Flips to a suite failure — forcing the "
+    "marker's removal — once a guard rejects a leading-zero token bound for an "
+    "INT column with a clear, actionable error."
+))
+def test_int_typed_codes_fail_loudly_not_silent():
+    # A hand-declared INT code column fed "007"/"0012" must not SILENTLY store
+    # 7/12. Per the contract it should raise a clear error (or preserve the
+    # value). Today it silently corrupts, so pytest.raises finds no exception and
+    # the test fails — captured as a strict xfail (known gap on the real path).
+    with pytest.raises(Exception):
+        _ingest({"code": "INT"}, "code\n007\n0012\n")
 
 
 def test_float_precision_preserved():

--- a/tests/test_image_validator_min_size.py
+++ b/tests/test_image_validator_min_size.py
@@ -121,12 +121,49 @@ def test_falsy_override_falls_back_to_default_floor():
     assert ImageResolutionValidator().min_size == MIN_IMAGE_SIZE
 
 
-@pytest.mark.parametrize("bad", [32, (16,), (16, 16, 16)])
+# A bare string is iterable: "32" would unpack to ('3', '2') and "1234" would
+# fail the 2-element unpack — both are shape errors, never a (width, height)
+# pair. Reject them (and other non-iterable / wrong-length shapes) up front.
+@pytest.mark.parametrize("bad", [32, (16,), (16, 16, 16), "32", "1234", b"32"])
 def test_malformed_min_size_raises_at_construction(bad):
-    """A non-iterable or non-2-element override is a config error surfaced at
-    construction — not swallowed mid-scan as a per-file image-read error."""
+    """A non-iterable, wrong-length, or string override is a config error
+    surfaced at construction — not swallowed mid-scan as a per-file image-read
+    error, and never char-split into a bogus floor."""
     with pytest.raises(ValueError, match="min_size must be a"):
         ImageResolutionValidator(min_size=bad)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        (0, 32),  # zero side
+        (32, 0),
+        (-1, 32),  # negative side
+        (32, -5),
+        (32.5, 32),  # non-integral float
+        ("32", 32),  # per-element string is rejected, not coerced
+        (32, "32"),
+        ("abc", 32),  # non-numeric string
+        (None, 32),  # missing side
+        (True, 32),  # bool is an int subclass but not a pixel count
+    ],
+)
+def test_non_positive_integer_min_size_raises_at_construction(bad):
+    """A 2-element override whose sides are not positive integers is still a
+    config error surfaced at construction — otherwise an int-vs-str comparison
+    in _meets_min_size raises mid-scan and is mislabeled as a corrupt image."""
+    with pytest.raises(ValueError, match="positive integer"):
+        ImageResolutionValidator(min_size=bad)
+
+
+@pytest.mark.parametrize("override", [(32.0, 32.0), [16.0, 16], (64.0, 48)])
+def test_min_size_coerces_integer_valued_floats(override):
+    """Integer-valued floats (as a numeric literal can arrive from JSON/YAML
+    file_options) are normalized to positive ints at construction, so
+    _meets_min_size compares plain ints."""
+    v = ImageResolutionValidator(min_size=override)
+    assert all(isinstance(side, int) for side in v.min_size)
+    assert v.min_size == (int(override[0]), int(override[1]))
 
 
 # --- floor takes precedence over a uniformity/target mismatch -----------------

--- a/tests/test_image_validator_min_size.py
+++ b/tests/test_image_validator_min_size.py
@@ -1,0 +1,217 @@
+"""Tests for the minimum-image-size floor (#348, RFC-0002 §12.9 + Principle 6).
+
+Before this change there was no lower bound on image dimensions: a uniform
+dataset of 8x8 (or 1x1) images sailed through ``ImageResolutionValidator``
+because the only size check was uniformity against ``target_size``. These tests
+pin the absolute floor — rejection below the minimum, a normal image passing,
+the exact boundary, the ``min_size`` override, and that a ``file_options``
+override reaches the validator (the discovery/preview contract cli#183 relies
+on).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from tracebloc_ingestor.utils.validators_mapping import map_validators
+from tracebloc_ingestor.validators.image_validator import (
+    MIN_IMAGE_SIZE,
+    ImageResolutionValidator,
+)
+
+
+@pytest.fixture
+def images_dir(tmp_path):
+    """Return a factory that creates <tmp>/images/<name> at a given size."""
+    d = tmp_path / "images"
+    d.mkdir()
+
+    def _add(name, size, color=(120, 120, 120)):
+        Image.new("RGB", size, color).save(d / name)
+        return d / name
+
+    return tmp_path, _add
+
+
+# --- default floor: reject too-small, pass normal, hold the boundary --------
+
+
+def test_too_small_uniform_dataset_is_rejected(clean_env, images_dir):
+    """The regression this ticket targets: a uniform 8x8 dataset used to pass
+    (auto-detected expected == 8x8, all match). It must now be rejected with an
+    actionable 'too small' message naming the file, its dimensions and the floor."""
+    src, add = images_dir
+    add("tiny.jpg", (8, 8))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+    (msg,) = result.errors
+    assert "below the minimum size" in msg
+    assert "(32, 32)" in msg  # the floor
+    assert "tiny.jpg" in msg  # the offending file
+    assert "(8, 8)" in msg  # its dimensions
+    assert result.metadata["min_size"] == (32, 32)
+    assert result.metadata["too_small"]
+
+
+def test_normal_image_passes(clean_env, images_dir):
+    """A comfortably-above-floor dataset is unaffected by the gate."""
+    src, add = images_dir
+    add("a.jpg", (64, 64))
+    add("b.jpg", (64, 64))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert result.is_valid, result.errors
+    assert result.metadata["min_size"] == (32, 32)
+
+
+def test_boundary_exactly_at_floor_passes(clean_env, images_dir):
+    """An image whose sides equal the floor exactly is accepted (>=, not >)."""
+    src, add = images_dir
+    add("edge.jpg", (32, 32))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert result.is_valid, result.errors
+
+
+@pytest.mark.parametrize("size", [(31, 32), (32, 31)])
+def test_boundary_one_below_floor_on_either_axis_is_rejected(
+    clean_env, images_dir, size
+):
+    """One pixel below the floor on EITHER axis is rejected — the floor is
+    checked per-dimension, independently of target_size uniformity."""
+    src, add = images_dir
+    add("just_under.jpg", size)
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+    assert "below the minimum size" in result.errors[0]
+
+
+# --- override -----------------------------------------------------------------
+
+
+def test_lower_override_admits_smaller_images(clean_env, images_dir):
+    """A per-model override may lower the floor for models that accept smaller
+    inputs — 16x16 images pass once min_size is dropped to (16, 16)."""
+    src, add = images_dir
+    add("a.png", (16, 16))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator(min_size=(16, 16)).validate(None)
+    assert result.is_valid, result.errors
+
+
+def test_higher_override_rejects_below_it(clean_env, images_dir):
+    """A raised floor rejects images that clear the default but not the override."""
+    src, add = images_dir
+    add("a.png", (32, 32))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator(min_size=(64, 64)).validate(None)
+    assert not result.is_valid
+    assert "(64, 64)" in result.errors[0]
+
+
+def test_falsy_override_falls_back_to_default_floor():
+    """A None / empty override never silently disables the gate."""
+    assert ImageResolutionValidator(min_size=None).min_size == MIN_IMAGE_SIZE
+    assert ImageResolutionValidator().min_size == MIN_IMAGE_SIZE
+
+
+@pytest.mark.parametrize("bad", [32, (16,), (16, 16, 16)])
+def test_malformed_min_size_raises_at_construction(bad):
+    """A non-iterable or non-2-element override is a config error surfaced at
+    construction — not swallowed mid-scan as a per-file image-read error."""
+    with pytest.raises(ValueError, match="min_size must be a"):
+        ImageResolutionValidator(min_size=bad)
+
+
+# --- floor takes precedence over a uniformity/target mismatch -----------------
+
+
+def test_floor_precedes_uniformity_error(clean_env, images_dir):
+    """When a dataset is both too-small and non-uniform, the floor error wins —
+    it names the more fundamental problem (the images can't be trained on)."""
+    src, add = images_dir
+    add("small.jpg", (8, 8))
+    add("big.jpg", (64, 64))
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+    assert "below the minimum size" in result.errors[0]
+    assert "small.jpg" in result.errors[0]
+
+
+def test_too_small_result_still_reports_corrupt_files(clean_env, images_dir):
+    """When a dataset is both too-small and partly corrupt, the floor error
+    wins but the corrupt files are still surfaced in metadata — otherwise they
+    stay hidden until the user fixes the tiny images and re-runs."""
+    src, add = images_dir
+    add("tiny.jpg", (8, 8))
+    (src / "images" / "broken.jpg").write_bytes(b"not a real jpeg")
+    clean_env.setenv("SRC_PATH", str(src))
+    result = ImageResolutionValidator().validate(None)
+    assert not result.is_valid
+    assert "below the minimum size" in result.errors[0]
+    assert any("broken.jpg" in f for f in result.metadata["invalid_files"])
+
+
+# --- _meets_min_size unit ----------------------------------------------------
+
+
+def test_meets_min_size_normalizes_list_override():
+    """A list-typed override (as parsed from JSON/YAML file_options) compares by
+    value, like _resolution_matches — (32, 32) meets a [32, 32] floor."""
+    v = ImageResolutionValidator(min_size=[32, 32])
+    assert v._meets_min_size((32, 32)) is True
+    assert v._meets_min_size((31, 32)) is False
+    assert v._meets_min_size((32, 31)) is False
+    assert v._meets_min_size((1920, 1080)) is True
+
+
+# --- file_options.min_size reaches the validator (cli#183 discovery/preview) --
+
+
+def test_file_options_min_size_reaches_validator():
+    """map_validators must thread ``file_options["min_size"]`` into the image
+    validator so the CLI's preview reads the SAME floor the ingestor enforces."""
+    validators = map_validators(
+        "image_classification",
+        {"target_size": [256, 256], "extension": ".jpg", "min_size": [64, 64]},
+    )
+    image_validators = [
+        v for v in validators if isinstance(v, ImageResolutionValidator)
+    ]
+    assert image_validators, "expected an ImageResolutionValidator in the set"
+    assert all(v.min_size == (64, 64) for v in image_validators)
+
+
+def test_default_when_no_file_option():
+    """Without an override the validator uses the documented default floor."""
+    validators = map_validators(
+        "image_classification",
+        {"target_size": [256, 256], "extension": ".jpg"},
+    )
+    image_validators = [
+        v for v in validators if isinstance(v, ImageResolutionValidator)
+    ]
+    assert image_validators
+    assert all(v.min_size == MIN_IMAGE_SIZE for v in image_validators)
+
+
+# --- schema documents the field (the CLI's discovery surface) -----------------
+
+
+def test_schema_documents_min_size():
+    schema_path = (
+        Path(__file__).resolve().parents[1]
+        / "tracebloc_ingestor"
+        / "schema"
+        / "ingest.v1.json"
+    )
+    schema = json.loads(schema_path.read_text())
+    file_options = schema["properties"]["spec"]["properties"]["file_options"]
+    assert "min_size" in file_options["properties"]

--- a/tests/test_schema_inference.py
+++ b/tests/test_schema_inference.py
@@ -1,0 +1,187 @@
+"""Owned tabular schema-inference rules (#349, RFC-0002 §8.1).
+
+`schema_inference.infer_column_type` is the platform's source of truth for
+turning raw column values into SQL types; the Go CLI (`InferSchema`, cli#185)
+mirrors it. These tests pin the rule precedence and the leading-zero fix, and
+load the shared parity fixture so a change to the contract updates both sides
+from one file (backend#1009).
+"""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.schema_inference import (
+    SAMPLE_CAP,
+    infer_column_type,
+    infer_schema,
+)
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "schema_inference_parity.json"
+_PARITY = json.loads(_FIXTURE.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Parity fixture — the contract the CLI must also satisfy.
+# ---------------------------------------------------------------------------
+
+def test_parity_fixture_cap_matches_module():
+    # The fixture advertises the sampling cap; it must equal the code's cap so
+    # a CLI reading the fixture caps identically.
+    assert _PARITY["sample_cap"] == SAMPLE_CAP
+
+
+@pytest.mark.parametrize(
+    "case", _PARITY["cases"], ids=[c["name"] for c in _PARITY["cases"]]
+)
+def test_parity_cases(case):
+    assert infer_column_type(case["values"]) == case["expected"]
+
+
+# ---------------------------------------------------------------------------
+# The #349 fix — leading-zero codes are text, not INT.
+# ---------------------------------------------------------------------------
+
+def test_leading_zero_code_is_varchar_not_int():
+    # THE bug: "007" must never infer INT (it would corrupt to 7). A single
+    # leading-zero token pins the whole column to text.
+    assert infer_column_type(["007", "0012"]) == "VARCHAR(4)"
+    assert infer_column_type(["123", "007", "456"]) == "VARCHAR(3)"
+
+
+def test_plain_zero_is_still_int():
+    # "0" alone is not a code (length 1, no padding) — a real 0/1/2 column.
+    assert infer_column_type(["0", "1", "2"]) == "INT"
+
+
+def test_signed_leading_zero_is_varchar():
+    assert infer_column_type(["+007", "12"]).startswith("VARCHAR")
+
+
+# ---------------------------------------------------------------------------
+# Positive inference — one real column of each type.
+# ---------------------------------------------------------------------------
+
+def test_int_column_infers_int():
+    assert infer_column_type(["10", "20", "-30"]) == "INT"
+
+
+def test_large_int_infers_bigint():
+    assert infer_column_type(["3000000000", "42"]) == "BIGINT"
+
+
+def test_float_column_infers_float():
+    assert infer_column_type(["3.14", "-0.5", "1e3"]) == "FLOAT"
+
+
+def test_bool_column_infers_boolean():
+    assert infer_column_type(["yes", "no", "YES"]) == "BOOLEAN"
+    assert infer_column_type(["true", "false"]) == "BOOLEAN"
+
+
+def test_date_column_infers_date():
+    assert infer_column_type(["2024-01-02", "2024-12-31"]) == "DATE"
+
+
+def test_datetime_column_infers_datetime():
+    assert infer_column_type(["2024-01-02 13:45:00", "2024-01-03 08:00:00"]) == "DATETIME"
+
+
+def test_text_column_infers_varchar():
+    assert infer_column_type(["apple", "banana", "kiwi"]) == "VARCHAR(6)"
+
+
+# ---------------------------------------------------------------------------
+# Negative / precedence — the ambiguous cases resolve deterministically.
+# ---------------------------------------------------------------------------
+
+def test_numeric_id_is_int_not_date():
+    # An 8-digit id must stay INT — numeric is checked before date so an id
+    # column can't be mis-read as a calendar date.
+    assert infer_column_type(["20240101", "20240102"]) == "INT"
+
+
+def test_zero_one_is_int_not_bool():
+    # 0/1 is ambiguous; the lossless INT reading wins over BOOL.
+    assert infer_column_type(["0", "1", "1", "0"]) == "INT"
+
+
+def test_infinity_is_text_not_float():
+    # A column of "inf" must not be called numeric (it isn't finite).
+    assert infer_column_type(["inf", "inf"]).startswith("VARCHAR")
+
+
+def test_missing_only_column_is_varchar1():
+    assert infer_column_type(["", "NA", "null", None]) == "VARCHAR(1)"
+
+
+def test_missing_values_are_ignored():
+    # NA sentinels don't change the inferred type of the present values.
+    assert infer_column_type(["1", "NA", "2", ""]) == "INT"
+
+
+# ---------------------------------------------------------------------------
+# Sampling cap — only the first SAMPLE_CAP rows influence the type.
+# ---------------------------------------------------------------------------
+
+def test_off_type_token_past_cap_is_ignored():
+    # 5,000 clean ints, then a float and a leading-zero code beyond the cap:
+    # the column still infers INT because inference stops at the cap.
+    values = [str(i) for i in range(SAMPLE_CAP)] + ["3.5", "007"]
+    assert infer_column_type(values) == "INT"
+
+
+def test_within_cap_off_type_token_counts():
+    # The same off-type token INSIDE the cap does change the verdict.
+    values = [str(i) for i in range(SAMPLE_CAP - 1)] + ["3.5"]
+    assert infer_column_type(values) == "FLOAT"
+
+
+# ---------------------------------------------------------------------------
+# infer_schema — DataFrame and mapping forms.
+# ---------------------------------------------------------------------------
+
+def test_infer_schema_from_mapping():
+    schema = infer_schema({"code": ["007", "012"], "age": ["30", "40"]})
+    assert schema == {"code": "VARCHAR(3)", "age": "INT"}
+
+
+def test_infer_schema_from_dataframe():
+    # Read as strings (the input contract) so the leading zeros survive to
+    # inference — a pandas-typed frame would already be lossy.
+    df = pd.DataFrame({"code": ["007", "012"], "flag": ["yes", "no"]}, dtype=str)
+    assert infer_schema(df) == {"code": "VARCHAR(3)", "flag": "BOOLEAN"}
+
+
+# ---------------------------------------------------------------------------
+# ASCII-only numeric matching + charset — Go-CLI parity guardrails.
+# ---------------------------------------------------------------------------
+
+def test_unicode_digits_are_text_not_int():
+    # `\d`/int() accept Unicode digits, but the Go mirror matches [0-9] only and
+    # MySQL INT can't hold the glyphs — so a non-ASCII-digit column is VARCHAR.
+    assert infer_column_type(["١٢٣", "٤٥٦"]) == "VARCHAR(3)"
+
+
+def test_underscore_grouped_numbers_are_text_not_float():
+    # Python float("1_000")==1000.0, but Go's strconv.ParseFloat rejects
+    # underscores — pre-screening with an ASCII float grammar keeps them text.
+    assert infer_column_type(["1_000", "2_000"]) == "VARCHAR(5)"
+    assert infer_column_type(["1_000", "2.5"]) == "VARCHAR(5)"
+
+
+def test_varchar_length_is_char_count_not_bytes():
+    # VARCHAR(n) counts characters (MySQL semantics); a multibyte value must not
+    # be sized by its UTF-8 byte length (which is what a naive Go len() gives).
+    assert infer_column_type(["café", "naïve"]) == "VARCHAR(5)"  # not 6 (bytes)
+
+
+def test_mixed_timezone_datetimes_do_not_crash():
+    # Mixed UTC offsets parse to an object-dtype Series (no .dt accessor); the
+    # function must fall back to text, never raise AttributeError.
+    got = infer_column_type(
+        ["2024-01-01T00:00:00+00:00", "2024-01-01T00:00:00+05:00"]
+    )
+    assert got.startswith("VARCHAR")

--- a/tests/test_semseg_mask_id_contract.py
+++ b/tests/test_semseg_mask_id_contract.py
@@ -1,0 +1,422 @@
+"""backend#816 — the semseg ``mask_id`` contract, enforced at preflight.
+
+The training client resolves each mask file from a MySQL ``mask_id`` column
+(``segmentation_dataset_pytorch.py``: ``str(row["mask_id"])`` → filename, with
+no naming-convention fallback), so a semseg ingest that stores a NULL/absent
+``mask_id`` makes the client crash with ``FileNotFoundError`` — not a silent
+skip.
+
+The contract is REQUIRED and ENFORCED (di#358, per reviewer): rather than
+silently auto-adding ``mask_id`` to the schema, the manifest must declare it and
+populate it on every row, and :class:`MaskIdColumnValidator` rejects a manifest
+that doesn't at preflight. These tests pin:
+
+- a semseg manifest WITHOUT a ``mask_id`` column → the validator FAILS with an
+  actionable message;
+- ``mask_id`` empty/NULL on any row → FAILS;
+- a valid manifest (``mask_id`` present + populated) → PASSES;
+- (record level) a DECLARED ``mask_id`` is stored populated on the processed
+  row — the exact ingestor→client boundary the develop regression (#212's
+  blanket ``mask_id`` pop) slipped through.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tracebloc_ingestor.ingestors.record_processor import RecordProcessor
+from tracebloc_ingestor.validators.mask_id_validator import MaskIdColumnValidator
+
+
+# ---------------------------------------------------------------------------
+# The preflight validator — the enforcement point for the required contract.
+# ---------------------------------------------------------------------------
+def test_missing_mask_id_column_is_rejected(make_csv):
+    # A semseg manifest whose header omits mask_id (only filename + label).
+    path = make_csv(
+        pd.DataFrame(
+            {"filename": ["image_001", "image_002"], "image_label": ["road", "sky"]}
+        )
+    )
+    result = MaskIdColumnValidator(column="mask_id").validate(str(path))
+    assert not result.is_valid
+    msg = result.errors[0]
+    # names the missing column, explains the client contract + where to look
+    assert "'mask_id' not found" in msg
+    assert "training client reads 'mask_id'" in msg
+    assert "backend#816" in msg
+    assert "templates/semantic_segmentation/" in msg
+    # lists the columns that ARE present, to guide the fix
+    assert "filename" in msg and "image_label" in msg
+    assert result.metadata["columns"] == ["filename", "image_label"]
+
+
+def test_empty_mask_id_on_a_row_is_rejected(make_csv):
+    # mask_id present in the header but blank on one row.
+    path = make_csv(
+        pd.DataFrame(
+            {
+                "filename": ["image_001", "image_002"],
+                "mask_id": ["image_001_mask", ""],
+                "image_label": ["road", "sky"],
+            }
+        )
+    )
+    result = MaskIdColumnValidator(column="mask_id").validate(str(path))
+    assert not result.is_valid
+    msg = result.errors[0]
+    # 0-based data-row index (row_refs), matching every other validator.
+    assert "'mask_id' is empty/NULL at rows [1]" in msg
+    assert "FileNotFoundError" in msg
+    assert "templates/semantic_segmentation/" in msg
+    assert result.metadata["empty_rows"] == [1]
+
+
+def test_null_mask_id_on_a_row_is_rejected(make_csv):
+    # A truly missing cell (NaN), not just an empty string.
+    path = make_csv(
+        pd.DataFrame(
+            {
+                "filename": ["image_001", "image_002"],
+                "mask_id": ["image_001_mask", None],
+                "image_label": ["road", "sky"],
+            }
+        )
+    )
+    result = MaskIdColumnValidator(column="mask_id").validate(str(path))
+    assert not result.is_valid
+    assert result.metadata["empty_rows"] == [1]
+
+
+def test_na_sentinel_literal_mask_id_is_rejected(make_csv):
+    # mask_id is a DECLARED schema column, so CSVIngestor reads it with the
+    # curated NA_SENTINELS set (build_csv_na_values + keep_default_na=False) and
+    # stores a literal "none"/"null"/"NA" cell as SQL NULL -> the client crashes
+    # with FileNotFoundError. pandas' DEFAULT NA set misses lowercase "none", so
+    # the validator MUST use the same NA_SENTINELS to stay byte-identical to the
+    # write path and reject it at preflight rather than passing a row that is
+    # nulled a layer later. ("none" is the concrete divergence; "NA"/"null"/
+    # "None"/"nan" the default set happens to share.)
+    path = make_csv(
+        pd.DataFrame(
+            {
+                "filename": ["image_001", "image_002"],
+                "mask_id": ["image_001_mask", "none"],
+                "image_label": ["road", "sky"],
+            }
+        )
+    )
+    result = MaskIdColumnValidator(column="mask_id").validate(str(path))
+    assert not result.is_valid, "literal 'none' is nulled by the ingestor"
+    assert result.metadata["empty_rows"] == [1]
+
+
+def test_valid_semseg_manifest_passes(make_csv):
+    # mask_id present and populated on every row → passes.
+    path = make_csv(
+        pd.DataFrame(
+            {
+                "filename": ["image_001", "image_002", "image_003"],
+                "mask_id": ["image_001_mask", "image_002_mask", "image_003_mask"],
+                "image_label": ["road", "building", "person"],
+            }
+        )
+    )
+    result = MaskIdColumnValidator(column="mask_id").validate(str(path))
+    assert result.is_valid
+    assert result.metadata["checked"] is True
+
+
+def test_non_lowercase_header_is_rejected(make_csv):
+    # The stored column IS the CSV header and the training client reads the mask
+    # column by the LITERAL lowercase name 'mask_id' — so a 'Mask_Id' header is
+    # rejected with a rename hint, not silently accepted (it would break training
+    # after a green preflight).
+    path = make_csv(
+        pd.DataFrame({"filename": ["image_001"], "Mask_Id": ["image_001_mask"]})
+    )
+    result = MaskIdColumnValidator(column="mask_id").validate(str(path))
+    assert not result.is_valid
+    assert "must be named exactly 'mask_id'" in result.errors[0]
+
+
+def test_missing_column_message_caps_header_list(make_csv):
+    # A wide manifest without mask_id: the error names only a capped sample of
+    # headers (bounded message); the full list stays in metadata.
+    path = make_csv(pd.DataFrame({f"c{i}": ["x"] for i in range(50)}))
+    result = MaskIdColumnValidator(column="mask_id").validate(str(path))
+    assert not result.is_valid
+    assert "more)" in result.errors[0]  # truncation marker
+    assert len(result.metadata["columns"]) == 50  # full detail retained
+
+
+def test_undeclared_message_caps_schema_key_list(make_csv):
+    # Symmetric to the header cap: a wide schema that OMITS mask_id names only a
+    # capped sample of declared keys in the message; the full list stays in
+    # metadata (bugbot: unbounded undeclared-schema error string).
+    path = make_csv(pd.DataFrame({"filename": ["x"], "mask_id": ["m"]}))
+    schema = {f"c{i}": "VARCHAR(255)" for i in range(50)}  # 50 keys, no mask_id
+    result = MaskIdColumnValidator(column="mask_id", schema=schema).validate(str(path))
+    assert not result.is_valid
+    assert "more)" in result.errors[0]  # truncation marker
+    assert len(result.metadata["schema_columns"]) == 50  # full detail retained
+
+
+def test_semseg_factory_checks_stored_schema_not_full_schema(make_csv):
+    # If mask_id is (mis)configured as the label/unique_id/annotation column,
+    # BaseIngestor strips it from the STORED table schema and RecordProcessor
+    # drops it — so the semseg factory must wire the validator with the stripped
+    # options["schema"], not full_schema, or preflight green-lights a manifest
+    # whose stored table has no mask_id column (backend#816).
+    from tracebloc_ingestor.modalities import validators as modality_validators
+
+    path = make_csv(pd.DataFrame({"filename": ["a"], "mask_id": ["a_mask"]}))
+    options = {
+        "extension": ".jpg",
+        "target_size": [128, 128],
+        "full_schema": {"mask_id": "VARCHAR(255)"},  # mask_id IS in the full schema
+        "schema": {"other": "INT"},  # ...but stripped out of the stored schema
+    }
+    mask_validator = next(
+        v
+        for v in modality_validators.semantic_segmentation(options)
+        if isinstance(v, MaskIdColumnValidator)
+    )
+    result = mask_validator.validate(str(path))
+    assert not result.is_valid  # stored schema lacks mask_id -> rejected
+
+
+def test_non_csv_input_defers(make_csv):
+    # JSON / non-path inputs are handled by their own read path — defer (pass),
+    # exactly like LabelColumnValidator.
+    result = MaskIdColumnValidator(column="mask_id").validate("data.json")
+    assert result.is_valid
+    assert result.metadata["checked"] is False
+
+
+def test_unreadable_csv_is_a_benign_skip(tmp_path):
+    # A missing CSV path can't be introspected; the read/transfer path raises
+    # its own clear error. Don't double-report — defer.
+    result = MaskIdColumnValidator(column="mask_id").validate(str(tmp_path / "no.csv"))
+    assert result.is_valid
+    assert result.metadata["checked"] is False
+
+
+# ---------------------------------------------------------------------------
+# The declaration half of the contract — mask_id must be a DECLARED schema
+# column, or RecordProcessor drops it and the stored table has none (the exact
+# backend#816 shape a CSV-only check waves through). Enforced only when a schema
+# is supplied; the semseg factory always supplies it, bare construction skips it.
+# ---------------------------------------------------------------------------
+def test_undeclared_mask_id_in_schema_is_rejected(make_csv):
+    # mask_id present + populated in the CSV, but the schema OMITS it: the
+    # ingestor would drop the column -> broken table. This is the original #816
+    # bug shape; a CSV-only check would pass it.
+    path = make_csv(
+        pd.DataFrame(
+            {
+                "filename": ["image_001", "image_002"],
+                "mask_id": ["image_001_mask", "image_002_mask"],
+                "image_label": ["road", "sky"],
+            }
+        )
+    )
+    result = MaskIdColumnValidator(
+        column="mask_id", schema={"image_label": "VARCHAR(255)"}
+    ).validate(str(path))
+    assert not result.is_valid
+    msg = result.errors[0]
+    assert "DECLARED" in msg and "'mask_id'" in msg
+    assert "backend#816" in msg
+    assert "templates/semantic_segmentation/" in msg
+    assert result.metadata["schema_columns"] == ["image_label"]
+
+
+def test_no_schema_at_all_is_rejected(make_csv):
+    # A semseg ingest with no schema can't store mask_id -> reject. An explicit
+    # None counts as "supplied" (the factory passes the resolved schema, which is
+    # None when the config omits the schema key entirely).
+    path = make_csv(
+        pd.DataFrame({"filename": ["image_001"], "mask_id": ["image_001_mask"]})
+    )
+    result = MaskIdColumnValidator(column="mask_id", schema=None).validate(str(path))
+    assert not result.is_valid
+    assert "DECLARED" in result.errors[0]
+
+
+def test_declared_schema_with_mask_id_passes(make_csv):
+    # Declared in the schema AND populated in the CSV -> the full contract holds.
+    path = make_csv(
+        pd.DataFrame(
+            {
+                "filename": ["image_001", "image_002"],
+                "mask_id": ["image_001_mask", "image_002_mask"],
+                "image_label": ["road", "sky"],
+            }
+        )
+    )
+    result = MaskIdColumnValidator(
+        column="mask_id", schema={"mask_id": "VARCHAR(255)"}
+    ).validate(str(path))
+    assert result.is_valid
+    assert result.metadata["checked"] is True
+
+
+def test_non_lowercase_schema_key_is_rejected(make_csv):
+    # Schema declares "Mask_Id" (header is lowercase "mask_id"): the schema key
+    # must be exactly lowercase "mask_id" — the client reads the stored column by
+    # that literal name — so it's rejected with a rename hint.
+    path = make_csv(
+        pd.DataFrame({"filename": ["image_001"], "mask_id": ["image_001_mask"]})
+    )
+    result = MaskIdColumnValidator(
+        column="mask_id", schema={"Mask_Id": "VARCHAR(255)"}
+    ).validate(str(path))
+    assert not result.is_valid
+    assert "Rename the schema key to 'mask_id'" in result.errors[0]
+
+
+def test_non_lowercase_header_with_lowercase_schema_is_rejected(make_csv):
+    # Schema declares lowercase 'mask_id' but the CSV header is 'Mask_ID': the
+    # header must be exactly lowercase 'mask_id' (the stored + client-read name),
+    # rejected with a rename hint.
+    path = make_csv(
+        pd.DataFrame({"filename": ["image_001"], "Mask_ID": ["image_001_mask"]})
+    )
+    result = MaskIdColumnValidator(
+        column="mask_id", schema={"mask_id": "VARCHAR(255)"}
+    ).validate(str(path))
+    assert not result.is_valid
+    assert "must be named exactly 'mask_id'" in result.errors[0]
+
+
+def test_delimiter_from_csv_options_is_honored(tmp_path):
+    # A semicolon-delimited manifest (a supported csv_options.delimiter) must be
+    # parsed with that delimiter. Without it the whole header collapses into one
+    # column and mask_id is falsely reported missing — a false reject of a
+    # dataset the ingestor would parse and ingest fine.
+    path = tmp_path / "labels_semi.csv"
+    path.write_text("filename;mask_id;image_label\nimg_001;img_001_mask;road\n")
+    # Default (comma) parse: single collapsed column -> false "missing".
+    assert not MaskIdColumnValidator(column="mask_id").validate(str(path)).is_valid
+    # With the run's delimiter -> parses correctly and passes.
+    honored = MaskIdColumnValidator(
+        column="mask_id",
+        schema={"mask_id": "VARCHAR(255)"},
+        csv_options={"delimiter": ";"},
+    ).validate(str(path))
+    assert honored.is_valid, honored.errors
+
+
+def test_quotechar_from_csv_options_is_honored(tmp_path):
+    # A custom quotechar (') quotes a mask_id embedding the delimiter on one row,
+    # and mask_id is BLANK on another. Only when the validator parses with the
+    # run's quotechar (like CSVIngestor) does the quoted row parse cleanly so the
+    # blank is caught; without it that row is ragged, the scan errors out, and the
+    # blank mask_id slips through as a false pass.
+    path = tmp_path / "labels_quoted.csv"
+    path.write_text("filename;mask_id;image_label\nimg_001;'a;b';road\nimg_002;;sky\n")
+    result = MaskIdColumnValidator(
+        column="mask_id",
+        schema={"mask_id": "VARCHAR(255)"},
+        csv_options={"delimiter": ";", "quotechar": "'"},
+    ).validate(str(path))
+    assert not result.is_valid  # blank mask_id on the 2nd row is caught
+    assert "empty/NULL" in result.errors[0]
+
+
+def test_index_col_csv_option_does_not_defeat_the_gate(tmp_path):
+    # index_col is a valid read_csv option a run might set, but forwarding it into
+    # the single-column scan would collide with usecols and (if swallowed)
+    # fail-open the gate. It must be dropped from the dialect passthrough so a
+    # blank mask_id is still rejected.
+    path = tmp_path / "labels_idx.csv"
+    path.write_text("id,filename,mask_id\n1,img_001,\n")
+    result = MaskIdColumnValidator(
+        column="mask_id",
+        schema={"filename": "VARCHAR(255)", "mask_id": "VARCHAR(255)"},
+        csv_options={"index_col": "id"},
+    ).validate(str(path))
+    assert not result.is_valid  # blank mask_id caught despite index_col
+    assert "empty/NULL" in result.errors[0]
+
+
+def test_validation_error_does_not_leak_cell_content(tmp_path):
+    # A manifest whose header reads fine but whose body has an unterminated quote:
+    # the full scan raises a pandas ParserError (which can embed raw cell content).
+    # The validator must surface only the exception TYPE + generic guidance, never
+    # str(e) — customer cell values stay on-prem (bugbot: leaked-cell-values rule).
+    path = tmp_path / "labels_badquote.csv"
+    path.write_text('filename,mask_id\nimg_001,ok\nimg_002,"leaky_secret_value\n')
+    result = MaskIdColumnValidator(
+        column="mask_id", schema={"mask_id": "VARCHAR(255)"}
+    ).validate(str(path))
+    assert not result.is_valid  # a broken manifest is rejected (not fail-open)
+    msg = result.errors[0]
+    assert "leaky_secret_value" not in msg  # no raw cell content leaked
+    assert result.metadata.get("error_type") == "validation_exception"
+
+
+def test_non_string_delimiter_rejected_at_construction():
+    # csv_options is validated at construction, not mid-scan: a non-string
+    # delimiter raises a clear ValueError up front instead of a generic mask-id
+    # failure deep in the read (bugbot: validate-config-at-construction rule).
+    with pytest.raises(ValueError, match="delimiter"):
+        MaskIdColumnValidator(column="mask_id", csv_options={"delimiter": 3})
+
+
+def test_malformed_manifest_defers_gracefully(tmp_path):
+    # A manifest with invalid UTF-8 bytes: the header read can't introspect it,
+    # so the validator DEFERS (checked=False) rather than crashing — the
+    # ingestor's own read (same dialect, on_bad_lines="error") surfaces the
+    # malformation. (On a file large enough that the nrows=0 header buffer clears
+    # the corruption, the body scan reaches it and PROPAGATES the parse error to
+    # a rejection instead of a misleading partial count — see _empty_value_rows.)
+    path = tmp_path / "labels_badbytes.csv"
+    path.write_bytes(b"filename,mask_id\nimg_001,\xff\xfe\n")
+    result = MaskIdColumnValidator(
+        column="mask_id", schema={"mask_id": "VARCHAR(255)"}
+    ).validate(str(path))
+    assert result.is_valid  # defers (checked=False); does not crash
+    assert result.metadata["checked"] is False
+
+
+def test_case_colliding_headers_inspect_the_schema_exact_column(tmp_path):
+    # Header carries BOTH 'Mask_ID' (empty) and 'mask_id' (populated); the schema
+    # declares lowercase 'mask_id', which the ingestor keeps verbatim. The
+    # emptiness scan must inspect the schema-exact 'mask_id' (populated) — not the
+    # case-colliding empty 'Mask_ID' — else it false-rejects a manifest that
+    # ingests fine.
+    path = tmp_path / "labels_collide.csv"
+    path.write_text("filename,Mask_ID,mask_id\nimg_001,,img_001_mask\n")
+    result = MaskIdColumnValidator(
+        column="mask_id", schema={"mask_id": "VARCHAR(255)"}
+    ).validate(str(path))
+    assert result.is_valid, result.errors
+
+
+# ---------------------------------------------------------------------------
+# Record level — a DECLARED mask_id is stored populated on the processed row.
+# This pins the ingestor→client boundary #212's blanket pop regressed.
+# ---------------------------------------------------------------------------
+def test_declared_mask_id_is_stored_populated_on_the_row():
+    rp = RecordProcessor(
+        schema={"mask_id": "VARCHAR(255)", "image_label": "VARCHAR(255)"},
+        intent="train",
+        label_column=None,
+        annotation_column=None,
+        unique_id_column=None,
+        label_policy=None,
+        ingestor_id="t",
+    )
+    row = rp.process(
+        {
+            "filename": "image_001.jpg",
+            "extension": "jpg",
+            "mask_id": "image_001_mask.png",
+            "image_label": "road",
+        }
+    )
+    assert row is not None
+    assert row.get("mask_id") == "image_001_mask.png"

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -375,6 +375,20 @@ class BaseIngestor(ABC):
                 # sneak an effectively single-class dataset past the gate
                 # (bugbot #252).
                 "full_schema": self.schema,
+                # The run's csv read options (delimiter / encoding / ...), so a
+                # CSV-reading validator parses the manifest BYTE-IDENTICALLY to
+                # CSVIngestor. Without it a non-comma or BOM manifest that ingests
+                # fine is falsely rejected at preflight (delimiter is a supported
+                # option — schema/ingest.v1.json). getattr: only CSVIngestor
+                # carries csv_options; JSON/other ingestors default to {}.
+                "csv_options": getattr(self, "csv_options", {}),
+                # The run's data_id source column (data_id.strategy=column),
+                # for SequenceGroupValidator's T6 guard: mapping data_id
+                # from the sequence column would upsert-collapse every
+                # sequence to one row (backend#1054 WS1). None for the
+                # default UUID / content_hash strategies; non-grouped
+                # factories ignore the key.
+                "unique_id_column": self.unique_id_column,
             },
             # Inject the run's resolved Config so path-reading validators
             # (SRC_PATH / DEST_PATH / TABLE_NAME) use it instead of a

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -411,13 +411,14 @@ class CSVIngestor(BaseIngestor):
 
             # NA handling — PER COLUMN, identical to the validator gate. Every
             # schema column treats ""/NA/null/None as missing (-> NULL);
-            # non-schema columns (filename, mask_id, …) are omitted so a file
-            # named "NA.jpg" survives. The same builder feeds DataValidator's
-            # read, so a file can't pass validation and then crash the cast on a
-            # token one layer treats as missing and the other as data — the
-            # whole-category split (tabular vs other) that caused #237. Used
-            # with keep_default_na=False so pandas' global default set never
-            # reaches a non-schema column.
+            # non-schema columns (filename, unique-id, …) are omitted so a file
+            # named "NA.jpg" survives. (semseg's mask_id is a DECLARED schema
+            # column — backend#816 — so it DOES get this treatment.) The same
+            # builder feeds DataValidator's read, so a file can't pass validation
+            # and then crash the cast on a token one layer treats as missing and
+            # the other as data — the whole-category split (tabular vs other)
+            # that caused #237. Used with keep_default_na=False so pandas' global
+            # default set never reaches a non-schema column.
             na_values = coercion.build_csv_na_values(self.schema)
 
             # Pin string-family schema columns to dtype=str so pandas can't infer

--- a/tracebloc_ingestor/ingestors/record_processor.py
+++ b/tracebloc_ingestor/ingestors/record_processor.py
@@ -278,14 +278,16 @@ class RecordProcessor:
             cleaned_record["ingestor_id"] = self.ingestor_id
             cleaned_record["filename"] = record.get("filename")
             cleaned_record["extension"] = record.get("extension")
-            # The cleaned record carries ONLY DB columns + framework columns —
-            # no runtime-only sidecar pointers. semantic_segmentation's mask_id
-            # is a per-row pointer to a mask FILE, not a table column (there's no
-            # mask_id column on the standard tracebloc table — #212); it stays on
-            # the RAW source record and is lent to the transfer by
-            # ``map_file_transfer`` for the duration of the copy. So mask_id no
-            # longer rides the DB-bound record through process -> transfer ->
-            # batch (the cross-layer leak this split removes — P5).
+            # The cleaned record carries ONLY schema-declared DB columns +
+            # framework columns. A sidecar's link column is a table column IFF
+            # the schema declares it: semantic_segmentation MUST declare mask_id
+            # (backend#816, enforced at preflight by MaskIdColumnValidator), so a
+            # declared mask_id IS stored — kept by the `k in self.schema` filter
+            # above — and the training client reads it to locate each mask. An
+            # UNdeclared sidecar pointer is not a table column: it is lent to the
+            # transfer by ``map_file_transfer`` for the copy only, without riding
+            # the DB-bound record through process -> transfer -> batch (the
+            # cross-layer leak this split removes — P5).
             return cleaned_record
 
         except Exception as e:

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -33,6 +33,7 @@ from ..validators.keypoint_annotation_validator import KeypointAnnotationValidat
 from ..validators.keypoint_visibility_validator import KeypointVisibilityValidator
 from ..validators.label_column_validator import LabelColumnValidator
 from ..validators.label_diversity_validator import LabelDiversityValidator
+from ..validators.mask_id_validator import MaskIdColumnValidator
 from ..validators.numeric_columns_validator import NumericColumnsValidator
 from ..validators.sentence_pair_validator import SentencePairValidator
 from ..validators.text_content_validator import TextContentValidator
@@ -127,6 +128,27 @@ def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
             # so image_001.jpg pairs with image_001_mask.png. object_detection's
             # pairing is plain stem (no suffix) — the default.
             sidecar_suffix="_mask",
+        ),
+        # Enforce the semseg mask_id contract at preflight (backend#816): the
+        # manifest MUST declare mask_id in the schema (so it becomes a stored DB
+        # column — an undeclared one is dropped, the original bug) AND populate it
+        # on every row, because the training client reads that column to locate
+        # each mask file with no naming-convention fallback. Required + enforced
+        # here rather than silently auto-added to the schema, so the per-category
+        # "which link column" knowledge stays on the modality spec/registry.
+        # Use the STRIPPED schema (options["schema"] = file_options["schema"]) —
+        # the columns that ACTUALLY become the stored table — NOT full_schema. If
+        # mask_id is (mis)configured as the label / unique_id / annotation column,
+        # BaseIngestor strips it from the table schema and RecordProcessor drops
+        # it, so it must not count as "declared": full_schema would pass preflight
+        # while CREATE TABLE + inserts carry no mask_id column — the exact #816
+        # shape. Direct callers / tests pass the schema explicitly.
+        MaskIdColumnValidator(
+            column="mask_id",
+            schema=options.get("schema"),
+            # Parse the manifest with the run's delimiter/encoding so a non-comma
+            # or BOM manifest that ingests fine isn't falsely rejected at preflight.
+            csv_options=options.get("csv_options"),
         ),
         ImageResolutionValidator(
             expected_resolution=options["target_size"],

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -83,7 +83,10 @@ def _text_content_validator(
 def image_classification(options: Dict[str, Any]) -> List[BaseValidator]:
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
-        ImageResolutionValidator(expected_resolution=options["target_size"]),
+        ImageResolutionValidator(
+            expected_resolution=options["target_size"],
+            min_size=options.get("min_size"),
+        ),
         # Fail fast when the configured label column is absent from the CSV
         # (else every record cleans to label=None and the backend rejects each
         # row with HTTP 400 "label: may not be null"). image_classification is
@@ -104,7 +107,10 @@ def object_detection(options: Dict[str, Any]) -> List[BaseValidator]:
             sidecar_path="annotations",
             sidecar_label="annotation",
         ),
-        ImageResolutionValidator(expected_resolution=options["target_size"]),
+        ImageResolutionValidator(
+            expected_resolution=options["target_size"],
+            min_size=options.get("min_size"),
+        ),
     ]
 
 
@@ -122,7 +128,10 @@ def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
             # pairing is plain stem (no suffix) — the default.
             sidecar_suffix="_mask",
         ),
-        ImageResolutionValidator(expected_resolution=options["target_size"]),
+        ImageResolutionValidator(
+            expected_resolution=options["target_size"],
+            min_size=options.get("min_size"),
+        ),
         # Masks are pixel-wise label maps: validate they're readable PNGs and
         # share the images' resolution. The default ImageResolution instance only
         # scans <SRC>/images, so without this a corrupt mask, or a mask whose size
@@ -131,6 +140,7 @@ def semantic_segmentation(options: Dict[str, Any]) -> List[BaseValidator]:
             expected_resolution=options["target_size"],
             name="Mask Resolution Validator",
             subdir="masks",
+            min_size=options.get("min_size"),
         ),
     ]
 
@@ -143,7 +153,10 @@ def keypoint_detection(options: Dict[str, Any]) -> List[BaseValidator]:
     # rejects datasets whose annotations drift from the declared K.
     return [
         FileTypeValidator(allowed_extension=options["extension"], path="images"),
-        ImageResolutionValidator(expected_resolution=options["target_size"]),
+        ImageResolutionValidator(
+            expected_resolution=options["target_size"],
+            min_size=options.get("min_size"),
+        ),
         KeypointAnnotationValidator(
             num_keypoints=options.get("number_of_keypoints"),
             # Bound keypoint coords by the declared image size (images are

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -204,6 +204,13 @@
               "maxItems": 2,
               "description": "[width, height]. Image categories only. Default [512, 512]. The order matches PIL.Image.size and what ImageResolutionValidator expects."
             },
+            "min_size": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1 },
+              "minItems": 2,
+              "maxItems": 2,
+              "description": "[width, height] absolute minimum image size (#348). Images with either side below this are rejected as too small to train on. Image categories only. Defaults to [32, 32] (ImageResolutionValidator.MIN_IMAGE_SIZE) when unset; override per-model to match the model-zoo input requirement."
+            },
             "extension": {
               "type": "string",
               "enum": [".jpg", ".jpeg", ".png", ".txt", ".text", ".xml"],

--- a/tracebloc_ingestor/schema_inference.py
+++ b/tracebloc_ingestor/schema_inference.py
@@ -1,0 +1,262 @@
+"""Owned tabular schema-inference rules — the platform's source of truth.
+
+RFC-0002 §8.1 (epic backend#1008, design cli#174). When a tabular dataset
+arrives without a declared column→type schema, *something* has to decide each
+column's SQL type. That decision is load-bearing: it is meant to drive the
+CREATE TABLE DDL, the per-column cast/validation (``CSVIngestor._validate_csv``),
+and the model's ``num_feature_points``. A wrong type silently corrupts training
+data — the canonical case being a zero-padded code like ``"007"`` inferred as
+``INT`` and stored as ``7``, destroying a ZIP / accession / gene / account id.
+
+NOT YET WIRED (#349 scope): this module defines and pins the rules; the ingest
+path is not changed to *call* it in this diff. Today ``CSVIngestor`` still
+receives a caller-supplied schema (``resolved.schema``) and never infers. So the
+``"007"`` corruption is prevented at the layer that OWNS the decision, but only
+once a follow-up routes the no-schema path through ``infer_schema`` (and the Go
+CLI through ``InferSchema``). Until then the protection lives in the tests and
+the parity contract, not in a running ingest.
+
+Under Option A these rules live HERE and the Go CLI (``InferSchema``, re-scoped
+cli#185) mirrors them, verified by the value-level parity harness
+(backend#1009). ``tests/fixtures/schema_inference_parity.json`` enumerates the
+(values → expected type) contract both sides must satisfy — edit it once and
+both implementations are pinned to the same answer.
+
+INPUT CONTRACT
+--------------
+Inference must run on the RAW, string-form values (a CSV read with
+``dtype=str``, or the CLI's raw byte columns). If pandas has already
+type-inferred the frame, ``"007"`` is *already* ``7`` and the leading-zero
+signal is gone — inference then can't help. Feed strings.
+
+RULES — evaluated per column, FIRST MATCH WINS (this is the precedence):
+  0. All values missing/empty       -> ``VARCHAR(1)``  (nothing to infer)
+  1. Any leading-zero numeric code   -> ``VARCHAR(n)``  (THE #349 fix)
+       a token matching ``^[+-]?0\\d+$`` (all digits, leading zero,
+       length > 1: ``"007"``, ``"00123"``) is a CODE, not a number — typing it
+       INT strips the zeros. ONE such token in the sample pins the whole
+       column to text.
+  2. All values textual boolean      -> ``BOOLEAN``
+       every token in ``{true,false,t,f,yes,no,y,n}`` (case-insensitive). A
+       pure ``0``/``1`` column is deliberately INT, not BOOL: ``0/1`` is
+       ambiguous and the INT reading is lossless.
+  3. All values integer              -> ``INT`` / ``BIGINT``
+       ``^[+-]?\\d+$`` and within signed int64. ``BIGINT`` when any ``|value|``
+       exceeds signed int32 (2147483647), so a large id can't overflow a MySQL
+       ``INT`` column. An all-digit value beyond int64 is not storable as an
+       integer and falls through to ``VARCHAR``.
+  4. All values float                -> ``FLOAT``
+       parseable by ``float()`` and finite (``inf``/``-inf`` are rejected so a
+       column of ``"inf"`` is not called numeric).
+  5. All values date / datetime      -> ``DATE`` / ``DATETIME``
+       parseable as a calendar date — checked AFTER numeric, so an all-digit id
+       column (e.g. ``"20240101"``) is INT, never a date. ``DATETIME`` when any
+       value carries a time-of-day component, else ``DATE``.
+  6. Otherwise                       -> ``VARCHAR(n)``  (n = longest sampled
+       value length in CHARACTERS / code points, floor 1).
+
+``VARCHAR(n)`` — ``n`` counts CHARACTERS (Unicode code points), matching MySQL's
+``VARCHAR(n)`` semantics (n characters, not bytes). The Go CLI mirror MUST size
+by rune count (``utf8.RuneCountInString``), NOT ``len(string)`` (which counts
+UTF-8 bytes) — otherwise the two emit different DDL for any multibyte value
+(``"café"`` -> ``VARCHAR(4)`` here vs ``VARCHAR(5)`` for a byte count). The parity
+fixture is ASCII-only, so it cannot catch that drift; the unit is fixed here.
+
+SAMPLING CAP
+------------
+Inference reads at most the first :data:`SAMPLE_CAP` (5,000) rows per column —
+matching the CLI. This bounds work on wide/deep files. The trade-off: a value
+longer than the sample's max, or a rare off-type token, that appears only past
+row 5,000 won't influence the inferred type.
+
+The cast layer (``CSVIngestor._validate_csv``) is a PARTIAL backstop here, not a
+full one. A token that is genuinely non-castable to the inferred type (e.g.
+``"abc"`` in an INT column) surfaces as a clear per-column error. But a token
+that is *numerically castable yet semantically wrong* is coerced SILENTLY: a
+zero-padded code like ``"00501"`` first appearing past the cap infers ``INT`` and
+casts to ``501`` (zeros stripped), and a ``"3.5"`` past the cap in an otherwise
+integer column is coerced by ``pd.to_numeric`` without error. So the cap can
+still lose a leading-zero code or truncate a float if the giveaway row sits
+beyond row 5,000 — a real (if narrow) residual risk, not "never silent
+corruption". Raise :data:`SAMPLE_CAP` (in lockstep with the CLI) if a dataset is
+known to hide off-type values deep in a column.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import warnings
+from itertools import islice
+from typing import Any, Dict, Iterable, List, Mapping, Union
+
+import pandas as pd
+
+from .utils import coercion
+
+__all__ = ["SAMPLE_CAP", "infer_column_type", "infer_schema"]
+
+# First N rows per column that influence inference. Mirrors the CLI's cap so
+# the two implementations agree on the same prefix of a file.
+SAMPLE_CAP = 5000
+
+# Signed 32-bit bounds — a value outside this range needs BIGINT, not INT, or
+# it overflows a MySQL INT column on write. (int64 bounds live in ``coercion``.)
+INT32_MIN = -2147483648
+INT32_MAX = 2147483647
+
+# Textual boolean tokens ONLY — deliberately NOT the 0/1 digit forms that
+# ``coercion.BOOL_STRINGS`` also blesses. A pure 0/1 column is inferred INT
+# (lossless); only unambiguous words map to BOOLEAN here.
+_BOOL_TEXT = frozenset({"true", "false", "t", "f", "yes", "no", "y", "n"})
+
+_NA = frozenset(coercion.NA_SENTINELS)
+
+# ASCII-only digit classes ([0-9], NOT \d). Python's ``\d`` also matches Unicode
+# decimal digits (e.g. Arabic-Indic ``"١٢٣"``) and ``int()``/``float()`` happily
+# parse them — but the Go CLI mirror matches ASCII only, and a MySQL INT/FLOAT
+# column can't store the raw glyphs. Restricting to ``[0-9]`` keeps the two
+# implementations in lockstep and routes non-ASCII-digit tokens to VARCHAR.
+_LEADING_ZERO_CODE = re.compile(r"^[+-]?0[0-9]+$")
+_INT_RE = re.compile(r"^[+-]?[0-9]+$")
+
+# Finite-float grammar, ASCII-only. Pre-screens the token BEFORE ``float()`` so
+# Python leniencies that Go's ``strconv.ParseFloat`` rejects can't diverge:
+# underscore grouping (``float("1_000") == 1000.0``), Unicode digits, and the
+# ``inf``/``nan``/``Infinity`` spellings ``float()`` accepts. Scientific notation
+# is allowed (Go parses it too). The ``math.isfinite`` guard below still catches
+# a regex-valid overflow like ``"1e400"`` -> ``inf``.
+_FLOAT_RE = re.compile(r"^[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$")
+
+
+def _clean_tokens(values: Iterable[Any]) -> List[str]:
+    """First :data:`SAMPLE_CAP` raw values → stripped, non-missing strings.
+
+    The cap is applied to the RAW values (first 5,000 rows), then missing
+    tokens are dropped — so a column of 5,000 blanks followed by data still
+    reads as effectively empty, exactly as the CLI's row-capped scan would.
+    """
+    out: List[str] = []
+    for v in islice(values, SAMPLE_CAP):
+        if v is None:
+            continue
+        try:
+            if pd.isna(v):
+                continue
+        except (TypeError, ValueError):
+            pass  # non-scalar (list/dict) — keep, str() below handles it
+        s = str(v).strip()
+        if s == "" or s in _NA:
+            continue
+        out.append(s)
+    return out
+
+
+def _is_finite_float(token: str) -> bool:
+    if not _FLOAT_RE.match(token):
+        return False
+    try:
+        return math.isfinite(float(token))
+    except (TypeError, ValueError):
+        return False
+
+
+def _varchar(tokens: List[str]) -> str:
+    return f"VARCHAR({max((len(t) for t in tokens), default=1)})"
+
+
+def _infer_datetime(tokens: List[str]) -> Union[str, None]:
+    """``DATE`` / ``DATETIME`` if every token parses as a calendar date, else
+    ``None``.
+
+    Guard against over-eager matching on plain words: require each token to
+    contain at least one ASCII digit (so ``"apple"`` / month-name columns stay
+    text). ASCII specifically — ``str.isdigit()`` is true for Unicode digits
+    (``"١٢٣"``) which some pandas versions then PARSE as a date, mis-typing a
+    non-ASCII-digit column DATE instead of VARCHAR. A real calendar date only
+    ever contains ASCII digits. Numeric columns never reach here — classified
+    earlier.
+    """
+    if not all(any(c in "0123456789" for c in t) for t in tokens):
+        return None
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            parsed = pd.to_datetime(pd.Series(tokens), errors="coerce", format="mixed")
+    except (ValueError, TypeError):
+        # pandas is not version-stable here: mixed-timezone tokens (one
+        # "+00:00", one "+05:00") RAISE "Mixed timezones detected" on newer
+        # pandas and return an OBJECT-dtype Series (handled below) on older —
+        # either way it's not a clean single-tz calendar column. Fall back to
+        # text rather than crash the whole schema pass.
+        return None
+    if parsed.isna().any():
+        return None
+    if not pd.api.types.is_datetime64_any_dtype(parsed):
+        # Older pandas: mixed-tz tokens parse to an OBJECT-dtype Series of
+        # Timestamps, not a DatetimeIndex — it has no ``.dt`` accessor, so the
+        # ``has_time`` line below would raise an uncaught AttributeError and
+        # abort the whole schema pass. Fall back to text: a tz-mixed column is
+        # safer as VARCHAR than a tz-naive MySQL DATETIME that silently drops
+        # the offset anyway.
+        return None
+    has_time = bool(
+        ((parsed.dt.hour != 0) | (parsed.dt.minute != 0) | (parsed.dt.second != 0)).any()
+    ) or any(":" in t for t in tokens)
+    return "DATETIME" if has_time else "DATE"
+
+
+def infer_column_type(values: Iterable[Any]) -> str:
+    """Infer the SQL type for one column from its RAW values.
+
+    See the module docstring for the full rule precedence. Returns an
+    ``_get_sqlalchemy_type``-compatible type string (``INT``, ``BIGINT``,
+    ``FLOAT``, ``BOOLEAN``, ``DATE``, ``DATETIME``, ``VARCHAR(n)``).
+    """
+    tokens = _clean_tokens(values)
+    if not tokens:
+        # No signal — the narrowest string type. The cast layer widens on
+        # write; a real value never lands here (all-missing column).
+        return "VARCHAR(1)"
+
+    # 1. Leading-zero code — one such token pins the column to text (#349).
+    if any(_LEADING_ZERO_CODE.match(t) for t in tokens):
+        return _varchar(tokens)
+
+    # 2. Textual boolean.
+    if all(t.lower() in _BOOL_TEXT for t in tokens):
+        return "BOOLEAN"
+
+    # 3. Integer (INT vs BIGINT by magnitude; >int64 all-digit -> text).
+    if all(_INT_RE.match(t) for t in tokens):
+        ints = [int(t) for t in tokens]
+        if all(coercion.INT64_MIN <= v <= coercion.INT64_MAX for v in ints):
+            if all(INT32_MIN <= v <= INT32_MAX for v in ints):
+                return "INT"
+            return "BIGINT"
+        return _varchar(tokens)  # beyond int64: not storable as an integer
+
+    # 4. Float.
+    if all(_is_finite_float(t) for t in tokens):
+        return "FLOAT"
+
+    # 5. Date / datetime (after numeric, so numeric ids can't be mis-dated).
+    dt = _infer_datetime(tokens)
+    if dt:
+        return dt
+
+    # 6. Fallback.
+    return _varchar(tokens)
+
+
+def infer_schema(
+    data: Union[pd.DataFrame, Mapping[str, Iterable[Any]]],
+) -> Dict[str, str]:
+    """Infer a full ``column -> SQL type`` schema.
+
+    Accepts a pandas ``DataFrame`` (read with ``dtype=str`` — see the INPUT
+    CONTRACT) or any ``column -> values`` mapping. Column order is preserved.
+    """
+    if isinstance(data, pd.DataFrame):
+        return {str(col): infer_column_type(data[col].tolist()) for col in data.columns}
+    return {str(col): infer_column_type(vals) for col, vals in data.items()}

--- a/tracebloc_ingestor/utils/coercion.py
+++ b/tracebloc_ingestor/utils/coercion.py
@@ -51,7 +51,10 @@ INT64_MAX = 9223372036854775807
 # set, which has shifted across versions) so the validator and the ingestor
 # apply byte-identical rules. Applied only to schema columns by
 # ``build_csv_na_values`` — never to the framework's own ``filename`` /
-# ``mask_id`` columns — so a file legitimately named ``NA.jpg`` survives.
+# unique-id columns — so a file legitimately named ``NA.jpg`` survives. (A
+# category that DECLARES a link column in its schema — e.g. semseg's required
+# ``mask_id``, backend#816 — makes it a schema column, so it DOES get this
+# coercion; the mask_id preflight validator applies the same set to match.)
 NA_SENTINELS: List[str] = [
     "",
     "NA",
@@ -115,10 +118,13 @@ def build_csv_na_values(schema: Dict[str, str]) -> Dict[str, List[str]]:
 
     Use with ``keep_default_na=False`` so pandas' global default NA set never
     reaches a non-schema column. Columns absent from the schema — the
-    framework's own ``filename`` / ``mask_id`` / unique-id columns — are
-    intentionally omitted: they get no NA coercion at read time, so a file
-    named ``"NA.jpg"`` keeps its name (an empty cell there is normalised to
-    ``None`` later by ``BaseIngestor.process_record``).
+    framework's own ``filename`` / unique-id columns, plus any sidecar link
+    column a category does NOT declare — are intentionally omitted: they get no
+    NA coercion at read time, so a file named ``"NA.jpg"`` keeps its name (an
+    empty cell there is normalised to ``None`` later by
+    ``BaseIngestor.process_record``). A DECLARED sidecar link column such as
+    semseg's required ``mask_id`` (backend#816) IS a schema column and so does
+    get the coercion above.
     """
     return {col: list(NA_SENTINELS) for col in schema}
 

--- a/tracebloc_ingestor/validators/__init__.py
+++ b/tracebloc_ingestor/validators/__init__.py
@@ -19,6 +19,7 @@ from .time_ordered_validator import TimeOrderedValidator
 from .time_before_today_validator import TimeBeforeTodayValidator
 from .keypoint_annotation_validator import KeypointAnnotationValidator
 from .keypoint_visibility_validator import KeypointVisibilityValidator
+from .mask_id_validator import MaskIdColumnValidator
 
 __all__ = [
     "BaseValidator",
@@ -35,4 +36,5 @@ __all__ = [
     "TimeBeforeTodayValidator",
     "KeypointAnnotationValidator",
     "KeypointVisibilityValidator",
+    "MaskIdColumnValidator",
 ]

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -84,19 +84,35 @@ class ImageResolutionValidator(BaseValidator):
         self.expected_resolution = expected_resolution
         self.subdir = subdir
         # Absolute floor (width, height), normalized once here so every
-        # downstream read can trust it is a 2-tuple. A falsy override falls
-        # back to the module default so the gate is always active, never
-        # silently disabled. A non-iterable or non-2-element override is a
-        # config error, surfaced at construction rather than swallowed
-        # mid-scan as a per-file image-read error.
+        # downstream read can trust it is a 2-tuple of positive ints. A falsy
+        # override falls back to the module default so the gate is always
+        # active, never silently disabled. A non-iterable or non-2-element
+        # override is a config error, surfaced at construction rather than
+        # swallowed mid-scan as a per-file image-read error.
         if min_size:
+            # A str/bytes is iterable, so a 2-char value like "32" would unpack
+            # to ('3', '2') and quietly weaken the floor to (3, 2). Reject it up
+            # front as a shape error — a string is never a (width, height) pair.
+            if isinstance(min_size, (str, bytes)):
+                raise ValueError(
+                    f"min_size must be a (width, height) pair; got {min_size!r}"
+                )
             try:
                 min_w, min_h = min_size
             except (TypeError, ValueError):
                 raise ValueError(
                     f"min_size must be a (width, height) pair; got {min_size!r}"
                 )
-            self.min_size = (min_w, min_h)
+            # Each side must also be a positive integer. A non-integer override
+            # (a "32" string, a float, None) unpacks cleanly above but would blow
+            # up later as an int-vs-str TypeError inside _meets_min_size — caught
+            # by the per-image handler and mislabeled as a corrupt-image error
+            # rather than the config error it is. Normalize each axis once,
+            # loudly, at construction.
+            self.min_size = (
+                self._coerce_dimension(min_w, min_size),
+                self._coerce_dimension(min_h, min_size),
+            )
         else:
             self.min_size = MIN_IMAGE_SIZE
         self.tolerance = 0  # Whether to enforce strict file type checking . we can later make this configurable
@@ -436,6 +452,35 @@ class ImageResolutionValidator(BaseValidator):
                 "tolerance": self.tolerance,
             },
         )
+
+    @staticmethod
+    def _coerce_dimension(value: Any, min_size: Any) -> int:
+        """Normalize one ``min_size`` axis to a positive int at construction.
+
+        Accepts an int or an integer-valued float (``32.0``) — the shapes a
+        numeric literal reaches ``file_options`` as from JSON/YAML — and returns
+        the pixel count. Anything else (``bool``, a non-integral float, a string,
+        ``None``, a negative or zero value) is a config error and raises here, so
+        it never survives to raise a TypeError inside :meth:`_meets_min_size`
+        where the per-image handler would mislabel it as a corrupt-image read.
+        ``bool`` is rejected explicitly — it is an ``int`` subclass but never a
+        valid pixel count. Strings are rejected too (not coerced): the schema
+        declares integers, and a digit string like ``"32"`` would otherwise
+        char-split through the (width, height) unpack into ``('3', '2')`` and
+        silently weaken the floor.
+        """
+        pixels: Optional[int] = None
+        if isinstance(value, bool):
+            pixels = None
+        elif isinstance(value, int):
+            pixels = value
+        elif isinstance(value, float) and value.is_integer():
+            pixels = int(value)
+        if pixels is None or pixels <= 0:
+            raise ValueError(
+                f"min_size must be a pair of positive integers; got {min_size!r}"
+            )
+        return pixels
 
     def _meets_min_size(self, resolution: Tuple[int, int]) -> bool:
         """Return True if ``resolution`` (width, height) is at least the floor

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -26,6 +26,24 @@ config = Config()
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
+# Absolute lower bound on image dimensions, as (width, height) in pixels
+# (#348, RFC-0002 §12.9 + Principle 6). Images with either side below this are
+# rejected outright — independently of the per-model ``target_size`` uniformity
+# check — because they carry too little spatial structure to train on: standard
+# vision backbones downsample by 2 five times (total /32), so a side below 32px
+# collapses to a sub-pixel feature map, and 32x32 is the canonical small-image
+# benchmark size (CIFAR). A per-model override travels in ``file_options`` as
+# ``min_size`` (schema-plumbed like ``target_size``), so the CLI can discover
+# and preview the same floor (cli#183). Kept conservative on purpose: this is a
+# floor, not the recommended resolution.
+MIN_IMAGE_SIZE: Tuple[int, int] = (32, 32)
+
+# Cap on how many offending files are named inline in a too-small error
+# message (the full list is always kept in result metadata). Keeps the
+# logged / API-bound error string bounded when an entire dataset is below
+# the floor — the common case for this gate.
+_MAX_LISTED_FILES = 20
+
 
 class ImageResolutionValidator(BaseValidator):
     """Validator for ensuring image resolution uniformity.
@@ -44,6 +62,7 @@ class ImageResolutionValidator(BaseValidator):
         expected_resolution: Optional[Tuple[int, int]] = None,
         name: str = "Image Resolution Validator",
         subdir: str = "images",
+        min_size: Optional[Tuple[int, int]] = None,
     ):
         """Initialize the image resolution validator.
 
@@ -56,10 +75,30 @@ class ImageResolutionValidator(BaseValidator):
                 semantic-segmentation masks — pixel-wise label maps that must be
                 readable and share the images' resolution; the default instance
                 only ever scans ``<SRC_PATH>/images``.
+            min_size: Minimum acceptable image size as (width, height). Images
+                with either side below this are rejected. Defaults to
+                :data:`MIN_IMAGE_SIZE`; a per-model override is plumbed from
+                ``file_options["min_size"]`` (#348).
         """
         super().__init__(name)
         self.expected_resolution = expected_resolution
         self.subdir = subdir
+        # Absolute floor (width, height), normalized once here so every
+        # downstream read can trust it is a 2-tuple. A falsy override falls
+        # back to the module default so the gate is always active, never
+        # silently disabled. A non-iterable or non-2-element override is a
+        # config error, surfaced at construction rather than swallowed
+        # mid-scan as a per-file image-read error.
+        if min_size:
+            try:
+                min_w, min_h = min_size
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"min_size must be a (width, height) pair; got {min_size!r}"
+                )
+            self.min_size = (min_w, min_h)
+        else:
+            self.min_size = MIN_IMAGE_SIZE
         self.tolerance = 0  # Whether to enforce strict file type checking . we can later make this configurable
         self.supported_formats = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"}
 
@@ -258,6 +297,7 @@ class ImageResolutionValidator(BaseValidator):
 
         invalid_files = []
         resolution_errors = []
+        too_small = []
         warnings = []
         resolutions_found = set()
 
@@ -277,6 +317,12 @@ class ImageResolutionValidator(BaseValidator):
                         continue
 
                     resolutions_found.add(resolution)
+                    # Absolute minimum-size floor (#348): reject images with
+                    # either side below ``min_size``, independently of the
+                    # target_size uniformity check below — a uniform dataset of
+                    # tiny (e.g. 8x8) images would otherwise pass.
+                    if not self._meets_min_size(resolution):
+                        too_small.append(f"{image_path}: {resolution}")
                     # Check if resolution matches expected (with tolerance)
                     if not self._resolution_matches(
                         resolution, self.expected_resolution
@@ -295,6 +341,37 @@ class ImageResolutionValidator(BaseValidator):
             # Close progress bar
             if progress_bar:
                 progress_bar.close()
+
+        # Enforce the minimum-size floor first: it's the most fundamental,
+        # actionable failure (the images simply can't be trained on), so it
+        # takes precedence over a uniformity / target_size mismatch.
+        if too_small:
+            # The trigger for this branch is typically a uniformly-tiny
+            # dataset, i.e. EVERY file is offending, so cap the list echoed
+            # into the (logged, API-bound) error string; the full set stays
+            # in metadata. invalid_files is preserved here too — otherwise a
+            # dataset that is both too-small and partly corrupt would hide the
+            # corrupt files until a second run.
+            sample = too_small[:_MAX_LISTED_FILES]
+            more = len(too_small) - len(sample)
+            listed = f"{sample}{f' (and {more} more)' if more else ''}"
+            return self._create_result(
+                is_valid=False,
+                errors=[
+                    f"Images below the minimum size {self.min_size} (width, height) "
+                    f"were found — they are too small to train on. Provide larger images or, "
+                    f"if your model accepts smaller inputs, lower the floor via "
+                    f"file_options.min_size. Offending files: {listed}"
+                ],
+                metadata={
+                    "files_checked": len(image_files),
+                    "min_size": self.min_size,
+                    "too_small": too_small,
+                    "invalid_files": invalid_files,
+                    "resolutions_found": sorted(resolutions_found),
+                    "expected_resolution": self.expected_resolution,
+                },
+            )
 
         # Check for uniformity
         if len(resolutions_found) > 1:
@@ -355,9 +432,19 @@ class ImageResolutionValidator(BaseValidator):
                 "files_checked": len(image_files),
                 "uniform_resolution": uniform_resolution,
                 "expected_resolution": self.expected_resolution,
+                "min_size": self.min_size,
                 "tolerance": self.tolerance,
             },
         )
+
+    def _meets_min_size(self, resolution: Tuple[int, int]) -> bool:
+        """Return True if ``resolution`` (width, height) is at least the floor
+        on BOTH axes. An image exactly at the floor passes; either side below
+        it fails. ``self.min_size`` is already normalized to a 2-tuple in
+        ``__init__``, so a list-typed ``file_options.min_size`` compares by
+        value here without re-casting."""
+        min_w, min_h = self.min_size
+        return resolution[0] >= min_w and resolution[1] >= min_h
 
     def _resolution_matches(
         self, actual: Tuple[int, int], expected: Tuple[int, int]

--- a/tracebloc_ingestor/validators/mask_id_validator.py
+++ b/tracebloc_ingestor/validators/mask_id_validator.py
@@ -1,0 +1,435 @@
+"""Mask-ID Column Validator Module.
+
+Fail-fast guard for the semantic-segmentation ``mask_id`` contract (backend#816),
+run at preflight (before the destination table is created).
+
+Why this exists: the training client resolves each mask file from a MySQL
+column named ``mask_id`` (``segmentation_dataset_pytorch.py`` does
+``str(row["mask_id"])`` → filename, with NO naming-convention fallback). So a
+semseg ingest whose manifest either lacks the ``mask_id`` column, or leaves it
+empty on some rows, produces a table the client cannot read: every affected
+mask lookup crashes with ``FileNotFoundError`` at train time — a late, opaque
+failure for what is simply a missing / unpopulated link column in the manifest.
+
+Rather than silently mutating the dataset schema at ingest time (auto-adding
+the column), the contract is REQUIRED and ENFORCED here: the manifest must
+declare ``mask_id`` and populate it on every ingestable row. Per-category
+knowledge (which sidecar link column a category needs) stays on the modality
+spec/registry (backend#796); this validator is the reusable enforcement of a
+"sidecar link column" check, parametrized by column name so other file-linked
+modalities can reuse it.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+from .base import BaseValidator, ValidationResult
+from ..config import Config
+from ..utils.coercion import NA_SENTINELS
+
+config = Config()
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
+
+# Sentinel distinguishing "no schema argument was supplied" (bare construction /
+# unit test — skip the declaration check, validate only the CSV) from an
+# explicitly-passed schema, INCLUDING ``None`` / ``{}`` (a real ingest with no
+# schema at all, which MUST be rejected because ``mask_id`` can't be a stored
+# column then). The semseg factory always passes the resolved schema, so the
+# real ingest path always runs the declaration check.
+_SCHEMA_UNSET = object()
+
+# The ONLY csv_options forwarded to the validator's reads: the keys that control
+# how the manifest is TOKENIZED into columns + cells, so its parse matches
+# CSVIngestor's. A whitelist, not a blacklist — frame-RESTRUCTURING keys
+# (index_col, header, names, usecols, skiprows, nrows, ...) are excluded, because
+# the scan pins its own usecols/dtype/chunksize and forwarding a restructuring
+# key would collide with those (a swallowed error that fail-opens the gate) or
+# change which column mask_id is. New/unknown csv_options are dropped by default.
+_READ_DIALECT_KEYS = frozenset(
+    {
+        "sep",
+        "delimiter",
+        "quotechar",
+        "doublequote",
+        "escapechar",
+        "quoting",
+        "skipinitialspace",
+        "encoding",
+        "encoding_errors",
+        "lineterminator",
+        "comment",
+        "engine",
+    }
+)
+
+# Cap on how many offending row indices the empty-value scan keeps: only a few
+# are shown in the message (redaction.row_refs slices to 5) and the rest are a
+# scalar count, so bounding the sample keeps an all-empty giant manifest from
+# accumulating millions of ints — the OOM the chunked read exists to avoid.
+_EMPTY_ROWS_SAMPLE_CAP = 20
+
+# Cap on how many column names a message lists (headers OR schema keys), so a
+# very wide manifest/schema can't produce an unbounded error string; the full
+# list stays in metadata (mirrors how the other validators cap offender lists).
+_HEADER_SAMPLE_CAP = 20
+
+
+def _capped_join(names: Any) -> str:
+    """Comma-join ``names`` for an error message, capped at
+    :data:`_HEADER_SAMPLE_CAP` with a ``(+N more)`` suffix so a very wide
+    schema/header can't build an unbounded string. Callers keep the full list in
+    metadata. Returns ``"(none)"`` for an empty iterable."""
+    names = list(names)
+    shown = ", ".join(map(str, names[:_HEADER_SAMPLE_CAP]))
+    if len(names) > _HEADER_SAMPLE_CAP:
+        shown += f" (+{len(names) - _HEADER_SAMPLE_CAP} more)"
+    return shown or "(none)"
+
+
+class MaskIdColumnValidator(BaseValidator):
+    """Reject a semantic-segmentation manifest that would NOT produce a
+    populated ``mask_id`` DB column — i.e. the column is undeclared in the
+    schema, absent from the manifest CSV, or empty on any ingestable row.
+
+    The stored table carries ``mask_id`` only when it is BOTH declared in the
+    ingest schema (``RecordProcessor`` keeps a column iff it's in the schema — an
+    undeclared ``mask_id`` is silently dropped, the exact regression backend#816
+    reported) AND present + populated in the manifest CSV. This validator
+    enforces the whole contract at preflight so the failure is a clear "fix the
+    manifest / schema" message, rather than a ``FileNotFoundError`` deep in the
+    training client, which reads the column with no naming-convention fallback.
+
+    Attributes:
+        column: CSV / schema column the training client reads to locate each
+            sidecar (mask) file. Resolved case- and whitespace-insensitively via
+            :meth:`BaseValidator._match_column`, matching how the ingestor and
+            sibling column validators resolve it. Parametrized so this reads as a
+            reusable sidecar-link-column check, not a semseg-only special case.
+        schema: the resolved ingest schema, used to enforce that ``column`` is a
+            DECLARED (hence stored) column. Omit it (bare construction) to skip
+            the declaration check and validate only the CSV; the semseg factory
+            always passes it, so the real ingest path always enforces it.
+        csv_options: the run's pandas read options (delimiter / encoding / ...),
+            so the manifest is parsed exactly as :class:`CSVIngestor` parses it.
+            Without it a non-comma or BOM manifest that ingests fine is falsely
+            rejected here. The semseg factory passes ``options["csv_options"]``.
+    """
+
+    def __init__(
+        self,
+        column: str = "mask_id",
+        schema: Any = _SCHEMA_UNSET,
+        csv_options: Optional[Dict[str, Any]] = None,
+        name: str = "Mask Id Column",
+    ):
+        super().__init__(name)
+        self.column = column or "mask_id"
+        # Only enforce the schema-declaration half of the contract when a schema
+        # was actually supplied (see _SCHEMA_UNSET). An explicit None / {} counts
+        # as "supplied" and fails the check — a semseg ingest with no schema
+        # can't store mask_id at all.
+        self._check_declared = schema is not _SCHEMA_UNSET
+        self._schema = {} if schema is _SCHEMA_UNSET or schema is None else schema
+        self._csv_options = csv_options or {}
+        self._validate_csv_options()
+
+    def _validate_csv_options(self) -> None:
+        """Fail fast at construction on a malformed csv_options value, rather than
+        deep inside the read where it surfaces as a generic mask-id failure
+        (validate config at construction, not mid-scan). Checks only the dialect
+        keys this validator forwards to pandas (see :data:`_READ_DIALECT_KEYS`)."""
+        str_keys = (
+            "sep",
+            "delimiter",
+            "quotechar",
+            "escapechar",
+            "encoding",
+            "encoding_errors",
+            "lineterminator",
+            "comment",
+            "engine",
+        )
+        for key in str_keys:
+            val = self._csv_options.get(key)
+            if val is not None and not isinstance(val, str):
+                raise ValueError(
+                    f"csv_options['{key}'] must be a string, got "
+                    f"{type(val).__name__} — check the ingest config."
+                )
+        quoting = self._csv_options.get("quoting")
+        if quoting is not None and not isinstance(quoting, int):
+            raise ValueError(
+                f"csv_options['quoting'] must be an int (csv.QUOTE_*), got "
+                f"{type(quoting).__name__} — check the ingest config."
+            )
+
+    def _read_kwargs(self) -> Dict[str, Any]:
+        """The pandas read options needed to parse the manifest exactly as
+        CSVIngestor does (csv_ingestor.py:499/533) — delimiter, encoding AND the
+        quoting dialect (quotechar / escapechar / quoting / ...), so preflight and
+        the write path resolve the same columns + values from the same bytes. A
+        sep or quotechar mismatch would split fields differently and desync them.
+        """
+        # Lazy import: csv_ingestor -> base -> validators_mapping ->
+        # modalities.validators -> this module, so a top-level import would cycle.
+        from ..ingestors.csv_ingestor import _bom_safe_encoding
+
+        # Forward only the tokenizing dialect keys CSVIngestor honors (see
+        # _READ_DIALECT_KEYS) — never a frame-restructuring key.
+        opts = {k: v for k, v in self._csv_options.items() if k in _READ_DIALECT_KEYS}
+        opts["encoding"] = _bom_safe_encoding(opts.get("encoding"))
+        if "sep" not in opts and "delimiter" not in opts:
+            opts["sep"] = ","
+        return opts
+
+    def validate(self, data: Any, **kwargs) -> ValidationResult:
+        try:
+            # (1) Declaration: the schema must declare 'mask_id' EXACTLY (lower-
+            # case). RecordProcessor keeps a column iff its (stripped) header is a
+            # schema key, and the training client reads the mask column by the
+            # LITERAL name 'mask_id' (str(row["mask_id"]), no fallback) — so a
+            # differently-cased or undeclared key stores nothing the client can
+            # read and breaks training after a green preflight (backend#816).
+            # Checked first: it's independent of the manifest contents.
+            if self._check_declared and self.column not in self._schema:
+                # Distinguish "declared under the wrong case/whitespace" (rename)
+                # from "not declared at all" for an actionable message.
+                variant = self._match_column(list(self._schema.keys()), self.column)
+                return self._create_result(
+                    is_valid=False,
+                    errors=[self._undeclared_message(variant)],
+                    metadata={
+                        "column": self.column,
+                        "schema_columns": list(map(str, self._schema.keys())),
+                    },
+                )
+
+            columns = self._read_columns(data)
+            if columns is None:
+                # Not a CSV manifest / DataFrame we can introspect (e.g. an
+                # unreadable file) — not this validator's error to raise; the read
+                # path / sibling validators surface those. Pass, like
+                # LabelColumnValidator.
+                return self._create_result(
+                    is_valid=True,
+                    metadata={"checked": False, "column": self.column},
+                )
+
+            # (2) Header: the manifest column must be named EXACTLY 'mask_id'
+            # (ignoring the surrounding whitespace CSVIngestor strips), so the
+            # STORED column is literally 'mask_id' for the client to read. A
+            # case/whitespace variant is detected only to give a rename hint.
+            stripped = [str(c).strip() for c in columns]
+            if self.column not in stripped:
+                variant = self._match_column(columns, self.column)
+                return self._create_result(
+                    is_valid=False,
+                    errors=[self._missing_column_message(columns, variant)],
+                    metadata={
+                        "column": self.column,
+                        "columns": list(map(str, columns)),
+                    },
+                )
+            resolved = next(c for c in columns if str(c).strip() == self.column)
+
+            empty_rows, empty_count = self._empty_value_rows(data, resolved)
+            if empty_count:
+                return self._create_result(
+                    is_valid=False,
+                    errors=[self._empty_value_message(empty_rows, empty_count)],
+                    metadata={
+                        "column": self.column,
+                        "empty_rows": empty_rows,
+                        "empty_count": empty_count,
+                    },
+                )
+
+            return self._create_result(
+                is_valid=True,
+                metadata={"checked": True, "column": self.column},
+            )
+
+        except Exception as e:  # noqa: BLE001
+            # Never surface str(e): a pandas tokenizing/parse error can embed raw
+            # cell/field content, which must NOT egress via the failure report or
+            # logs — customer data stays on-prem. Report only the exception TYPE +
+            # where to look; enough to act on, with nothing from the file leaked.
+            err_type = type(e).__name__
+            logger.error(f"Error during mask-id-column validation: {err_type}")
+            return self._create_result(
+                is_valid=False,
+                errors=[
+                    f"Could not read the semantic-segmentation manifest to verify "
+                    f"the '{self.column}' column ({err_type}). Check the CSV's "
+                    f"delimiter / quoting / encoding (csv_options) and that the "
+                    f"file is well-formed. See templates/semantic_segmentation/."
+                ],
+                metadata={"error_type": "validation_exception"},
+            )
+
+    def _undeclared_message(self, variant: Optional[str] = None) -> str:
+        if variant is not None:
+            # Declared, but under the wrong case/whitespace — the stored column
+            # would carry that spelling, which the client can't read.
+            return (
+                f"Semantic segmentation requires the schema to declare "
+                f"'{self.column}' (lowercase), but it declares '{variant}'. The "
+                f"training client reads the mask column by the exact name "
+                f"'{self.column}' (backend#816), so a differently-cased key stores "
+                f"a column it can't read and breaks training after a green "
+                f"preflight. Rename the schema key to '{self.column}'. See "
+                f"templates/semantic_segmentation/."
+            )
+        declared = _capped_join(self._schema.keys())
+        return (
+            f"Semantic segmentation requires '{self.column}' to be a DECLARED "
+            f"schema column (e.g. schema={{'{self.column}': 'VARCHAR(255)'}}), but "
+            f"the ingest schema declares: {declared}. An undeclared '{self.column}' "
+            f"is dropped at ingest, so the stored table has no '{self.column}' "
+            f"column and the training client raises FileNotFoundError for every "
+            f"mask at train time (backend#816). Declare '{self.column}' in the "
+            f"schema, matching templates/semantic_segmentation/."
+        )
+
+    def _missing_column_message(
+        self, columns: List[Any], variant: Optional[str] = None
+    ) -> str:
+        if variant is not None:
+            # Present, but under the wrong case/whitespace — the stored column
+            # would carry that spelling, which the client can't read.
+            return (
+                f"The manifest's '{variant}' column must be named exactly "
+                f"'{self.column}' (lowercase) — the training client reads the mask "
+                f"column by that literal name (backend#816), so a differently-cased "
+                f"header stores a column it can't read. Rename the CSV header to "
+                f"'{self.column}'. See templates/semantic_segmentation/."
+            )
+        return (
+            f"Required column '{self.column}' not found in semantic-segmentation "
+            f"manifest CSV header (columns: {_capped_join(columns)}). The training "
+            f"client "
+            f"reads '{self.column}' to locate each mask file (backend#816) — "
+            f"without it, every mask lookup raises FileNotFoundError at train "
+            f"time. Add a '{self.column}' column mapping each row to its mask "
+            f"filename. See templates/semantic_segmentation/ for the layout."
+        )
+
+    def _empty_value_message(self, empty_rows: List[int], empty_count: int) -> str:
+        from ..utils import redaction
+
+        refs = redaction.row_refs(empty_rows, empty_count)
+        return (
+            f"Required column '{self.column}' is empty/NULL at {refs} of the "
+            f"semantic-segmentation manifest. The training client reads "
+            f"'{self.column}' to locate each mask file (backend#816) — a blank "
+            f"value makes it derive a garbage filename and raise FileNotFoundError "
+            f"at train time. Populate '{self.column}' on every row with its mask "
+            f"filename. See templates/semantic_segmentation/ for the expected "
+            f"manifest layout."
+        )
+
+    def _read_columns(self, data: Any) -> Optional[list]:
+        """Return the manifest column names, or ``None`` when the input isn't an
+        introspectable CSV / DataFrame.
+
+        Reads only the header row for a path (``nrows=0``) so a wide or multi-GB
+        manifest costs almost nothing, using the run's delimiter/encoding
+        (:meth:`_read_kwargs`) so the parse matches CSVIngestor's. Any manifest
+        extension is accepted — the ingestor reads the configured path regardless
+        of suffix, so gating on ``.csv`` would silently skip this check for a
+        ``.txt`` manifest. A read error (missing / unparseable file) returns
+        ``None`` — a benign skip, since the read/transfer path raises its own
+        clear error for those.
+        """
+        if isinstance(data, pd.DataFrame):
+            return list(data.columns)
+        if isinstance(data, (str, Path)):
+            try:
+                header = pd.read_csv(Path(data), nrows=0, **self._read_kwargs())
+            except Exception:  # noqa: BLE001 — missing/unparseable -> benign skip
+                return None
+            return list(header.columns)
+        return None
+
+    def _empty_value_rows(self, data: Any, resolved_column: str):
+        """Return ``(sample_indices, total_count)`` for the rows whose
+        ``resolved_column`` value the ingestor would store as an unresolvable
+        ``mask_id``. ``total_count == 0`` means every row is populated;
+        ``sample_indices`` is a bounded (``_EMPTY_ROWS_SAMPLE_CAP``) 0-based
+        prefix — enough for the error message — so an all-empty giant manifest
+        can't accumulate millions of ints (the OOM the chunked read avoids, #137).
+
+        A value is "empty" when it is a missing cell (NaN), an ``NA_SENTINELS``
+        token, or stringifies to only whitespace. This mirrors the ingestor
+        BYTE-FOR-BYTE: ``mask_id`` is a declared schema column, so ``CSVIngestor``
+        reads it with ``build_csv_na_values`` (the curated ``NA_SENTINELS`` set)
+        under ``keep_default_na=False`` and stores every sentinel as SQL NULL —
+        after which the client derives a garbage filename and raises
+        ``FileNotFoundError``. Reading with pandas' DEFAULT NA set instead would
+        DIVERGE (it misses lowercase ``"none"`` and adds ``"#NA"``/``"-nan"`` the
+        ingestor keeps), so a ``"none"`` mask_id would pass here then be nulled at
+        ingest. The whitespace-only case is flagged too because the client strips
+        (``str(row["mask_id"]).strip()``).
+
+        Reads ONLY the resolved column, in chunks (``usecols`` + ``chunksize``) —
+        like ``ingestable_records_validator`` / ``CSVIngestor._count_records`` —
+        with the run's dialect (:meth:`_read_kwargs`). Selects the SCHEMA-exact
+        ``resolved_column`` (not a case-insensitive match) so that when two
+        headers collide under case/whitespace normalization it inspects the same
+        column the ingestor stores, not the wrong one. Indices are 0-based,
+        matching ``redaction.row_refs``.
+        """
+        na_tokens = set(NA_SENTINELS)
+
+        def _is_empty(value: Any) -> bool:
+            return pd.isna(value) or str(value) in na_tokens or str(value).strip() == ""
+
+        def _series(frame):
+            # A frame carrying duplicate columns of this name yields a DataFrame;
+            # take the first (the ingestor rejects exact-duplicate headers, so
+            # this only guards the reusable DataFrame path).
+            col = frame[resolved_column]
+            return col.iloc[:, 0] if isinstance(col, pd.DataFrame) else col
+
+        sample: List[int] = []
+        total = 0
+
+        def _accumulate(series, offset: int) -> int:
+            nonlocal total
+            for i, value in enumerate(series):
+                if _is_empty(value):
+                    if len(sample) < _EMPTY_ROWS_SAMPLE_CAP:
+                        sample.append(offset + i)
+                    total += 1
+            return offset + len(series)
+
+        if isinstance(data, pd.DataFrame):
+            if resolved_column not in data.columns:
+                return sample, total
+            _accumulate(_series(data), 0)
+            return sample, total
+
+        # No local try/except: a body-read failure (malformed encoding / quoting)
+        # propagates to validate()'s handler, which rejects with the REAL parse
+        # error. Swallowing it here would either fail-open (miss empties past the
+        # failure) or reject with a misleading PARTIAL count that masks the actual
+        # structural fault. The header read already succeeded, so reaching here
+        # means the file is readable — a body error is a genuine data fault worth
+        # surfacing, and the ingestor's own read (same dialect, on_bad_lines=
+        # "error") would trip on it too.
+        offset = 0
+        reader = pd.read_csv(
+            data,
+            usecols=[resolved_column],
+            keep_default_na=False,
+            dtype=str,
+            chunksize=50_000,
+            **self._read_kwargs(),
+        )
+        for chunk in reader:
+            offset = _accumulate(_series(chunk), offset)
+        return sample, total


### PR DESCRIPTION
Closes #363.

Release-sync of `develop` into `master` for **0.7.0**, **excluding** time_series_classification (#359 / 7b4ecac) — deferred to a later release.

## Included
| PR | |
|---|---|
| #348 | minimum-image-size floor |
| #349 | tabular schema-inference rules |
| #358 | semseg mask_id contract |
| #362 | version bump → 0.7.0 |

## Excluded
- **#359 time_series_classification (WS1)** — deferred, not dropped. Remains on `develop`; ships in a future sync.

## How this was built (please read before approving)
This is **not** a plain `merge develop`. #358 (semseg) was committed on top of #359 (TSC) and touches the same files, so the branch is a **cherry-pick reconstruction** of develop-minus-TSC, with hand-resolved conflicts:
- `tracebloc_ingestor/validators/__init__.py` — kept `MaskIdColumnValidator`; dropped the 3 TSC validators (`SequenceGroupValidator`, `LabelConstantWithinGroupValidator`, `PerGroupTimeOrderedValidator`) whose source files aren't present without #359.
- `tracebloc_ingestor/ingestors/base.py` — kept semseg's `csv_options` + `unique_id_column` preflight keys. `unique_id_column` is an inert dict key here (no grouped validator consumes it without TSC); the neighbouring comment still references `SequenceGroupValidator` by design, documenting the forward-compatible key.

## Verification
- Diff vs `master`: exactly #348 + #349 + #358 + version bump; **zero TSC artifacts** (no `templates/time_series_classification/`, no sequence validators, no `layout.v1.json` contract-v2 bump, no `database.py` grouping code).
- `pytest tests/`: **1492 passed**, 1 xfailed. The 4 float/int-overflow failures are pre-existing Py3.9-local env drift (identical on `origin/develop`; the package requires ≥3.11, which is what CI runs) — not introduced here.

## Go-forward note
Because this is a cherry-pick (not a merge), the next `develop→master` sync will carry #359 along — consistent with the deferral intent.

⚠️ Release policy: requires a 2nd approver; no self-approve/bypass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preflight validation and what semantic-segmentation ingests store in MySQL; regressions would block or break training datasets, but coverage is extensive (unit, adversarial, e2e).
> 
> **Overview**
> **Release 0.7.0** bundles three ingestion hardening features plus docs/tests; version is bumped in `tracebloc_ingestor/__init__.py`.
> 
> **Minimum image size (#348):** `ImageResolutionValidator` now enforces a default **32×32** floor (override via `file_options.min_size`), plumbed through vision modalities and documented in `ingest.v1.json`. Tiny uniform datasets (e.g. 8×8) fail preflight with an actionable error instead of passing uniformity checks alone.
> 
> **Tabular schema inference (#349):** New `schema_inference` module defines owned `infer_column_type` / `infer_schema` rules (leading-zero codes → `VARCHAR`, parity with Go CLI). A shared `schema_inference_parity.json` fixture pins the contract; adversarial tests now assert inference for zero-padded codes, with a strict **xfail** for hand-declared `INT` columns that still silently corrupt `007` → `7`.
> 
> **Semantic segmentation `mask_id` (#358 / backend#816):** `MaskIdColumnValidator` rejects manifests missing the column, blank/NA values, undeclared schema keys, or wrong header casing at preflight. Declared `mask_id` is stored on DB rows (no blanket pop); semseg examples/README require `schema.mask_id`. Preflight passes `csv_options` from `BaseIngestor` so CSV dialect matches `CSVIngestor`. MySQL e2e tests assert the ingestor→training-client mask resolution contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82e642bce77b135197b936497f3492e2ecc5f683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->