### PR TITLE
fix(validators): validate min_size dimensions are positive integers (#348)

### DIFF
--- a/tests/test_image_validator_min_size.py
+++ b/tests/test_image_validator_min_size.py
@@ -121,12 +121,49 @@ def test_falsy_override_falls_back_to_default_floor():
     assert ImageResolutionValidator().min_size == MIN_IMAGE_SIZE
 
 
-@pytest.mark.parametrize("bad", [32, (16,), (16, 16, 16)])
+# A bare string is iterable: "32" would unpack to ('3', '2') and "1234" would
+# fail the 2-element unpack — both are shape errors, never a (width, height)
+# pair. Reject them (and other non-iterable / wrong-length shapes) up front.
+@pytest.mark.parametrize("bad", [32, (16,), (16, 16, 16), "32", "1234", b"32"])
 def test_malformed_min_size_raises_at_construction(bad):
-    """A non-iterable or non-2-element override is a config error surfaced at
-    construction — not swallowed mid-scan as a per-file image-read error."""
+    """A non-iterable, wrong-length, or string override is a config error
+    surfaced at construction — not swallowed mid-scan as a per-file image-read
+    error, and never char-split into a bogus floor."""
     with pytest.raises(ValueError, match="min_size must be a"):
         ImageResolutionValidator(min_size=bad)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        (0, 32),  # zero side
+        (32, 0),
+        (-1, 32),  # negative side
+        (32, -5),
+        (32.5, 32),  # non-integral float
+        ("32", 32),  # per-element string is rejected, not coerced
+        (32, "32"),
+        ("abc", 32),  # non-numeric string
+        (None, 32),  # missing side
+        (True, 32),  # bool is an int subclass but not a pixel count
+    ],
+)
+def test_non_positive_integer_min_size_raises_at_construction(bad):
+    """A 2-element override whose sides are not positive integers is still a
+    config error surfaced at construction — otherwise an int-vs-str comparison
+    in _meets_min_size raises mid-scan and is mislabeled as a corrupt image."""
+    with pytest.raises(ValueError, match="positive integer"):
+        ImageResolutionValidator(min_size=bad)
+
+
+@pytest.mark.parametrize("override", [(32.0, 32.0), [16.0, 16], (64.0, 48)])
+def test_min_size_coerces_integer_valued_floats(override):
+    """Integer-valued floats (as a numeric literal can arrive from JSON/YAML
+    file_options) are normalized to positive ints at construction, so
+    _meets_min_size compares plain ints."""
+    v = ImageResolutionValidator(min_size=override)
+    assert all(isinstance(side, int) for side in v.min_size)
+    assert v.min_size == (int(override[0]), int(override[1]))
 
 
 # --- floor takes precedence over a uniformity/target mismatch -----------------

--- a/tracebloc_ingestor/validators/image_validator.py
+++ b/tracebloc_ingestor/validators/image_validator.py
@@ -84,19 +84,35 @@ class ImageResolutionValidator(BaseValidator):
         self.expected_resolution = expected_resolution
         self.subdir = subdir
         # Absolute floor (width, height), normalized once here so every
-        # downstream read can trust it is a 2-tuple. A falsy override falls
-        # back to the module default so the gate is always active, never
-        # silently disabled. A non-iterable or non-2-element override is a
-        # config error, surfaced at construction rather than swallowed
-        # mid-scan as a per-file image-read error.
+        # downstream read can trust it is a 2-tuple of positive ints. A falsy
+        # override falls back to the module default so the gate is always
+        # active, never silently disabled. A non-iterable or non-2-element
+        # override is a config error, surfaced at construction rather than
+        # swallowed mid-scan as a per-file image-read error.
         if min_size:
+            # A str/bytes is iterable, so a 2-char value like "32" would unpack
+            # to ('3', '2') and quietly weaken the floor to (3, 2). Reject it up
+            # front as a shape error — a string is never a (width, height) pair.
+            if isinstance(min_size, (str, bytes)):
+                raise ValueError(
+                    f"min_size must be a (width, height) pair; got {min_size!r}"
+                )
             try:
                 min_w, min_h = min_size
             except (TypeError, ValueError):
                 raise ValueError(
                     f"min_size must be a (width, height) pair; got {min_size!r}"
                 )
-            self.min_size = (min_w, min_h)
+            # Each side must also be a positive integer. A non-integer override
+            # (a "32" string, a float, None) unpacks cleanly above but would blow
+            # up later as an int-vs-str TypeError inside _meets_min_size — caught
+            # by the per-image handler and mislabeled as a corrupt-image error
+            # rather than the config error it is. Normalize each axis once,
+            # loudly, at construction.
+            self.min_size = (
+                self._coerce_dimension(min_w, min_size),
+                self._coerce_dimension(min_h, min_size),
+            )
         else:
             self.min_size = MIN_IMAGE_SIZE
         self.tolerance = 0  # Whether to enforce strict file type checking . we can later make this configurable
@@ -436,6 +452,35 @@ class ImageResolutionValidator(BaseValidator):
                 "tolerance": self.tolerance,
             },
         )
+
+    @staticmethod
+    def _coerce_dimension(value: Any, min_size: Any) -> int:
+        """Normalize one ``min_size`` axis to a positive int at construction.
+
+        Accepts an int or an integer-valued float (``32.0``) — the shapes a
+        numeric literal reaches ``file_options`` as from JSON/YAML — and returns
+        the pixel count. Anything else (``bool``, a non-integral float, a string,
+        ``None``, a negative or zero value) is a config error and raises here, so
+        it never survives to raise a TypeError inside :meth:`_meets_min_size`
+        where the per-image handler would mislabel it as a corrupt-image read.
+        ``bool`` is rejected explicitly — it is an ``int`` subclass but never a
+        valid pixel count. Strings are rejected too (not coerced): the schema
+        declares integers, and a digit string like ``"32"`` would otherwise
+        char-split through the (width, height) unpack into ``('3', '2')`` and
+        silently weaken the floor.
+        """
+        pixels: Optional[int] = None
+        if isinstance(value, bool):
+            pixels = None
+        elif isinstance(value, int):
+            pixels = value
+        elif isinstance(value, float) and value.is_integer():
+            pixels = int(value)
+        if pixels is None or pixels <= 0:
+            raise ValueError(
+                f"min_size must be a pair of positive integers; got {min_size!r}"
+            )
+        return pixels
 
     def _meets_min_size(self, resolution: Tuple[int, int]) -> bool:
         """Return True if ``resolution`` (width, height) is at least the floor


### PR DESCRIPTION
Bugbot flagged this on the 0.7.0 release PR (#364); fixing at source on `develop`.

`ImageResolutionValidator` unpacked `min_size` at construction but only checked it was a 2-element iterable — not that each side was a positive integer. A non-numeric override (a quoted `"32"` from YAML, a float, `None`) unpacked cleanly, then `_meets_min_size` raised an int-vs-str `TypeError` inside the per-image loop, which the per-file handler caught and **mislabeled as a corrupt image** instead of surfacing the config error.

Fix: normalize each axis once at construction via `_coerce_dimension` — accept int / integer-valued float / numeric string; reject bool, non-integral floats, non-numeric strings, `None`, and non-positive values with a clear `min_size must be a pair of positive integers` error. Adds value-validation + coercion tests.

Rolls up under the 0.7.0 release ticket #363. The same fix is cherry-picked onto the release branch `sync/develop-to-master-v0.7.0` so #364 goes green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validator-only input normalization for `min_size`; no auth, data mutation, or ingest pipeline behavior change beyond clearer failures on bad config.
> 
> **Overview**
> **`ImageResolutionValidator`** now normalizes `file_options.min_size` at construction so each side is a **positive int**, instead of only checking that the override is a 2-element iterable.
> 
> Construction **rejects** bare `str`/`bytes` overrides (so values like `"32"` cannot unpack into bogus `(3, 2)` floors) and **rejects** 2-tuples whose sides are zero, negative, non-integral floats, per-element strings, `None`, or `bool`. **Integer-valued floats** (e.g. from JSON/YAML) are coerced to ints. Invalid config raises a clear `ValueError` at construction rather than a `TypeError` during scanning that was reported as a corrupt image.
> 
> Tests cover malformed shapes, invalid dimensions, float coercion, and the existing default-floor behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0a8b70360d71827eddc80c2a95fa94b5eb880df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->