### PR TITLE
feat(backfill): metadata builder for pre-cutover datasets (di#360)

### DIFF
--- a/tests/test_metadata_backfill.py
+++ b/tests/test_metadata_backfill.py
@@ -1,0 +1,227 @@
+"""Tests for metadata_backfill — recomputing a dataset's {schema, meta_data}
+payload from an already-ingested table via SQL, without re-ingesting rows.
+
+Two tiers:
+* unit — the SQL-shaping helpers (_numeric_feature_stats / _categorical_counts)
+  against a hand-built SQLAlchemy Table + a fake connection, so the exclusion /
+  coercion / cardinality logic is covered with no database;
+* integration — build_dataset_metadata end-to-end over a real in-memory SQLite
+  table, asserting it reuses the ingestor's shapes (enriched schema with
+  role:"target", numeric feature_stats, categorical vocab).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import (
+    Column,
+    Float,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    text,
+)
+
+from tracebloc_ingestor import metadata_backfill as mb
+from tracebloc_ingestor.config import Config
+
+
+# ---- fakes ---------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, one=None, all_=None):
+        self._one = one
+        self._all = all_
+
+    def one(self):
+        return self._one
+
+    def all(self):
+        return self._all
+
+
+class _FakeConn:
+    """Returns canned aggregate results in execute() call order."""
+
+    def __init__(self, results):
+        self._results = list(results)
+
+    def execute(self, _stmt):
+        return self._results.pop(0)
+
+
+def _table(cols):
+    md = MetaData()
+    type_map = {"int": Integer, "float": Float, "str": String}
+    return Table("t", md, *(Column(n, type_map[t]) for n, t in cols.items()))
+
+
+# ---- unit: _numeric_feature_stats ----------------------------------------
+
+
+def test_numeric_stats_excludes_framework_and_nonnumeric_keeps_regression_label():
+    # schema order drives the query order: id(framework→skip), label(regression
+    # target→keep), age(int feature), feat(float feature), city(string→skip).
+    schema = {
+        "id": "BIGINT",
+        "label": "FLOAT",
+        "age": "INT",
+        "feat": "FLOAT",
+        "city": "VARCHAR(255)",
+    }
+    table = _table({"id": "int", "label": "float", "age": "int", "feat": "float"})
+    conn = _FakeConn(
+        [
+            _FakeResult(one=(3, Decimal("60"), Decimal("1400"), 10.0, 30.0)),  # label
+            _FakeResult(one=(3, Decimal("60"), Decimal("1400"), 18, 42)),  # age (INT)
+            _FakeResult(one=(3, 6.0, 14.0, 1.0, 3.0)),  # feat
+        ]
+    )
+    stats = mb._numeric_feature_stats(conn, table, schema, "tabular_regression")
+
+    assert set(stats) == {"label", "age", "feat"}  # id + city excluded
+    # sum/sum_sq always float; INT column keeps integer min/max, float stays float.
+    assert stats["label"] == {
+        "count": 3,
+        "sum": 60.0,
+        "sum_sq": 1400.0,
+        "min": 10.0,
+        "max": 30.0,
+    }
+    assert stats["age"]["min"] == 18 and isinstance(stats["age"]["min"], int)
+    assert stats["feat"]["min"] == 1.0 and isinstance(stats["feat"]["min"], float)
+    assert isinstance(stats["age"]["sum"], float)  # Decimal coerced
+
+
+def test_numeric_stats_excludes_label_for_classification():
+    # For a classification task the `label` column is the class label, not a
+    # numeric feature — it must NOT contribute feature_stats even if numeric.
+    schema = {"label": "INT", "feat": "FLOAT"}
+    table = _table({"label": "int", "feat": "float"})
+    conn = _FakeConn([_FakeResult(one=(2, 3.0, 5.0, 1.0, 2.0))])  # only feat queried
+    stats = mb._numeric_feature_stats(conn, table, schema, "tabular_classification")
+    assert set(stats) == {"feat"}
+
+
+def test_numeric_stats_omits_all_null_column():
+    # An all-null column has count 0 → no stats (min/max undefined), matching the
+    # live ingest's "empty column omitted".
+    schema = {"feat": "FLOAT"}
+    table = _table({"feat": "float"})
+    conn = _FakeConn([_FakeResult(one=(0, None, None, None, None))])
+    assert mb._numeric_feature_stats(conn, table, schema, "tabular_classification") == {}
+
+
+# ---- unit: _categorical_counts -------------------------------------------
+
+
+def test_categorical_counts_excludes_label_and_framework_builds_counter():
+    schema = {
+        "data_id": "VARCHAR(255)",  # framework → skip
+        "label": "VARCHAR(255)",  # target/class → skip
+        "city": "VARCHAR(255)",  # feature → keep
+        "age": "INT",  # non-string → skip
+    }
+    table = _table({"data_id": "str", "label": "str", "city": "str", "age": "int"})
+    conn = _FakeConn([_FakeResult(all_=[("N", 2), ("S", 1)])])  # only city queried
+    counts = mb._categorical_counts(conn, table, schema)
+    assert set(counts) == {"city"}
+    assert counts["city"] == Counter({"N": 2, "S": 1})
+
+
+def test_categorical_counts_drops_over_cardinality_cap(monkeypatch):
+    monkeypatch.setattr(mb, "_MAX_CATEGORICAL_CARDINALITY", 1)
+    schema = {"city": "VARCHAR(255)"}
+    table = _table({"city": "str"})
+    conn = _FakeConn([_FakeResult(all_=[("N", 2), ("S", 1)])])  # 2 distinct > cap 1
+    assert mb._categorical_counts(conn, table, schema) == {}
+
+
+# ---- integration: build_dataset_metadata over real SQLite ----------------
+
+
+class _FakeDB:
+    def __init__(self, engine, schema):
+        self.engine = engine
+        self._schema = schema
+        self.config = Config(EMIT_ENRICHED_SCHEMA=True, CATEGORICAL_MIN_COUNT=1)
+
+    def get_table_schema(self, _name):
+        return dict(self._schema)
+
+
+def _sqlite_with_rows():
+    engine = create_engine("sqlite://")
+    with engine.begin() as c:
+        c.execute(
+            text("CREATE TABLE t (id INTEGER, label REAL, feat REAL, city TEXT)")
+        )
+        for i, (lab, f, city) in enumerate(
+            [(10.0, 1.0, "N"), (20.0, 2.0, "S"), (30.0, 3.0, "N")]
+        ):
+            c.execute(
+                text("INSERT INTO t (id, label, feat, city) VALUES (:i,:l,:f,:c)"),
+                {"i": i, "l": lab, "f": f, "c": city},
+            )
+    return engine
+
+
+def test_build_dataset_metadata_regression_end_to_end():
+    engine = _sqlite_with_rows()
+    schema = {
+        "id": "BIGINT",
+        "label": "FLOAT",
+        "feat": "FLOAT",
+        "city": "VARCHAR(255)",
+    }
+    db = _FakeDB(engine, schema)
+
+    out = mb.build_dataset_metadata(
+        db, "t", category="tabular_regression", label_column="target"
+    )
+
+    # Enriched schema: label carries role:"target"; id/framework still present as
+    # a plain column (parity with the live _schema_payload over get_table_schema).
+    assert out["schema"]["label"]["role"] == "target"
+    assert out["schema"]["label"]["dtype"] == "float"
+
+    fs = out["meta_data"]["attributes"]["feature_stats"]
+    # Regression target's stats land under "label"; id (framework) is excluded.
+    assert fs["label"] == {
+        "count": 3,
+        "sum": 60.0,
+        "sum_sq": 10.0**2 + 20.0**2 + 30.0**2,
+        "min": 10.0,
+        "max": 30.0,
+    }
+    assert fs["feat"]["count"] == 3 and fs["feat"]["sum"] == 6.0
+    assert "id" not in fs
+    # Categorical vocab (union, sorted) for the string feature.
+    assert fs["city"] == {"categories": ["N", "S"]}
+
+
+def test_build_dataset_metadata_classification_excludes_label_from_stats():
+    engine = create_engine("sqlite://")
+    with engine.begin() as c:
+        c.execute(text("CREATE TABLE c (id INTEGER, label TEXT, feat REAL)"))
+        for i, (lab, f) in enumerate([("cat", 1.0), ("dog", 2.0)]):
+            c.execute(
+                text("INSERT INTO c (id, label, feat) VALUES (:i,:l,:f)"),
+                {"i": i, "l": lab, "f": f},
+            )
+    schema = {"id": "BIGINT", "label": "VARCHAR(255)", "feat": "FLOAT"}
+    db = _FakeDB(engine, schema)
+
+    out = mb.build_dataset_metadata(
+        db, "c", category="tabular_classification", label_column="label"
+    )
+    fs = out["meta_data"]["attributes"]["feature_stats"]
+    assert "label" not in fs  # class label is not a feature
+    assert set(fs) == {"feat"}
+    assert out["schema"]["label"]["role"] == "target"

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -234,6 +234,12 @@ class CSVIngestor(BaseIngestor):
         # cast pass (_validate_csv) and emitted on the global-metadata channel
         # for federated/global normalization (data-ingestors#360, backend#1037).
         # Additive aggregates only — no raw values leave the client.
+        #
+        # NOTE: metadata_backfill.build_dataset_metadata reuses this ingestor by
+        # injecting SQL-computed accumulators into `_feature_stats_acc` /
+        # `_categorical_acc` and calling `_schema_payload` / `_collect_run_metadata`
+        # to reproduce this shape — keep those names/shapes stable, or update the
+        # backfill alongside a rename.
         self._feature_stats_acc: Dict[str, Dict[str, Any]] = {}
         # Row-id and annotation columns are never features — a data_id would
         # pollute normalization. The label column is excluded for CLASSIFICATION

--- a/tracebloc_ingestor/metadata_backfill.py
+++ b/tracebloc_ingestor/metadata_backfill.py
@@ -1,0 +1,247 @@
+"""Metadata backfill for pre-cutover datasets (di#360 / backend#1037).
+
+Recompute the enriched ``schema`` + ``feature_stats`` metadata payload for an
+ALREADY-INGESTED table **without re-ingesting rows**. Numeric sufficient
+statistics come from SQL aggregates (``COUNT`` / ``SUM`` / ``SUM(x*x)`` / ``MIN``
+/ ``MAX``); categorical vocabularies from a bounded ``GROUP BY``.
+
+Why: datasets ingested before the federated-alignment cutover have no per-column
+``feature_stats`` and no enriched schema on the global-metadata channel, so the
+backend#1037 combine-time checks can't reconcile them. This rebuilds the exact
+``{schema, meta_data}`` shape a live ingest ships — it reuses
+``CSVIngestor._schema_payload`` / ``_collect_run_metadata`` rather than
+reimplementing the shapes, so a backfilled dataset's metadata is
+indistinguishable from a freshly-ingested one (guarded by a parity test).
+
+The API send is deliberately **not** done here: :func:`build_dataset_metadata`
+returns the payload; a caller wires it to the backend metadata endpoint
+separately (that surface is intentionally out of scope for now).
+
+Limitations (v1), all WARN-only alignment facts rather than block-causing ones:
+
+* The time-series ``timezone`` / ``sampling_frequency`` facts are not recomputed
+  (they need the ordered timestamp series, not a scalar aggregate).
+* The uploader-declared scalar attributes (``color_mode``, ``bit_depth``,
+  ``language``, ``normalization``, ``time_unit``, ``event_indicator``,
+  ``positive_definition``) live only in the original ingest config, not in the
+  table. Pass them through ``file_options`` when the caller has them (e.g. from
+  the stored dataset config); otherwise they are omitted.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from typing import Any, Dict, Optional
+
+from sqlalchemy import Float, MetaData, Table, cast, func, select
+
+from .cli.conventions import REGRESSION_CLASS_CATEGORIES
+from .database import Database
+from .ingestors.csv_ingestor import _MAX_CATEGORICAL_CARDINALITY, CSVIngestor
+from .modalities.registry import spec_for
+from .schema_inference import canonical_dtype
+
+logger = logging.getLogger(__name__)
+
+# Framework/bookkeeping columns every dataset table carries
+# (``Database.create_table``). They are never dataset features, so they never
+# contribute ``feature_stats`` or categorical vocab. ``label`` is handled
+# separately: it holds the prediction target, whose numeric stats ARE wanted for
+# regression-class tasks (emitted under the ``label`` key, matching the live
+# ingest's target re-key and the enriched schema's ``role: "target"``).
+_FRAMEWORK_COLUMNS = frozenset(
+    {
+        "id",
+        "created_at",
+        "updated_at",
+        "status",
+        "data_intent",
+        "data_id",
+        "filename",
+        "extension",
+        "annotation",
+        "ingestor_id",
+    }
+)
+
+# The framework target column (mirrors ``ingestors.base._TARGET_COLUMN``).
+_TARGET_COLUMN = "label"
+
+# Canonical dtypes the live ingest accumulates numeric feature_stats for — the
+# INT / FLOAT cast branches. ``bool`` / ``datetime`` / ``string`` are not folded.
+_NUMERIC_DTYPES = frozenset({"int", "float"})
+
+# The distinct-value cap for a categorical column (past it: free text / an id,
+# not a feature) is imported from CSVIngestor so the two can't drift.
+
+
+def build_dataset_metadata(
+    database: Database,
+    table_name: str,
+    *,
+    category: str,
+    label_column: Optional[str] = None,
+    data_format: Optional[str] = None,
+    file_options: Optional[Dict[str, Any]] = None,
+    api_client: Any = None,
+) -> Dict[str, Any]:
+    """Return the ``{"schema", "meta_data"}`` metadata payload for an
+    already-ingested table, recomputed from the persisted rows via SQL.
+
+    Args:
+        database: A connected :class:`Database` for the client's MySQL.
+        table_name: The dataset table to backfill.
+        category: The dataset's task category (drives the target/role handling
+            and the emitted scalar attributes). Required — it is not derivable
+            from the table.
+        label_column: The manifest label column name, if any. Used to mark the
+            enriched schema's ``label`` column ``role: "target"`` and to keep the
+            regression target's numeric stats (which live in the physical
+            ``label`` column). Pass the value from the stored dataset config.
+        data_format: The dataset's data format; defaults to the category's
+            registry default. Governs the base scalar attributes (image
+            ``resolution``, text ``encoding``).
+        file_options: Uploader-declared facts to pass through unchanged
+            (``column_descriptors`` for per-column ``unit``/``ordinal``, and the
+            scalar alignment facts ``color_mode``/``language``/… when the caller
+            has them). Nothing here is recomputed from the table.
+        api_client: Unused while building (kept out of the metadata computation);
+            accepted so a caller can hand its client through to a later send
+            step. Defaults to ``None``.
+
+    Returns:
+        ``{"schema": <flat or enriched schema>, "meta_data": {"attributes": {...}}}``
+        — the same shape ``send_ingest_summary`` ships, minus the row-level
+        ``labels`` / ``samples``. ``meta_data`` is ``{}`` when there is nothing
+        to contribute.
+    """
+    schema = database.get_table_schema(table_name)
+    if data_format is None:
+        data_format = spec_for(category).data_format
+
+    # Reuse the live ingestor's shaping so the output is byte-identical to a fresh
+    # ingest: we only feed it the accumulators (computed via SQL instead of a
+    # chunked read) and call its existing metadata methods. api_client is only
+    # stored by __init__, never used by the methods we call, so None is safe.
+    ingestor = CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name=table_name,
+        schema=schema,
+        category=category,
+        label_column=label_column,
+        data_format=data_format,
+        file_options=dict(file_options or {}),
+    )
+
+    table = Table(table_name, MetaData(), autoload_with=database.engine)
+    with database.engine.connect() as conn:
+        ingestor._feature_stats_acc = _numeric_feature_stats(
+            conn, table, schema, category
+        )
+        ingestor._categorical_acc = _categorical_counts(conn, table, schema)
+
+    enriched_schema = ingestor._schema_payload(schema)
+    run_meta = ingestor._collect_run_metadata()
+
+    meta_data: Dict[str, Any] = {}
+    attributes = run_meta.get("attributes")
+    if attributes:
+        meta_data["attributes"] = attributes
+    return {"schema": enriched_schema, "meta_data": meta_data}
+
+
+def _numeric_feature_stats(conn, table, schema, category) -> Dict[str, Dict[str, Any]]:
+    """Per-numeric-column sufficient statistics from SQL aggregates, in the exact
+    ``{count, sum, sum_sq, min, max}`` shape the live ingest accumulates.
+
+    ``count`` is the non-null count and every aggregate ignores nulls (``WHERE
+    col IS NOT NULL``), matching the ingest path's ``dropna()``. An all-null
+    column is omitted (min/max undefined), also matching. The ``label`` column is
+    the target: its stats are kept for regression-class tasks (emitted under
+    ``label``) and skipped otherwise (there it is the class label, not a feature).
+    """
+    stats: Dict[str, Dict[str, Any]] = {}
+    for col, sql_type in schema.items():
+        if col in _FRAMEWORK_COLUMNS:
+            continue
+        if col == _TARGET_COLUMN and category not in REGRESSION_CLASS_CATEGORIES:
+            continue
+        dtype = canonical_dtype(sql_type)
+        if dtype not in _NUMERIC_DTYPES:
+            continue
+        column = table.c[col]
+        # Sum and sum-of-squares in float (DOUBLE), matching the live path which
+        # squares in float64 (``(fvals**2).sum()``). Without the cast, MySQL
+        # squares an INT column in integer/DECIMAL — which can drift from the
+        # float64 result (so sum_sq wouldn't stay byte-identical) and can overflow
+        # BIGINT on large values. min/max keep the raw column so an INT column
+        # still reports integer extremes (matches the ingest's ``.item()``).
+        column_as_float = cast(column, Float)
+        count, total, total_sq, low, high = conn.execute(
+            select(
+                func.count(column),
+                func.sum(column_as_float),
+                func.sum(column_as_float * column_as_float),
+                func.min(column),
+                func.max(column),
+            ).where(column.isnot(None))
+        ).one()
+        if not count:
+            continue
+        is_int = dtype == "int"
+        stats[col] = {
+            "count": int(count),
+            "sum": float(total),
+            "sum_sq": float(total_sq),
+            "min": _coerce_scalar(low, is_int),
+            "max": _coerce_scalar(high, is_int),
+        }
+    return stats
+
+
+def _categorical_counts(conn, table, schema) -> Dict[str, Counter]:
+    """Per-categorical-column value counts (a ``Counter``) from a bounded ``GROUP
+    BY``, matching the accumulator ``CSVIngestor.categorical_vocab`` consumes.
+
+    String columns only; the framework columns and the ``label`` target/class are
+    excluded (the label is never a categorical *feature*). A column with more
+    distinct values than the cardinality cap is dropped (free text / id). The
+    per-value ``CATEGORICAL_MIN_COUNT`` suppression is applied later by
+    ``categorical_vocab`` — here we just carry the raw counts.
+    """
+    counts: Dict[str, Counter] = {}
+    for col, sql_type in schema.items():
+        if col in _FRAMEWORK_COLUMNS or col == _TARGET_COLUMN:
+            continue
+        if canonical_dtype(sql_type) != "string":
+            continue
+        column = table.c[col]
+        # LIMIT cap+1 so a high-cardinality free-text/id column doesn't pull every
+        # distinct value into memory just to be dropped: cap+1 rows is enough to
+        # know it exceeds the cap.
+        rows = conn.execute(
+            select(column, func.count())
+            .where(column.isnot(None))
+            .group_by(column)
+            .limit(_MAX_CATEGORICAL_CARDINALITY + 1)
+        ).all()
+        if len(rows) > _MAX_CATEGORICAL_CARDINALITY:
+            continue
+        counter: Counter = Counter()
+        for value, cnt in rows:
+            counter[str(value)] = int(cnt)
+        if counter:
+            counts[col] = counter
+    return counts
+
+
+def _coerce_scalar(value: Any, is_int: bool) -> Any:
+    """Coerce a SQL aggregate scalar to a JSON-serialisable native number, keeping
+    the column's real type (INT columns report integer min/max, like the live
+    ingest's ``.item()``). ``SUM`` of an INT column comes back as ``Decimal``;
+    ``int()`` / ``float()`` normalise it."""
+    if value is None:
+        return None
+    return int(value) if is_int else float(value)


### PR DESCRIPTION
## What & why

Datasets ingested **before** the federated-alignment cutover (di#360 / backend#1037) carry no per-column `feature_stats` and no enriched schema on the global-metadata channel, so the backend's combine-time alignment checks can't reconcile them. This adds a **metadata-only backfill builder** so an operator can rebuild that metadata per client, per dataset table, for pre-cutover datasets — **without re-ingesting rows**.

`tracebloc_ingestor/metadata_backfill.build_dataset_metadata(database, table_name, *, category, label_column=None, data_format=None, file_options=None)` returns the same `{schema, meta_data}` payload a fresh ingest ships:

- **Numeric `feature_stats`** — computed from SQL aggregates (`COUNT` / `SUM` / `SUM(x*x)` / `MIN` / `MAX`) over the persisted table, not a chunked re-read.
- **Categorical vocab** — a bounded `GROUP BY` (drops columns past the cardinality cap; per-value min-count suppression applied by the ingestor).
- **Enriched schema** — the framework `label` column marked `role: "target"` for supervised tasks.

It **reuses** `CSVIngestor._schema_payload` / `_collect_run_metadata` rather than reimplementing the shapes, so a backfilled dataset's metadata is byte-identical to a freshly-ingested one (guarded by the integration tests).

## Scope — deliberately no API send

Per the agreed scope, this only **builds** the payload. Wiring it to the backend metadata endpoint (and iterating the client's dataset tables) is a separate step, left as a hook — `build_dataset_metadata` returns the dict for a caller to send.

## What is / isn't recomputed

| Fact | Source |
|---|---|
| enriched schema, numeric `feature_stats`, categorical vocab | **recomputed from the table** (the block-causing alignment facts) |
| target handling (regression target kept as `label`; class label excluded) | derived from `category` + `label_column` |
| time-series `timezone` / `sampling_frequency` | **not** recomputed (needs the ordered timestamp series) — WARN-only |
| uploader-declared scalars (`color_mode`, `language`, `time_unit`, …) | pass-through via `file_options` when the caller has them; else omitted — WARN-only |

## Correctness details

- `count` is the non-null count; all aggregates ignore nulls (`WHERE col IS NOT NULL`), matching the ingest path's `dropna()`. All-null columns are omitted.
- Framework/bookkeeping columns (`id`, `created_at`, `data_id`, …) never contribute stats/vocab. The `label` column is the exception: its numeric stats are kept for regression-class tasks (emitted under `label`, matching the live target re-key) and skipped otherwise.
- `SUM` of an INT column returns `Decimal`; scalars are coerced to native JSON numbers, keeping the column's real type (INT → integer min/max, like the live ingest's `.item()`).

## Tests

`tests/test_metadata_backfill.py`:
- **unit** (fake connection, hand-built table): framework/label exclusion, regression target kept as `label`, classification label excluded, int-vs-float + `Decimal` coercion, all-null omission, categorical cardinality cap.
- **integration** (in-memory SQLite): `build_dataset_metadata` end-to-end for regression (target stats under `label`, `id` excluded, categorical vocab) and classification (class label excluded from stats, `role: "target"` still set).

## Notes

- **Stacked on `feat/360-feature-stats`** (base of this PR) — it reuses that branch's enriched-schema / feature_stats shapes. Merge after #360.
- Storage-agnostic: it produces the payload; where the backend stores it (the ongoing Mongo → SQL move for `GlobalMetaData`) doesn't affect this builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches federated alignment metadata shapes and SQL over production dataset tables; correctness depends on parity with live ingest, but changes are additive with no automatic API send.
> 
> **Overview**
> Adds **`metadata_backfill.build_dataset_metadata`** so operators can rebuild the **`{schema, meta_data}`** global-metadata payload for **already-ingested** dataset tables **without re-reading or re-ingesting CSV rows**—addressing pre–federated-alignment datasets that lack **`feature_stats`** and enriched schema for backend combine checks.
> 
> The builder runs **SQL aggregates** (`COUNT` / `SUM` / `SUM(x²)` / `MIN` / `MAX`) for numeric sufficient statistics and a **bounded `GROUP BY`** for categorical vocab, with the same exclusion rules as live ingest (framework columns, classification **`label`** omitted from stats, regression target stats under **`label`**, cardinality cap, null handling). It **injects** those accumulators into **`CSVIngestor`** and calls **`_schema_payload`** / **`_collect_run_metadata`** so output shape matches a fresh ingest; **API upload is out of scope** (caller sends the returned dict). v1 does **not** recompute time-series **`timezone`** / **`sampling_frequency`**; uploader scalars can be passed via **`file_options`**.
> 
> **`csv_ingestor`** gains a comment documenting that **`_feature_stats_acc`** / **`_categorical_acc`** names and shapes must stay stable for backfill. **`tests/test_metadata_backfill.py`** adds unit tests for the SQL helpers and SQLite integration tests for regression vs classification end-to-end output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 288bd23ab42e345fc09f0c0d475aaae79dc2d80a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->