### PR TITLE
feat(ingest): flip default data_id strategy uuid → content_hash (#350)

### DIFF
--- a/e2e/test_characterization.py
+++ b/e2e/test_characterization.py
@@ -101,6 +101,12 @@ CASES = [
             images=str(T / "image_classification/data/images"),
             label="label",
             spec={"file_options": {"extension": ".jpeg", "target_size": [256, 256]}},
+            # #350: this fixture is 6 unique (filename,label) rows repeated 96×
+            # (576 rows). Under the new content_hash default those collapse to 6
+            # stored rows (content-level dedup, working as designed). This
+            # harness pins the row-per-source-row golden, so opt into uuid here;
+            # content_hash dedup/retry is covered by test_database_e2e.py.
+            data_id={"strategy": "uuid"},
         ),
         sidecars=[str(T / "image_classification/data/images")],
         roundtrip_col=None,
@@ -206,6 +212,10 @@ CASES = [
             annotations=str(T / "object_detection/data/annotations"),
             label="image_label",
             target_size=[1920, 1080],
+            # #350: fixture is 10 unique rows repeated to 128; pin uuid so the
+            # row-per-source-row golden holds (content_hash would dedup to 10).
+            # See the image_classification note above.
+            data_id={"strategy": "uuid"},
         ),
         sidecars=[
             str(T / "object_detection/data/images"),

--- a/e2e/test_content_compare_e2e.py
+++ b/e2e/test_content_compare_e2e.py
@@ -59,6 +59,14 @@ CASES = [
             images=str(T / "image_classification/data/images"),
             label="label",
             spec={"file_options": {"extension": ".jpeg", "target_size": [256, 256]}},
+            # #350: this fixture is 6 unique (filename,label) rows repeated 96×.
+            # The content-vs-source comparison below assumes 1:1 storage, so pin
+            # uuid; under the content_hash default these rows dedup to 6 (working
+            # as designed). content_hash dedup/retry is covered by
+            # test_database_e2e.py. The tabular case below keeps the default
+            # (unique rows ⇒ content_hash stores 1:1 too), exercising the full
+            # run.main() stack with content_hash.
+            data_id={"strategy": "uuid"},
         ),
     ),
     dict(

--- a/tests/test_adversarial_ingestion_harness.py
+++ b/tests/test_adversarial_ingestion_harness.py
@@ -73,6 +73,11 @@ def _ingestor(schema, **opts):
         schema=schema,
         category=opts.pop("category", TAB),
         intent=opts.pop("intent", "train"),
+        # #350: these tests call process_record() directly, bypassing ingest()
+        # (which is what fetches the content_hash salt). The id strategy is
+        # irrelevant to the CSV cast/parse behaviour under test here, so pin
+        # uuid to keep the record processor constructible without a salt.
+        data_id_strategy=opts.pop("data_id_strategy", "uuid"),
         **opts,
     )
 

--- a/tests/test_batch_send_failure_accounting.py
+++ b/tests/test_batch_send_failure_accounting.py
@@ -68,6 +68,9 @@ class FakeIngestor(BaseIngestor):
 
 def make_ingestor(records=None, **overrides):
     db = MagicMock(name="Database")
+    # #350: content_hash is the default id strategy; the mock DB must return a
+    # real salt string (a MagicMock salt poisons the hash and drops every row).
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
     db.get_table_schema.return_value = {"a": "INT"}

--- a/tests/test_causal_language_modeling.py
+++ b/tests/test_causal_language_modeling.py
@@ -54,6 +54,9 @@ class FakeIngestor(BaseIngestor):
 
 def make_ingestor(records=None, **overrides):
     db = MagicMock(name="Database")
+    # #350: content_hash is the default id strategy; the mock DB must return a
+    # real salt string (a MagicMock salt poisons the hash and drops every row).
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.return_value = ([1, 2], [])
     db.get_table_schema.return_value = {"a": "INT"}

--- a/tests/test_content_hash_data_id.py
+++ b/tests/test_content_hash_data_id.py
@@ -127,9 +127,10 @@ def _cfg(strategy=None):
     return cfg
 
 
-def test_resolve_default_is_uuid():
+def test_resolve_default_is_content_hash():
+    # #350: content_hash is now the default when no data_id block is present.
     r = resolve(_cfg())
-    assert r.data_id_strategy == "uuid"
+    assert r.data_id_strategy == "content_hash"
     assert r.unique_id_column is None
 
 
@@ -139,10 +140,19 @@ def test_resolve_content_hash():
     assert r.unique_id_column is None
 
 
+def test_resolve_uuid_is_explicit_opt_out():
+    # #350: after the default flipped, strategy=uuid must still opt back in.
+    r = resolve(_cfg("uuid"))
+    assert r.data_id_strategy == "uuid"
+    assert r.unique_id_column is None
+
+
 def test_resolve_column_still_sets_unique_id_column():
     r = resolve(_cfg("column"))
     assert r.unique_id_column == "feature"
-    assert r.data_id_strategy == "uuid"  # column path, not hash
+    # column path maps unique_id_column and leaves data_id_strategy at its
+    # default; unique_id_column wins over the strategy in RecordProcessor.
+    assert r.data_id_strategy == "content_hash"
 
 
 # ── schema acceptance ────────────────────────────────────────────────────────
@@ -204,7 +214,7 @@ def test_build_ingestor_threads_strategy_through_both_subclasses(source_key, str
         cfg.pop("csv")
         cfg["json"] = "/data/shared/d.json"
     ing = _build(cfg)
-    expected = strategy or "uuid"
+    expected = strategy or "content_hash"  # #350: default flipped to content_hash
     assert ing.data_id_strategy == expected
     # salt is deferred to ingest(); never fetched at construction
     ing.database.get_or_create_table_salt.assert_not_called()

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -236,16 +236,29 @@ def test_object_label_without_policy_defaults_to_passthrough():
 # data_id resolution
 # ---------------------------------------------------------------------------
 
-def test_no_data_id_block_means_uuid_generation():
+def test_no_data_id_block_means_content_hash():
+    # #350: content_hash is now the default when no data_id block is present.
     r = resolve(_load("image_classification.yaml"))
     assert r.unique_id_column is None
+    assert r.data_id_strategy == "content_hash"
 
 
-def test_uuid_strategy_explicit():
+def test_content_hash_strategy_explicit():
+    config = _load("image_classification.yaml")
+    config["data_id"] = {"strategy": "content_hash"}
+    r = resolve(config)
+    assert r.unique_id_column is None
+    assert r.data_id_strategy == "content_hash"
+
+
+def test_uuid_strategy_explicit_is_opt_out():
+    # #350: after the default flipped to content_hash, an explicit
+    # strategy=uuid must still opt back into fresh-per-record UUIDs.
     config = _load("image_classification.yaml")
     config["data_id"] = {"strategy": "uuid"}
     r = resolve(config)
     assert r.unique_id_column is None
+    assert r.data_id_strategy == "uuid"
 
 
 def test_column_strategy_sets_unique_id_column():

--- a/tests/test_correlation_id.py
+++ b/tests/test_correlation_id.py
@@ -88,6 +88,8 @@ def test_resolver_rejects_malformed_values_with_warning(caplog):
 
 def _make_ingestor(**overrides):
     database = MagicMock(name="Database")
+    # #350: content_hash default ⇒ mock DB must return a real salt string.
+    database.get_or_create_table_salt.return_value = "0" * 64
     api_client = MagicMock(name="APIClient")
     kwargs = dict(
         database=database,
@@ -145,6 +147,8 @@ def _make_full_ingestor():
     test_time_series_classification (tabular control variant)."""
     db = MagicMock(name="Database")
     db.config = Config(TABLE_NAME="corr_toy")
+    # #350: content_hash default ⇒ mock DB must return a real salt string.
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.side_effect = lambda table, batch: (
         list(range(len(batch))),

--- a/tests/test_coverage_gaps2.py
+++ b/tests/test_coverage_gaps2.py
@@ -30,6 +30,8 @@ class FakeIngestor(BaseIngestor):
 
 def make_ingestor(records=None, **overrides):
     db = MagicMock()
+    # #350: content_hash default ⇒ mock DB must return a real salt string.
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock()
     db.insert_batch.return_value = ([1], [])
     db.get_table_schema.return_value = {"a": "INT"}
@@ -48,7 +50,11 @@ def make_ingestor(records=None, **overrides):
         category=None,
     )
     kwargs.update(overrides)
-    return FakeIngestor(records or [], **kwargs)
+    ing = FakeIngestor(records or [], **kwargs)
+    # #350: content_hash default — process_record() tests skip ingest() (the
+    # salt fetch), so pre-set the salt the record processor needs.
+    ing._table_salt = "0" * 64
+    return ing
 
 
 def test_map_unique_id_warns_on_missing_label_column():
@@ -166,6 +172,8 @@ def _csv_ingestor(schema=None, **ov):
     from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
 
     db = MagicMock()
+    # #350: content_hash default ⇒ mock DB must return a real salt string.
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock()
     db.insert_batch.return_value = ([1], [])
     db.get_table_schema.return_value = {}
@@ -218,6 +226,8 @@ def _json_ingestor(schema=None, **ov):
     from tracebloc_ingestor.ingestors.json_ingestor import JSONIngestor
 
     db = MagicMock()
+    # #350: content_hash default ⇒ mock DB must return a real salt string.
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock()
     db.insert_batch.return_value = ([1], [])
     db.get_table_schema.return_value = {}

--- a/tests/test_csv_ingestor.py
+++ b/tests/test_csv_ingestor.py
@@ -13,6 +13,8 @@ from tracebloc_ingestor.utils.constants import TaskCategory
 
 def make_csv_ingestor(schema=None, **overrides):
     db = MagicMock()
+    # #350: content_hash default ⇒ mock DB must return a real salt string.
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock()
     api = MagicMock()
     kwargs = dict(

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -59,6 +59,9 @@ class FakeIngestor(BaseIngestor):
 
 def make_ingestor(records=None, **overrides):
     db = MagicMock(name="Database")
+    # #350: content_hash is the default id strategy; the mock DB must return a
+    # real salt string (a MagicMock salt poisons the hash and drops every row).
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.return_value = ([1, 2], [])
     db.get_table_schema.return_value = {"a": "INT"}

--- a/tests/test_error_redaction.py
+++ b/tests/test_error_redaction.py
@@ -100,6 +100,8 @@ def _rp(unique_id_column=None):
         unique_id_column=unique_id_column,
         label_policy=label_policy_module.PASSTHROUGH,
         ingestor_id="run-1",
+        # #350: content_hash is now the default strategy and needs a salt.
+        table_salt="0" * 64,
     )
 
 

--- a/tests/test_file_transfer_summary.py
+++ b/tests/test_file_transfer_summary.py
@@ -305,6 +305,8 @@ def test_ingest_counts_file_transfer_failures_separately(monkeypatch):
     mock_api.prepare_dataset.return_value = True
 
     mock_db = MagicMock()
+    # #350: content_hash default ⇒ mock DB must return a real salt string.
+    mock_db.get_or_create_table_salt.return_value = "0" * 64
     mock_db.create_table.return_value = MagicMock()
     mock_db.get_table_schema.return_value = {}
     mock_db.insert_batch.return_value = ([], [])

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -6,6 +6,7 @@ SQLAlchemy Session is patched out so no real engine is touched.
 
 from __future__ import annotations
 
+import uuid
 from typing import Any, Dict, Generator, List
 from unittest.mock import MagicMock, patch
 
@@ -31,6 +32,10 @@ class FakeIngestor(BaseIngestor):
 
 def make_ingestor(records=None, **overrides):
     db = MagicMock(name="Database")
+    # #350: content_hash is the default id strategy, so a real DB always
+    # returns a salt string from get_or_create_table_salt — the mock must too,
+    # else the auto-Mock poisons the SHA-256 hash and every record is dropped.
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
     db.get_table_schema.return_value = {"a": "INT"}
@@ -48,7 +53,13 @@ def make_ingestor(records=None, **overrides):
         category=None,
     )
     kwargs.update(overrides)
-    return FakeIngestor(records or [], **kwargs)
+    ing = FakeIngestor(records or [], **kwargs)
+    # #350: content_hash is the default id strategy. Tests that call
+    # process_record() directly skip ingest() (which is what fetches the
+    # salt), so pre-set it here — otherwise the record processor raises for
+    # the salt-less content_hash default.
+    ing._table_salt = "0" * 64
+    return ing
 
 
 # ---------------------------------------------------------------------------
@@ -163,12 +174,29 @@ def test_init_does_not_reorder_non_tabular_schema():
 
 
 def test_process_record_generates_uuid_data_id():
-    ing = make_ingestor(category=None, label_column="a")
+    # #350: uuid is now an explicit opt-out (content_hash is the default), so
+    # pin it here to keep exercising the fresh-per-record UUID path.
+    ing = make_ingestor(category=None, label_column="a", data_id_strategy="uuid")
     rec = ing.process_record({"a": "cat", "filename": "x", "extension": ".jpg"})
     assert rec["label"] == "cat"
     assert rec["data_intent"] == "train"
-    assert rec["data_id"]  # uuid string
+    assert uuid.UUID(rec["data_id"])  # a valid uuid string
     assert rec["ingestor_id"] == ing.ingestor_id
+
+
+def test_process_record_generates_content_hash_data_id_by_default():
+    # #350: with no strategy specified, process_record derives a deterministic
+    # salted content hash (64-hex SHA-256) — the same record re-processed under
+    # the same salt reproduces the id, so a retried Job re-claims its rows.
+    ing = make_ingestor(category=None, label_column="a")
+    rec = ing.process_record({"a": "cat", "filename": "x", "extension": ".jpg"})
+    data_id = rec["data_id"]
+    assert len(data_id) == 64 and all(c in "0123456789abcdef" for c in data_id)
+    # deterministic: a fresh ingestor with the same salt reproduces the id
+    again = make_ingestor(category=None, label_column="a")
+    assert again.process_record(
+        {"a": "cat", "filename": "x", "extension": ".jpg"}
+    )["data_id"] == data_id
 
 
 def test_process_record_uses_unique_id_column():

--- a/tests/test_label_policy.py
+++ b/tests/test_label_policy.py
@@ -109,9 +109,11 @@ def _TestIngestor(label_column, label_policy_value, intent="train"):
         intent=intent,
         label_column=label_column,
         annotation_column=None,
-        unique_id_column=None,  # → UUID generation
+        unique_id_column=None,  # → content_hash generation (#350 default)
         label_policy=label_policy_value,
         ingestor_id="test",
+        # #350: content_hash is the default strategy and needs a salt.
+        table_salt="0" * 64,
     )
 
 

--- a/tests/test_modality_failure_accounting.py
+++ b/tests/test_modality_failure_accounting.py
@@ -100,6 +100,9 @@ class FakeIngestor(BaseIngestor):
 
 def make_ingestor(records=None, **overrides):
     db = MagicMock(name="Database")
+    # #350: content_hash is the default id strategy; the mock DB must return a
+    # real salt string (a MagicMock salt poisons the hash and drops every row).
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
     db.get_table_schema.return_value = {"a": "INT"}

--- a/tests/test_semseg_mask_id_contract.py
+++ b/tests/test_semseg_mask_id_contract.py
@@ -409,6 +409,8 @@ def test_declared_mask_id_is_stored_populated_on_the_row():
         unique_id_column=None,
         label_policy=None,
         ingestor_id="t",
+        # #350: content_hash is now the default strategy and needs a salt.
+        table_salt="0" * 64,
     )
     row = rp.process(
         {

--- a/tests/test_sentence_pair_classification.py
+++ b/tests/test_sentence_pair_classification.py
@@ -59,6 +59,9 @@ class FakeIngestor(BaseIngestor):
 
 def make_ingestor(records=None, **overrides):
     db = MagicMock(name="Database")
+    # #350: content_hash is the default id strategy; the mock DB must return a
+    # real salt string (a MagicMock salt poisons the hash and drops every row).
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.return_value = ([1, 2], [])
     db.get_table_schema.return_value = {"a": "INT"}

--- a/tests/test_seq2seq.py
+++ b/tests/test_seq2seq.py
@@ -56,6 +56,9 @@ class FakeIngestor(BaseIngestor):
 
 def make_ingestor(records=None, **overrides):
     db = MagicMock(name="Database")
+    # #350: content_hash is the default id strategy; the mock DB must return a
+    # real salt string (a MagicMock salt poisons the hash and drops every row).
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.return_value = ([1, 2], [])
     db.get_table_schema.return_value = {"a": "INT"}

--- a/tests/test_time_series_classification.py
+++ b/tests/test_time_series_classification.py
@@ -88,6 +88,9 @@ def _make_ingestor(csv_path, **overrides):
     # Real Config so the config-reading validators (TableName, Duplicate)
     # behave: TABLE_NAME set; DEST_PATH (/data/shared/<table>) won't exist.
     db.config = Config(TABLE_NAME="tsc_toy")
+    # #350: content_hash is the default id strategy; the mock DB must return a
+    # real salt string (a MagicMock salt poisons the hash and drops every row).
+    db.get_or_create_table_salt.return_value = "0" * 64
     db.create_table.return_value = MagicMock(name="table")
     db.insert_batch.side_effect = lambda table, batch: (
         list(range(len(batch))),

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -213,7 +213,7 @@ class ResolvedConfig:
 
     # ----- data_id -----
     unique_id_column: Optional[str] = None  # None ⇒ strategy below decides
-    data_id_strategy: str = "uuid"  # uuid | content_hash (column ⇒ unique_id_column)
+    data_id_strategy: str = "content_hash"  # content_hash (default, #350) | uuid (column ⇒ unique_id_column)
 
     # ----- Pass-through to ingestors -----
     annotation_column: Optional[str] = None
@@ -290,18 +290,23 @@ def resolve(config: Dict[str, Any]) -> ResolvedConfig:
         resolved.label_column = label["column"]
         resolved.label_policy = label.get("policy", "passthrough")
 
-    # 5. data_id — strategy: uuid (default, no source col leaves the cluster),
-    #    column (loud, opt-in, captured in unique_id_column for the
-    #    BaseIngestor warning we added in #43), or content_hash (#225:
-    #    deterministic salted hash — a Job retry re-claims its previous rows
-    #    via the data_id UNIQUE upsert instead of duplicating them; landed
-    #    dark, default stays uuid until a release of soak).
+    # 5. data_id — strategy: content_hash (default, #350: deterministic salted
+    #    hash — a Job retry re-claims its previous rows via the data_id UNIQUE
+    #    upsert instead of duplicating them; the salt never leaves the cluster),
+    #    column (loud, opt-in, captured in unique_id_column for the BaseIngestor
+    #    warning we added in #43), or uuid (fresh per-record id — no source col
+    #    leaves the cluster, but a retried run re-inserts every row). content_hash
+    #    landed dark in #225 and soaked opt-in before this flip.
+    #
+    #    ResolvedConfig defaults to content_hash, so an absent data_id key ⇒
+    #    content_hash. The explicit ``uuid`` branch below is the opt-out: without
+    #    it, ``strategy: uuid`` would fall through and silently stay content_hash.
     data_id = config.get("data_id") or {}
     if data_id.get("strategy") == "column":
         resolved.unique_id_column = data_id["column"]
-    elif data_id.get("strategy") == "content_hash":
-        resolved.data_id_strategy = "content_hash"
-    # else: leave defaults ⇒ UUID generation
+    elif data_id.get("strategy") == "uuid":
+        resolved.data_id_strategy = "uuid"
+    # else (content_hash, or absent): leave default ⇒ content_hash
 
     # 6. csv_options — merge customer overrides over defaults.
     csv_overrides = (config.get("spec") or {}).get("csv_options") or {}

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -152,7 +152,7 @@ class BaseIngestor(ABC):
         data_format: Optional[str] = None,
         file_options: Optional[Dict[str, Any]] = None,
         label_policy: str = label_policy_module.PASSTHROUGH,
-        data_id_strategy: str = "uuid",
+        data_id_strategy: str = "content_hash",
     ):
         """Initialize the base ingestor.
 
@@ -179,7 +179,11 @@ class BaseIngestor(ABC):
             ValueError: If unique_id_column is not provided
         """
         self.ingestor_id = str(uuid.uuid4())
-        # #225: deterministic content-hash data_id (opt-in, landed dark).
+        # #225: deterministic content-hash data_id. Now the default (#350):
+        # landed dark in v0.5.7, soaked opt-in through v0.6.0/v0.7.x, flipped
+        # here so a retried k8s Job re-claims its rows via the data_id UNIQUE
+        # upsert instead of duplicating them. Pass ``data_id_strategy="uuid"``
+        # to opt back into fresh-per-record UUIDs.
         # unique_id_column wins if both are set (schema can't express both;
         # belt-and-suspenders). The salt fetch is DEFERRED to ingest() —
         # mirroring #260's deferred create_table — so a validator-rejected

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -167,7 +167,7 @@ class CSVIngestor(BaseIngestor):
         category: Optional[str] = None,
         data_format: Optional[str] = None,
         label_policy: str = label_policy_module.PASSTHROUGH,
-        data_id_strategy: str = "uuid",
+        data_id_strategy: str = "content_hash",
     ):
         """Initialize CSV Ingestor.
 

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -218,7 +218,7 @@ class JSONIngestor(BaseIngestor):
         file_options: Optional[Dict[str, Any]] = None,
         log_level: Optional[int] = None,
         label_policy: str = label_policy_module.PASSTHROUGH,
-        data_id_strategy: str = "uuid",
+        data_id_strategy: str = "content_hash",
     ):
         """Initialize JSON Ingestor.
 

--- a/tracebloc_ingestor/ingestors/record_processor.py
+++ b/tracebloc_ingestor/ingestors/record_processor.py
@@ -51,7 +51,7 @@ class RecordProcessor:
         unique_id_column: Optional[str],
         label_policy: Any,
         ingestor_id: str,
-        data_id_strategy: str = "uuid",
+        data_id_strategy: str = "content_hash",
         table_salt: Optional[str] = None,
     ):
         self.schema = schema

--- a/tracebloc_ingestor/schema/ingest.v1.json
+++ b/tracebloc_ingestor/schema/ingest.v1.json
@@ -165,8 +165,8 @@
         "strategy": {
           "type": "string",
           "enum": ["uuid", "column", "content_hash"],
-          "default": "uuid",
-          "description": "How `data_id` is generated. `uuid` (default) generates a fresh UUID per record — no source column leaves the cluster, but a retried run re-inserts every row under new ids. `column` maps a source column's value, which is louder (logged warning) and only safe when the column doesn't carry PII. `content_hash` derives a deterministic id from the record's content (features + label + source filename), salted with a random per-table value that never leaves the cluster — a retried run re-claims its previous rows instead of duplicating them. Note: genuinely identical source rows therefore collapse into one stored row (content-level dedup)."
+          "default": "content_hash",
+          "description": "How `data_id` is generated. `content_hash` (default) derives a deterministic id from the record's content (features + label + source filename), salted with a random per-table value that never leaves the cluster — a retried run re-claims its previous rows instead of duplicating them. Note: genuinely identical source rows therefore collapse into one stored row (content-level dedup). `uuid` generates a fresh UUID per record — no source column leaves the cluster, but a retried run re-inserts every row under new ids. `column` maps a source column's value, which is louder (logged warning) and only safe when the column doesn't carry PII."
         },
         "column": {
           "type": "string",


### PR DESCRIPTION
Closes #350.

## What

Flips the default `data_id_strategy` from `uuid` to `content_hash`. #225 shipped the salted content-hash `data_id` **dark** in v0.5.7 — the default stayed `uuid` everywhere, so the retry-duplication cure was inert. Privacy sign-off is approved (backend#818, Lukas 2026-07-07) and `content_hash` has soaked opt-in through v0.6.0 / v0.7.x, so the flip is due.

## Changes

- Default `data_id_strategy` `uuid` → `content_hash` at the four constructor sites (`base.py`, `record_processor.py`, `csv_ingestor.py`, `json_ingestor.py`) and in the CLI `ResolvedConfig` (`cli/conventions.py`).
- **Added an explicit `uuid` opt-out branch to `resolve()`.** With the default now `content_hash`, a user's `data_id: {strategy: uuid}` would otherwise fall through the `else` and silently stay `content_hash`. `column` still maps `unique_id_column` (which wins over the strategy in `RecordProcessor` regardless of its value).
- Updated `schema/ingest.v1.json` `default` + description to match.

## Tests

- Lock the new default and the `uuid` opt-out in `test_conventions.py` and `test_content_hash_data_id.py`; add a `process_record` content-hash-default test in `test_ingestor_base.py`.
- Mocked-DB harnesses that exercise the full `ingest()` path now stub `get_or_create_table_salt` (a real DB always returns a salt string; an unstubbed MagicMock salt poisons the SHA-256 and drops every row). `process_record`-direct harnesses pre-set `_table_salt` (they skip `ingest()`, which is what fetches the salt) or pin `uuid` where the id strategy is orthogonal to what they test.
- Full suite green locally except 4 pre-existing `float_overflow` tests that fail identically on clean `develop` (a local pandas `1e400` quirk on py3.9; they pass on the CI 3.11/3.12 legs).

## Not in this PR (per the ticket)

- **Release cut** — separate gated release PR; no version bump here.
- **Rollout prerequisite** — post-tracebloc-client#420 images must be fleet-wide before this matters (pre-#420 images KeyError against current backend regardless). Operational, not a code gate.
- **Fold-in decisions** (orphan-sweep source, double-registration dedupe) are marked non-blocking / self-healing once this flips.

Refs: epic backend#820, design backend#818, data-ingestors#225 (PR #339).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Flipping the default changes row identity and dedup behavior for every ingest without an explicit data_id block; identical source rows now collapse to one stored row, which is intended but is a fleet-wide behavioral change at the data layer.
> 
> **Overview**
> Makes **salted `content_hash`** the default `data_id` strategy when YAML omits `data_id` (or sets `strategy: content_hash`), so retried jobs reuse stable ids and upsert re-claims rows instead of duplicating. **`uuid`** remains available via an explicit `data_id: { strategy: uuid }` opt-out; **`resolve()`** now sets that branch explicitly so `uuid` is not ignored after the default flip.
> 
> Constructor defaults and **`ingest.v1.json`** (`default` + description) align across **`ResolvedConfig`**, **`BaseIngestor`**, **`RecordProcessor`**, and CSV/JSON ingestors.
> 
> **Tests/e2e:** mock DB salt and pre-set `_table_salt` where `process_record` bypasses `ingest()`; image/object-detection characterization and content-compare cases pin **`uuid`** where fixtures repeat identical rows and goldens assume one stored row per CSV line; tabular content-compare keeps the default to exercise **`content_hash`** end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dfa34f24d56c506121b7b787b1dfc8406959178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->