### PR TITLE
feat(ingest): optional enriched schema with role:target for combine-time alignment (#360)

### DIFF
--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -356,3 +356,22 @@ def test_json_source_dispatches_correctly():
     r = resolve(config)
     assert r.source_type == "json"
     assert r.source_path == "/data/events.json"
+
+
+# ---------------------------------------------------------------------------
+# Uploader-declared per-column descriptors (di#360)
+# ---------------------------------------------------------------------------
+
+def test_columns_bridge_into_file_options():
+    """Top-level `columns` (unit/ordinal) is carried on file_options as
+    `column_descriptors`, where BaseIngestor merges it into the enriched
+    schema."""
+    config = _load("tabular_classification.yaml")
+    config["columns"] = {"age": {"unit": "years"}}
+    r = resolve(config)
+    assert r.file_options["column_descriptors"] == {"age": {"unit": "years"}}
+
+
+def test_no_columns_leaves_no_descriptors():
+    r = resolve(_load("tabular_classification.yaml"))
+    assert "column_descriptors" not in r.file_options

--- a/tests/test_enriched_schema.py
+++ b/tests/test_enriched_schema.py
@@ -75,11 +75,16 @@ def test_enriched_shape_and_target_role_for_supervised():
 
     out = ing._schema_payload(flat)
 
-    # dtype is the CANONICAL logical type, not the raw storage type.
-    assert out["a"] == {"dtype": "int"}
-    assert out["b"] == {"dtype": "string"}
+    # dtype is the CANONICAL logical type, not the raw storage type; every column
+    # states the ingested null encoding (missing → SQL NULL).
+    assert out["a"] == {"dtype": "int", "null_encoding": "null"}
+    assert out["b"] == {"dtype": "string", "null_encoding": "null"}
     # `label` is the framework target column → role:"target" for supervised.
-    assert out["label"] == {"dtype": "float", "role": "target"}
+    assert out["label"] == {
+        "dtype": "float",
+        "role": "target",
+        "null_encoding": "null",
+    }
 
 
 def test_dtype_is_canonicalized_across_storage_variants():
@@ -98,7 +103,7 @@ def test_no_target_role_for_self_supervised():
     ing = make_ingestor(enriched=True, label_column=None)
     out = ing._schema_payload({"a": "INT", "label": "VARCHAR(255)"})
 
-    assert out["label"] == {"dtype": "string"}
+    assert out["label"] == {"dtype": "string", "null_encoding": "null"}
     assert "role" not in out["label"]
 
 
@@ -116,8 +121,12 @@ def test_declared_unit_and_ordinal_merged_into_descriptors():
         },
     )
     out = ing._schema_payload({"a": "INT", "b": "VARCHAR(10)"})
-    assert out["a"] == {"dtype": "int", "unit": "years"}
-    assert out["b"] == {"dtype": "string", "ordinal": ["low", "med", "high"]}
+    assert out["a"] == {"dtype": "int", "null_encoding": "null", "unit": "years"}
+    assert out["b"] == {
+        "dtype": "string",
+        "null_encoding": "null",
+        "ordinal": ["low", "med", "high"],
+    }
 
 
 def test_declared_descriptor_for_unknown_column_ignored():
@@ -126,7 +135,23 @@ def test_declared_descriptor_for_unknown_column_ignored():
         file_options={"column_descriptors": {"ghost": {"unit": "kg"}}},
     )
     out = ing._schema_payload({"a": "INT"})
-    assert out == {"a": {"dtype": "int"}}
+    assert out == {"a": {"dtype": "int", "null_encoding": "null"}}
+
+
+def test_bool_and_null_encoding():
+    ing = make_ingestor(enriched=True, label_column=None)
+    out = ing._schema_payload({"flag": "BOOLEAN", "age": "INT", "name": "VARCHAR(9)"})
+
+    # Bool columns state the stored 1/0 encoding; non-bool columns don't.
+    assert out["flag"] == {
+        "dtype": "bool",
+        "null_encoding": "null",
+        "bool_encoding": "1/0",
+    }
+    assert "bool_encoding" not in out["age"]
+    assert "bool_encoding" not in out["name"]
+    # Every column states the null encoding.
+    assert all(d["null_encoding"] == "null" for d in out.values())
 
 
 def test_declared_descriptors_ignored_when_gate_off():

--- a/tests/test_enriched_schema.py
+++ b/tests/test_enriched_schema.py
@@ -1,0 +1,98 @@
+"""Tests for the enriched-schema emission (data-ingestors#360 slice 1b).
+
+The emitted ``schema`` gains an optional per-column object shape
+``{col: {dtype, role}}`` behind the ``EMIT_ENRICHED_SCHEMA`` gate — a breaking
+wire-format change cut over with backend#1037. Default stays the flat
+``{col: SQL_type}`` map. The framework ``label`` column carries
+``role: "target"`` for supervised tasks so combine-time alignment identifies
+the prediction target from the contract instead of inferring it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+
+
+def make_ingestor(*, enriched: bool, label_column=None):
+    db = MagicMock()
+    db.config = Config(EMIT_ENRICHED_SCHEMA=enriched)
+    api = MagicMock()
+    return CSVIngestor(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=None,
+        label_column=label_column,
+    )
+
+
+# ---- the config gate ----------------------------------------------------
+
+
+def test_gate_defaults_off(monkeypatch):
+    monkeypatch.delenv("EMIT_ENRICHED_SCHEMA", raising=False)
+    assert Config().EMIT_ENRICHED_SCHEMA is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "On"])
+def test_gate_truthy_env(monkeypatch, val):
+    monkeypatch.setenv("EMIT_ENRICHED_SCHEMA", val)
+    assert Config().EMIT_ENRICHED_SCHEMA is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "", "maybe"])
+def test_gate_falsy_env(monkeypatch, val):
+    monkeypatch.setenv("EMIT_ENRICHED_SCHEMA", val)
+    assert Config().EMIT_ENRICHED_SCHEMA is False
+
+
+def test_gate_override_wins_over_env(monkeypatch):
+    monkeypatch.setenv("EMIT_ENRICHED_SCHEMA", "true")
+    assert Config(EMIT_ENRICHED_SCHEMA=False).EMIT_ENRICHED_SCHEMA is False
+
+
+# ---- the schema payload -------------------------------------------------
+
+
+def test_flat_schema_unchanged_when_gate_off():
+    ing = make_ingestor(enriched=False, label_column="y")
+    flat = {"a": "INT", "b": "VARCHAR(255)", "label": "VARCHAR(255)"}
+    # Identity: the legacy shape ships verbatim, target unmarked.
+    assert ing._schema_payload(flat) == flat
+
+
+def test_enriched_shape_and_target_role_for_supervised():
+    ing = make_ingestor(enriched=True, label_column="y")
+    flat = {"a": "INT", "b": "VARCHAR(255)", "label": "VARCHAR(255)"}
+
+    out = ing._schema_payload(flat)
+
+    assert out["a"] == {"dtype": "INT"}
+    assert out["b"] == {"dtype": "VARCHAR(255)"}
+    # `label` is the framework target column → role:"target" for supervised.
+    assert out["label"] == {"dtype": "VARCHAR(255)", "role": "target"}
+
+
+def test_no_target_role_for_self_supervised():
+    # No label_column (e.g. masked language modeling) → the `label` column is
+    # present but is not a prediction target, so it must not be marked.
+    ing = make_ingestor(enriched=True, label_column=None)
+    out = ing._schema_payload({"a": "INT", "label": "VARCHAR(255)"})
+
+    assert out["label"] == {"dtype": "VARCHAR(255)"}
+    assert "role" not in out["label"]
+
+
+def test_enriched_does_not_mutate_input():
+    ing = make_ingestor(enriched=True, label_column="y")
+    flat = {"a": "INT", "label": "VARCHAR(255)"}
+    ing._schema_payload(flat)
+    # The caller's dict is untouched (values still strings).
+    assert flat == {"a": "INT", "label": "VARCHAR(255)"}

--- a/tests/test_enriched_schema.py
+++ b/tests/test_enriched_schema.py
@@ -18,7 +18,7 @@ from tracebloc_ingestor.config import Config
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
 
 
-def make_ingestor(*, enriched: bool, label_column=None):
+def make_ingestor(*, enriched: bool, label_column=None, file_options=None):
     db = MagicMock()
     db.config = Config(EMIT_ENRICHED_SCHEMA=enriched)
     api = MagicMock()
@@ -30,6 +30,7 @@ def make_ingestor(*, enriched: bool, label_column=None):
         intent="train",
         category=None,
         label_column=label_column,
+        file_options=file_options,
     )
 
 
@@ -99,6 +100,43 @@ def test_no_target_role_for_self_supervised():
 
     assert out["label"] == {"dtype": "string"}
     assert "role" not in out["label"]
+
+
+def test_declared_unit_and_ordinal_merged_into_descriptors():
+    # Uploader-declared column descriptors (di#360) ride on file_options and are
+    # merged into the enriched schema for columns that exist in it.
+    ing = make_ingestor(
+        enriched=True,
+        label_column="y",
+        file_options={
+            "column_descriptors": {
+                "a": {"unit": "years"},
+                "b": {"ordinal": ["low", "med", "high"]},
+            }
+        },
+    )
+    out = ing._schema_payload({"a": "INT", "b": "VARCHAR(10)"})
+    assert out["a"] == {"dtype": "int", "unit": "years"}
+    assert out["b"] == {"dtype": "string", "ordinal": ["low", "med", "high"]}
+
+
+def test_declared_descriptor_for_unknown_column_ignored():
+    ing = make_ingestor(
+        enriched=True,
+        file_options={"column_descriptors": {"ghost": {"unit": "kg"}}},
+    )
+    out = ing._schema_payload({"a": "INT"})
+    assert out == {"a": {"dtype": "int"}}
+
+
+def test_declared_descriptors_ignored_when_gate_off():
+    # Descriptors are part of the enriched contract; the flat legacy shape
+    # carries none.
+    ing = make_ingestor(
+        enriched=False,
+        file_options={"column_descriptors": {"a": {"unit": "years"}}},
+    )
+    assert ing._schema_payload({"a": "INT"}) == {"a": "INT"}
 
 
 def test_enriched_does_not_mutate_input():

--- a/tests/test_enriched_schema.py
+++ b/tests/test_enriched_schema.py
@@ -70,14 +70,25 @@ def test_flat_schema_unchanged_when_gate_off():
 
 def test_enriched_shape_and_target_role_for_supervised():
     ing = make_ingestor(enriched=True, label_column="y")
-    flat = {"a": "INT", "b": "VARCHAR(255)", "label": "VARCHAR(255)"}
+    flat = {"a": "INT", "b": "VARCHAR(255)", "label": "DECIMAL(10,2)"}
 
     out = ing._schema_payload(flat)
 
-    assert out["a"] == {"dtype": "INT"}
-    assert out["b"] == {"dtype": "VARCHAR(255)"}
+    # dtype is the CANONICAL logical type, not the raw storage type.
+    assert out["a"] == {"dtype": "int"}
+    assert out["b"] == {"dtype": "string"}
     # `label` is the framework target column → role:"target" for supervised.
-    assert out["label"] == {"dtype": "VARCHAR(255)", "role": "target"}
+    assert out["label"] == {"dtype": "float", "role": "target"}
+
+
+def test_dtype_is_canonicalized_across_storage_variants():
+    # Two datasets whose "same" column differs only in storage width/size must
+    # canonicalize to the SAME logical dtype (so #1037 doesn't spuriously block).
+    ing = make_ingestor(enriched=True, label_column=None)
+    a = ing._schema_payload({"name": "VARCHAR(255)", "n": "BIGINT"})
+    b = ing._schema_payload({"name": "VARCHAR(100)", "n": "INT"})
+    assert a["name"]["dtype"] == b["name"]["dtype"] == "string"
+    assert a["n"]["dtype"] == b["n"]["dtype"] == "int"
 
 
 def test_no_target_role_for_self_supervised():
@@ -86,7 +97,7 @@ def test_no_target_role_for_self_supervised():
     ing = make_ingestor(enriched=True, label_column=None)
     out = ing._schema_payload({"a": "INT", "label": "VARCHAR(255)"})
 
-    assert out["label"] == {"dtype": "VARCHAR(255)"}
+    assert out["label"] == {"dtype": "string"}
     assert "role" not in out["label"]
 
 
@@ -94,5 +105,5 @@ def test_enriched_does_not_mutate_input():
     ing = make_ingestor(enriched=True, label_column="y")
     flat = {"a": "INT", "label": "VARCHAR(255)"}
     ing._schema_payload(flat)
-    # The caller's dict is untouched (values still strings).
+    # The caller's dict is untouched (values still storage-type strings).
     assert flat == {"a": "INT", "label": "VARCHAR(255)"}

--- a/tests/test_schema_inference.py
+++ b/tests/test_schema_inference.py
@@ -15,9 +15,49 @@ import pytest
 
 from tracebloc_ingestor.schema_inference import (
     SAMPLE_CAP,
+    canonical_dtype,
     infer_column_type,
     infer_schema,
 )
+
+
+@pytest.mark.parametrize(
+    "sql_type,expected",
+    [
+        ("INT", "int"),
+        ("integer", "int"),
+        ("BIGINT", "int"),
+        ("SMALLINT", "int"),
+        ("TINYINT", "int"),
+        ("FLOAT", "float"),
+        ("DOUBLE", "float"),
+        ("DECIMAL(10,2)", "float"),
+        ("NUMERIC", "float"),
+        ("BOOLEAN", "bool"),
+        ("BOOL", "bool"),
+        ("VARCHAR(255)", "string"),
+        ("CHAR(3)", "string"),
+        ("TEXT", "string"),
+        ("DATE", "date"),
+        ("DATETIME", "datetime"),
+        ("TIMESTAMP", "datetime"),
+        ("TIME", "time"),
+        ("BLOB", "binary"),
+    ],
+)
+def test_canonical_dtype_maps_storage_types(sql_type, expected):
+    assert canonical_dtype(sql_type) == expected
+
+
+def test_canonical_dtype_folds_width_and_size_variants():
+    # Width/size differences must not read as a type divergence at combine time.
+    assert canonical_dtype("VARCHAR(255)") == canonical_dtype("VARCHAR(100)")
+    assert canonical_dtype("INT") == canonical_dtype("BIGINT")
+
+
+def test_canonical_dtype_unknown_falls_through_lowercased():
+    # Honest passthrough rather than a silent coercion to "string".
+    assert canonical_dtype("GEOMETRY") == "geometry"
 
 _FIXTURE = Path(__file__).parent / "fixtures" / "schema_inference_parity.json"
 _PARITY = json.loads(_FIXTURE.read_text())

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -252,6 +252,31 @@ def test_tabular_without_schema_rejected(validator):
         validator.validate(config)
 
 
+def test_columns_descriptors_accepted(validator):
+    # Optional per-column alignment descriptors (di#360): unit + ordinal.
+    config = _load_example("tabular_classification.yaml")
+    config["columns"] = {
+        "age": {"unit": "years"},
+        "size": {"ordinal": ["low", "med", "high"]},
+    }
+    validator.validate(config)  # must not raise
+
+
+def test_columns_unknown_descriptor_key_rejected(validator):
+    # additionalProperties:false on the descriptor catches typos like "units".
+    config = _load_example("tabular_classification.yaml")
+    config["columns"] = {"age": {"units": "years"}}
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
+def test_columns_ordinal_must_be_string_array(validator):
+    config = _load_example("tabular_classification.yaml")
+    config["columns"] = {"size": {"ordinal": [1, 2, 3]}}
+    with pytest.raises(ValidationError):
+        validator.validate(config)
+
+
 def test_masked_language_modeling_with_label_rejected(validator):
     """Issue #213: self-supervised categories (MLM, …) MUST NOT carry a
     `label:` field. The CSV has no label column, and the framework registers

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -220,7 +220,7 @@ class APIClient:
         data_format: str,
         data_intent: str,
         category: str,
-        schema: Dict[str, str],
+        schema: Dict[str, Any],
         samples: List[Dict[str, Any]],
         meta_data: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -335,6 +335,15 @@ def resolve(config: Dict[str, Any]) -> ResolvedConfig:
     ):
         resolved.file_options["number_of_keypoints"] = config["number_of_keypoints"]
 
+    # 7c. Uploader-declared per-column descriptors (`unit`, `ordinal`) — the
+    #     alignment facts that CAN'T be inferred from the data (di#360). Carried
+    #     on file_options so BaseIngestor merges them into the enriched schema
+    #     descriptors, where the backend's combine-time checks read them (a USD
+    #     vs EUR `unit` mismatch is a silent federated-data hazard). Same
+    #     spec.file_options-wins precedence as the bridges above.
+    if "columns" in config and "column_descriptors" not in spec_file_options:
+        resolved.file_options["column_descriptors"] = config["columns"]
+
     # 8. annotation_column — keypoint_detection's existing template uses
     #    column "Annotation" (the keypoint coords carried in the CSV). The
     #    YAML schema doesn't expose this directly in v1; we honour the

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -42,7 +42,12 @@ class Config:
         "BACKEND_TOKEN", "CLIENT_USERNAME", "CLIENT_PASSWORD",
         "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
         "LOG_LEVEL",
+        "EMIT_ENRICHED_SCHEMA",
     })
+
+    # Env values (case-insensitive) that read as boolean true; anything else
+    # (including unset) is false.
+    _TRUE_STRINGS = frozenset({"1", "true", "yes", "on"})
 
     # Numeric fields whose properties unconditionally coerce via ``int(...)``.
     # ``Config(FIELD=None)`` works for nullable fields (BACKEND_TOKEN etc.)
@@ -191,6 +196,25 @@ class Config:
         if ov is not _MISSING:
             return ov if isinstance(ov, int) else LogLevel.get_level_code(ov)
         return LogLevel.get_level_code(os.environ.get("LOG_LEVEL", "WARNING"))
+
+    @property
+    def EMIT_ENRICHED_SCHEMA(self) -> bool:
+        """Whether to emit the per-column *enriched* ``schema`` on the global-
+        metadata channel — ``{col: {dtype, role, …}}`` — instead of the legacy
+        flat ``{col: SQL_type}`` map (data-ingestors#360 slice 1b).
+
+        This is a **breaking wire-format change**: the object-per-column shape is
+        only understood by a backend carrying backend#1037 (its ``_column_dtype``
+        reads both shapes; older backends parse ``schema`` values as type
+        strings). So it defaults to **off** and must be flipped on in the
+        deployment only once the paired backend is live — the coordinated
+        cutover the #360 plan calls for. ``feature_stats`` is unaffected
+        (additive, already live).
+        """
+        ov = self._override("EMIT_ENRICHED_SCHEMA")
+        if ov is not _MISSING:
+            return ov if isinstance(ov, bool) else str(ov).strip().lower() in self._TRUE_STRINGS
+        return os.environ.get("EMIT_ENRICHED_SCHEMA", "").strip().lower() in self._TRUE_STRINGS
 
     def validate(self) -> None:
         """Fail fast on missing backend authentication.

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -21,6 +21,7 @@ from ..utils.columns import resolve_column
 from ..utils.validators_mapping import map_validators
 from ..file_transfer import map_file_transfer
 from ..text_profile import compute_text_profile
+from ..schema_inference import canonical_dtype
 from ..reporting import ConsoleRenderer
 from . import preflight
 from .batch_writer import BatchWriter
@@ -446,19 +447,23 @@ class BaseIngestor(ABC):
         current backend consumes.
 
         Enriched (``EMIT_ENRICHED_SCHEMA`` — data-ingestors#360 slice 1b, gated
-        for the backend#1037 cutover) — ``{col: {"dtype": SQL_type}}`` with the
+        for the backend#1037 cutover) — ``{col: {"dtype": <canonical>}}`` with the
         framework ``label`` column carrying ``role: "target"`` for supervised
         tasks. That lets combine-time alignment identify the prediction target
         from the contract (backend#1037's ``role``-based check) rather than
-        inferring it. Physical-table shape: keys/types are exactly what
-        ``get_table_schema`` reflected, so ``label`` (String(255)) is the target
-        key — distinct from ``feature_stats``, which keys the target by its
-        original column name.
+        inferring it. ``dtype`` is the CANONICAL logical type
+        (``schema_inference.canonical_dtype``), not the raw storage type, so a
+        merged dataset compares column types by logical family — ``VARCHAR(255)``
+        vs ``VARCHAR(100)`` (or ``INT`` vs ``BIGINT``) no longer read as a
+        divergence. Physical-table shape otherwise: keys are exactly what
+        ``get_table_schema`` reflected, so ``label`` is the target key — distinct
+        from ``feature_stats``, which keys the target by its original column name.
         """
         if not self.database.config.EMIT_ENRICHED_SCHEMA:
             return schema_dict
         enriched: Dict[str, Any] = {
-            col: {"dtype": sql_type} for col, sql_type in schema_dict.items()
+            col: {"dtype": canonical_dtype(sql_type)}
+            for col, sql_type in schema_dict.items()
         }
         # ``label`` is the standard column the user's label_column is mapped onto
         # (database.create_table). It's always present, but is only a prediction

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -45,6 +45,12 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["BaseIngestor", "IngestionSummary"]
 
+# The framework's standard prediction-target column. The user's declared
+# label_column is mapped onto it (database.create_table creates a fixed
+# ``label`` column), so this — not the original CSV name — is the target key in
+# the physical-table schema emitted to the backend.
+_TARGET_COLUMN = "label"
+
 
 def _rows_state_clause(inserted_records: int) -> str:
     """Phrase the parenthetical about what's already in the database for a
@@ -433,6 +439,35 @@ class BaseIngestor(ABC):
         """Read data from the input source"""
         pass
 
+    def _schema_payload(self, schema_dict: Dict[str, str]) -> Dict[str, Any]:
+        """The ``schema`` value shipped on the global-metadata channel.
+
+        Default — the legacy flat ``{col: SQL_type}`` map, unchanged, which the
+        current backend consumes.
+
+        Enriched (``EMIT_ENRICHED_SCHEMA`` — data-ingestors#360 slice 1b, gated
+        for the backend#1037 cutover) — ``{col: {"dtype": SQL_type}}`` with the
+        framework ``label`` column carrying ``role: "target"`` for supervised
+        tasks. That lets combine-time alignment identify the prediction target
+        from the contract (backend#1037's ``role``-based check) rather than
+        inferring it. Physical-table shape: keys/types are exactly what
+        ``get_table_schema`` reflected, so ``label`` (String(255)) is the target
+        key — distinct from ``feature_stats``, which keys the target by its
+        original column name.
+        """
+        if not self.database.config.EMIT_ENRICHED_SCHEMA:
+            return schema_dict
+        enriched: Dict[str, Any] = {
+            col: {"dtype": sql_type} for col, sql_type in schema_dict.items()
+        }
+        # ``label`` is the standard column the user's label_column is mapped onto
+        # (database.create_table). It's always present, but is only a prediction
+        # target for SUPERVISED tasks — self-supervised runs (no label_column)
+        # must not claim one.
+        if self.label_column and _TARGET_COLUMN in enriched:
+            enriched[_TARGET_COLUMN]["role"] = "target"
+        return enriched
+
     def _count_records(self, source: Any) -> Optional[int]:
         """
         Try to count total records in the source for progress tracking.
@@ -779,7 +814,7 @@ class BaseIngestor(ABC):
                         data_format=self.data_format,
                         data_intent=self.intent,
                         category=self.category,
-                        schema=schema_dict,
+                        schema=self._schema_payload(schema_dict),
                         samples=samples,
                         meta_data=self.file_options,
                     )

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -52,6 +52,15 @@ __all__ = ["BaseIngestor", "IngestionSummary"]
 # the physical-table schema emitted to the backend.
 _TARGET_COLUMN = "label"
 
+# Post-normalization value encodings the ingested (physical) table uses, stated
+# per column in the enriched schema so combine-time alignment can confirm they
+# agree (backend#1037's WARN checks) — di#360. The ingestor maps every
+# recognized NA token to SQL NULL and stores booleans as MySQL 1/0, so these are
+# uniform across every dataset it produces; a dataset ingested under a different
+# convention would surface as a mismatch.
+_NULL_ENCODING = "null"
+_BOOL_ENCODING = "1/0"
+
 
 def _rows_state_clause(inserted_records: int) -> str:
     """Phrase the parenthetical about what's already in the database for a
@@ -465,6 +474,13 @@ class BaseIngestor(ABC):
             col: {"dtype": canonical_dtype(sql_type)}
             for col, sql_type in schema_dict.items()
         }
+        # Value encodings of the ingested data: missing is SQL NULL for every
+        # column; booleans are stored MySQL 1/0. Uniform by construction, stated
+        # per column so #1037 can verify cross-dataset consistency.
+        for desc in enriched.values():
+            desc["null_encoding"] = _NULL_ENCODING
+            if desc["dtype"] == "bool":
+                desc["bool_encoding"] = _BOOL_ENCODING
         # ``label`` is the standard column the user's label_column is mapped onto
         # (database.create_table). It's always present, but is only a prediction
         # target for SUPERVISED tasks — self-supervised runs (no label_column)

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -471,6 +471,21 @@ class BaseIngestor(ABC):
         # must not claim one.
         if self.label_column and _TARGET_COLUMN in enriched:
             enriched[_TARGET_COLUMN]["role"] = "target"
+
+        # Merge uploader-declared per-column descriptors that CAN'T be inferred
+        # from the data — ``unit`` and ``ordinal`` (di#360). These activate the
+        # backend's combine-time descriptor checks (e.g. a ``unit`` mismatch —
+        # merging a USD column with an EUR one — is otherwise silent). Declared
+        # by CSV column name; entries for a column absent from the schema (or the
+        # target, which the physical schema keys as ``label``) are ignored.
+        declared = self.file_options.get("column_descriptors") or {}
+        for col, desc in declared.items():
+            if col not in enriched or not isinstance(desc, dict):
+                continue
+            if desc.get("unit") is not None:
+                enriched[col]["unit"] = desc["unit"]
+            if desc.get("ordinal") is not None:
+                enriched[col]["ordinal"] = desc["ordinal"]
         return enriched
 
     def _count_records(self, source: Any) -> Optional[int]:

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -137,6 +137,28 @@
       "description": "Column → SQL type map (e.g. {'age': 'INT', 'name': 'VARCHAR(255)'}). Required for tabular and time-series categories."
     },
 
+    "columns": {
+      "type": "object",
+      "description": "Optional per-column alignment descriptors that cannot be inferred from the data. Keyed by column name; every field is optional. Used at dataset-combination time to keep merged datasets consistent.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "unit": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Physical unit of the column's values (e.g. 'years', 'USD'). Combining columns whose declared units disagree is flagged, so an income-in-USD dataset isn't silently merged with income-in-EUR."
+          },
+          "ordinal": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "description": "Category values in order (low → high) for an ordinal column, so the ordering is preserved consistently across merged datasets."
+          }
+        }
+      }
+    },
+
     "time_column": {
       "type": "string",
       "minLength": 1,

--- a/tracebloc_ingestor/schema_inference.py
+++ b/tracebloc_ingestor/schema_inference.py
@@ -94,7 +94,45 @@ import pandas as pd
 
 from .utils import coercion
 
-__all__ = ["SAMPLE_CAP", "infer_column_type", "infer_schema"]
+__all__ = ["SAMPLE_CAP", "canonical_dtype", "infer_column_type", "infer_schema"]
+
+# Storage SQL type -> canonical LOGICAL dtype, for the enriched schema's
+# cross-dataset comparison at combine time (data-ingestors#360 slice 1b,
+# backend#1037). Parametrisation (``VARCHAR(255)``, ``DECIMAL(10,2)``) is
+# stripped first, so two datasets whose "same" column differs only in width
+# (``VARCHAR(255)`` vs ``VARCHAR(100)``) — or in integer storage size (``INT``
+# vs ``BIGINT``) — compare EQUAL, while a genuine ``int`` vs ``float`` divergence
+# still differs. Covers both the MySQL keywords ``get_table_schema`` reflects
+# and the types ``infer_column_type`` emits.
+_CANONICAL_DTYPE = {
+    "INT": "int", "INTEGER": "int", "BIGINT": "int", "SMALLINT": "int",
+    "MEDIUMINT": "int", "TINYINT": "int",
+    "FLOAT": "float", "DOUBLE": "float", "DOUBLE_PRECISION": "float",
+    "REAL": "float", "DECIMAL": "float", "NUMERIC": "float",
+    "BOOL": "bool", "BOOLEAN": "bool",
+    "DATE": "date",
+    "DATETIME": "datetime", "TIMESTAMP": "datetime",
+    "TIME": "time",
+    "VARCHAR": "string", "CHAR": "string", "TEXT": "string",
+    "TINYTEXT": "string", "MEDIUMTEXT": "string", "LONGTEXT": "string",
+    "STRING": "string", "ENUM": "string",
+    "BLOB": "binary", "BINARY": "binary", "VARBINARY": "binary",
+    "LARGEBINARY": "binary",
+}
+
+
+def canonical_dtype(sql_type: str) -> str:
+    """Map a storage SQL type (``"VARCHAR(255)"``, ``"BIGINT"``) to a canonical
+    logical dtype (``"string"``, ``"int"``).
+
+    Strips any ``(...)`` parametrisation and folds storage-size variants to one
+    logical family, so cross-dataset ``dtype`` equality reflects a real type
+    divergence rather than a width difference. An unrecognised type falls
+    through as its lower-cased base keyword — honest rather than silently
+    coerced to ``"string"``.
+    """
+    base = sql_type.split("(", 1)[0].strip().upper()
+    return _CANONICAL_DTYPE.get(base, base.lower())
 
 # First N rows per column that influence inference. Mirrors the CLI's cap so
 # the two implementations agree on the same prefix of a file.


### PR DESCRIPTION
**Slice 1b of tracebloc/data-ingestors#360.** Producer side of the enriched-schema half of #924 G4a. Pairs with backend#1037 (the reconciler) and unblocks deterministic target identification for tracebloc-engine#460 (see [#361 discussion](https://github.com/tracebloc/data-ingestors/pull/361)).

## What

Adds an optional **enriched** shape to the `schema` emitted on the global-metadata channel:

```jsonc
// legacy (default, unchanged)
"schema": { "a": "INT", "label": "VARCHAR(255)" }

// enriched (EMIT_ENRICHED_SCHEMA=true) — dtype is the CANONICAL logical type
"schema": { "a": {"dtype": "int"}, "label": {"dtype": "string", "role": "target"} }
```

The framework `label` column (what the user's `label_column` is mapped onto) carries **`role: "target"`** for supervised tasks, so combine-time alignment can identify the prediction target from the **contract** — backend#1037's `role`-based check and `_column_dtype` dual-shape reader — instead of inferring it by elimination (the fragile path documented on #361).

Descriptors that **can't be inferred** from the data — `unit` and `ordinal` — are declared per column in `ingest.yaml` (a new optional top-level `columns` map) and merged into the enriched schema. This activates backend#1037's descriptor checks, most importantly the **`unit` mismatch guard**: an income-in-USD dataset is no longer silently merged with income-in-EUR.

```jsonc
// ingest.yaml
"columns": { "income": {"unit": "USD"}, "size": {"ordinal": ["low","med","high"]} }
// → emitted enriched schema
"income": {"dtype": "float", "null_encoding": "null", "unit": "USD"}
```

The descriptor set is complete: **`dtype`, `role`, `unit`, `ordinal`, `null_encoding`, `bool_encoding`**. `null_encoding` (`"null"`) and `bool_encoding` (`"1/0"` on bool columns) describe the *ingested* table — the ingestor normalizes every recognized NA token to SQL `NULL` and stores booleans as MySQL `1/0` — so they're uniform by construction and let #1037 confirm cross-dataset consistency.

## Why gated

This is a **breaking wire-format change**: `schema` values go from type *strings* to *objects*. A backend without backend#1037 parses them as type strings. So it's behind **`EMIT_ENRICHED_SCHEMA` (default off)** and must be flipped on in the deployment **only once the paired backend is live** — the coordinated cutover #360 calls for. Default runs are byte-for-byte unchanged.

## Design decisions

- **Physical-table shape** (chosen on #361): keys/types are exactly what `get_table_schema` reflects, so the target key is the framework `label` column (`String(255)`), framework columns remain. This is deliberately distinct from `feature_stats` (PR #361), which keys the target by its *original* column name — the two channels serve different consumers (backend `role` check vs. engine `scaler_y`).
- **`role: "target"` only for supervised tasks** (`label_column` set) — self-supervised runs have a `label` column but no prediction target.
- Kept the numeric half (`feature_stats`) out of scope — it's PR #361 and already matches #1037 (numeric-only).
- **`dtype` is the canonical logical type**, not the raw storage type: `schema_inference.canonical_dtype` strips `(...)` parametrisation and folds storage-size variants to one logical family (`int`/`float`/`bool`/`date`/`datetime`/`time`/`string`/`binary`). So `VARCHAR(255)` vs `VARCHAR(100)` (or `INT` vs `BIGINT`) don't read as a type divergence in #1037's cross-dataset comparison, while a genuine `int` vs `float` still does. Housed with the #349 type-inference rules.

## Changes

- `config.py`: `EMIT_ENRICHED_SCHEMA` env-backed bool gate (default off).
- `ingestors/base.py`: `_schema_payload()` builds the flat or enriched shape (dtype + `role` + declared `unit`/`ordinal` + `null_encoding`/`bool_encoding`); `_TARGET_COLUMN = "label"`.
- `schema_inference.py`: `canonical_dtype()` (storage SQL type → canonical logical dtype).
- `schema/ingest.v1.json`: optional top-level `columns` map `{col: {unit?, ordinal?}}`, `additionalProperties:false` on the descriptor (typos rejected).
- `cli/conventions.py`: bridges top-level `columns` onto `file_options.column_descriptors`.
- `api/client.py`: `schema` param typed `Dict[str, Any]` (accepts both shapes).

## Tests

`tests/test_enriched_schema.py` — the gate; flat-unchanged when off; enriched shape + `label` `role:"target"`; canonical dtype across storage variants; declared `unit`/`ordinal` merged (and ignored for unknown columns / when gate off); no role for self-supervised; input not mutated. `tests/test_schema_inference.py` — `canonical_dtype` mapping + folding. `tests/test_schema_validation.py` — `columns` accept + reject (unknown key, non-string ordinal). `tests/test_conventions.py` — `columns` → `file_options` bridge; plus `bool_encoding`/`null_encoding` presence + scoping. **Full suite 1644 passed, 1 xfailed (pre-existing).**

## Follow-ups

- `categories` (categorical vocab) is in PR #367, under `attributes.feature_stats` where the engine reads it.
- Engine #460 (**done**, commit `ace0e1c6`): resolves the target from the aligned schema `role`, elimination as fallback.
- Quantile summaries for Robust/Quantile scalers need a *mergeable sketch* (t-digest / aligned histogram) — per-dataset quantiles don't combine into a global; separate design (Power's λ can't be federated regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
