### PR TITLE
fix(validators): use redaction.column_preview for mask_id error column lists

### DIFF
--- a/tests/test_semseg_mask_id_contract.py
+++ b/tests/test_semseg_mask_id_contract.py
@@ -147,7 +147,7 @@ def test_missing_column_message_caps_header_list(make_csv):
     path = make_csv(pd.DataFrame({f"c{i}": ["x"] for i in range(50)}))
     result = MaskIdColumnValidator(column="mask_id").validate(str(path))
     assert not result.is_valid
-    assert "more)" in result.errors[0]  # truncation marker
+    assert "more of 50)" in result.errors[0]  # column_preview truncation marker
     assert len(result.metadata["columns"]) == 50  # full detail retained
 
 
@@ -159,7 +159,7 @@ def test_undeclared_message_caps_schema_key_list(make_csv):
     schema = {f"c{i}": "VARCHAR(255)" for i in range(50)}  # 50 keys, no mask_id
     result = MaskIdColumnValidator(column="mask_id", schema=schema).validate(str(path))
     assert not result.is_valid
-    assert "more)" in result.errors[0]  # truncation marker
+    assert "more of 50)" in result.errors[0]  # column_preview truncation marker
     assert len(result.metadata["schema_columns"]) == 50  # full detail retained
 
 

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/validators/mask_id_validator.py
+++ b/tracebloc_ingestor/validators/mask_id_validator.py
@@ -72,24 +72,6 @@ _READ_DIALECT_KEYS = frozenset(
 # accumulating millions of ints — the OOM the chunked read exists to avoid.
 _EMPTY_ROWS_SAMPLE_CAP = 20
 
-# Cap on how many column names a message lists (headers OR schema keys), so a
-# very wide manifest/schema can't produce an unbounded error string; the full
-# list stays in metadata (mirrors how the other validators cap offender lists).
-_HEADER_SAMPLE_CAP = 20
-
-
-def _capped_join(names: Any) -> str:
-    """Comma-join ``names`` for an error message, capped at
-    :data:`_HEADER_SAMPLE_CAP` with a ``(+N more)`` suffix so a very wide
-    schema/header can't build an unbounded string. Callers keep the full list in
-    metadata. Returns ``"(none)"`` for an empty iterable."""
-    names = list(names)
-    shown = ", ".join(map(str, names[:_HEADER_SAMPLE_CAP]))
-    if len(names) > _HEADER_SAMPLE_CAP:
-        shown += f" (+{len(names) - _HEADER_SAMPLE_CAP} more)"
-    return shown or "(none)"
-
-
 class MaskIdColumnValidator(BaseValidator):
     """Reject a semantic-segmentation manifest that would NOT produce a
     populated ``mask_id`` DB column — i.e. the column is undeclared in the
@@ -284,7 +266,9 @@ class MaskIdColumnValidator(BaseValidator):
                 f"preflight. Rename the schema key to '{self.column}'. See "
                 f"templates/semantic_segmentation/."
             )
-        declared = _capped_join(self._schema.keys())
+        from ..utils import redaction
+
+        declared = redaction.column_preview(list(self._schema.keys()))
         return (
             f"Semantic segmentation requires '{self.column}' to be a DECLARED "
             f"schema column (e.g. schema={{'{self.column}': 'VARCHAR(255)'}}), but "
@@ -308,10 +292,12 @@ class MaskIdColumnValidator(BaseValidator):
                 f"header stores a column it can't read. Rename the CSV header to "
                 f"'{self.column}'. See templates/semantic_segmentation/."
             )
+        from ..utils import redaction
+
         return (
             f"Required column '{self.column}' not found in semantic-segmentation "
-            f"manifest CSV header (columns: {_capped_join(columns)}). The training "
-            f"client "
+            f"manifest CSV header (columns: {redaction.column_preview(columns)}). "
+            f"The training client "
             f"reads '{self.column}' to locate each mask file (backend#816) — "
             f"without it, every mask lookup raises FileNotFoundError at train "
             f"time. Add a '{self.column}' column mapping each row to its mask "


### PR DESCRIPTION
## Summary

Fixes the Bugbot finding on the develop→prod promotion PR (#371): `MaskIdColumnValidator` built its "available columns" and undeclared-schema error messages with a local `_capped_join` helper instead of `redaction.column_preview`, which is the canonical capped column-list format for validator errors on wide manifests (learned rule / #359).

Drops `_capped_join` + `_HEADER_SAMPLE_CAP` and routes both messages through `redaction.column_preview`, so mask-id errors match every other validator: `['a', 'b', ...] (+N more of M)`, with the full list still retained in the result metadata.

Also bumps the version `0.7.0` → `0.7.1`.

## Related
Ref #371 (Bugbot finding)

## Type of change
- [x] Bug fix

## Test plan
- Updated the two contract tests (`test_missing_column_message_caps_header_list`, `test_undeclared_message_caps_schema_key_list`) to assert the `column_preview` truncation marker (`(+N more of M)`).
- `pytest tests/test_semseg_mask_id_contract.py tests/test_error_redaction.py` — 40 passed.

## Checklist
- [x] Tests added / updated and passing locally
- [x] No secrets / credentials in the diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error-message formatting only; validation logic and metadata behavior are unchanged aside from consistent truncation text.
> 
> **Overview**
> **`MaskIdColumnValidator`** no longer formats wide column/schema lists with a local **`_capped_join`** helper. Undeclared-schema and missing-header errors now use **`redaction.column_preview`**, matching other validators: `['a', 'b', ...] (+N more of M)` while full lists stay in result metadata.
> 
> The private **`_HEADER_SAMPLE_CAP`** / **`_capped_join`** code is removed. Contract tests assert the **`column_preview`** truncation marker (`more of 50)`). Package version is bumped **0.7.0 → 0.7.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8424dad4861febb4b5cc3165eae019913e1060fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->