### PR TITLE
fix(ingest): journal registration before send + redact DB errors in logs

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -808,6 +808,24 @@ def test_mark_ingest_registered_flips_journal_flag(db, mock_engine_factory):
     conn.commit.assert_called()
 
 
+def test_mark_ingest_unregistered_resets_journal_flag(db, mock_engine_factory):
+    """The failure-path undo must UPDATE the run's journal row back to
+    registered=0 (and clear registered_at), scoped to this
+    (ingestor_id, table_name) — so a send failure after the pre-send flip
+    leaves the rows reclaimable (backend#1028, bugbot High)."""
+    _, _, conn = mock_engine_factory
+    db.mark_ingest_unregistered("tbl", "run-a")
+    update = next(s for s in _executed_sql(conn) if "UPDATE" in s)
+    assert "registered = 0" in update
+    assert "registered_at = NULL" in update
+    assert "ingestor_id = :ingestor_id" in update
+    stmt = next(
+        c.args[0] for c in conn.execute.call_args_list if "UPDATE" in str(c.args[0])
+    )
+    assert stmt.compile().params == {"ingestor_id": "run-a", "table_name": "tbl"}
+    conn.commit.assert_called()
+
+
 def test_reclaim_dead_run_rows_deletes_each_dead_run(db, mock_engine_factory):
     """The reconcile pass deletes rows per dead run via the #227
     delete_by_ingestor_id (so logging/retry behavior is shared) and reports

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -1544,21 +1544,33 @@ def test_reconcile_and_start_journal_run_before_first_insert():
     assert names.index("record_ingest_started") < names.index("insert_batch")
 
 
-def test_successful_registration_marks_journal_registered():
-    """After send_ingest_summary returns, the run must be journaled as
-    REGISTERED — the durable marker that stops any future reconcile pass from
-    reclaiming this run's rows."""
+def test_successful_registration_marks_journal_registered_before_send():
+    """The run must be journaled as REGISTERED BEFORE send_ingest_summary, not
+    after (backend#1028, bugbot High). The local flip and the remote register
+    can't be atomic; writing the journal first makes a crash in that window a
+    recoverable duplicate rather than a deletion of registered rows. Ordering
+    is the contract, so it is asserted explicitly on the interleaved call log
+    of the db + api mocks (attached to a shared parent BEFORE the run)."""
     ing = make_ingestor(records=[{"a": "1"}], label_column="a")
+    parent = MagicMock()
+    parent.attach_mock(ing.database, "db")
+    parent.attach_mock(ing.api_client, "api")
     _run_happy_ingest(ing)
     ing.database.mark_ingest_registered.assert_called_once_with(
         ing.table_name, ing.ingestor_id
     )
+    seq = [c[0] for c in parent.mock_calls]
+    assert seq.index("db.mark_ingest_registered") < seq.index(
+        "api.send_ingest_summary"
+    )
 
 
-def test_failed_registration_never_marks_journal_registered():
-    """A run whose registration failed must stay started-but-unregistered in
-    the journal (its rows are removed by the #227 delete anyway, which still
-    fires — asserted here so the two cleanups are known to coexist)."""
+def test_failed_registration_undoes_optimistic_flip_and_deletes(caplog):
+    """The journal is flipped to REGISTERED before the summary call, so a
+    FAILED send must undo that flip (mark_ingest_unregistered) — otherwise a
+    later compensating-delete failure would strand the rows as a phantom
+    registered entry no reconcile pass would clean. The #227 delete still
+    fires (rows are not registered)."""
     ing = make_ingestor(records=[{"a": "1"}], label_column="a")
     ing.api_client.send_ingest_summary.side_effect = RuntimeError(
         "backend rejected"
@@ -1569,26 +1581,65 @@ def test_failed_registration_never_marks_journal_registered():
         Sess.return_value.__enter__.return_value = MagicMock()
         with pytest.raises(RuntimeError):
             ing.ingest("src", batch_size=10)
-    ing.database.mark_ingest_registered.assert_not_called()
+    # flipped before send, then undone on failure, then rows deleted.
+    ing.database.mark_ingest_registered.assert_called_once_with(
+        ing.table_name, ing.ingestor_id
+    )
+    ing.database.mark_ingest_unregistered.assert_called_once_with(
+        ing.table_name, ing.ingestor_id
+    )
     ing.database.delete_by_ingestor_id.assert_called_once_with(
         ing.table_name, ing.ingestor_id
     )
 
 
-def test_mark_registered_failure_never_fails_a_registered_run(caplog):
-    """The journal UPDATE failing AFTER successful registration must not fail
-    the run (the dataset exists!) nor trigger the #227 delete — raising here
-    would hand the retry a journal entry telling it to purge a registered
-    dataset's rows. Logged CRITICAL instead."""
+def test_journal_flip_failure_aborts_before_registration(caplog):
+    """If the pre-send journal flip itself fails, the summary call must NOT be
+    attempted (registration never happens) and the run's rows must be removed
+    by the #227 delete — the rows are not registered anywhere, so deleting
+    them is correct and safe, the opposite of the old post-send ordering that
+    could strand a registered dataset."""
     import logging
 
     ing = make_ingestor(records=[{"a": "1"}], label_column="a")
     ing.database.mark_ingest_registered.side_effect = Exception("journal down")
     with caplog.at_level(logging.CRITICAL):
-        _run_happy_ingest(ing)  # must NOT raise
-    ing.database.delete_by_ingestor_id.assert_not_called()
+        with patch.object(base_mod, "Session") as Sess, patch.object(
+            ing, "validate_data", return_value=True
+        ):
+            Sess.return_value.__enter__.return_value = MagicMock()
+            with pytest.raises(Exception):
+                ing.ingest("src", batch_size=10)
+    ing.api_client.send_ingest_summary.assert_not_called()
+    ing.database.delete_by_ingestor_id.assert_called_once_with(
+        ing.table_name, ing.ingestor_id
+    )
+
+
+def test_journal_reset_failure_never_masks_original_error(caplog):
+    """On the failure path, a mark_ingest_unregistered error must be logged
+    CRITICAL (redacted) and swallowed — the original ingestion error, not the
+    journal-reset error, is what propagates, and the #227 delete still runs."""
+    import logging
+
+    ing = make_ingestor(records=[{"a": "1"}], label_column="a")
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError(
+        "backend rejected"
+    )
+    ing.database.mark_ingest_unregistered.side_effect = Exception("journal down")
+    with caplog.at_level(logging.CRITICAL):
+        with patch.object(base_mod, "Session") as Sess, patch.object(
+            ing, "validate_data", return_value=True
+        ):
+            Sess.return_value.__enter__.return_value = MagicMock()
+            with pytest.raises(RuntimeError, match="backend rejected"):
+                ing.ingest("src", batch_size=10)
+    ing.database.delete_by_ingestor_id.assert_called_once_with(
+        ing.table_name, ing.ingestor_id
+    )
     assert any(
-        "Failed to journal registration" in r.message for r in caplog.records
+        "reset the run journal to unregistered" in r.message
+        for r in caplog.records
     )
 
 

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -699,10 +699,13 @@ class Database:
     def mark_ingest_registered(self, table_name: str, ingestor_id: str) -> None:
         """Flip the run's journal entry to REGISTERED (backend#1028 item 2).
 
-        Called immediately after ``send_ingest_summary`` returns — the same
-        point that flips the #227 ``dataset_registered`` guard — so no future
-        reconcile pass can mistake this run's rows for orphans. Idempotent
-        (repeating the UPDATE is a no-op).
+        Called immediately BEFORE ``send_ingest_summary`` (not after): the
+        local flip and the remote registration can't be atomic, and writing
+        the journal first makes a crash in that window a recoverable duplicate
+        instead of a deletion of registered rows — see ``BaseIngestor.ingest``
+        and :meth:`mark_ingest_unregistered` (the failure-path undo). Once set,
+        no future reconcile pass can mistake this run's rows for orphans.
+        Idempotent (repeating the UPDATE is a no-op).
         """
         with self.engine.connect() as connection:
             self._ensure_runs_table(connection)
@@ -711,6 +714,32 @@ class Database:
                 text(
                     f"UPDATE `{self.RUNS_TABLE}` "
                     "SET registered = 1, registered_at = CURRENT_TIMESTAMP "
+                    "WHERE ingestor_id = :ingestor_id "
+                    "AND table_name = :table_name"
+                ).bindparams(ingestor_id=ingestor_id, table_name=table_name),
+            )
+            connection.commit()
+
+    def mark_ingest_unregistered(self, table_name: str, ingestor_id: str) -> None:
+        """Flip the run's journal entry back to NOT-registered (backend#1028
+        item 2).
+
+        The registration flip is written BEFORE ``send_ingest_summary`` so a
+        crash in that window degrades to a recoverable duplicate rather than a
+        deletion of registered rows (see ``BaseIngestor.ingest``). When the
+        summary call then FAILS, that optimistic flip must be undone so the
+        run's rows read as reclaimable again — otherwise a compensating-delete
+        failure would strand them as a ``registered = 1`` entry that no future
+        reconcile pass would ever clean. Idempotent (repeating is a no-op); the
+        caller invokes it best-effort on the failure path.
+        """
+        with self.engine.connect() as connection:
+            self._ensure_runs_table(connection)
+            _execute_with_retry(
+                connection,
+                text(
+                    f"UPDATE `{self.RUNS_TABLE}` "
+                    "SET registered = 0, registered_at = NULL "
                     "WHERE ingestor_id = :ingestor_id "
                     "AND table_name = :table_name"
                 ).bindparams(ingestor_id=ingestor_id, table_name=table_name),

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -17,6 +17,7 @@ from ..utils.constants import (
     CYAN,
 )
 from ..utils import label_policy as label_policy_module
+from ..utils import redaction
 from ..utils.columns import resolve_column
 from ..utils.correlation import resolve_correlation_id
 from ..utils.validators_mapping import map_validators
@@ -586,9 +587,9 @@ class BaseIngestor(ABC):
         except Exception as reclaim_error:
             logger.critical(
                 f"Orphan-row reconciliation failed for table "
-                f"{self.table_name!r}: {reclaim_error}. Continuing the "
-                f"ingest — rows left by a previous hard-killed run may "
-                f"remain in the table (backend#1028)."
+                f"{self.table_name!r}: {redaction.safe_db_error(reclaim_error)}. "
+                f"Continuing the ingest — rows left by a previous hard-killed "
+                f"run may remain in the table (backend#1028)."
             )
         # Journal this run as STARTED before its first row insert, so that if
         # THIS process dies hard at any later point, the next attempt's
@@ -841,6 +842,27 @@ class BaseIngestor(ABC):
                         if text_profile:
                             self.file_options["text_profile"] = text_profile
 
+                    # Flip the run journal to REGISTERED (backend#1028 item 2)
+                    # BEFORE the remote summary call, not after. The local flip
+                    # and the backend registration can't be made atomic, so
+                    # whichever runs SECOND owns the crash/failure window. With
+                    # the flip second (its previous position) a failed-and-
+                    # swallowed UPDATE — or a hard kill after send returned —
+                    # left the journal at registered=0 while the dataset WAS
+                    # registered, so the next ingest's reclaim pass deleted a
+                    # registered dataset's rows (silent, unrecoverable loss —
+                    # bugbot High). Flipping FIRST inverts the failure mode: a
+                    # crash between this commit and send completing just leaves
+                    # the dataset unregistered, and the k8s retry re-ingests
+                    # from source — a recoverable duplicate the 409-idempotent
+                    # resend and the #227 delete already tolerate — never a
+                    # deletion of registered rows. If send then FAILS, the
+                    # except-branch undoes this flip (mark_ingest_unregistered)
+                    # so reclaim can still recover the rows.
+                    self.database.mark_ingest_registered(
+                        self.table_name, self.ingestor_id
+                    )
+
                     self.api_client.send_ingest_summary(
                         table_name=self.table_name,
                         ingestor_id=self.ingestor_id,
@@ -854,30 +876,6 @@ class BaseIngestor(ABC):
                         meta_data=self.file_options,
                     )
                     dataset_registered = True
-                    # Durably flip the run journal to REGISTERED
-                    # (backend#1028 item 2) so no future reconcile pass can
-                    # mistake this run's rows for orphans. Swallow-and-log on
-                    # failure: the dataset IS registered — raising here would
-                    # fail a healthy run and, worse, hand the retry a
-                    # started-but-unregistered journal entry telling it to
-                    # delete a registered dataset's rows. The residual window
-                    # (process killed between send_ingest_summary returning
-                    # and this UPDATE committing) is strictly narrower than
-                    # the #227 two-generals window documented below.
-                    try:
-                        self.database.mark_ingest_registered(
-                            self.table_name, self.ingestor_id
-                        )
-                    except Exception as journal_error:
-                        logger.critical(
-                            f"Failed to journal registration for "
-                            f"ingestor_id={self.ingestor_id!r} in table "
-                            f"{self.table_name!r}: {journal_error}. A future "
-                            f"ingest into this table could reclaim this "
-                            f"registered dataset's rows as orphans "
-                            f"(backend#1028) — investigate before "
-                            f"re-ingesting into this table."
-                        )
                     stats["api_sent_records"] = stats["inserted_records"]
 
                 summary = IngestionSummary(**stats)
@@ -917,6 +915,28 @@ class BaseIngestor(ABC):
                     logger.warning(f"session.rollback() failed: {rollback_error}")
                 logger.error(f"Error during ingestion: {str(e)}")
                 if stats.get("inserted_records") and not dataset_registered:
+                    # The journal was flipped to REGISTERED just before the
+                    # summary call (see above). Since registration did NOT
+                    # complete, undo that optimistic flip FIRST — so if the
+                    # compensating delete below fails, a later reclaim pass
+                    # still sees registered=0 and can recover these rows
+                    # instead of stranding them as a phantom registered entry
+                    # (backend#1028). Best-effort: a reset failure must not
+                    # mask the original error or skip the delete.
+                    try:
+                        self.database.mark_ingest_unregistered(
+                            self.table_name, self.ingestor_id
+                        )
+                    except Exception as journal_reset_error:
+                        logger.critical(
+                            f"Failed to reset the run journal to unregistered "
+                            f"for ingestor_id={self.ingestor_id!r} in table "
+                            f"{self.table_name!r}: "
+                            f"{redaction.safe_db_error(journal_reset_error)}. "
+                            f"If the compensating delete also fails, these "
+                            f"rows may not be reclaimed automatically "
+                            f"(backend#1028)."
+                        )
                     try:
                         deleted = self.database.delete_by_ingestor_id(
                             self.table_name, self.ingestor_id
@@ -931,7 +951,8 @@ class BaseIngestor(ABC):
                         logger.critical(
                             f"Compensating delete FAILED for "
                             f"ingestor_id={self.ingestor_id!r} in table "
-                            f"{self.table_name!r}: {cleanup_error}. "
+                            f"{self.table_name!r}: "
+                            f"{redaction.safe_db_error(cleanup_error)}. "
                             f"{stats.get('inserted_records', 0)} unregistered "
                             "row(s) remain orphaned (#227)."
                         )


### PR DESCRIPTION
## Summary

Fixes the two new Bugbot findings on the develop→prod promotion PR #371. Both live in the backend#1028 run-journal / orphan-reclaim path.

### HIGH — journal miss deletes registered rows
`mark_ingest_registered` (the local journal flip) ran **after** `send_ingest_summary` (the remote registration). The two can't be atomic, so the flip owned the crash/failure window: a swallowed flip error — or a hard kill right after `send` returned — left the journal at `registered = 0` while the dataset **was** registered. The next ingest's `reclaim_dead_run_rows` pass then treated the run as an orphan and **deleted a registered dataset's rows** (silent, unrecoverable). Swallowing the error didn't help — it just deferred the deletion to the retry.

**Fix:** flip the journal to `registered` **before** the summary call. Now the unavoidable crash window degrades to a *recoverable* re-ingest-from-source duplicate (already tolerated by the 409-idempotent resend and the #227 compensating delete) instead of a deletion of registered rows. If `send` then fails, the optimistic flip is undone via a new `Database.mark_ingest_unregistered`, so even a compensating-delete failure stays recoverable by a later reclaim pass.

Failure-mode trade: **data-loss window → recoverable-duplication window.** Loss is silent and unrecoverable; duplication is detectable and matches the codebase's existing "re-ingest from source" fallback.

### MEDIUM — critical logs embed raw exceptions
The orphan-reconciliation and journal CRITICAL handlers interpolated the raw exception object, which can carry MySQL bound-parameter (cell) values — a violation of the on-prem redaction policy (#226). Routed through `redaction.safe_db_error`, matching the rest of the codebase (also applied to the pre-existing compensating-delete CRITICAL for consistency).

## Related
Ref #371 (Bugbot findings). Builds on the run journal from #369.

## Type of change
- [x] Bug fix
- [x] Security / hardening (log redaction)

## Test plan
- Reworked the journal tests to the new before-send ordering contract:
  - `test_successful_registration_marks_journal_registered_before_send` — asserts the flip precedes `send_ingest_summary`.
  - `test_failed_registration_undoes_optimistic_flip_and_deletes` — send failure → undo flip → #227 delete.
  - `test_journal_flip_failure_aborts_before_registration` — a pre-send flip failure never calls `send` and cleans up.
  - `test_journal_reset_failure_never_masks_original_error` — undo failure is logged (redacted) and swallowed; original error propagates.
  - `test_mark_ingest_unregistered_resets_journal_flag` (db-level).
- `pytest tests/` — **1641 passed, 1 xfailed**.

## Checklist
- [x] Tests added / updated and passing locally
- [x] No secrets / credentials in the diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core ingest registration/reclaim ordering where a mistake can delete registered data or strand orphans; mitigated by extensive tests and explicit failure-path undo.
> 
> **Overview**
> Fixes backend#1028 run-journal behavior so a missed local **registered** flip can no longer cause the next ingest’s orphan reclaim to delete rows for an already-registered dataset.
> 
> **Journal ordering:** `mark_ingest_registered` now runs **before** `send_ingest_summary` instead of after (with swallow-on-failure removed). The unavoidable non-atomic window is traded from silent data loss to a recoverable re-ingest duplicate. On summary failure, the flow calls new **`mark_ingest_unregistered`** before the existing #227 compensating delete; a failed pre-send journal flip aborts without calling the API and still deletes rows.
> 
> **Logging:** CRITICAL paths for orphan reconciliation, journal reset, and compensating delete use **`redaction.safe_db_error`** instead of raw exception text (#226).
> 
> Tests cover before-send ordering, undo-on-failure, flip-failure abort, and unregistered SQL. Version **0.7.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37231fa92875d61f25fc9fe8f9a8a983176704aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->