### PR TITLE
feat(ingest): per-dataset scalar attributes + categorical vocab for alignment (#360)

### DIFF
--- a/tests/test_config_lazy.py
+++ b/tests/test_config_lazy.py
@@ -102,7 +102,7 @@ def test_unknown_override_kwarg_raises(clean_env):
     assert "NOT_A_REAL_FIELD" in str(exc.value)
 
 
-@pytest.mark.parametrize("field", ["DB_PORT", "BATCH_SIZE"])
+@pytest.mark.parametrize("field", ["DB_PORT", "BATCH_SIZE", "CATEGORICAL_MIN_COUNT"])
 def test_numeric_override_rejects_none_at_construction(clean_env, field):
     """``None`` is a valid suppression for nullable fields (BACKEND_TOKEN
     etc.) but is nonsensical for numeric ones whose properties do
@@ -116,10 +116,20 @@ def test_numeric_override_rejects_none_at_construction(clean_env, field):
     assert "None" in msg
 
 
-@pytest.mark.parametrize("field,value", [("DB_PORT", 3307), ("BATCH_SIZE", "8000")])
+@pytest.mark.parametrize(
+    "field,value",
+    [("DB_PORT", 3307), ("BATCH_SIZE", "8000"), ("CATEGORICAL_MIN_COUNT", "5")],
+)
 def test_numeric_override_accepts_ints_and_str_ints(clean_env, field, value):
     config = Config(**{field: value})
     assert getattr(config, field) == int(value)
+
+
+def test_categorical_min_count_defaults_to_one(clean_env, monkeypatch):
+    """Default is 1 — no rare-category suppression until a deployment opts in
+    (the privacy/OOV trade needs backend sign-off)."""
+    monkeypatch.delenv("CATEGORICAL_MIN_COUNT", raising=False)
+    assert Config().CATEGORICAL_MIN_COUNT == 1
 
 
 def test_laptop_path_defaults_are_gone(clean_env):

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -356,3 +356,35 @@ def test_json_source_dispatches_correctly():
     r = resolve(config)
     assert r.source_type == "json"
     assert r.source_path == "/data/events.json"
+
+
+# ---------------------------------------------------------------------------
+# Vision alignment facts: color_mode (RGB/grayscale) + bit_depth bridged into
+# file_options for combine-time alignment (di#360).
+# ---------------------------------------------------------------------------
+def test_color_mode_bridged_and_canonicalized():
+    config = _load("image_classification.yaml")
+    config["color_mode"] = "rgb"
+    r = resolve(config)
+    assert r.file_options["color_mode"] == "RGB"
+
+
+def test_bit_depth_bridged():
+    config = _load("image_classification.yaml")
+    config["bit_depth"] = 16
+    r = resolve(config)
+    assert r.file_options["bit_depth"] == 16
+
+
+def test_invalid_color_mode_raises():
+    config = _load("image_classification.yaml")
+    config["color_mode"] = "RGBA"
+    with pytest.raises(ValueError, match="color_mode"):
+        resolve(config)
+
+
+def test_invalid_bit_depth_raises():
+    config = _load("image_classification.yaml")
+    config["bit_depth"] = 12
+    with pytest.raises(ValueError, match="bit_depth"):
+        resolve(config)

--- a/tests/test_feature_stats.py
+++ b/tests/test_feature_stats.py
@@ -267,6 +267,23 @@ def test_categorical_vocab_excludes_label_id_annotation(make_csv):
     assert set(ing.categorical_vocab()) == {"region"}
 
 
+def test_categorical_vocab_excludes_label_by_case_insensitive_name(make_csv):
+    # The CSV header spelling differs from the configured name (Label vs label):
+    # exclusion must still match case-/whitespace-insensitively (the #340 rule),
+    # or the label column's raw values would leak into the emitted vocab.
+    path = make_csv({"region": ["N", "S"], "Label": ["cat", "dog"]})
+    ing = make_csv_ingestor(
+        schema={"region": "VARCHAR(4)", "Label": "VARCHAR(8)"},
+        label_column="label",  # lower-case config vs "Label" header
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    list(ing.read_data(str(path)))
+
+    vocab = ing.categorical_vocab()
+    assert set(vocab) == {"region"}
+    assert "Label" not in vocab
+
+
 def test_categorical_vocab_ignores_nulls(make_csv):
     path = make_csv({"c": ["a", None, "b"]})
     ing = make_csv_ingestor(schema={"c": "VARCHAR(4)"})

--- a/tests/test_feature_stats.py
+++ b/tests/test_feature_stats.py
@@ -164,14 +164,18 @@ def test_feature_stats_omits_all_null_column(make_csv):
     assert "blank" not in stats
 
 
-def test_feature_stats_empty_when_no_numeric_columns(make_csv):
+def test_numeric_feature_stats_empty_but_categorical_vocab_emitted(make_csv):
+    # No numeric columns, but a VARCHAR column is a categorical feature (di#360):
+    # numeric feature_stats() stays empty while the emit hook contributes the
+    # union vocab. A DATE column is not categorical and contributes nothing.
     path = make_csv({"name": ["x", "y"], "when": ["2024-01-01", "2024-01-02"]})
     ing = make_csv_ingestor(schema={"name": "VARCHAR(10)", "when": "DATE"})
     list(ing.read_data(str(path)))
 
     assert ing.feature_stats() == {}
-    # And the emit hook contributes nothing to the payload.
-    assert ing._collect_run_metadata() == {}
+    fs = ing._collect_run_metadata()["attributes"]["feature_stats"]
+    assert fs["name"] == {"categories": ["x", "y"]}
+    assert "when" not in fs
 
 
 def test_feature_stats_nested_under_attributes(make_csv):
@@ -203,10 +207,92 @@ def test_apply_run_metadata_merges_into_attributes(make_csv):
     assert attrs["feature_stats"]["age"]["count"] == 3
 
 
-def test_apply_run_metadata_noop_without_numeric(make_csv):
-    path = make_csv({"name": ["x", "y"]})
-    ing = make_csv_ingestor(schema={"name": "VARCHAR(10)"})
+def test_apply_run_metadata_noop_without_features(make_csv):
+    # No numeric and no categorical feature columns (a lone DATE column) — the
+    # emit hook contributes nothing to the payload.
+    path = make_csv({"when": ["2024-01-01", "2024-01-02"]})
+    ing = make_csv_ingestor(schema={"when": "DATE"})
     list(ing.read_data(str(path)))
 
     ing._apply_run_metadata()
     assert "attributes" not in ing.file_options
+
+
+# ---------------------------------------------------------------------------
+# Categorical union vocab (di#360) — emitted under feature_stats[col].categories
+# ---------------------------------------------------------------------------
+def test_categorical_vocab_sorted_and_deduped(make_csv):
+    path = make_csv({"region": ["S", "N", "S", "E", "N"]})
+    ing = make_csv_ingestor(schema={"region": "VARCHAR(4)"})
+    list(ing.read_data(str(path)))
+
+    assert ing.categorical_vocab() == {"region": ["E", "N", "S"]}
+    fs = ing._collect_run_metadata()["attributes"]["feature_stats"]
+    assert fs["region"] == {"categories": ["E", "N", "S"]}
+
+
+def test_categorical_vocab_accumulates_across_chunks(make_csv):
+    path = make_csv({"c": ["a", "b", "a", "c", "b", "d"]})
+    ing = make_csv_ingestor(schema={"c": "VARCHAR(4)"}, csv_options={"chunk_size": 2})
+    list(ing.read_data(str(path)))
+
+    assert ing.categorical_vocab() == {"c": ["a", "b", "c", "d"]}
+
+
+def test_categorical_vocab_excludes_label_id_annotation(make_csv):
+    # A categorical label is a class (gated by check_same_labels), not a feature
+    # vocab; row-id and annotation are never features.
+    path = make_csv(
+        {
+            "region": ["N", "S"],
+            "label": ["cat", "dog"],
+            "rowid": ["r1", "r2"],
+            "ann": ["a1", "a2"],
+        }
+    )
+    ing = make_csv_ingestor(
+        schema={
+            "region": "VARCHAR(4)",
+            "label": "VARCHAR(8)",
+            "rowid": "VARCHAR(4)",
+            "ann": "VARCHAR(4)",
+        },
+        label_column="label",
+        unique_id_column="rowid",
+        annotation_column="ann",
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    list(ing.read_data(str(path)))
+
+    assert set(ing.categorical_vocab()) == {"region"}
+
+
+def test_categorical_vocab_ignores_nulls(make_csv):
+    path = make_csv({"c": ["a", None, "b"]})
+    ing = make_csv_ingestor(schema={"c": "VARCHAR(4)"})
+    list(ing.read_data(str(path)))
+
+    assert ing.categorical_vocab() == {"c": ["a", "b"]}
+
+
+def test_categorical_vocab_dropped_above_cardinality_cap(make_csv, monkeypatch):
+    # A near-unique VARCHAR (free text / id) is not a categorical feature and is
+    # dropped once it crosses the cap, rather than emitting a huge value-set.
+    import tracebloc_ingestor.ingestors.csv_ingestor as mod
+
+    monkeypatch.setattr(mod, "_MAX_CATEGORICAL_CARDINALITY", 3)
+    path = make_csv({"c": ["a", "b", "c", "d", "e"]})  # 5 distinct > cap of 3
+    ing = make_csv_ingestor(schema={"c": "VARCHAR(4)"})
+    list(ing.read_data(str(path)))
+
+    assert ing.categorical_vocab() == {}
+
+
+def test_numeric_and_categorical_coexist_in_feature_stats(make_csv):
+    path = make_csv({"age": [1, 2, 3], "region": ["N", "S", "N"]})
+    ing = make_csv_ingestor(schema={"age": "INT", "region": "VARCHAR(4)"})
+    list(ing.read_data(str(path)))
+
+    fs = ing._collect_run_metadata()["attributes"]["feature_stats"]
+    assert fs["age"]["count"] == 3  # numeric sufficient stats
+    assert fs["region"] == {"categories": ["N", "S"]}  # categorical vocab

--- a/tests/test_feature_stats.py
+++ b/tests/test_feature_stats.py
@@ -13,13 +13,17 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tracebloc_ingestor.config import Config
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
 from tracebloc_ingestor.utils.constants import TaskCategory
 
 
-def make_csv_ingestor(schema=None, **overrides):
+def make_csv_ingestor(schema=None, categorical_min_count=1, **overrides):
     db = MagicMock()
     db.create_table.return_value = MagicMock()
+    # A real Config so categorical_vocab's CATEGORICAL_MIN_COUNT is a true int
+    # (default 1 ⇒ keep all values).
+    db.config = Config(CATEGORICAL_MIN_COUNT=categorical_min_count)
     api = MagicMock()
     kwargs = dict(
         database=db,
@@ -290,6 +294,48 @@ def test_categorical_vocab_ignores_nulls(make_csv):
     list(ing.read_data(str(path)))
 
     assert ing.categorical_vocab() == {"c": ["a", "b"]}
+
+
+def test_categorical_vocab_min_count_suppresses_rare_values(make_csv):
+    # "S" appears 3×, "N" 2×, "E" once. With CATEGORICAL_MIN_COUNT=2 the
+    # single-occurrence "E" (a re-identification risk) is dropped.
+    path = make_csv({"region": ["S", "N", "S", "E", "N", "S"]})
+    ing = make_csv_ingestor(schema={"region": "VARCHAR(4)"}, categorical_min_count=2)
+    list(ing.read_data(str(path)))
+
+    assert ing.categorical_vocab() == {"region": ["N", "S"]}
+
+
+def test_categorical_vocab_default_keeps_all_values(make_csv):
+    # Default CATEGORICAL_MIN_COUNT=1 ⇒ no suppression (every observed value).
+    path = make_csv({"region": ["S", "N", "E"]})
+    ing = make_csv_ingestor(schema={"region": "VARCHAR(4)"})
+    list(ing.read_data(str(path)))
+
+    assert ing.categorical_vocab() == {"region": ["E", "N", "S"]}
+
+
+def test_categorical_vocab_column_dropped_when_all_values_suppressed(make_csv):
+    # Every value unique (count 1) → with min_count=2 the column has nothing left
+    # and is omitted entirely rather than emitted empty.
+    path = make_csv({"c": ["a", "b", "c"]})
+    ing = make_csv_ingestor(schema={"c": "VARCHAR(4)"}, categorical_min_count=2)
+    list(ing.read_data(str(path)))
+
+    assert ing.categorical_vocab() == {}
+
+
+def test_categorical_vocab_min_count_across_chunks(make_csv):
+    # Counts accumulate across chunks: "a" reaches 2 only by summing chunks.
+    path = make_csv({"c": ["a", "b", "a", "c"]})
+    ing = make_csv_ingestor(
+        schema={"c": "VARCHAR(4)"},
+        categorical_min_count=2,
+        csv_options={"chunk_size": 2},
+    )
+    list(ing.read_data(str(path)))
+
+    assert ing.categorical_vocab() == {"c": ["a"]}
 
 
 def test_categorical_vocab_dropped_above_cardinality_cap(make_csv, monkeypatch):

--- a/tests/test_scalar_attributes.py
+++ b/tests/test_scalar_attributes.py
@@ -41,6 +41,56 @@ def test_image_resolution_from_target_size_height_width():
     assert attrs["resolution"] == [480, 640]  # emitted [height, width]
 
 
+def test_color_mode_and_derived_channels_from_file_options():
+    ing = make_ingestor(
+        schema={"filename": "VARCHAR(64)"},
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        data_format=DataFormat.IMAGE,
+        file_options={"color_mode": "rgb"},  # user-provided, case-insensitive
+    )
+    attrs = ing._collect_run_metadata()["attributes"]
+    assert attrs["color_mode"] == "RGB"
+    assert attrs["channels"] == 3
+
+
+def test_grayscale_color_mode_channels():
+    ing = make_ingestor(
+        schema={"filename": "VARCHAR(64)"},
+        category=TaskCategory.SEMANTIC_SEGMENTATION,
+        data_format=DataFormat.IMAGE,
+        file_options={"color_mode": "grayscale", "bit_depth": 16},
+    )
+    attrs = ing._collect_run_metadata()["attributes"]
+    assert attrs["color_mode"] == "grayscale"
+    assert attrs["channels"] == 1
+    assert attrs["bit_depth"] == 16
+
+
+def test_invalid_color_mode_in_file_options_is_skipped():
+    # Directly-set (unvalidated) file_options with a non-canonical mode: the base
+    # hook emits nothing rather than shipping a value the contract would reject.
+    ing = make_ingestor(
+        schema={"filename": "VARCHAR(64)"},
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        data_format=DataFormat.IMAGE,
+        file_options={"color_mode": "RGBA"},
+    )
+    attrs = ing._collect_run_metadata().get("attributes", {})
+    assert "color_mode" not in attrs
+    assert "channels" not in attrs
+
+
+def test_no_color_mode_when_absent():
+    ing = make_ingestor(
+        schema={"filename": "VARCHAR(64)"},
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        data_format=DataFormat.IMAGE,
+        file_options={"target_size": [64, 64]},
+    )
+    attrs = ing._collect_run_metadata()["attributes"]
+    assert "color_mode" not in attrs and "channels" not in attrs
+
+
 def test_no_resolution_for_non_image():
     ing = make_ingestor(
         schema={"a": "INT"},

--- a/tests/test_scalar_attributes.py
+++ b/tests/test_scalar_attributes.py
@@ -1,0 +1,140 @@
+"""Tests for auto-detected scalar attributes emitted for combine-time alignment
+(di#360): image ``resolution`` and text ``encoding`` from the base hook, and
+time-series ``timezone`` / ``sampling_frequency`` from the CSV timestamp pass.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils.constants import TaskCategory, DataFormat
+
+
+def make_ingestor(schema=None, **overrides):
+    db = MagicMock()
+    db.create_table.return_value = MagicMock()
+    api = MagicMock()
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema=schema if schema is not None else {"a": "INT"},
+        intent="train",
+        category=None,
+    )
+    kwargs.update(overrides)
+    return CSVIngestor(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Image resolution — from the uniform target_size (no image read)
+# ---------------------------------------------------------------------------
+def test_image_resolution_from_target_size_height_width():
+    ing = make_ingestor(
+        schema={"filename": "VARCHAR(64)"},
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        data_format=DataFormat.IMAGE,
+        file_options={"target_size": [640, 480]},  # [width, height]
+    )
+    attrs = ing._collect_run_metadata()["attributes"]
+    assert attrs["resolution"] == [480, 640]  # emitted [height, width]
+
+
+def test_no_resolution_for_non_image():
+    ing = make_ingestor(
+        schema={"a": "INT"},
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+        data_format=DataFormat.TABULAR,
+        file_options={"target_size": [640, 480]},
+    )
+    assert "resolution" not in ing._collect_run_metadata().get("attributes", {})
+
+
+# ---------------------------------------------------------------------------
+# Text encoding — utf-8 for NLP categories
+# ---------------------------------------------------------------------------
+def test_text_encoding_utf8_for_nlp():
+    ing = make_ingestor(
+        schema={"filename": "VARCHAR(64)", "label": "VARCHAR(8)"},
+        category=TaskCategory.TEXT_CLASSIFICATION,
+        data_format=DataFormat.TEXT,
+        label_column="label",
+    )
+    attrs = ing._collect_run_metadata()["attributes"]
+    assert attrs["encoding"] == "utf-8"
+
+
+def test_no_encoding_for_tabular():
+    ing = make_ingestor(
+        schema={"a": "INT"}, category=TaskCategory.TABULAR_CLASSIFICATION
+    )
+    assert "encoding" not in ing._collect_run_metadata().get("attributes", {})
+
+
+# ---------------------------------------------------------------------------
+# Temporal — timezone + sampling_frequency for time_series_forecasting
+# ---------------------------------------------------------------------------
+def test_temporal_timezone_and_frequency(make_csv):
+    path = make_csv(
+        {
+            "timestamp": [
+                "2024-01-01 00:00:00+00:00",
+                "2024-01-01 01:00:00+00:00",
+                "2024-01-01 02:00:00+00:00",
+                "2024-01-01 03:00:00+00:00",
+            ],
+            "value": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+    ing = make_ingestor(
+        schema={"timestamp": "TIMESTAMP", "value": "FLOAT"},
+        category=TaskCategory.TIME_SERIES_FORECASTING,
+        data_format=DataFormat.TABULAR,
+    )
+    list(ing.read_data(str(path)))
+
+    attrs = ing._collect_run_metadata()["attributes"]
+    assert attrs["timezone"] == "UTC"
+    # Regular hourly cadence -> pandas infers a frequency (alias spelling is
+    # pandas-version dependent, so assert presence, not the exact string).
+    assert attrs["sampling_frequency"]
+
+
+def test_temporal_naive_timestamps_no_timezone(make_csv):
+    path = make_csv(
+        {
+            "timestamp": [
+                "2024-01-01 00:00:00",
+                "2024-01-02 00:00:00",
+                "2024-01-03 00:00:00",
+            ],
+            "value": [1.0, 2.0, 3.0],
+        }
+    )
+    ing = make_ingestor(
+        schema={"timestamp": "TIMESTAMP", "value": "FLOAT"},
+        category=TaskCategory.TIME_SERIES_FORECASTING,
+    )
+    list(ing.read_data(str(path)))
+
+    attrs = ing._collect_run_metadata()["attributes"]
+    assert "timezone" not in attrs  # tz-naive
+    assert attrs["sampling_frequency"]  # daily cadence still inferable
+
+
+def test_temporal_not_emitted_for_non_time_series(make_csv):
+    # A timestamp column outside time-series forecasting contributes no temporal
+    # attributes.
+    path = make_csv(
+        {"timestamp": ["2024-01-01 00:00:00", "2024-01-02 00:00:00"], "a": [1, 2]}
+    )
+    ing = make_ingestor(
+        schema={"timestamp": "TIMESTAMP", "a": "INT"},
+        category=TaskCategory.TABULAR_REGRESSION,
+    )
+    list(ing.read_data(str(path)))
+
+    attrs = ing._collect_run_metadata().get("attributes", {})
+    assert "timezone" not in attrs
+    assert "sampling_frequency" not in attrs

--- a/tests/test_scalar_attributes.py
+++ b/tests/test_scalar_attributes.py
@@ -66,6 +66,21 @@ def test_grayscale_color_mode_channels():
     assert attrs["bit_depth"] == 16
 
 
+def test_invalid_bit_depth_in_file_options_is_skipped():
+    # bit_depth set directly in file_options bypasses conventions.resolve()'s
+    # 8/16 gate; the base hook must still drop a value the contract rejects
+    # (mirrors color_mode canonicalisation).
+    ing = make_ingestor(
+        schema={"filename": "VARCHAR(64)"},
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        data_format=DataFormat.IMAGE,
+        file_options={"color_mode": "rgb", "bit_depth": 12},
+    )
+    attrs = ing._collect_run_metadata()["attributes"]
+    assert "bit_depth" not in attrs  # 12 is not a contract-accepted depth
+    assert attrs["color_mode"] == "RGB"  # the valid sibling still emits
+
+
 def test_invalid_color_mode_in_file_options_is_skipped():
     # Directly-set (unvalidated) file_options with a non-canonical mode: the base
     # hook emits nothing rather than shipping a value the contract would reject.

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, FrozenSet, List, Optional
 
 from ..modalities.registry import spec_for
-from ..utils.constants import TaskCategory
+from ..utils.constants import TaskCategory, canonical_color_mode
 
 # ---------------------------------------------------------------------------
 # Category groupings — used both here and by the entrypoint when deciding
@@ -312,6 +312,27 @@ def resolve(config: Dict[str, Any]) -> ResolvedConfig:
         and "number_of_keypoints" not in spec_file_options
     ):
         resolved.file_options["number_of_keypoints"] = config["number_of_keypoints"]
+
+    # 7c. Bridge the vision alignment facts the user declares (di#360): the
+    #     dataset's `color_mode` (RGB/grayscale only — the values the combine-time
+    #     contract accepts; channels are derived from it downstream) and optional
+    #     `bit_depth`. Same precedence as target_size (spec > top-level). Validated
+    #     here so a bad value fails at config time, not after ingest.
+    if "color_mode" in config and "color_mode" not in spec_file_options:
+        canonical = canonical_color_mode(config["color_mode"])
+        if canonical is None:
+            raise ValueError(
+                f"Invalid color_mode {config['color_mode']!r}; supported values "
+                f"are 'RGB' and 'grayscale'."
+            )
+        resolved.file_options["color_mode"] = canonical
+    if "bit_depth" in config and "bit_depth" not in spec_file_options:
+        bit_depth = config["bit_depth"]
+        if bit_depth not in (8, 16):
+            raise ValueError(
+                f"Invalid bit_depth {bit_depth!r}; supported values are 8 and 16."
+            )
+        resolved.file_options["bit_depth"] = bit_depth
 
     # 8. annotation_column — keypoint_detection's existing template uses
     #    column "Annotation" (the keypoint coords carried in the CSV). The

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -42,13 +42,14 @@ class Config:
         "BACKEND_TOKEN", "CLIENT_USERNAME", "CLIENT_PASSWORD",
         "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
         "LOG_LEVEL",
+        "CATEGORICAL_MIN_COUNT",
     })
 
     # Numeric fields whose properties unconditionally coerce via ``int(...)``.
     # ``Config(FIELD=None)`` works for nullable fields (BACKEND_TOKEN etc.)
     # but is nonsensical here — reject at construction with a clear message
     # rather than letting ``int(None)`` blow up later at property access.
-    _NUMERIC_FIELDS = frozenset({"DB_PORT", "BATCH_SIZE"})
+    _NUMERIC_FIELDS = frozenset({"DB_PORT", "BATCH_SIZE", "CATEGORICAL_MIN_COUNT"})
 
     def __init__(self, **overrides: Any) -> None:
         unknown = set(overrides) - self._ENV_FIELDS
@@ -125,6 +126,23 @@ class Config:
         ov = self._override("BATCH_SIZE")
         raw = ov if ov is not _MISSING else os.environ.get("BATCH_SIZE", "4000")
         return self._as_int("BATCH_SIZE", "BATCH_SIZE", raw)
+
+    @property
+    def CATEGORICAL_MIN_COUNT(self) -> int:
+        """Minimum occurrence count for a categorical value to be emitted in the
+        alignment vocab (data-ingestors#360). Values seen fewer than this many
+        times are suppressed — a re-identification guard for rare categories
+        (a value present for a single record).
+
+        Defaults to **1** (keep every observed value — no suppression), because
+        raising it drops rare values from the union vocab, which the edge must
+        then handle as out-of-vocabulary at encode time; that trade needs the
+        backend privacy sign-off + engine OOV handling (backend#1079/#1053). Set
+        it above 1 in the deployment once those are in place.
+        """
+        ov = self._override("CATEGORICAL_MIN_COUNT")
+        raw = ov if ov is not _MISSING else os.environ.get("CATEGORICAL_MIN_COUNT", "1")
+        return self._as_int("CATEGORICAL_MIN_COUNT", "CATEGORICAL_MIN_COUNT", raw)
 
     # ===== API =====
     @property

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -16,6 +16,8 @@ from ..utils.constants import (
     YELLOW,
     CYAN,
     DataFormat,
+    COLOR_MODE_CHANNELS,
+    canonical_color_mode,
 )
 from ..utils import label_policy as label_policy_module
 from ..utils.columns import resolve_column
@@ -432,14 +434,14 @@ class BaseIngestor(ABC):
 
         - **Image:** ``resolution`` from the run's uniform ``target_size`` (the
           resolution validator enforces every image to it, so no image read is
-          needed here). Emitted as ``[height, width]`` — ``target_size`` is
-          ``[width, height]``.
+          needed here), emitted as ``[height, width]`` (``target_size`` is
+          ``[width, height]``); ``color_mode`` + derived ``channels`` and
+          ``bit_depth`` from ``file_options`` when the user supplies them for the
+          vision run (RGB/grayscale only — the values the contract accepts). Not
+          auto-detected: PIL modes like RGBA/CMYK aren't in the contract enum.
         - **Text/NLP:** ``encoding`` is ``"utf-8"`` — text is staged and
           validated as UTF-8 (non-UTF-8 is rejected at validation), so that is
           the canonical, true value.
-
-        ``channels``/``color_mode``/``bit_depth`` (need a per-image PIL scan) and
-        ``sampling_frequency`` are separate slices.
         """
         attributes: Dict[str, Any] = {}
 
@@ -448,6 +450,17 @@ class BaseIngestor(ABC):
             if isinstance(target, (list, tuple)) and len(target) == 2:
                 width, height = int(target[0]), int(target[1])
                 attributes["resolution"] = [height, width]
+
+            # color_mode is user-provided in file_options for vision use cases;
+            # emit only the canonical RGB/grayscale values and derive channels.
+            color_mode = canonical_color_mode(self.file_options.get("color_mode"))
+            if color_mode:
+                attributes["color_mode"] = color_mode
+                attributes["channels"] = COLOR_MODE_CHANNELS[color_mode]
+
+            bit_depth = self.file_options.get("bit_depth")
+            if isinstance(bit_depth, int) and not isinstance(bit_depth, bool):
+                attributes["bit_depth"] = bit_depth
 
         if self.category in _NLP_CATEGORIES:
             attributes["encoding"] = "utf-8"

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -47,6 +47,11 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["BaseIngestor", "IngestionSummary"]
 
+# Image bit depths the combine-time contract accepts (mirrors the check in
+# cli.conventions.resolve). Values outside this set must not reach the emitted
+# attributes even when bit_depth bypasses resolve() via spec.file_options.
+_SUPPORTED_BIT_DEPTHS = (8, 16)
+
 
 def _rows_state_clause(inserted_records: int) -> str:
     """Phrase the parenthetical about what's already in the database for a
@@ -458,8 +463,16 @@ class BaseIngestor(ABC):
                 attributes["color_mode"] = color_mode
                 attributes["channels"] = COLOR_MODE_CHANNELS[color_mode]
 
+            # Only the contract-accepted depths (8/16) — mirrors color_mode's
+            # canonicalisation. conventions.resolve() rejects other values, but a
+            # bit_depth set directly in spec.file_options or a modality spec
+            # bypasses that gate, so re-check here before it reaches the contract.
             bit_depth = self.file_options.get("bit_depth")
-            if isinstance(bit_depth, int) and not isinstance(bit_depth, bool):
+            if (
+                isinstance(bit_depth, int)
+                and not isinstance(bit_depth, bool)
+                and bit_depth in _SUPPORTED_BIT_DEPTHS
+            ):
                 attributes["bit_depth"] = bit_depth
 
         if self.category in _NLP_CATEGORIES:

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -15,6 +15,7 @@ from ..utils.constants import (
     RED,
     YELLOW,
     CYAN,
+    DataFormat,
 )
 from ..utils import label_policy as label_policy_module
 from ..utils.columns import resolve_column
@@ -420,7 +421,38 @@ class BaseIngestor(ABC):
         text/image facts in later #360 slices) is merged *into* any existing
         ``attributes`` rather than replacing it; other keys ``.update`` normally.
         """
-        return {}
+        return self._scalar_attribute_metadata()
+
+    def _scalar_attribute_metadata(self) -> Dict[str, Any]:
+        """Data-format-derived scalar attributes for combine-time alignment
+        (di#360). Format-agnostic so any ingestor (CSV or JSON manifest)
+        contributes them — image/text datasets are manifest-based and inherit
+        this base hook. Subclasses that override ``_collect_run_metadata`` (e.g.
+        ``CSVIngestor``) must fold this in via ``super()``.
+
+        - **Image:** ``resolution`` from the run's uniform ``target_size`` (the
+          resolution validator enforces every image to it, so no image read is
+          needed here). Emitted as ``[height, width]`` — ``target_size`` is
+          ``[width, height]``.
+        - **Text/NLP:** ``encoding`` is ``"utf-8"`` — text is staged and
+          validated as UTF-8 (non-UTF-8 is rejected at validation), so that is
+          the canonical, true value.
+
+        ``channels``/``color_mode``/``bit_depth`` (need a per-image PIL scan) and
+        ``sampling_frequency`` are separate slices.
+        """
+        attributes: Dict[str, Any] = {}
+
+        if self.data_format == DataFormat.IMAGE:
+            target = self.file_options.get("target_size")
+            if isinstance(target, (list, tuple)) and len(target) == 2:
+                width, height = int(target[0]), int(target[1])
+                attributes["resolution"] = [height, width]
+
+        if self.category in _NLP_CATEGORIES:
+            attributes["encoding"] = "utf-8"
+
+        return {"attributes": attributes} if attributes else {}
 
     def _apply_run_metadata(self) -> None:
         """Merge ``_collect_run_metadata()`` into ``file_options`` just before the

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -10,6 +10,7 @@ import csv as _csv
 import numpy as np
 import pandas as pd
 from ..utils import redaction
+from ..utils.columns import resolve_column
 import logging
 from pathlib import Path
 
@@ -520,10 +521,15 @@ class CSVIngestor(BaseIngestor):
         ``_MAX_CATEGORICAL_CARDINALITY`` it is dropped and never re-considered
         (free text / id, not a categorical feature). Excluded columns (label,
         row-id, annotation) are skipped.
+
+        Exclusion matches the configured names case- and whitespace-insensitively
+        via ``resolve_column`` (the #340 rule): this runs during ``_validate_csv``
+        on the raw header, before label pinning, so a header spelled ``Label`` /
+        ``" label "`` must still exclude a config that says ``label`` — otherwise
+        a row-id / label column's raw values would leak into ``feature_stats``.
         """
-        if (
-            column in self._categorical_excluded
-            or column in self._categorical_over_cap
+        if column in self._categorical_over_cap or any(
+            resolve_column([column], name) for name in self._categorical_excluded
         ):
             return
         vals = series.dropna()

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -17,12 +17,25 @@ from .base import BaseIngestor
 from ..database import Database
 from ..api.client import APIClient
 from ..cli.conventions import REGRESSION_CLASS_CATEGORIES
-from ..utils.constants import RESET, RED, YELLOW
+from ..utils.constants import RESET, RED, YELLOW, TaskCategory
 from ..utils import label_policy as label_policy_module
 from ..utils import coercion
 from ..config import Config
 
 config = Config()
+
+# Above this many distinct values a VARCHAR column is treated as free text / an
+# id-like field rather than a categorical feature, and no union vocabulary is
+# emitted for it (di#360). A near-unique column's value-set is useless for
+# stable cross-client encoding and would bloat the payload / leak more values.
+_MAX_CATEGORICAL_CARDINALITY = 1000
+
+# The time-series forecasting timestamp column is the literal name "timestamp"
+# (TimeFormatValidator). A bounded, in-order sample is enough for
+# ``pd.infer_freq`` to derive the sampling cadence; retaining all rows would be
+# wasteful on large series.
+_TIMESTAMP_COLUMN = "timestamp"
+_MAX_TIMESTAMP_SAMPLE = 500
 
 
 def _bom_safe_encoding(encoding: Optional[str]) -> str:
@@ -229,6 +242,36 @@ class CSVIngestor(BaseIngestor):
             excluded.add(self.label_column)
         self._feature_stats_excluded = excluded
 
+        # Per categorical-feature-column union vocabulary, accumulated in the
+        # VARCHAR/CHAR/TEXT cast pass and emitted under the same
+        # ``attributes.feature_stats[col].categories`` key the backend folds into
+        # the merged dataset's union vocab (backend#1037) and the edge encodes
+        # against for a stable cross-client index (tracebloc-engine#455). The
+        # label column is always excluded — its value-set is a *class* set gated
+        # by ``check_same_labels``, not a feature vocab — as are the row-id and
+        # annotation columns. A column whose distinct count crosses
+        # ``_MAX_CATEGORICAL_CARDINALITY`` is dropped (free text / id, not a
+        # categorical feature). Emitting the value-set discloses category
+        # presence — the same accepted trade as feature_stats min/max.
+        self._categorical_acc: Dict[str, set] = {}
+        self._categorical_over_cap: set = set()
+        self._categorical_excluded = {
+            c
+            for c in (
+                self.unique_id_column,
+                self.annotation_column,
+                self.label_column,
+            )
+            if c
+        }
+
+        # Temporal facts for time-series forecasting (di#360): the timestamp
+        # column's timezone (tz-aware iff the parsed dtype carries a tz) and a
+        # bounded in-order sample used to infer ``sampling_frequency`` via
+        # ``pd.infer_freq``. Accumulated in the TIMESTAMP cast branch.
+        self._timestamp_sample: List[Any] = []
+        self._timestamp_tz: Optional[str] = None
+
     def _validate_csv(self, df: pd.DataFrame) -> None:
         """Validate CSV data against schema using pandas functionality.
 
@@ -369,6 +412,8 @@ class CSVIngestor(BaseIngestor):
                     # substrings "DATE" and "TIME" both appear in "DATETIME"
                     # (and "TIME" in "TIMESTAMP").
                     df[column] = _cast_datetime_strict(df[column], column, dtype)
+                    if column == _TIMESTAMP_COLUMN:
+                        self._accumulate_temporal(df[column])
                 elif "DATE" in dtype.upper():
                     # DATE only — emit a plain date so the value doesn't gain a
                     # spurious time ('2026-01-02' was becoming '2026-01-02 00:00:00').
@@ -393,6 +438,7 @@ class CSVIngestor(BaseIngestor):
                             df[column].notna(), None
                         )
                     )
+                    self._accumulate_categorical(column, df[column])
             except Exception as e:
                 # Our own ValueErrors above are already content-safe; any
                 # OTHER exception may embed cell values (pandas/numpy
@@ -465,18 +511,110 @@ class CSVIngestor(BaseIngestor):
         """
         return {col: dict(stats) for col, stats in self._feature_stats_acc.items()}
 
-    def _collect_run_metadata(self) -> Dict[str, Any]:
-        """Contribute ``feature_stats`` under the shared ``attributes`` namespace
-        on the global-metadata channel (#360).
+    def _accumulate_categorical(self, column: str, series: pd.Series) -> None:
+        """Fold one chunk's distinct categorical values into the running vocab.
 
-        Per backend#1037's final ``dataset_meta`` shape, every per-column extra
-        lives under ``attributes.feature_stats`` — ``schema`` stays a plain
-        ``{column: dtype}`` map. See ``BaseIngestor._collect_run_metadata``.
-        Omitted entirely when there are no numeric feature columns so the payload
-        stays clean.
+        Called from the VARCHAR/CHAR/TEXT cast branch of ``_validate_csv`` with
+        the already-cast column, so there is no second read. Non-null distinct
+        values accumulate into a set per column; once a column crosses
+        ``_MAX_CATEGORICAL_CARDINALITY`` it is dropped and never re-considered
+        (free text / id, not a categorical feature). Excluded columns (label,
+        row-id, annotation) are skipped.
         """
-        stats = self.feature_stats()
-        return {"attributes": {"feature_stats": stats}} if stats else {}
+        if (
+            column in self._categorical_excluded
+            or column in self._categorical_over_cap
+        ):
+            return
+        vals = series.dropna()
+        if vals.empty:
+            return
+        acc = self._categorical_acc.setdefault(column, set())
+        acc.update(str(v) for v in pd.unique(vals))
+        if len(acc) > _MAX_CATEGORICAL_CARDINALITY:
+            self._categorical_over_cap.add(column)
+            self._categorical_acc.pop(column, None)
+
+    def categorical_vocab(self) -> Dict[str, List[str]]:
+        """The finalized per-categorical-column union vocabulary (sorted).
+
+        Empty when the dataset has no categorical feature columns within the
+        cardinality cap. Sorted so the emitted order is deterministic and the
+        backend's union / the edge's label index are stable.
+        """
+        return {
+            col: sorted(vals)
+            for col, vals in self._categorical_acc.items()
+            if vals
+        }
+
+    def _accumulate_temporal(self, series: pd.Series) -> None:
+        """Fold one chunk of the (already-parsed) timestamp column into the
+        temporal accumulators: capture the timezone and grow a bounded in-order
+        sample for ``pd.infer_freq``. Rows arrive in time order
+        (``TimeOrderedValidator`` gates it), so appending across chunks preserves
+        the cadence.
+        """
+        s = series.dropna()
+        if s.empty:
+            return
+        tz = getattr(s.dt, "tz", None)
+        if tz is not None:
+            self._timestamp_tz = str(tz)
+        if len(self._timestamp_sample) < _MAX_TIMESTAMP_SAMPLE:
+            need = _MAX_TIMESTAMP_SAMPLE - len(self._timestamp_sample)
+            self._timestamp_sample.extend(s.iloc[:need].tolist())
+
+    def _temporal_attributes(self) -> Dict[str, Any]:
+        """Reconcilable temporal facts for time-series forecasting (di#360):
+        ``timezone`` (when the timestamps are tz-aware) and ``sampling_frequency``
+        (a pandas offset alias, only when a regular cadence is inferable). Both
+        are omitted when unavailable — forward-compatible (absent → WARN)."""
+        if self.category != TaskCategory.TIME_SERIES_FORECASTING:
+            return {}
+        attrs: Dict[str, Any] = {}
+        if self._timestamp_tz is not None:
+            attrs["timezone"] = self._timestamp_tz
+        if len(self._timestamp_sample) >= 3:
+            try:
+                freq = pd.infer_freq(pd.DatetimeIndex(self._timestamp_sample))
+            except (ValueError, TypeError):
+                freq = None
+            if freq:
+                attrs["sampling_frequency"] = freq
+        return attrs
+
+    def _collect_run_metadata(self) -> Dict[str, Any]:
+        """Contribute this run's derived facts under the shared ``attributes``
+        namespace on the global-metadata channel (#360).
+
+        Per backend#1037's final ``dataset_meta`` shape, per-column extras live
+        under ``attributes.feature_stats`` (``schema`` stays a plain
+        ``{column: dtype}`` map): numeric columns carry the folded sufficient
+        stats ``{count, sum, sum_sq, min, max}``; categorical columns carry the
+        union vocabulary ``{categories: [...]}`` — a column is one or the other,
+        so they never collide. Time-series runs also add the reconcilable
+        ``timezone`` / ``sampling_frequency`` scalar facts. The base's
+        data-format scalar attributes (image ``resolution``, text ``encoding``)
+        are folded in via ``super()`` so a CSV manifest for an image/text dataset
+        still emits them. Omitted entirely when there is nothing to contribute so
+        the payload stays clean.
+        """
+        # Start from the base's data-format scalar attributes (image resolution,
+        # text encoding) so a CSV manifest for an image/text dataset still emits
+        # them, then add the tabular/temporal facts this ingestor derives.
+        meta = super()._collect_run_metadata()
+        attributes = meta.get("attributes", {})
+
+        feature_stats = self.feature_stats()
+        for column, categories in self.categorical_vocab().items():
+            feature_stats[column] = {"categories": categories}
+        if feature_stats:
+            attributes["feature_stats"] = feature_stats
+
+        attributes.update(self._temporal_attributes())
+
+        return {"attributes": attributes} if attributes else {}
 
     def read_data(self, file_path: str) -> Generator[Dict[str, Any], None, None]:
         """Read and validate CSV file using pandas optimizations.

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -6,6 +6,7 @@ pandas-based reading and validation capabilities.
 
 from typing import Dict, Any, Generator, Optional, List
 import codecs
+from collections import Counter
 import csv as _csv
 import numpy as np
 import pandas as pd
@@ -254,7 +255,10 @@ class CSVIngestor(BaseIngestor):
         # ``_MAX_CATEGORICAL_CARDINALITY`` is dropped (free text / id, not a
         # categorical feature). Emitting the value-set discloses category
         # presence — the same accepted trade as feature_stats min/max.
-        self._categorical_acc: Dict[str, set] = {}
+        # Per-value OCCURRENCE COUNTS (not just presence) so a min-count
+        # threshold can suppress rare, re-identifying values at finalize
+        # (CATEGORICAL_MIN_COUNT).
+        self._categorical_acc: Dict[str, Counter] = {}
         self._categorical_over_cap: set = set()
         self._categorical_excluded = {
             c
@@ -516,11 +520,12 @@ class CSVIngestor(BaseIngestor):
         """Fold one chunk's distinct categorical values into the running vocab.
 
         Called from the VARCHAR/CHAR/TEXT cast branch of ``_validate_csv`` with
-        the already-cast column, so there is no second read. Non-null distinct
-        values accumulate into a set per column; once a column crosses
-        ``_MAX_CATEGORICAL_CARDINALITY`` it is dropped and never re-considered
-        (free text / id, not a categorical feature). Excluded columns (label,
-        row-id, annotation) are skipped.
+        the already-cast column, so there is no second read. Non-null values
+        accumulate into a per-column ``Counter`` (occurrence counts, so a
+        min-count threshold can drop rare values at finalize); once a column's
+        distinct count crosses ``_MAX_CATEGORICAL_CARDINALITY`` it is dropped and
+        never re-considered (free text / id, not a categorical feature). Excluded
+        columns (label, row-id, annotation) are skipped.
 
         Exclusion matches the configured names case- and whitespace-insensitively
         via ``resolve_column`` (the #340 rule): this runs during ``_validate_csv``
@@ -535,8 +540,9 @@ class CSVIngestor(BaseIngestor):
         vals = series.dropna()
         if vals.empty:
             return
-        acc = self._categorical_acc.setdefault(column, set())
-        acc.update(str(v) for v in pd.unique(vals))
+        acc = self._categorical_acc.setdefault(column, Counter())
+        # Vectorised per-chunk counts; Counter.update ADDS them across chunks.
+        acc.update(vals.astype(str).value_counts().to_dict())
         if len(acc) > _MAX_CATEGORICAL_CARDINALITY:
             self._categorical_over_cap.add(column)
             self._categorical_acc.pop(column, None)
@@ -544,15 +550,20 @@ class CSVIngestor(BaseIngestor):
     def categorical_vocab(self) -> Dict[str, List[str]]:
         """The finalized per-categorical-column union vocabulary (sorted).
 
-        Empty when the dataset has no categorical feature columns within the
-        cardinality cap. Sorted so the emitted order is deterministic and the
-        backend's union / the edge's label index are stable.
+        Values seen fewer than ``CATEGORICAL_MIN_COUNT`` times are suppressed —
+        a re-identification guard for rare categories (default 1 ⇒ keep all; see
+        the config field). A column left with no values is omitted. Empty when
+        the dataset has no categorical feature columns within the cardinality
+        cap. Sorted so the emitted order is deterministic and the backend's union
+        / the edge's label index are stable.
         """
-        return {
-            col: sorted(vals)
-            for col, vals in self._categorical_acc.items()
-            if vals
-        }
+        min_count = self.database.config.CATEGORICAL_MIN_COUNT
+        vocab: Dict[str, List[str]] = {}
+        for col, counts in self._categorical_acc.items():
+            kept = sorted(v for v, n in counts.items() if n >= min_count)
+            if kept:
+                vocab[col] = kept
+        return vocab
 
     def _accumulate_temporal(self, series: pd.Series) -> None:
         """Fold one chunk of the (already-parsed) timestamp column into the

--- a/tracebloc_ingestor/utils/constants.py
+++ b/tracebloc_ingestor/utils/constants.py
@@ -2,6 +2,8 @@
 Constants used throughout the application.
 """
 
+from typing import Optional
+
 # API Constants
 API_TIMEOUT = 1500
 
@@ -121,6 +123,31 @@ class DataFormat:
         Check if a given format is valid.
         """
         return format in cls.get_all_formats()
+
+
+# Canonical vision color modes for the combine-time attributes contract
+# (di#360). Deliberately RGB/grayscale only — the values the backend G4a
+# contract and the edge preprocessor both accept — and user-provided via
+# file_options for vision use cases (not auto-detected, which would surface PIL
+# modes like RGBA/CMYK the contract rejects). ``channels`` derives from the mode.
+COLOR_MODE_CHANNELS: dict = {"RGB": 3, "grayscale": 1}
+_COLOR_MODE_ALIASES: dict = {
+    "rgb": "RGB",
+    "grayscale": "grayscale",
+    "greyscale": "grayscale",
+    "gray": "grayscale",
+    "grey": "grayscale",
+    "l": "grayscale",
+}
+
+
+def canonical_color_mode(value) -> Optional[str]:
+    """Canonical ``"RGB"``/``"grayscale"`` for a user-supplied ``color_mode``,
+    or ``None`` when unrecognized. Accepts common spellings case-insensitively
+    (``rgb``, ``grayscale``/``greyscale``/``gray``/``grey``/``l``)."""
+    if not isinstance(value, str):
+        return None
+    return _COLOR_MODE_ALIASES.get(value.strip().lower())
 
 
 # ANSI color codes


### PR DESCRIPTION
## What & why

Next slice of di#360: emit the **per-dataset scalar attributes** (and categorical vocab) the backend folds into the merged dataset (`build_aligned_metadata`, backend#1037 / the G4a contract) and the edge consumes at train time (tracebloc-engine#455 / #459) — everything the ingestor can derive from the data, plus the vision facts the user declares. No raw *rows* leave the client — numeric/temporal/image facts are aggregate summaries. **Exception:** the categorical union vocab (`attributes.feature_stats[col].categories`) is a set of the column's **raw distinct values** (capped, deduped); it discloses category presence — the same accepted trade as `feature_stats` `min`/`max`, pending the backend privacy sign-off noted below.

**Stacked on #361** (feature_stats base). This PR is the `attributes` sibling of that numeric tier.

## Changes

**Categorical union vocab** (`csv_ingestor.py`)
- The VARCHAR/CHAR/TEXT cast pass accumulates each categorical feature column's distinct value-set, emitted under `attributes.feature_stats[col].categories` — the stable cross-client vocabulary the edge encodes against (`CategoricalEncodingStep`).
- Capped at `_MAX_CATEGORICAL_CARDINALITY` (free-text / id-like columns dropped); label / row-id / annotation columns excluded (a categorical label is a *class*, gated by `check_same_labels`, not a feature vocab).

**Temporal** (`csv_ingestor.py`, time-series forecasting)
- The timestamp cast pass captures `timezone` (when tz-aware) and a bounded in-order sample; `sampling_frequency` is inferred via `pd.infer_freq`. Both omitted when unavailable.

**Image `resolution` + text `encoding`** (`base.py` — format-gated `_scalar_attribute_metadata`)
- `resolution` as `[height, width]` from the run's uniform `target_size` (the resolution validator enforces it — no image read).
- `encoding: "utf-8"` for NLP categories (non-UTF-8 text is rejected at validation, so this is the true canonical value).
- Lives in the base hook so manifest-based image/text datasets emit them regardless of CSV/JSON ingestor; `CSVIngestor` folds them in via `super()`.

**Image `color_mode` / `channels` / `bit_depth`** (user-declared — `base.py` + `conventions.py` + `constants.py`)
- `color_mode` is **user-provided in `file_options`** for vision use cases and restricted to **RGB/grayscale** (the values the backend contract and the edge accept). Not auto-detected — PIL modes like RGBA/CMYK aren't in the contract enum, and `bit_depth` isn't cleanly exposed by PIL.
- `channels` derives from `color_mode` (RGB→3, grayscale→1); `bit_depth` (8/16) is optional.
- `conventions.resolve()` bridges top-level `color_mode`/`bit_depth` into `file_options` (spec > top-level precedence, like `target_size`) and validates them at config time — a bad value fails fast. A non-canonical value reaching the emit hook is skipped, never shipped.

## Emitted shape (example)

```jsonc
"attributes": {
  "feature_stats": {
    "age":    { "count": 1000, "sum": 41230.0, "sum_sq": 1.9e6, "min": 18, "max": 91 },  // numeric (#361)
    "region": { "categories": ["E", "N", "S", "W"] }                                      // categorical (this PR)
  },
  "resolution": [224, 224],      // image (target_size)
  "color_mode": "RGB", "channels": 3, "bit_depth": 8,   // image (user-declared)
  "timezone": "UTC", "sampling_frequency": "h",         // time-series
  "encoding": "utf-8"                                    // text
}
```

## Verification

- ✅ Full suite green: **1504 passed, 1 xfailed**.
- Targeted tests: categorical vocab (sorted/dedup/cross-chunk/exclusions/cardinality-cap/nulls, coexists with numeric); temporal (tz-aware vs naive, frequency, gated to time-series); image resolution `[h,w]`; text encoding; color_mode/channels/bit_depth emission (RGB/grayscale, invalid skipped, absent); conventions bridge + canonicalization + fail-fast validation.

## Scope / notes

- Draft: stacked on #361; review that first.
- The backend G4a contract (backend#1079) accepts `color_mode ∈ {RGB, BGR, grayscale}` — a superset of what this emits (RGB/grayscale), so no conflict.
- **Out of scope** (the declared/semantic tier, not auto-detectable): per-column schema enrichment (`units` / `ordinal` / `boolean` / `null_encoding`) and text `language` / `normalization`.

Refs #360. Consumers: backend#1079 (G4a contract), backend#1037 (fold), tracebloc-engine#455/#459.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the API metadata contract and ships raw categorical distinct values (privacy trade-off); default min-count=1 limits behavior change, but mis-tuned thresholds or cardinality logic could affect edge OOV encoding downstream.
> 
> **Overview**
> Extends ingest **run metadata** (`file_options.attributes`) for backend combine-time alignment (#360): numeric `feature_stats` from #361 now sit alongside **categorical union vocab** under `attributes.feature_stats[col].categories`, built during the VARCHAR cast pass with chunk accumulation, label/id/annotation exclusion, a **1000-distinct cardinality cap**, and optional suppression via new **`CATEGORICAL_MIN_COUNT`** (env/override, default **1**).
> 
> **Vision & text scalars** move into `BaseIngestor._scalar_attribute_metadata` (image `resolution` from `target_size`, user-declared `color_mode`/`channels`/`bit_depth`; NLP `encoding: utf-8`). YAML **`color_mode` / `bit_depth`** are bridged in `conventions.resolve()` with fail-fast validation; `canonical_color_mode` lives in `constants.py`. Invalid values that bypass resolve are dropped at emit time.
> 
> **Time-series forecasting** adds `timezone` and `sampling_frequency` (from the `timestamp` column sample + `pd.infer_freq`) in `CSVIngestor`, merged with base scalars via `super()` in `_collect_run_metadata`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52e45e0afc19cc39960bb741f4e57159cf1f2fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

