### PR TITLE
fix(validators): honor csv_options in time_series_classification validators

### DIFF
--- a/tests/test_csv_dialect.py
+++ b/tests/test_csv_dialect.py
@@ -1,0 +1,63 @@
+"""Tests for the shared CSV read-dialect passthrough (#371).
+
+The single source of truth every CSV-reading validator uses so it tokenizes
+the manifest byte-identically to CSVIngestor — see
+``tracebloc_ingestor/utils/csv_dialect.py``.
+"""
+
+from __future__ import annotations
+
+from tracebloc_ingestor.utils.csv_dialect import (
+    READ_DIALECT_KEYS,
+    read_dialect_kwargs,
+)
+
+
+def test_defaults_comma_and_bom_safe_encoding():
+    # No options -> comma separator + BOM-stripping utf-8-sig (Excel export).
+    kw = read_dialect_kwargs(None)
+    assert kw["sep"] == ","
+    assert kw["encoding"] == "utf-8-sig"
+
+
+def test_none_and_empty_are_equivalent():
+    assert read_dialect_kwargs({}) == read_dialect_kwargs(None)
+
+
+def test_forwards_only_dialect_keys():
+    # Restructuring keys (usecols/nrows/header/index_col/...) must be dropped —
+    # forwarding them would collide with a validator's own read shape.
+    kw = read_dialect_kwargs(
+        {
+            "sep": ";",
+            "quotechar": "'",
+            "usecols": ["a"],
+            "nrows": 5,
+            "header": 0,
+            "index_col": "id",
+        }
+    )
+    assert kw["sep"] == ";"
+    assert kw["quotechar"] == "'"
+    assert "usecols" not in kw
+    assert "nrows" not in kw
+    assert "header" not in kw
+    assert "index_col" not in kw
+
+
+def test_delimiter_alias_suppresses_default_sep():
+    # A caller that passes `delimiter` must NOT also get a defaulted `sep`
+    # (pandas rejects both at once).
+    kw = read_dialect_kwargs({"delimiter": "\t"})
+    assert kw["delimiter"] == "\t"
+    assert "sep" not in kw
+
+
+def test_explicit_non_utf8_encoding_preserved():
+    assert read_dialect_kwargs({"encoding": "latin-1"})["encoding"] == "latin-1"
+
+
+def test_dialect_keys_are_tokenizing_only():
+    # Guard the whitelist against accidental inclusion of restructuring keys.
+    for restructuring in ("usecols", "nrows", "header", "names", "skiprows", "index_col"):
+        assert restructuring not in READ_DIALECT_KEYS

--- a/tests/test_csv_dialect.py
+++ b/tests/test_csv_dialect.py
@@ -7,9 +7,12 @@ the manifest byte-identically to CSVIngestor — see
 
 from __future__ import annotations
 
+import pytest
+
 from tracebloc_ingestor.utils.csv_dialect import (
     READ_DIALECT_KEYS,
     read_dialect_kwargs,
+    validate_csv_options,
 )
 
 
@@ -61,3 +64,29 @@ def test_dialect_keys_are_tokenizing_only():
     # Guard the whitelist against accidental inclusion of restructuring keys.
     for restructuring in ("usecols", "nrows", "header", "names", "skiprows", "index_col"):
         assert restructuring not in READ_DIALECT_KEYS
+
+
+# validate_csv_options (#376) — fail fast at construction on malformed dialect.
+def test_validate_csv_options_accepts_valid_and_empty():
+    validate_csv_options(None)
+    validate_csv_options({})
+    validate_csv_options({"sep": ";", "encoding": "latin-1", "quoting": 3})
+
+
+@pytest.mark.parametrize(
+    "opts,bad_key",
+    [
+        ({"sep": 3}, "sep"),
+        ({"delimiter": b";"}, "delimiter"),
+        ({"quotechar": 1}, "quotechar"),
+        ({"encoding": 0}, "encoding"),
+    ],
+)
+def test_validate_csv_options_rejects_non_string_dialect(opts, bad_key):
+    with pytest.raises(ValueError, match=f"csv_options\\['{bad_key}'\\] must be a string"):
+        validate_csv_options(opts)
+
+
+def test_validate_csv_options_rejects_non_int_quoting():
+    with pytest.raises(ValueError, match="quoting.* must be an int"):
+        validate_csv_options({"quoting": "all"})

--- a/tests/test_label_constant_within_group_validator.py
+++ b/tests/test_label_constant_within_group_validator.py
@@ -39,6 +39,18 @@ def test_csv_path_accepted(make_csv):
     assert LabelConstantWithinGroupValidator().validate(str(path)).is_valid
 
 
+def test_honors_csv_options_delimiter(tmp_path):
+    # #371 bugbot: parse a non-comma manifest with the run's csv_options. Under
+    # the default comma parse the semicolon file is one squashed column (no
+    # sequence/label columns -> fail); sep=';' resolves it.
+    path = tmp_path / "semi.csv"
+    _toy_df().to_csv(path, index=False, sep=";")
+    assert not LabelConstantWithinGroupValidator().validate(str(path)).is_valid
+    assert LabelConstantWithinGroupValidator(
+        csv_options={"sep": ";"}
+    ).validate(str(path)).is_valid
+
+
 def test_interleaved_sequences_pass():
     # Row order doesn't matter for constancy — only the per-sequence value set.
     df = _toy_df().sample(frac=1.0, random_state=7).reset_index(drop=True)

--- a/tests/test_label_constant_within_group_validator.py
+++ b/tests/test_label_constant_within_group_validator.py
@@ -51,6 +51,12 @@ def test_honors_csv_options_delimiter(tmp_path):
     ).validate(str(path)).is_valid
 
 
+def test_malformed_csv_options_rejected_at_construction():
+    # #376 bugbot: fail fast at construction on a bad dialect value.
+    with pytest.raises(ValueError, match="csv_options"):
+        LabelConstantWithinGroupValidator(csv_options={"quoting": "all"})
+
+
 def test_interleaved_sequences_pass():
     # Row order doesn't matter for constancy — only the per-sequence value set.
     df = _toy_df().sample(frac=1.0, random_state=7).reset_index(drop=True)

--- a/tests/test_per_group_time_ordered_validator.py
+++ b/tests/test_per_group_time_ordered_validator.py
@@ -65,6 +65,12 @@ def test_honors_csv_options_delimiter(tmp_path):
     ).validate(str(path)).is_valid
 
 
+def test_malformed_csv_options_rejected_at_construction():
+    # #376 bugbot: fail fast at construction on a bad dialect value.
+    with pytest.raises(ValueError, match="csv_options"):
+        PerGroupTimeOrderedValidator(schema=TS_SCHEMA, csv_options={"sep": 3})
+
+
 def test_interleaved_sequences_pass_where_global_validator_would_fail():
     # T4: p1 08:00, p2 08:00, p1 09:00, ... is globally NON-monotonic but
     # perfectly ordered per sequence — the whole reason this validator exists.

--- a/tests/test_per_group_time_ordered_validator.py
+++ b/tests/test_per_group_time_ordered_validator.py
@@ -51,6 +51,20 @@ def test_per_group_ordered_timestamps_pass():
     assert result.metadata["time_kind"] == "timestamp"
 
 
+def test_honors_csv_options_delimiter(tmp_path):
+    # #371 bugbot: parse a non-comma manifest with the run's csv_options. Under
+    # the default comma parse the semicolon file is one squashed column (the
+    # sequence/time columns are absent -> fail); sep=';' resolves it.
+    path = tmp_path / "semi.csv"
+    _ts_df().to_csv(path, index=False, sep=";")
+    assert not PerGroupTimeOrderedValidator(schema=TS_SCHEMA).validate(
+        str(path)
+    ).is_valid
+    assert PerGroupTimeOrderedValidator(
+        schema=TS_SCHEMA, csv_options={"sep": ";"}
+    ).validate(str(path)).is_valid
+
+
 def test_interleaved_sequences_pass_where_global_validator_would_fail():
     # T4: p1 08:00, p2 08:00, p1 09:00, ... is globally NON-monotonic but
     # perfectly ordered per sequence — the whole reason this validator exists.

--- a/tests/test_sequence_group_validator.py
+++ b/tests/test_sequence_group_validator.py
@@ -66,6 +66,13 @@ def test_honors_csv_options_delimiter(tmp_path):
     assert result.metadata["rows_checked"] == 15
 
 
+def test_malformed_csv_options_rejected_at_construction():
+    # #376 bugbot: a bad dialect value must fail fast at construction (clear
+    # config error), not surface as a generic load failure mid-scan.
+    with pytest.raises(ValueError, match="csv_options"):
+        SequenceGroupValidator(csv_options={"sep": 3})
+
+
 def test_column_resolved_case_insensitively():
     # #340 rule: header spelling may differ in case/whitespace.
     df = _toy_df().rename(columns={"sequence_id": " Sequence_ID "})

--- a/tests/test_sequence_group_validator.py
+++ b/tests/test_sequence_group_validator.py
@@ -48,6 +48,24 @@ def test_valid_csv_path_accepted(make_csv):
     assert "number_of_sequences" not in result.metadata
 
 
+def test_honors_csv_options_delimiter(tmp_path):
+    # #371 bugbot: a non-comma manifest must be parsed with the run's
+    # csv_options, exactly as CSVIngestor reads it. Written semicolon-
+    # delimited, it is one squashed column under the default comma parse
+    # (sequence_id not found), and only resolves when sep=';' is forwarded.
+    path = tmp_path / "semi.csv"
+    _toy_df().to_csv(path, index=False, sep=";")
+
+    # No csv_options -> misread as a single column -> the required column is
+    # absent, so validation fails (proves the delimiter actually matters).
+    assert not SequenceGroupValidator().validate(str(path)).is_valid
+
+    # Forwarding the run's delimiter parses it correctly.
+    result = SequenceGroupValidator(csv_options={"sep": ";"}).validate(str(path))
+    assert result.is_valid
+    assert result.metadata["rows_checked"] == 15
+
+
 def test_column_resolved_case_insensitively():
     # #340 rule: header spelling may differ in case/whitespace.
     df = _toy_df().rename(columns={"sequence_id": " Sequence_ID "})

--- a/tests/test_time_series_classification.py
+++ b/tests/test_time_series_classification.py
@@ -199,6 +199,28 @@ def test_factory_threads_unique_id_column_to_guard():
     assert guard.unique_id_column == "sequence_id"
 
 
+def test_factory_threads_csv_options_to_all_grouped_validators():
+    # #371 bugbot: every CSV-reading grouped validator must receive the run's
+    # csv_options so it tokenizes the manifest exactly as CSVIngestor does.
+    opts = {"sep": ";", "encoding": "latin-1"}
+    validators = map_validators(TSC, {"schema": dict(SCHEMA), "csv_options": opts})
+    grouped = [
+        v
+        for v in validators
+        if isinstance(
+            v,
+            (
+                SequenceGroupValidator,
+                LabelConstantWithinGroupValidator,
+                PerGroupTimeOrderedValidator,
+            ),
+        )
+    ]
+    assert len(grouped) == 3
+    for v in grouped:
+        assert v._csv_options == opts
+
+
 # ---------------------------------------------------------------------------
 # Done-contract scenario: 3-patient toy CSV, mocked DB boundary
 # ---------------------------------------------------------------------------

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.7.3"
+__version__ = "0.7.4"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/modalities/validators.py
+++ b/tracebloc_ingestor/modalities/validators.py
@@ -411,15 +411,21 @@ def time_series_classification(options: Dict[str, Any]) -> List[BaseValidator]:
             # T6: the run's data_id source column when strategy=column
             # (threaded through options by BaseIngestor.validate_data).
             unique_id_column=options.get("unique_id_column"),
+            # Parse the manifest with the run's delimiter/encoding so a
+            # non-comma or BOM manifest that ingests fine isn't falsely
+            # rejected — or passed for the wrong reason — at preflight (#371).
+            csv_options=options.get("csv_options"),
         ),
         LabelConstantWithinGroupValidator(
             sequence_column=group_column,
             label_column=options.get("label_column") or "label",
+            csv_options=options.get("csv_options"),
         ),
         PerGroupTimeOrderedValidator(
             sequence_column=group_column,
             time_column=time_column,
             schema=schema,
+            csv_options=options.get("csv_options"),
         ),
         NumericColumnsValidator(
             schema=schema, excluded_columns={group_column, time_column}

--- a/tracebloc_ingestor/utils/csv_dialect.py
+++ b/tracebloc_ingestor/utils/csv_dialect.py
@@ -39,6 +39,45 @@ READ_DIALECT_KEYS = frozenset(
 )
 
 
+# Dialect keys whose value must be a string when present — the char / encoding
+# options (a subset of READ_DIALECT_KEYS). ``quoting`` is an int (csv.QUOTE_*),
+# checked separately; the boolean/flag keys (doublequote, skipinitialspace) are
+# left for pandas to coerce.
+_STR_DIALECT_KEYS = (
+    "sep",
+    "delimiter",
+    "quotechar",
+    "escapechar",
+    "encoding",
+    "encoding_errors",
+    "lineterminator",
+    "comment",
+    "engine",
+)
+
+
+def validate_csv_options(csv_options: Optional[Dict[str, Any]]) -> None:
+    """Fail fast on a malformed *csv_options* dialect value, raising
+    ``ValueError`` at construction rather than letting it surface as a generic
+    parse failure deep inside a validator's read (validate config at
+    construction, not mid-scan). Checks only the dialect keys the validators
+    forward to pandas (see :data:`READ_DIALECT_KEYS`)."""
+    opts = csv_options or {}
+    for key in _STR_DIALECT_KEYS:
+        val = opts.get(key)
+        if val is not None and not isinstance(val, str):
+            raise ValueError(
+                f"csv_options['{key}'] must be a string, got "
+                f"{type(val).__name__} — check the ingest config."
+            )
+    quoting = opts.get("quoting")
+    if quoting is not None and not isinstance(quoting, int):
+        raise ValueError(
+            f"csv_options['quoting'] must be an int (csv.QUOTE_*), got "
+            f"{type(quoting).__name__} — check the ingest config."
+        )
+
+
 def read_dialect_kwargs(csv_options: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """pandas ``read_csv`` kwargs matching CSVIngestor's tokenizer for
     *csv_options*.

--- a/tracebloc_ingestor/utils/csv_dialect.py
+++ b/tracebloc_ingestor/utils/csv_dialect.py
@@ -1,0 +1,63 @@
+"""Shared CSV read-dialect passthrough for preflight validators.
+
+A validator that reads the manifest itself must tokenize it BYTE-IDENTICALLY to
+:class:`CSVIngestor`, or a non-comma / BOM / quoted manifest that ingests fine
+gets falsely rejected — or passes for the wrong reason — at preflight, then
+ingests differently at runtime. This centralises the whitelist of tokenizing
+dialect keys plus the BOM-safe encoding default so every CSV-reading validator
+resolves the same columns + cells the write path does.
+
+Used by :class:`MaskIdColumnValidator` and the ``time_series_classification``
+grouped validators (backend#1054 WS1); the single source of truth so the set
+can't drift between them (review: #371 bugbot).
+"""
+
+from typing import Any, Dict, Optional
+
+# The ONLY keys forwarded to a validator's read: those that control how bytes
+# are TOKENIZED into columns + cells. A whitelist, not a blacklist —
+# frame-RESTRUCTURING keys (index_col, header, names, usecols, skiprows, nrows,
+# ...) are excluded, because a validator pins its own usecols/nrows/dtype and
+# forwarding a restructuring key would collide with those (a swallowed error
+# that fail-opens the gate) or change which column is which. Unknown/new
+# csv_options are dropped by default.
+READ_DIALECT_KEYS = frozenset(
+    {
+        "sep",
+        "delimiter",
+        "quotechar",
+        "doublequote",
+        "escapechar",
+        "quoting",
+        "skipinitialspace",
+        "encoding",
+        "encoding_errors",
+        "lineterminator",
+        "comment",
+        "engine",
+    }
+)
+
+
+def read_dialect_kwargs(csv_options: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """pandas ``read_csv`` kwargs matching CSVIngestor's tokenizer for
+    *csv_options*.
+
+    Forwards only the dialect keys (see :data:`READ_DIALECT_KEYS`), upgrades the
+    encoding to its BOM-safe form (Excel's "CSV UTF-8" export, #338), and
+    defaults the separator to ``","`` — so a validator's read splits fields
+    exactly as the ingest write path does. Callers merge their own read-shape
+    kwargs (``nrows`` / ``usecols`` / ``on_bad_lines`` / ``dtype`` / ...) on top.
+    """
+    # Lazy import: csv_ingestor -> base -> validators_mapping ->
+    # modalities.validators -> the grouped validators -> this module, so a
+    # top-level import would cycle.
+    from ..ingestors.csv_ingestor import _bom_safe_encoding
+
+    opts = {
+        k: v for k, v in (csv_options or {}).items() if k in READ_DIALECT_KEYS
+    }
+    opts["encoding"] = _bom_safe_encoding(opts.get("encoding"))
+    if "sep" not in opts and "delimiter" not in opts:
+        opts["sep"] = ","
+    return opts

--- a/tracebloc_ingestor/validators/label_constant_within_group_validator.py
+++ b/tracebloc_ingestor/validators/label_constant_within_group_validator.py
@@ -16,7 +16,7 @@ from typing import Any, Optional
 
 from ..utils import redaction
 from ..utils.columns import resolve_column
-from ..utils.csv_dialect import read_dialect_kwargs
+from ..utils.csv_dialect import read_dialect_kwargs, validate_csv_options
 
 try:
     import pandas as pd
@@ -73,6 +73,9 @@ class LabelConstantWithinGroupValidator(BaseValidator):
         )
         self.label_column = label_column if label_column is not None else "label"
         self._csv_options = csv_options or {}
+        # Fail fast on a malformed dialect value at construction — same contract
+        # as MaskIdColumnValidator (bugbot #376).
+        validate_csv_options(self._csv_options)
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         """Validate that the label is constant within each sequence.

--- a/tracebloc_ingestor/validators/label_constant_within_group_validator.py
+++ b/tracebloc_ingestor/validators/label_constant_within_group_validator.py
@@ -16,6 +16,7 @@ from typing import Any, Optional
 
 from ..utils import redaction
 from ..utils.columns import resolve_column
+from ..utils.csv_dialect import read_dialect_kwargs
 
 try:
     import pandas as pd
@@ -51,6 +52,7 @@ class LabelConstantWithinGroupValidator(BaseValidator):
         self,
         sequence_column: Optional[str] = None,
         label_column: Optional[str] = None,
+        csv_options: Optional[dict] = None,
         name: str = "Label Constant Within Group Validator",
     ):
         """Initialize the label-constancy validator.
@@ -59,6 +61,10 @@ class LabelConstantWithinGroupValidator(BaseValidator):
             sequence_column: Name of the sequence group column (default:
                 "sequence_id")
             label_column: Name of the label column (default: "label")
+            csv_options: The run's pandas read options (delimiter / encoding /
+                ...), so the manifest is parsed exactly as CSVIngestor parses
+                it. Without it a non-comma or BOM manifest that ingests fine is
+                falsely rejected — or passes for the wrong reason — here.
             name: Human-readable name of the validator
         """
         super().__init__(name)
@@ -66,6 +72,7 @@ class LabelConstantWithinGroupValidator(BaseValidator):
             sequence_column if sequence_column is not None else "sequence_id"
         )
         self.label_column = label_column if label_column is not None else "label"
+        self._csv_options = csv_options or {}
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         """Validate that the label is constant within each sequence.
@@ -193,7 +200,14 @@ class LabelConstantWithinGroupValidator(BaseValidator):
             elif isinstance(data, (str, Path)):
                 path = Path(data)
                 if path.suffix.lower() == ".csv":
-                    return pd.read_csv(path, encoding="utf-8", on_bad_lines="warn")
+                    # Parse with the run's delimiter / encoding / quoting so the
+                    # validator tokenizes the manifest byte-identically to
+                    # CSVIngestor (bugbot #371).
+                    return pd.read_csv(
+                        path,
+                        on_bad_lines="warn",
+                        **read_dialect_kwargs(self._csv_options),
+                    )
                 logger.warning(f"Unsupported file type: {path.suffix}, \n\n{path}")
                 return None
             else:

--- a/tracebloc_ingestor/validators/mask_id_validator.py
+++ b/tracebloc_ingestor/validators/mask_id_validator.py
@@ -29,7 +29,7 @@ import pandas as pd
 from .base import BaseValidator, ValidationResult
 from ..config import Config
 from ..utils.coercion import NA_SENTINELS
-from ..utils.csv_dialect import read_dialect_kwargs
+from ..utils.csv_dialect import read_dialect_kwargs, validate_csv_options
 
 config = Config()
 logger = logging.getLogger(__name__)
@@ -99,33 +99,10 @@ class MaskIdColumnValidator(BaseValidator):
     def _validate_csv_options(self) -> None:
         """Fail fast at construction on a malformed csv_options value, rather than
         deep inside the read where it surfaces as a generic mask-id failure
-        (validate config at construction, not mid-scan). Checks only the dialect
-        keys this validator forwards to pandas (see
-        :data:`~..utils.csv_dialect.READ_DIALECT_KEYS`)."""
-        str_keys = (
-            "sep",
-            "delimiter",
-            "quotechar",
-            "escapechar",
-            "encoding",
-            "encoding_errors",
-            "lineterminator",
-            "comment",
-            "engine",
-        )
-        for key in str_keys:
-            val = self._csv_options.get(key)
-            if val is not None and not isinstance(val, str):
-                raise ValueError(
-                    f"csv_options['{key}'] must be a string, got "
-                    f"{type(val).__name__} — check the ingest config."
-                )
-        quoting = self._csv_options.get("quoting")
-        if quoting is not None and not isinstance(quoting, int):
-            raise ValueError(
-                f"csv_options['quoting'] must be an int (csv.QUOTE_*), got "
-                f"{type(quoting).__name__} — check the ingest config."
-            )
+        (validate config at construction, not mid-scan). Delegates to the shared
+        :func:`validate_csv_options` so this validator and the grouped
+        time-series validators reject the same malformed dialect values."""
+        validate_csv_options(self._csv_options)
 
     def _read_kwargs(self) -> Dict[str, Any]:
         """The pandas read options needed to parse the manifest exactly as

--- a/tracebloc_ingestor/validators/mask_id_validator.py
+++ b/tracebloc_ingestor/validators/mask_id_validator.py
@@ -29,6 +29,7 @@ import pandas as pd
 from .base import BaseValidator, ValidationResult
 from ..config import Config
 from ..utils.coercion import NA_SENTINELS
+from ..utils.csv_dialect import read_dialect_kwargs
 
 config = Config()
 logger = logging.getLogger(__name__)
@@ -41,30 +42,6 @@ logger.setLevel(config.LOG_LEVEL)
 # column then). The semseg factory always passes the resolved schema, so the
 # real ingest path always runs the declaration check.
 _SCHEMA_UNSET = object()
-
-# The ONLY csv_options forwarded to the validator's reads: the keys that control
-# how the manifest is TOKENIZED into columns + cells, so its parse matches
-# CSVIngestor's. A whitelist, not a blacklist — frame-RESTRUCTURING keys
-# (index_col, header, names, usecols, skiprows, nrows, ...) are excluded, because
-# the scan pins its own usecols/dtype/chunksize and forwarding a restructuring
-# key would collide with those (a swallowed error that fail-opens the gate) or
-# change which column mask_id is. New/unknown csv_options are dropped by default.
-_READ_DIALECT_KEYS = frozenset(
-    {
-        "sep",
-        "delimiter",
-        "quotechar",
-        "doublequote",
-        "escapechar",
-        "quoting",
-        "skipinitialspace",
-        "encoding",
-        "encoding_errors",
-        "lineterminator",
-        "comment",
-        "engine",
-    }
-)
 
 # Cap on how many offending row indices the empty-value scan keeps: only a few
 # are shown in the message (redaction.row_refs slices to 5) and the rest are a
@@ -123,7 +100,8 @@ class MaskIdColumnValidator(BaseValidator):
         """Fail fast at construction on a malformed csv_options value, rather than
         deep inside the read where it surfaces as a generic mask-id failure
         (validate config at construction, not mid-scan). Checks only the dialect
-        keys this validator forwards to pandas (see :data:`_READ_DIALECT_KEYS`)."""
+        keys this validator forwards to pandas (see
+        :data:`~..utils.csv_dialect.READ_DIALECT_KEYS`)."""
         str_keys = (
             "sep",
             "delimiter",
@@ -155,18 +133,10 @@ class MaskIdColumnValidator(BaseValidator):
         quoting dialect (quotechar / escapechar / quoting / ...), so preflight and
         the write path resolve the same columns + values from the same bytes. A
         sep or quotechar mismatch would split fields differently and desync them.
+        Delegates to the shared :func:`read_dialect_kwargs` so this validator and
+        the grouped time-series validators can't drift on the dialect whitelist.
         """
-        # Lazy import: csv_ingestor -> base -> validators_mapping ->
-        # modalities.validators -> this module, so a top-level import would cycle.
-        from ..ingestors.csv_ingestor import _bom_safe_encoding
-
-        # Forward only the tokenizing dialect keys CSVIngestor honors (see
-        # _READ_DIALECT_KEYS) — never a frame-restructuring key.
-        opts = {k: v for k, v in self._csv_options.items() if k in _READ_DIALECT_KEYS}
-        opts["encoding"] = _bom_safe_encoding(opts.get("encoding"))
-        if "sep" not in opts and "delimiter" not in opts:
-            opts["sep"] = ","
-        return opts
+        return read_dialect_kwargs(self._csv_options)
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         try:

--- a/tracebloc_ingestor/validators/per_group_time_ordered_validator.py
+++ b/tracebloc_ingestor/validators/per_group_time_ordered_validator.py
@@ -22,6 +22,7 @@ import pandas as pd
 
 from ..utils import redaction
 from ..utils.columns import resolve_column
+from ..utils.csv_dialect import read_dialect_kwargs
 
 from .base import BaseValidator, ValidationResult
 from .time_format_validator import parse_month_first_with_ambiguity_mask
@@ -70,6 +71,7 @@ class PerGroupTimeOrderedValidator(BaseValidator):
         sequence_column: Optional[str] = None,
         time_column: Optional[str] = None,
         schema: Optional[dict] = None,
+        csv_options: Optional[dict] = None,
         name: str = "Per Group Time Ordered Validator",
     ):
         super().__init__(name)
@@ -78,6 +80,11 @@ class PerGroupTimeOrderedValidator(BaseValidator):
         )
         self.time_column = time_column if time_column is not None else "timestamp"
         self.schema = schema or {}
+        # The run's pandas read options (delimiter / encoding / ...), so the
+        # manifest is tokenized exactly as CSVIngestor tokenizes it. Without it
+        # a non-comma or BOM manifest that ingests fine is falsely rejected —
+        # or passes for the wrong reason — here (bugbot #371).
+        self._csv_options = csv_options or {}
 
     def _declared_base_type(self) -> Optional[str]:
         """The schema's declared base type for the time column, or None."""
@@ -262,7 +269,14 @@ class PerGroupTimeOrderedValidator(BaseValidator):
             if isinstance(data, (str, Path)):
                 file_path = Path(data).expanduser()
                 if file_path.exists() and file_path.suffix.lower() == ".csv":
-                    return pd.read_csv(file_path, encoding="utf-8", on_bad_lines="warn")
+                    # Parse with the run's delimiter / encoding / quoting so the
+                    # validator tokenizes the manifest byte-identically to
+                    # CSVIngestor (bugbot #371).
+                    return pd.read_csv(
+                        file_path,
+                        on_bad_lines="warn",
+                        **read_dialect_kwargs(self._csv_options),
+                    )
 
             return None
         except Exception as e:

--- a/tracebloc_ingestor/validators/per_group_time_ordered_validator.py
+++ b/tracebloc_ingestor/validators/per_group_time_ordered_validator.py
@@ -22,7 +22,7 @@ import pandas as pd
 
 from ..utils import redaction
 from ..utils.columns import resolve_column
-from ..utils.csv_dialect import read_dialect_kwargs
+from ..utils.csv_dialect import read_dialect_kwargs, validate_csv_options
 
 from .base import BaseValidator, ValidationResult
 from .time_format_validator import parse_month_first_with_ambiguity_mask
@@ -85,6 +85,9 @@ class PerGroupTimeOrderedValidator(BaseValidator):
         # a non-comma or BOM manifest that ingests fine is falsely rejected —
         # or passes for the wrong reason — here (bugbot #371).
         self._csv_options = csv_options or {}
+        # Fail fast on a malformed dialect value at construction — same contract
+        # as MaskIdColumnValidator (bugbot #376).
+        validate_csv_options(self._csv_options)
 
     def _declared_base_type(self) -> Optional[str]:
         """The schema's declared base type for the time column, or None."""

--- a/tracebloc_ingestor/validators/sequence_group_validator.py
+++ b/tracebloc_ingestor/validators/sequence_group_validator.py
@@ -19,6 +19,7 @@ from typing import Any, Optional
 
 from ..utils import redaction
 from ..utils.columns import resolve_column
+from ..utils.csv_dialect import read_dialect_kwargs
 
 try:
     import pandas as pd
@@ -60,6 +61,7 @@ class SequenceGroupValidator(BaseValidator):
         sequence_column: Optional[str] = None,
         unique_id_column: Optional[str] = None,
         schema: Optional[dict] = None,
+        csv_options: Optional[dict] = None,
         name: str = "Sequence Group Validator",
     ):
         """Initialize the sequence group validator.
@@ -70,6 +72,10 @@ class SequenceGroupValidator(BaseValidator):
             unique_id_column: The configured ``data_id`` source column
                 (``data_id.strategy=column``), for the T6 guard
             schema: Optional schema dictionary
+            csv_options: The run's pandas read options (delimiter / encoding /
+                ...), so the manifest is parsed exactly as CSVIngestor parses
+                it. Without it a non-comma or BOM manifest that ingests fine is
+                falsely rejected — or passes for the wrong reason — here.
             name: Human-readable name of the validator
         """
         super().__init__(name)
@@ -78,6 +84,7 @@ class SequenceGroupValidator(BaseValidator):
         )
         self.unique_id_column = unique_id_column
         self.schema = schema or {}
+        self._csv_options = csv_options or {}
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         """Validate the sequence group column.
@@ -247,11 +254,14 @@ class SequenceGroupValidator(BaseValidator):
             elif isinstance(data, (str, Path)):
                 path = Path(data)
                 if path.suffix.lower() == ".csv":
+                    # Parse with the run's delimiter / encoding / quoting so the
+                    # validator tokenizes the manifest byte-identically to
+                    # CSVIngestor (bugbot #371); read-shape kwargs layered on top.
                     return pd.read_csv(
                         path,
                         nrows=sample_size,
-                        encoding="utf-8",
                         on_bad_lines="warn",
+                        **read_dialect_kwargs(self._csv_options),
                     )
                 logger.warning(f"Unsupported file type: {path.suffix}, \n\n{path}")
                 return None

--- a/tracebloc_ingestor/validators/sequence_group_validator.py
+++ b/tracebloc_ingestor/validators/sequence_group_validator.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 
 from ..utils import redaction
 from ..utils.columns import resolve_column
-from ..utils.csv_dialect import read_dialect_kwargs
+from ..utils.csv_dialect import read_dialect_kwargs, validate_csv_options
 
 try:
     import pandas as pd
@@ -85,6 +85,10 @@ class SequenceGroupValidator(BaseValidator):
         self.unique_id_column = unique_id_column
         self.schema = schema or {}
         self._csv_options = csv_options or {}
+        # Fail fast on a malformed dialect value (non-string sep, invalid
+        # quoting, ...) at construction, rather than as a generic load/"no data"
+        # error mid-scan — same contract as MaskIdColumnValidator (bugbot #376).
+        validate_csv_options(self._csv_options)
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         """Validate the sequence group column.


### PR DESCRIPTION
## Summary

Fixes the Bugbot finding on the develop→prod promotion PR #371.

**Medium — "TSC validators ignore CSV options."** The three `time_series_classification` preflight validators — `SequenceGroupValidator`, `LabelConstantWithinGroupValidator`, `PerGroupTimeOrderedValidator` — loaded the manifest with a hardcoded comma / `utf-8` `pd.read_csv`, ignoring the run's `csv_options` (delimiter, encoding, quoting) that `validate_data` already threads to validators and `CSVIngestor` honors. A non-comma / BOM / quoted manifest could **pass validation or fail for the wrong reason** at preflight, then ingest differently at runtime.

### Fix
- Extracted the dialect passthrough that `MaskIdColumnValidator` already had inline into a shared `tracebloc_ingestor/utils/csv_dialect.py` (`read_dialect_kwargs` + `READ_DIALECT_KEYS`) — a single source of truth for the tokenizing-key whitelist and BOM-safe encoding, so the two can't drift (the exact kind of duplication a reviewer flags).
- Routed `MaskIdColumnValidator` through the shared helper (behavior-identical; its existing dialect tests still pass).
- Added a `csv_options` parameter to the three grouped validators and used the helper in their `_load_data`, layering read-shape kwargs (`nrows` / `on_bad_lines`) on top.
- Threaded `csv_options` into all three via the `time_series_classification` factory in `modalities/validators.py`.

## Related
Ref #371 (Bugbot finding). Follows the `mask_id` dialect fix (#371) and the same learned rule as #359.

## Type of change
- [x] Bug fix

## Test plan
- `tests/test_csv_dialect.py` — helper unit suite (defaults, alias handling, whitelist guard).
- Per-validator delimiter tests writing **real semicolon-delimited files**: each validator fails under the default comma parse and passes only when `csv_options={"sep": ";"}` is forwarded.
- `test_factory_threads_csv_options_to_all_grouped_validators` — asserts all three grouped validators receive the run's `csv_options`.
- `pytest tests/` — **1651 passed, 1 xfailed**.

## Checklist
- [x] Tests added / updated and passing locally
- [x] No secrets / credentials in the diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preflight CSV parsing for TSC grouped validators; incorrect dialect handling could still cause false pass/fail at validation time, though the change aligns validators with ingest behavior and adds construction-time config checks.
> 
> **Overview**
> Fixes preflight for **time_series_classification** when manifests use non-default CSV dialects (semicolon delimiter, BOM/encoding, quoting). The three grouped validators previously read CSVs with a hardcoded comma/`utf-8` parse while `CSVIngestor` honors the run's `csv_options`, so preflight could pass or fail for the wrong reasons.
> 
> Adds shared **`tracebloc_ingestor/utils/csv_dialect.py`** (`read_dialect_kwargs`, `validate_csv_options`, tokenizing-key whitelist) and routes **`MaskIdColumnValidator`** through it so dialect logic cannot drift. **`SequenceGroupValidator`**, **`LabelConstantWithinGroupValidator`**, and **`PerGroupTimeOrderedValidator`** accept `csv_options`, validate dialect at construction (#376), and merge `read_dialect_kwargs` into `pd.read_csv` in `_load_data`. The TSC factory in **`modalities/validators.py`** forwards `options["csv_options"]` to all three.
> 
> Tests cover the helper, semicolon-delimited fixtures per validator, factory threading, and construction-time rejection of malformed `csv_options`. Package version **0.7.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b644c1153d6ff29f2c52702d8cd1438f1b7f116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->