### PR TITLE
feat(ingest): end-to-end ingest correlation id — honour the Job env (backend#1028 item 3)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ _ENV_VARS = (
     "DB_USER",
     "DB_PASSWORD",
     "DB_NAME",
+    "TRACEBLOC_INGEST_CORRELATION_ID",
 )
 
 

--- a/tests/test_correlation_id.py
+++ b/tests/test_correlation_id.py
@@ -1,0 +1,200 @@
+"""End-to-end ingest correlation id (backend#1028 item 3).
+
+The CLI's idempotency key reaches the ingestor as the
+``TRACEBLOC_INGEST_CORRELATION_ID`` env var (stamped by jobs-manager on the
+spawned Job). Covered here:
+
+- ``resolve_correlation_id``: honoured when valid, ``None`` when absent,
+  warned + ``None`` when malformed (observability must never fail an ingest);
+- ``BaseIngestor.__init__``: keeps the id ALONGSIDE the per-process
+  ``ingestor_id`` (never replacing it — row scoping across Job retries) and
+  rides it on ``file_options``;
+- full ingest: the id reaches the backend registration payload's
+  ``meta_data``; without the env the payload is byte-identical to before.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+from tracebloc_ingestor.utils.constants import DataFormat, TaskCategory
+from tracebloc_ingestor.utils.correlation import (
+    CORRELATION_ID_ENV,
+    resolve_correlation_id,
+)
+
+# The CLI's generated shape: 16 crypto/rand bytes, hex-encoded (32 chars).
+CLI_STYLE_KEY = "9f2c4a1de6b7085f3a9c0d12e4f56a7b"
+
+
+# ---------------------------------------------------------------------------
+# resolve_correlation_id — env honoured / validated / fallback
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_returns_none_when_unset(monkeypatch):
+    monkeypatch.delenv(CORRELATION_ID_ENV, raising=False)
+    assert resolve_correlation_id() is None
+
+
+def test_resolver_returns_none_for_blank_values(monkeypatch):
+    for blank in ("", "   ", "\n"):
+        monkeypatch.setenv(CORRELATION_ID_ENV, blank)
+        assert resolve_correlation_id() is None
+
+
+def test_resolver_honours_cli_style_key(monkeypatch):
+    monkeypatch.setenv(CORRELATION_ID_ENV, CLI_STYLE_KEY)
+    assert resolve_correlation_id() == CLI_STYLE_KEY
+
+
+def test_resolver_accepts_customer_chosen_keys():
+    # --idempotency-key overrides: dots, dashes, underscores, 64-char max —
+    # the same alphabet jobs-manager's Kubernetes labels keep verbatim.
+    for key in ("nightly-claims-2026.07", "run_1", "a" * 64):
+        assert resolve_correlation_id({CORRELATION_ID_ENV: key}) == key
+
+
+def test_resolver_strips_surrounding_whitespace():
+    assert (
+        resolve_correlation_id({CORRELATION_ID_ENV: f"  {CLI_STYLE_KEY}\n"})
+        == CLI_STYLE_KEY
+    )
+
+
+def test_resolver_rejects_malformed_values_with_warning(caplog):
+    # Over-long, illegal chars, log-injection attempts: warned and ignored —
+    # a bad value must degrade to "no correlation id", never fail the run.
+    for bad in ("a" * 65, "spaced key", "key:colon", "kéy", "a\nb"):
+        with caplog.at_level(logging.WARNING):
+            caplog.clear()
+            assert resolve_correlation_id({CORRELATION_ID_ENV: bad}) is None
+        assert any(
+            CORRELATION_ID_ENV in rec.getMessage() for rec in caplog.records
+        ), f"expected a warning naming the env var for {bad!r}"
+
+
+# ---------------------------------------------------------------------------
+# BaseIngestor wiring — alongside ingestor_id, onto file_options
+# ---------------------------------------------------------------------------
+
+
+def _make_ingestor(**overrides):
+    database = MagicMock(name="Database")
+    api_client = MagicMock(name="APIClient")
+    kwargs = dict(
+        database=database,
+        api_client=api_client,
+        table_name="corr_toy",
+        schema={"heart_rate": "FLOAT", "label": "INT"},
+        label_column="label",
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+        file_options={},
+    )
+    kwargs.update(overrides)
+    return CSVIngestor(**kwargs)
+
+
+def test_ingestor_picks_up_env_alongside_fresh_ingestor_id(monkeypatch):
+    monkeypatch.setenv(CORRELATION_ID_ENV, CLI_STYLE_KEY)
+    ing = _make_ingestor()
+
+    assert ing.correlation_id == CLI_STYLE_KEY
+    assert ing.file_options["correlation_id"] == CLI_STYLE_KEY
+    # ingestor_id stays a fresh per-process UUID — row scoping (label
+    # counts, the #227 compensating delete) must not be shared across a
+    # Job retry that reruns with the same env.
+    assert ing.ingestor_id != CLI_STYLE_KEY
+    assert str(uuid.UUID(ing.ingestor_id)) == ing.ingestor_id
+
+
+def test_ingestor_without_env_behaves_as_before(monkeypatch):
+    monkeypatch.delenv(CORRELATION_ID_ENV, raising=False)
+    ing = _make_ingestor()
+
+    assert ing.correlation_id is None
+    assert "correlation_id" not in ing.file_options
+
+
+def test_ingestor_ignores_malformed_env(monkeypatch):
+    monkeypatch.setenv(CORRELATION_ID_ENV, "not a valid key!")
+    ing = _make_ingestor()
+
+    assert ing.correlation_id is None
+    assert "correlation_id" not in ing.file_options
+
+
+# ---------------------------------------------------------------------------
+# Full ingest — the id reaches the registration payload's meta_data
+# ---------------------------------------------------------------------------
+
+
+def _toy_frame() -> pd.DataFrame:
+    return pd.DataFrame([{"heart_rate": 70.0 + i, "label": i % 2} for i in range(10)])
+
+
+def _make_full_ingestor():
+    """Mirror the mocked-DB full-ingest harness of
+    test_time_series_classification (tabular control variant)."""
+    db = MagicMock(name="Database")
+    db.config = Config(TABLE_NAME="corr_toy")
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.side_effect = lambda table, batch: (
+        list(range(len(batch))),
+        [],
+    )
+    db.get_table_schema.return_value = {"heart_rate": "FLOAT", "label": "INT"}
+    db.get_label_counts.return_value = {"0": 5, "1": 5}
+    db.get_samples.return_value = []
+    api = MagicMock(name="APIClient")
+    api.config.TITLE = "corr toy"
+    api.send_ingest_summary.return_value = {"dataset_id": 1}
+    return CSVIngestor(
+        database=db,
+        api_client=api,
+        table_name="corr_toy",
+        schema={"heart_rate": "FLOAT", "label": "INT"},
+        label_column="label",
+        intent="train",
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+        data_format=DataFormat.TABULAR,
+    )
+
+
+def _run_full_ingest(ing, csv_path):
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        return ing.ingest(str(csv_path), batch_size=50)
+
+
+def test_correlation_id_reaches_registration_payload(make_csv, monkeypatch):
+    monkeypatch.setenv(CORRELATION_ID_ENV, CLI_STYLE_KEY)
+    csv_path = make_csv(_toy_frame(), name="corr.csv")
+    ing = _make_full_ingestor()
+
+    failed = _run_full_ingest(ing, csv_path)
+
+    assert failed == []
+    summary_kwargs = ing.api_client.send_ingest_summary.call_args.kwargs
+    assert summary_kwargs["meta_data"]["correlation_id"] == CLI_STYLE_KEY
+    # The per-process id still scopes the run's rows and the summary call.
+    assert summary_kwargs["ingestor_id"] == ing.ingestor_id
+
+
+def test_payload_unchanged_without_env(make_csv, monkeypatch):
+    monkeypatch.delenv(CORRELATION_ID_ENV, raising=False)
+    csv_path = make_csv(_toy_frame(), name="corr.csv")
+    ing = _make_full_ingestor()
+
+    failed = _run_full_ingest(ing, csv_path)
+
+    assert failed == []
+    meta = ing.api_client.send_ingest_summary.call_args.kwargs["meta_data"]
+    assert "correlation_id" not in meta

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -139,6 +139,16 @@ def main(argv: List[str] | None = None) -> int:  # pragma: no cover - thin shell
 
     ingestor = _build_ingestor(database, api_client, resolved)
 
+    if ingestor.correlation_id:
+        # backend#1028 item 3: the one always-visible line (print, not
+        # logger — default LOG_LEVEL is WARNING) that ties this Job's log
+        # to the CLI's correlation id and to the per-process ingestor_id
+        # stamped on every MySQL row this run inserts.
+        print(
+            f"Correlation id: {ingestor.correlation_id} "
+            f"(ingestor_id: {ingestor.ingestor_id})"
+        )
+
     with ingestor:
         try:
             failed = ingestor.ingest(resolved.source_path, batch_size=config.BATCH_SIZE)

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -18,6 +18,7 @@ from ..utils.constants import (
 )
 from ..utils import label_policy as label_policy_module
 from ..utils.columns import resolve_column
+from ..utils.correlation import resolve_correlation_id
 from ..utils.validators_mapping import map_validators
 from ..file_transfer import map_file_transfer
 from ..text_profile import compute_text_profile
@@ -122,6 +123,9 @@ class BaseIngestor(ABC):
 
     Attributes:
         ingestor_id: Unique identifier for this ingestor instance
+        correlation_id: End-to-end run id from the TRACEBLOC_INGEST_CORRELATION_ID
+            env var (the CLI's idempotency key, stamped by jobs-manager), or
+            None outside jobs-manager-spawned Jobs (backend#1028 item 3)
         database: Database instance for data storage
         engine: SQLAlchemy engine instance
         api_client: API client for sending data
@@ -196,6 +200,24 @@ class BaseIngestor(ABC):
         self.data_format = data_format
         self.file_options = file_options or {}
         self.label_policy = label_policy
+
+        # backend#1028 item 3: end-to-end correlation id. When spawned by
+        # jobs-manager, the Job env carries the CLI's idempotency key — the
+        # same string the Job name is derived from and the
+        # tracebloc.io/ingestion-run label holds. Kept ALONGSIDE the
+        # per-process ingestor_id (row scoping — label counts, the #227
+        # compensating delete — must stay per-process across Job retries);
+        # riding file_options puts it in the registration payload's
+        # meta_data, so the backend dataset row carries it too. None when
+        # the env is absent/invalid — behaviour is then exactly as before.
+        self.correlation_id = resolve_correlation_id()
+        if self.correlation_id:
+            self.file_options["correlation_id"] = self.correlation_id
+            logger.info(
+                "Correlation id %s (ingestor_id %s)",
+                self.correlation_id,
+                self.ingestor_id,
+            )
 
         # Default behavior is UUID-generated data_id (no source column leaves
         # the cluster). Opting into source-column mapping is allowed but loud:

--- a/tracebloc_ingestor/utils/correlation.py
+++ b/tracebloc_ingestor/utils/correlation.py
@@ -1,7 +1,7 @@
 """End-to-end ingest correlation id (backend#1028 item 3).
 
 One id threads a single ingest run across every layer. The CLI generates an
-idempotency key per ``tracebloc dataset push`` invocation; jobs-manager
+idempotency key per ``tracebloc data ingest`` invocation; jobs-manager
 (client-runtime) derives the Job name from that key, labels every spawned
 resource with it (``tracebloc.io/ingestion-run``), and stamps it into the
 ingestor container as the ``TRACEBLOC_INGEST_CORRELATION_ID`` env var. This

--- a/tracebloc_ingestor/utils/correlation.py
+++ b/tracebloc_ingestor/utils/correlation.py
@@ -1,0 +1,71 @@
+"""End-to-end ingest correlation id (backend#1028 item 3).
+
+One id threads a single ingest run across every layer. The CLI generates an
+idempotency key per ``tracebloc dataset push`` invocation; jobs-manager
+(client-runtime) derives the Job name from that key, labels every spawned
+resource with it (``tracebloc.io/ingestion-run``), and stamps it into the
+ingestor container as the ``TRACEBLOC_INGEST_CORRELATION_ID`` env var. This
+module is where the ingestor picks the thread up: the resolved value is
+logged next to the per-process ``ingestor_id`` and rides the registration
+payload's ``meta_data`` to the backend — so CLI output, Job name/labels,
+ingestor logs, MySQL rows (via the logged ingestor_id) and the backend
+dataset row are all reachable by grepping one string.
+
+The env var is optional everywhere. Absent (direct/manual runs, template
+runs, older jobs-managers) → ``None`` and behaviour is exactly as before.
+Present but malformed → a warning, then ``None`` — observability must never
+fail an ingest.
+
+Deliberately **alongside**, not instead of, ``ingestor_id``: a Job retry
+(``restartPolicy: OnFailure``) reruns the container with the same env, and
+row scoping (label counts, the #227 compensating delete) must stay
+per-process, or a hard-killed first attempt's orphan rows would be counted
+into — and registered with — the retry's dataset.
+"""
+
+import logging
+import os
+import re
+from typing import Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+# The env var jobs-manager sets on the spawned ingestor Job
+# (client-runtime's submit_ingestion_run.build_job_spec extra_env).
+CORRELATION_ID_ENV = "TRACEBLOC_INGEST_CORRELATION_ID"
+
+# jobs-manager caps idempotency keys at 64 chars (VARCHAR(64) primary key in
+# its ingestion_runs table); the charset mirrors its Kubernetes-label-safe
+# alphabet (client-runtime's ``_safe_label_value``) so the same string is
+# valid in Job labels, log greps, and JSON. The CLI's generated keys are
+# 32 lowercase hex chars and always match.
+_CORRELATION_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+
+def resolve_correlation_id(env: Optional[Mapping[str, str]] = None) -> Optional[str]:
+    """Read and validate ``TRACEBLOC_INGEST_CORRELATION_ID``.
+
+    Returns the validated id, or ``None`` when the var is unset/blank (the
+    normal case outside jobs-manager-spawned Jobs). A present-but-malformed
+    value also returns ``None`` — after a WARNING naming the rejected value,
+    so a mangled key surfaces in the Job log instead of silently seeding a
+    bogus thread (default LOG_LEVEL is WARNING, so this line is visible).
+
+    Args:
+        env: Environment mapping to read from; defaults to ``os.environ``.
+            Injectable for tests.
+    """
+    source = os.environ if env is None else env
+    raw = (source.get(CORRELATION_ID_ENV) or "").strip()
+    if not raw:
+        return None
+    if not _CORRELATION_ID_RE.match(raw):
+        logger.warning(
+            "Ignoring %s=%r: expected 1-64 chars of [A-Za-z0-9._-] "
+            "(the CLI's idempotency-key format). Proceeding without a "
+            "correlation id.",
+            CORRELATION_ID_ENV,
+            raw,
+        )
+        return None
+    return raw


### PR DESCRIPTION
## Summary
Picks up the end-to-end ingest correlation id (backend#1028 item 3): when jobs-manager spawns the ingestor Job it stamps the CLI's idempotency key into the container as `TRACEBLOC_INGEST_CORRELATION_ID`; the ingestor now validates that value, keeps it **alongside** the per-process `ingestor_id`, prints the link line `Correlation id: <id> (ingestor_id: <uuid>)` into the Job log, and ships it to the backend inside the registration payload's `meta_data`. Absent env = today's behaviour, byte for byte.

## Related
Ref tracebloc/backend#1028 (item 3). Sibling PRs land the other two layers: `tracebloc/client-runtime` (stamp the Job env) and `tracebloc/cli` (print the id on submit) — same branch name `feat/1028-ingest-correlation-id`.

## The cross-repo contract
- **One id**: the CLI's existing per-invocation idempotency key (32-char `crypto/rand` hex, or the customer's `--idempotency-key`; jobs-manager caps it at 64 chars). No wire change anywhere — the key was already in the submit POST body.
- **Env**: `TRACEBLOC_INGEST_CORRELATION_ID`, set by jobs-manager on the spawned Job (client-runtime PR). The Job name (`ingest-job-<sha256(key)[:12]>`) and the `tracebloc.io/ingestion-run` label already derive from the same key.
- **Validation here**: `^[A-Za-z0-9._-]{1,64}$` (jobs-manager's key cap + its Kubernetes-label-safe alphabet). Unset/blank → `None`; malformed → WARNING + `None` — observability never fails an ingest, and direct/manual runs keep working unchanged.
- **Alongside, not instead of, `ingestor_id`** (deliberate): a Job retry (`restartPolicy: OnFailure`) reruns with the same env, and row scoping (label counts, the #227 compensating delete) must stay per-process — otherwise a hard-killed attempt's orphan rows would be counted into (and registered with) the retry's dataset, worsening item 2 of the same audit. The printed link line gives the `correlation_id ↔ ingestor_id` join instead.
- **Backend**: `meta_data` is a free-form `DictField` stored verbatim by `IngestSummarySerializer`, so `meta_data.correlation_id` lands on the dataset row with **no backend change**.
- **Merge order: any.** The env is optional at every layer — an old ingestor image ignores the extra env var; this change without the env behaves exactly as before.

## Test plan
- `pytest tests/test_correlation_id.py` — 11 new tests: resolver honoured/validated/fallback (incl. 64-char cap, log-injection shapes), `BaseIngestor` wiring alongside a fresh uuid4 `ingestor_id`, and a full mocked-DB ingest asserting the id reaches (and, without env, stays out of) `send_ingest_summary`'s `meta_data`.
- Full suite: `pytest --cov=tracebloc_ingestor --cov-fail-under=95` → **1624 passed, 1 xfailed, coverage 96.06%** (Python 3.11).
- Black run on the new/edited hunks (pre-existing drift elsewhere in `base.py` left untouched).

## Deployment notes
No env vars, migrations, or flags required. The id shows up in prod logs/payloads once this ships in an ingestor release AND the client-runtime jobs-manager change is deployed — in either order.

## Adjacency
Open drafts #361/#367 touch `ingestors/base.py` in other regions (feature-stats emission, `_collect_run_metadata`, the constants import block); this PR's hunks (`__init__`, one import line, class docstring) don't overlap, though the import line sits near #367's import hunk — worst case a trivial rebase.

## Checklist
- [x] Tests added / updated and passing locally
- [x] Docs updated if behavior or config changed (docstrings; no user-facing docs describe env vars of the Job)
- [x] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional observability metadata on an existing meta_data channel; invalid env values degrade to prior behavior without failing ingest.
> 
> **Overview**
> Adds **`resolve_correlation_id`** in a new `utils/correlation` module to read and validate **`TRACEBLOC_INGEST_CORRELATION_ID`** (jobs-manager’s stamp of the CLI idempotency key). Invalid or blank values log a warning and are ignored so ingestion never fails on bad observability input.
> 
> **`BaseIngestor`** now sets **`correlation_id`** next to the per-process **`ingestor_id`**, copies a valid id into **`file_options`** so it appears in **`send_ingest_summary`** **`meta_data`**, and logs the pair. When the env is missing, behavior and registration payloads stay unchanged.
> 
> The CLI entrypoint **`print`**s `Correlation id: … (ingestor_id: …)` when an id is present (visible at default WARNING log level). Tests cover the resolver, ingestor wiring, and full-ingest **`meta_data`**; **`conftest`** strips the new env var in **`clean_env`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e73608754907409dba04fa434e756d8faa887268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->