### PR TITLE
fix(ingest): reconcile orphan rows from hard-killed runs before retry ingest

### DIFF
--- a/e2e/test_database_e2e.py
+++ b/e2e/test_database_e2e.py
@@ -207,3 +207,91 @@ def test_blob_columns_roundtrip_from_string_cells(db, table):
     assert failures == []
     rows = _query(f"SELECT payload, thumb FROM `{table}`")
     assert rows[0][0] == b"JVBERi0xLjQ=" and rows[0][1] == b"iVBOR"
+
+
+# ── Run journal: orphan-row reconciliation (backend#1028 item 2) ─────────────
+# A hard kill (OOMKilled / SIGKILL) bypasses the #227 compensating delete, so
+# the dead run's rows survive while its dataset was never registered — and the
+# Job retry then duplicates them. The run journal + reclaim pass below is the
+# fix; these run it against a real MySQL (real DDL, INSERT IGNORE, JOIN).
+
+
+def _run_id(prefix):
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def test_hard_killed_run_rows_reclaimed_on_retry(db, table):
+    """The bug scenario end-to-end: attempt 1 journals its start, inserts
+    rows, and dies hard (no registration, no compensating delete). The
+    retry's reconcile pass removes exactly those rows, so its own insert
+    (fresh uuid data_ids) converges to N rows instead of 2N."""
+    dead, retry = _run_id("dead"), _run_id("retry")
+    db.create_table(table, {"feature": "FLOAT"})
+
+    # Attempt 1 — the same calls the engine makes, cut off mid-ingest:
+    db.record_ingest_started(table, dead)
+    db.insert_batch(
+        table,
+        [
+            _rec("a1", feature=1.0, ingestor_id=dead),
+            _rec("a2", feature=2.0, ingestor_id=dead),
+        ],
+    )
+    # -- hard kill here: no send_ingest_summary, no #227 delete --
+    assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2
+
+    # Attempt 2 (the Job retry), in engine order:
+    reclaimed = db.reclaim_dead_run_rows(table, retry)
+    assert reclaimed == {dead: 2}
+    db.record_ingest_started(table, retry)
+    db.insert_batch(
+        table,
+        [
+            _rec("b1", feature=1.0, ingestor_id=retry),
+            _rec("b2", feature=2.0, ingestor_id=retry),
+        ],
+    )
+    db.mark_ingest_registered(table, retry)
+
+    assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2  # converged
+    owners = {r[0] for r in _query(f"SELECT DISTINCT ingestor_id FROM `{table}`")}
+    assert owners == {retry}
+    assert db.get_label_counts(table, retry) == {"": 2}
+
+
+def test_reclaim_never_touches_registered_or_legacy_rows(db, table):
+    """Safety contract: rows of a REGISTERED run (journaled start + mark) and
+    legacy rows that predate the journal entirely (no entry at all — every
+    pre-fix dataset, registered or not) must both survive the reclaim pass
+    untouched."""
+    registered, legacy = _run_id("registered"), _run_id("legacy")
+    db.create_table(table, {"feature": "FLOAT"})
+
+    db.record_ingest_started(table, registered)
+    db.insert_batch(table, [_rec("r1", feature=1.0, ingestor_id=registered)])
+    db.mark_ingest_registered(table, registered)
+
+    # Legacy run: rows only, no journal entry (ingested before the fix).
+    db.insert_batch(table, [_rec("l1", feature=2.0, ingestor_id=legacy)])
+
+    assert db.reclaim_dead_run_rows(table, _run_id("current")) == {}
+    assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2
+
+
+def test_reclaim_is_idempotent_and_excludes_current_run(db, table):
+    """Running the reclaim pass twice is safe (second pass finds nothing),
+    and the current run's own journaled-but-unregistered rows are never
+    touched — so the pass may re-run at any point of a live ingest."""
+    dead, current = _run_id("dead"), _run_id("current")
+    db.create_table(table, {"feature": "FLOAT"})
+
+    db.record_ingest_started(table, dead)
+    db.insert_batch(table, [_rec("d1", feature=1.0, ingestor_id=dead)])
+
+    db.record_ingest_started(table, current)
+    db.insert_batch(table, [_rec("c1", feature=2.0, ingestor_id=current)])
+
+    assert db.reclaim_dead_run_rows(table, current) == {dead: 1}
+    assert db.reclaim_dead_run_rows(table, current) == {}  # idempotent
+    rows = _query(f"SELECT data_id, ingestor_id FROM `{table}`")
+    assert rows == [("c1", current)]

--- a/e2e/test_ingest_e2e.py
+++ b/e2e/test_ingest_e2e.py
@@ -390,3 +390,86 @@ def test_tsc_sequence_semantics(tmp_path, monkeypatch):
     )
     cur.close()
     conn.close()
+
+
+def test_hard_killed_prior_run_reclaimed_by_retry(tmp_path, monkeypatch):
+    """backend#1028 item 2, engine-level: a prior attempt that died HARD
+    (OOMKilled / SIGKILL — journaled as started, rows inserted, never
+    registered, #227 compensating delete bypassed) must not leak duplicates
+    into the retry. The real engine, re-ingesting the same CSV into the same
+    table, reclaims the dead run's rows on start and converges to the CSV's
+    row count."""
+    import uuid as _uuid
+
+    from tracebloc_ingestor.config import Config
+    from tracebloc_ingestor.database import Database
+
+    table = "e2e_orphan_reclaim"
+    _drop(table)
+
+    # Simulate the hard-killed attempt with the same calls the engine makes
+    # (create table → journal start → insert a batch), then "die": no
+    # registration, no cleanup. Feature columns must match the retry's
+    # cleaned schema or the stale-table guard would trip first.
+    dead = "dead-" + _uuid.uuid4().hex[:8]
+    db = Database(Config())
+    db.create_table(
+        table,
+        {"feature_00": "FLOAT", "feature_01": "FLOAT", "feature_02": "FLOAT"},
+    )
+    db.record_ingest_started(table, dead)
+    db.insert_batch(
+        table,
+        [
+            {
+                "data_id": f"orphan-{i}",
+                "ingestor_id": dead,
+                "data_intent": "train",
+                "label": "0",
+                "feature_00": float(i),
+                "feature_01": float(i),
+                "feature_02": float(i),
+            }
+            for i in range(3)
+        ],
+    )
+    assert _rows(table) == 3
+
+    # The retry: run the real engine on the bundled tabular template (8 data
+    # rows) into the same table.
+    cfg = _cfg(
+        table=table,
+        category="tabular_classification",
+        csv=str(
+            T / "tabular_classification/tabular_classification_sample_in_csv_format.csv"
+        ),
+        schema={
+            "feature_00": "FLOAT",
+            "feature_01": "FLOAT",
+            "feature_02": "FLOAT",
+            "label": "INT",
+        },
+        label="label",
+    )
+    config_path = tmp_path / "ingest.yaml"
+    config_path.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("INGEST_CONFIG", str(config_path))
+
+    rc = run.main()
+    assert rc == 0, f"retry ingest exited {rc}"
+
+    # Converged: the 8 CSV rows, not 8 + 3 — the dead run's rows are gone.
+    assert _rows(table) == 8
+    conn = _connect()
+    cur = conn.cursor()
+    cur.execute(
+        f"SELECT COUNT(*) FROM `{table}` WHERE ingestor_id = %s", (dead,)
+    )
+    assert cur.fetchone()[0] == 0
+    cur.close()
+    conn.close()
+    # …and the retry registered (mock backend), so its rows are protected: a
+    # THIRD attempt's reclaim pass finds nothing to remove.
+    probe = "probe-" + _uuid.uuid4().hex[:8]
+    assert db.reclaim_dead_run_rows(table, probe) == {}
+    assert _rows(table) == 8

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -767,3 +767,101 @@ def test_get_label_counts_null_label_normalised_to_empty_string(db, mock_engine_
     ]
     result = db.get_label_counts("tbl", "ing-uuid")
     assert result == {"": 5, "cat": 5}
+
+
+# ---------------------------------------------------------------------------
+# Run journal: orphan-row reconciliation (backend#1028 item 2)
+# ---------------------------------------------------------------------------
+
+
+def _executed_sql(conn):
+    """The raw SQL text of every statement executed on the mock connection."""
+    return [str(call.args[0]) for call in conn.execute.call_args_list]
+
+
+def test_record_ingest_started_journals_idempotently(db, mock_engine_factory):
+    """Journaling a run's start must lazily create the journal table and use
+    INSERT IGNORE (idempotent re-entry), then commit — mirroring the salt
+    store's lazy-creation pattern (#225)."""
+    _, _, conn = mock_engine_factory
+    db.record_ingest_started("tbl", "run-a")
+    sql = _executed_sql(conn)
+    assert any(
+        "CREATE TABLE IF NOT EXISTS `tracebloc_ingest_runs`" in s for s in sql
+    )
+    assert any("INSERT IGNORE INTO `tracebloc_ingest_runs`" in s for s in sql)
+    conn.commit.assert_called()
+
+
+def test_mark_ingest_registered_flips_journal_flag(db, mock_engine_factory):
+    """Marking registration must UPDATE the run's journal row to
+    registered=1, scoped to this (ingestor_id, table_name)."""
+    _, _, conn = mock_engine_factory
+    db.mark_ingest_registered("tbl", "run-a")
+    update = next(s for s in _executed_sql(conn) if "UPDATE" in s)
+    assert "registered = 1" in update
+    assert "ingestor_id = :ingestor_id" in update
+    stmt = next(
+        c.args[0] for c in conn.execute.call_args_list if "UPDATE" in str(c.args[0])
+    )
+    assert stmt.compile().params == {"ingestor_id": "run-a", "table_name": "tbl"}
+    conn.commit.assert_called()
+
+
+def test_reclaim_dead_run_rows_deletes_each_dead_run(db, mock_engine_factory):
+    """The reconcile pass deletes rows per dead run via the #227
+    delete_by_ingestor_id (so logging/retry behavior is shared) and reports
+    ``{dead_id: deleted_count}``."""
+    _, _, conn = mock_engine_factory
+    conn.execute.return_value.fetchall.return_value = [("dead-a",), ("dead-b",)]
+    with patch.object(db, "delete_by_ingestor_id", side_effect=[3, 2]) as delete:
+        result = db.reclaim_dead_run_rows("tbl", "current-run")
+    assert result == {"dead-a": 3, "dead-b": 2}
+    delete.assert_any_call("tbl", "dead-a")
+    delete.assert_any_call("tbl", "dead-b")
+
+
+def test_reclaim_query_targets_only_unregistered_non_current_runs(
+    db, mock_engine_factory
+):
+    """The orphan query must (i) join the journal — rows that predate it
+    (legacy ingests) never match, (ii) require registered = 0, and (iii)
+    exclude the current run, so re-running the pass mid-ingest is safe."""
+    _, _, conn = mock_engine_factory
+    conn.execute.return_value.fetchall.return_value = []
+    db.reclaim_dead_run_rows("tbl", "current-run")
+    select = next(s for s in _executed_sql(conn) if "SELECT DISTINCT" in s)
+    assert "JOIN `tracebloc_ingest_runs`" in select
+    assert "registered = 0" in select
+    assert "!= :current_ingestor_id" in select
+    stmt = next(
+        c.args[0]
+        for c in conn.execute.call_args_list
+        if "SELECT DISTINCT" in str(c.args[0])
+    )
+    assert stmt.compile().params == {
+        "table_name": "tbl",
+        "current_ingestor_id": "current-run",
+    }
+
+
+def test_reclaim_dead_run_rows_noop_when_nothing_dead(db, mock_engine_factory):
+    """No journaled-started-unregistered ids owning rows → no deletes, empty
+    result (idempotency: the second pass after a reclaim hits this path)."""
+    _, _, conn = mock_engine_factory
+    conn.execute.return_value.fetchall.return_value = []
+    with patch.object(db, "delete_by_ingestor_id") as delete:
+        assert db.reclaim_dead_run_rows("tbl", "current-run") == {}
+    delete.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "reserved", ["tracebloc_ingest_meta", "tracebloc_ingest_runs"]
+)
+def test_create_table_rejects_reserved_bookkeeping_tables(reserved):
+    """The salt store (#225) and the run journal (backend#1028) share the
+    cluster MySQL with dataset tables — a dataset must not be able to claim
+    (and corrupt) either name. The guard runs before any DB I/O."""
+    db = Database.__new__(Database)
+    with pytest.raises(ValueError, match="reserved"):
+        db.create_table(reserved, {"feature_0": "FLOAT"})

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -1466,3 +1466,120 @@ def test_late_failure_after_registration_never_deletes():
             ing.ingest("src", batch_size=10)
     ing.api_client.send_ingest_summary.assert_called_once()
     ing.database.delete_by_ingestor_id.assert_not_called()
+
+
+# ── backend#1028 item 2: orphan-row reconciliation on start ──────────────────
+# The #227 compensating delete only runs on a CAUGHT failure. A hard kill
+# (OOMKilled / SIGKILL mid-ingest) bypasses it, leaving the dead run's rows in
+# the table with its dataset never registered — and the k8s Job retry then
+# duplicates them. Every ingest therefore (1) reclaims rows of
+# journaled-started-but-never-registered prior runs BEFORE processing,
+# (2) journals its own start BEFORE its first insert, and (3) journals its
+# registration right after send_ingest_summary returns.
+
+
+def _run_happy_ingest(ing):
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        return ing.ingest("src", batch_size=10)
+
+
+def test_reconcile_and_start_journal_run_before_first_insert():
+    """Order contract: create_table → reclaim orphans → journal own start →
+    first insert_batch. Reconciling after inserting would misread the run's
+    own rows; journaling after inserting would let a kill in between leave
+    rows the journal never heard about (undetectable orphans)."""
+    ing = make_ingestor(records=[{"a": "1"}], label_column="a")
+    _run_happy_ingest(ing)
+
+    ing.database.reclaim_dead_run_rows.assert_called_once_with(
+        ing.table_name, ing.ingestor_id
+    )
+    ing.database.record_ingest_started.assert_called_once_with(
+        ing.table_name, ing.ingestor_id
+    )
+    names = [name for name, _, _ in ing.database.mock_calls]
+    assert names.index("create_table") < names.index("reclaim_dead_run_rows")
+    assert names.index("reclaim_dead_run_rows") < names.index(
+        "record_ingest_started"
+    )
+    assert names.index("record_ingest_started") < names.index("insert_batch")
+
+
+def test_successful_registration_marks_journal_registered():
+    """After send_ingest_summary returns, the run must be journaled as
+    REGISTERED — the durable marker that stops any future reconcile pass from
+    reclaiming this run's rows."""
+    ing = make_ingestor(records=[{"a": "1"}], label_column="a")
+    _run_happy_ingest(ing)
+    ing.database.mark_ingest_registered.assert_called_once_with(
+        ing.table_name, ing.ingestor_id
+    )
+
+
+def test_failed_registration_never_marks_journal_registered():
+    """A run whose registration failed must stay started-but-unregistered in
+    the journal (its rows are removed by the #227 delete anyway, which still
+    fires — asserted here so the two cleanups are known to coexist)."""
+    ing = make_ingestor(records=[{"a": "1"}], label_column="a")
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError(
+        "backend rejected"
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError):
+            ing.ingest("src", batch_size=10)
+    ing.database.mark_ingest_registered.assert_not_called()
+    ing.database.delete_by_ingestor_id.assert_called_once_with(
+        ing.table_name, ing.ingestor_id
+    )
+
+
+def test_mark_registered_failure_never_fails_a_registered_run(caplog):
+    """The journal UPDATE failing AFTER successful registration must not fail
+    the run (the dataset exists!) nor trigger the #227 delete — raising here
+    would hand the retry a journal entry telling it to purge a registered
+    dataset's rows. Logged CRITICAL instead."""
+    import logging
+
+    ing = make_ingestor(records=[{"a": "1"}], label_column="a")
+    ing.database.mark_ingest_registered.side_effect = Exception("journal down")
+    with caplog.at_level(logging.CRITICAL):
+        _run_happy_ingest(ing)  # must NOT raise
+    ing.database.delete_by_ingestor_id.assert_not_called()
+    assert any(
+        "Failed to journal registration" in r.message for r in caplog.records
+    )
+
+
+def test_reclaim_failure_never_blocks_the_ingest(caplog):
+    """Reconciliation failing (journal table unreachable, unexpected SQL
+    error) must degrade to today's status quo — orphans stay, the ingest
+    itself proceeds — never brick every ingest into that table. Logged
+    CRITICAL."""
+    import logging
+
+    ing = make_ingestor(records=[{"a": "1"}], label_column="a")
+    ing.database.reclaim_dead_run_rows.side_effect = Exception("mysql sick")
+    with caplog.at_level(logging.CRITICAL):
+        _run_happy_ingest(ing)  # must NOT raise
+    ing.database.insert_batch.assert_called()
+    ing.database.record_ingest_started.assert_called_once()
+    assert any(
+        "Orphan-row reconciliation failed" in r.message for r in caplog.records
+    )
+
+
+def test_zero_record_run_journals_start_but_not_registered():
+    """A run that inserts nothing sends no summary, so it must journal its
+    start but never its registration — its (row-less) journal entry is inert
+    for future reconcile passes, which only reclaim ids that still own rows."""
+    ing = make_ingestor(records=[], label_column="a")
+    ing.database.get_label_counts.return_value = {}
+    _run_happy_ingest(ing)
+    ing.database.record_ingest_started.assert_called_once()
+    ing.database.mark_ingest_registered.assert_not_called()

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -243,10 +243,11 @@ class Database:
                 or if ``index_columns`` references a column absent from
                 ``schema``.
         """
-        if table_name == self.SALT_TABLE:
+        if table_name in (self.SALT_TABLE, self.RUNS_TABLE):
             raise ValueError(
-                f"{table_name!r} is reserved for the content-hash salt store "
-                "(#225) and cannot be used as a dataset table."
+                f"{table_name!r} is reserved for tracebloc ingest bookkeeping "
+                "(the content-hash salt store #225 / the run journal "
+                "backend#1028) and cannot be used as a dataset table."
             )
         # Fail fast on reserved-column collisions before any DB I/O. `label`
         # is intentionally excluded — it's the user-facing label column the
@@ -631,6 +632,147 @@ class Database:
                 f"table {table_name!r}."
             )
         return row[0]
+
+    # ── Run journal: orphan-row reconciliation (backend#1028 item 2) ────────
+    #
+    # The #227 compensating delete removes a failed run's rows only when the
+    # failure is CAUGHT. A hard kill (OOMKilled / SIGKILL mid-ingest) never
+    # reaches that except-branch, so the dead run's rows stay in the table
+    # while its dataset was never registered — and the k8s Job retry then
+    # ingests the same source next to them under fresh data_ids, duplicating
+    # every row. "Registered" exists only in the central backend
+    # (send_ingest_summary), which exposes no lookup, so this cluster-local
+    # journal records each run's lifecycle in the same MySQL the rows land in:
+    #
+    #   record_ingest_started   — journaled before the run's first row insert
+    #   mark_ingest_registered  — right after send_ingest_summary returns
+    #   reclaim_dead_run_rows   — at the start of every ingest: delete rows
+    #                             whose ingestor_id was journaled as started
+    #                             but never registered (a dead prior attempt)
+    #
+    # Rows are reclaimed ONLY when the journal witnessed their run start and
+    # never saw it register. Rows that predate the journal (legacy ingests —
+    # registered or not) have no started-entry and are never touched, so
+    # shipping this cannot delete rows of any pre-existing dataset.
+
+    RUNS_TABLE = "tracebloc_ingest_runs"
+
+    def _ensure_runs_table(self, connection) -> None:
+        """Create the run-journal table if missing. Idempotent DDL, mirroring
+        the salt store's lazy creation (#225) — no migration step needed."""
+        _execute_with_retry(
+            connection,
+            text(
+                f"CREATE TABLE IF NOT EXISTS `{self.RUNS_TABLE}` ("
+                "  ingestor_id VARCHAR(64) NOT NULL PRIMARY KEY,"
+                "  table_name VARCHAR(64) NOT NULL,"
+                "  registered TINYINT(1) NOT NULL DEFAULT 0,"
+                "  started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,"
+                "  registered_at TIMESTAMP NULL DEFAULT NULL,"
+                "  KEY ix_tracebloc_ingest_runs_table (table_name)"
+                ")"
+            ),
+        )
+
+    def record_ingest_started(self, table_name: str, ingestor_id: str) -> None:
+        """Journal that *ingestor_id* is about to insert rows into
+        *table_name* (backend#1028 item 2).
+
+        Must be called before the run's first ``insert_batch`` so that a hard
+        kill at ANY later point leaves a started-but-unregistered journal
+        entry behind — the marker :meth:`reclaim_dead_run_rows` uses to
+        recognise the dead run's rows on the next attempt. ``INSERT IGNORE``
+        keeps it idempotent (re-entry with the same ingestor_id is a no-op).
+        """
+        with self.engine.connect() as connection:
+            self._ensure_runs_table(connection)
+            _execute_with_retry(
+                connection,
+                text(
+                    f"INSERT IGNORE INTO `{self.RUNS_TABLE}` "
+                    "(ingestor_id, table_name) "
+                    "VALUES (:ingestor_id, :table_name)"
+                ).bindparams(ingestor_id=ingestor_id, table_name=table_name),
+            )
+            connection.commit()
+
+    def mark_ingest_registered(self, table_name: str, ingestor_id: str) -> None:
+        """Flip the run's journal entry to REGISTERED (backend#1028 item 2).
+
+        Called immediately after ``send_ingest_summary`` returns — the same
+        point that flips the #227 ``dataset_registered`` guard — so no future
+        reconcile pass can mistake this run's rows for orphans. Idempotent
+        (repeating the UPDATE is a no-op).
+        """
+        with self.engine.connect() as connection:
+            self._ensure_runs_table(connection)
+            _execute_with_retry(
+                connection,
+                text(
+                    f"UPDATE `{self.RUNS_TABLE}` "
+                    "SET registered = 1, registered_at = CURRENT_TIMESTAMP "
+                    "WHERE ingestor_id = :ingestor_id "
+                    "AND table_name = :table_name"
+                ).bindparams(ingestor_id=ingestor_id, table_name=table_name),
+            )
+            connection.commit()
+
+    def reclaim_dead_run_rows(
+        self, table_name: str, current_ingestor_id: str
+    ) -> Dict[str, int]:
+        """Reconcile-on-start (backend#1028 item 2): delete rows left in
+        *table_name* by prior attempts that died without registering.
+
+        A prior run's rows are orphans exactly when its ``ingestor_id``
+        (i) still owns rows in the table, (ii) was journaled as STARTED, and
+        (iii) was never journaled as REGISTERED — i.e. the run began
+        inserting and then died hard (OOMKilled / SIGKILL) before it could
+        register, bypassing the #227 compensating delete. Requiring the
+        started-entry means rows that predate the journal are NEVER touched,
+        and (iii) excludes every registered run, so no registered dataset's
+        rows can be deleted. ``current_ingestor_id`` is excluded so the pass
+        is idempotent and safe to re-run at any point of the current ingest.
+
+        Runs under the caller's table lock (``BaseIngestor.ingest``), so a
+        journaled-started run for this table cannot still be live. Reuses
+        :meth:`delete_by_ingestor_id` per dead run (transient-retry wrapped,
+        logs each count).
+
+        Returns:
+            ``{dead_ingestor_id: rows_deleted}`` — empty when there is
+            nothing to reclaim.
+        """
+        safe_table = table_name.replace("`", "``")
+        with self.engine.connect() as connection:
+            self._ensure_runs_table(connection)
+            rows = _execute_with_retry(
+                connection,
+                text(
+                    f"SELECT DISTINCT d.ingestor_id "
+                    f"FROM `{safe_table}` d "
+                    f"JOIN `{self.RUNS_TABLE}` r "
+                    f"ON r.ingestor_id = d.ingestor_id "
+                    f"WHERE r.table_name = :table_name "
+                    f"AND r.registered = 0 "
+                    f"AND r.ingestor_id != :current_ingestor_id"
+                ).bindparams(
+                    table_name=table_name,
+                    current_ingestor_id=current_ingestor_id,
+                ),
+            ).fetchall()
+        reclaimed: Dict[str, int] = {}
+        for (dead_id,) in rows:
+            reclaimed[dead_id] = self.delete_by_ingestor_id(table_name, dead_id)
+        if reclaimed:
+            logger.warning(
+                f"Reclaimed {sum(reclaimed.values())} orphan row(s) in "
+                f"`{table_name}` from {len(reclaimed)} dead unregistered "
+                f"run(s) {sorted(reclaimed)} — left by a previous attempt "
+                f"killed before it could register or clean up "
+                f"(backend#1028); this run now converges instead of "
+                f"duplicating them."
+            )
+        return reclaimed
 
     def get_label_counts(self, table_name: str, ingestor_id: str) -> Dict[str, int]:
         """

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -529,6 +529,37 @@ class BaseIngestor(ABC):
                 self.table_name, self._table_schema, index_columns=index_columns
             )
 
+        # Reconcile-on-start (backend#1028 item 2): a prior attempt that died
+        # HARD (OOMKilled / SIGKILL) never reached the #227 compensating
+        # delete in the except-branch below, so its rows are still in the
+        # table while its dataset was never registered — and this run (the
+        # k8s Job retry re-ingests the SAME source into the SAME table) would
+        # otherwise duplicate every one of them under fresh data_ids. Reclaim
+        # those orphans BEFORE processing: the run journal knows exactly
+        # which ingestor_ids started here and never registered. Runs under
+        # the table lock, like the rest of this method. Defensive try/except:
+        # a reconcile failure must never block an otherwise healthy ingest —
+        # the fallback is simply today's status quo (the orphans stay), and
+        # this run's own counts are unaffected because every summary query
+        # is scoped to its ingestor_id.
+        try:
+            self.database.reclaim_dead_run_rows(self.table_name, self.ingestor_id)
+        except Exception as reclaim_error:
+            logger.critical(
+                f"Orphan-row reconciliation failed for table "
+                f"{self.table_name!r}: {reclaim_error}. Continuing the "
+                f"ingest — rows left by a previous hard-killed run may "
+                f"remain in the table (backend#1028)."
+            )
+        # Journal this run as STARTED before its first row insert, so that if
+        # THIS process dies hard at any later point, the next attempt's
+        # reconcile pass can recognise (and reclaim) whatever rows it left
+        # behind. Deliberately NOT wrapped: if MySQL can't take this one-row
+        # insert, the batch inserts below would fail anyway — better to fail
+        # now, before any row lands, than to insert rows the journal never
+        # heard about.
+        self.database.record_ingest_started(self.table_name, self.ingestor_id)
+
         batch = []
         failed_records = []
 
@@ -784,6 +815,30 @@ class BaseIngestor(ABC):
                         meta_data=self.file_options,
                     )
                     dataset_registered = True
+                    # Durably flip the run journal to REGISTERED
+                    # (backend#1028 item 2) so no future reconcile pass can
+                    # mistake this run's rows for orphans. Swallow-and-log on
+                    # failure: the dataset IS registered — raising here would
+                    # fail a healthy run and, worse, hand the retry a
+                    # started-but-unregistered journal entry telling it to
+                    # delete a registered dataset's rows. The residual window
+                    # (process killed between send_ingest_summary returning
+                    # and this UPDATE committing) is strictly narrower than
+                    # the #227 two-generals window documented below.
+                    try:
+                        self.database.mark_ingest_registered(
+                            self.table_name, self.ingestor_id
+                        )
+                    except Exception as journal_error:
+                        logger.critical(
+                            f"Failed to journal registration for "
+                            f"ingestor_id={self.ingestor_id!r} in table "
+                            f"{self.table_name!r}: {journal_error}. A future "
+                            f"ingest into this table could reclaim this "
+                            f"registered dataset's rows as orphans "
+                            f"(backend#1028) — investigate before "
+                            f"re-ingesting into this table."
+                        )
                     stats["api_sent_records"] = stats["inserted_records"]
 
                 summary = IngestionSummary(**stats)


### PR DESCRIPTION
## Summary
An OOMKill/SIGKILL mid-ingest bypasses the #227 compensating delete (it only runs on a *caught* failure), so the dead run's rows stay in MySQL while its dataset was never registered — and the k8s Job retry then re-ingests the same source next to them under fresh `data_id`s, duplicating every row. This adds a cluster-local **run journal** and a **reconcile-on-start pass**: every ingest first reclaims rows left by prior runs that were journaled as *started* but never *registered*, so a retry converges instead of duplicating.

## Related
Ref tracebloc/backend#1028 (item 2)

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Design
"Registered" exists only in the central backend (`send_ingest_summary`, no lookup endpoint), so the journal lives in the same cluster MySQL the rows land in — a `tracebloc_ingest_runs` table created lazily like the #225 salt store (no migration step):

- `record_ingest_started` — journaled **before the run's first row insert**, so a hard kill at any later point leaves a started-but-unregistered entry behind (`INSERT IGNORE`, idempotent).
- `mark_ingest_registered` — right after `send_ingest_summary` returns, at the same point that flips the #227 `dataset_registered` guard.
- `reclaim_dead_run_rows` — at ingest start (after `create_table`, under the existing table lock): deletes rows whose `ingestor_id` was journaled as started and never registered, via the existing #227 `delete_by_ingestor_id`, with a WARNING naming the reclaimed runs and row counts.

**Why it's safe:**
- Rows are reclaimed **only** when the journal witnessed the run start and never saw it register. Registered runs are excluded by the mark; rows that predate the journal (every pre-fix dataset, registered or not) have no started-entry and are **never touched** — shipping this cannot delete rows of any existing dataset.
- Idempotent: the pass excludes the current run and a second pass finds nothing; both journal writes are re-entrant.
- Failure-isolated: a reconcile error is logged CRITICAL and the ingest proceeds (degrades to today's status quo — orphans stay, and the run's own summary counts are unaffected because every query is scoped to its `ingestor_id`). A `mark_ingest_registered` failure after successful registration is likewise swallowed with CRITICAL — raising would fail a healthy run and hand the retry a journal entry telling it to purge a registered dataset's rows.
- Residual two-generals window (killed between `send_ingest_summary` returning and the one-row journal UPDATE committing → the retry reclaims a backend-registered dataset's rows and re-registers under a new id): strictly narrower than the #227 window already documented in `base.py` for the caught-failure path, with the same recovery (the retry re-ingests from source).

**Known limitation (called out, not hidden):** orphans left by hard kills *before this ships* have no journal entry and are deliberately not reclaimed — locally they are indistinguishable from legacy registered datasets, and constraint one is never deleting registered rows. They remain sweepable by `ingestor_id` as before. Also note the reclaim runs when the next ingest on that table actually starts; on PVC-backed clusters a hard-killed run's stale table lock can delay that retry (existing 12h stale-reclaim behavior, unchanged here).

## Test plan
- `pytest --cov=tracebloc_ingestor --cov-fail-under=95` (mirrors `tests.yml`, Python 3.11): **1626 passed, 1 xfailed**, coverage 96.09% — all new lines covered.
- `docker compose -f e2e/docker-compose.yml up -d` + `pytest e2e/ -v` against real MySQL 8 (mirrors `e2e.yml`): **47 passed**, including 4 new tests:
  - hard-killed run (journaled start + rows, no registration) → retry reclaims exactly those rows and converges (DB-level and full-engine-level via `run.main()` on the bundled tabular template: 8 rows, not 8+3);
  - registered runs and pre-journal legacy rows survive the pass untouched;
  - reclaim is idempotent and never touches the current run's rows.
- New unit tests pin the orchestration order (`create_table` → reclaim → journal start → first insert; mark-registered only after a successful summary) and the failure isolation (reclaim/mark failures never fail a healthy run, `#227` delete still fires on caught failures).
- Not tested: a real OOMKilled pod on a cluster — simulated instead as "rows present + journaled started + never registered", which is byte-identical to the post-kill DB state.

## Deployment notes
No migration: the journal table is created lazily on first use, and the first deploy sees an empty journal (reconcile no-ops). No config/env changes. The two bookkeeping table names are now rejected as dataset table names.

## Checklist
- [x] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [x] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes rows by `ingestor_id` when the journal says started-but-unregistered; mis-journaling or the narrow post-registration window could affect live data, though registered and pre-journal rows are explicitly excluded.
> 
> **Overview**
> Fixes **duplicate rows on k8s Job retry** when a prior ingest was **hard-killed** (OOM/SIGKILL) after inserting into MySQL but before backend registration — a path that bypasses the existing #227 compensating delete.
> 
> Adds a cluster-local **`tracebloc_ingest_runs` journal** (lazy DDL, like the salt store) with **`record_ingest_started`**, **`mark_ingest_registered`**, and **`reclaim_dead_run_rows`**. **`BaseIngestor.ingest`** now runs **reconcile → journal start → inserts**, then marks registered after a successful **`send_ingest_summary`**. Reclaim only targets **journaled started + never registered** `ingestor_id`s (join with data rows); **legacy rows without journal entries** and **registered runs** are excluded. **`create_table`** also rejects **`tracebloc_ingest_runs`** as a dataset name.
> 
> **Failure isolation:** reconcile errors are logged CRITICAL and ingest continues; post-registration journal failures are swallowed so a registered dataset is not failed or deleted. Unit and MySQL e2e tests cover ordering, safety, idempotency, and full-engine retry convergence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab4481c3f254e13798f1ba88be91954ba7e8fcfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->