### PR TITLE
fix(objdet): resolve annotation by stem so extension-bearing filename works (#379)

### DIFF
--- a/tests/test_file_transfer_transfers.py
+++ b/tests/test_file_transfer_transfers.py
@@ -64,6 +64,43 @@ def test_find_src_missing(dirs):
     assert path is None and fname == "ghost.jpg"
 
 
+def test_find_src_force_extension_swaps_real_extension(dirs):
+    """force_extension: an extension-bearing value (the image name) is swapped
+    to the sidecar's fixed extension — ``cat.jpg`` -> ``cat.xml`` — instead of
+    keeping ``.jpg``. This is the object_detection annotation contract."""
+    src, _ = dirs
+    _seed(src, "annotations", "cat.xml", b"<a/>")
+    path, fname = file_transfer._find_src(
+        "annotations", "cat.jpg", ".xml", force_extension=True
+    )
+    assert path is not None and fname == "cat.xml"
+
+
+def test_find_src_force_extension_bare_stem(dirs):
+    """force_extension: a bare stem still appends the sidecar extension, so the
+    bare-stem manifest form keeps resolving to ``cat.xml``."""
+    src, _ = dirs
+    _seed(src, "annotations", "cat.xml", b"<a/>")
+    path, fname = file_transfer._find_src(
+        "annotations", "cat", ".xml", force_extension=True
+    )
+    assert path is not None and fname == "cat.xml"
+
+
+def test_find_src_force_extension_keeps_non_extension_dot(dirs):
+    """force_extension only strips a RECOGNISED trailing extension. ``image.001``
+    has none, so the whole value is kept and the annotation is
+    ``image.001.xml`` — never ``image.xml``. This agrees with the on-disk image
+    ``image.001.jpg``, whose ``Path.stem`` (``image.001``) is the key File
+    Pairing compares on."""
+    src, _ = dirs
+    _seed(src, "annotations", "image.001.xml", b"<a/>")
+    path, fname = file_transfer._find_src(
+        "annotations", "image.001", ".xml", force_extension=True
+    )
+    assert path is not None and fname == "image.001.xml"
+
+
 def test_find_mask_src_tries_extensions(dirs):
     src, _ = dirs
     _seed(src, "masks", "m1.png")
@@ -133,6 +170,17 @@ def test_annotation_transfer_success(dirs):
     assert (dest / "img.xml").exists()
 
 
+def test_annotation_transfer_resolves_stem_from_extension_bearing_filename(dirs):
+    """Standalone annotation_transfer (src_path unresolved) must derive the
+    annotation from the image stem: a record ``filename`` of ``img.jpg`` still
+    copies ``img.xml``, not the non-existent ``img.jpg`` under annotations/."""
+    src, dest = dirs
+    _seed(src, "annotations", "img.xml", b"<x/>")
+    rec = file_transfer.annotation_transfer({"filename": "img.jpg"}, {}, ".xml")
+    assert rec is not None
+    assert (dest / "img.xml").exists()
+
+
 def test_mask_transfer_success(dirs):
     src, dest = dirs
     s = _seed(src, "masks", "m.png")
@@ -181,6 +229,47 @@ def test_map_object_detection_missing_filename_returns_none(dirs):
         TaskCategory.OBJECT_DETECTION, {}, {"extension": ".jpg"}
     )
     assert rec is None
+
+
+def test_map_object_detection_extension_bearing_filename(dirs):
+    """Regression: a manifest ``filename`` carrying the image extension
+    (``x.jpg`` — the objdet-ok parity fixture format, and the documented
+    "with or without extension" form) stages BOTH the image and its
+    ``<stem>.xml`` annotation.
+
+    Before the fix the annotation lookup kept ``.jpg`` and searched
+    ``annotations/x.jpg`` (never present), so every record was skipped and the
+    Job exited 9 with 0 ingested — even though every validator, including File
+    Pairing (which pairs by on-disk stem), had passed."""
+    src, dest = dirs
+    _seed(src, "images", "x.jpg")
+    _seed(src, "annotations", "x.xml", b"<a/>")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.OBJECT_DETECTION, {"filename": "x.jpg"}, {"extension": ".jpg"}
+    )
+    assert rec is not None
+    assert (dest / "x.jpg").exists()
+    assert (dest / "x.xml").exists()
+    # The stored record must be identical to the bare-stem form: filename is
+    # the stem, extension the image extension — no ".jpg" leaks into the DB row.
+    assert rec["filename"] == "x"
+    assert rec["extension"] == ".jpg"
+
+
+def test_map_object_detection_extension_bearing_filename_jpeg(dirs):
+    """The extension swap covers every recognised image extension, not just
+    ``.jpg``: ``photo.jpeg`` stages ``photo.jpeg`` + ``photo.xml``."""
+    src, dest = dirs
+    _seed(src, "images", "photo.jpeg")
+    _seed(src, "annotations", "photo.xml", b"<a/>")
+    rec = file_transfer.map_file_transfer(
+        TaskCategory.OBJECT_DETECTION,
+        {"filename": "photo.jpeg"},
+        {"extension": ".jpeg"},
+    )
+    assert rec is not None
+    assert (dest / "photo.jpeg").exists()
+    assert (dest / "photo.xml").exists()
 
 
 def test_map_semantic_segmentation_success(dirs):

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -163,10 +163,16 @@ def _find_src(
     """
     cfg = cfg or config
     if force_extension:
-        # Mirror _has_extension's rsplit so the stem matches Path.stem exactly
-        # (what FilePairingValidator pairs on). A value with no recognised
-        # extension — a bare stem, or an internal dot like ``image.001`` — is
-        # kept whole so we never strip a non-extension segment.
+        # Strip only a RECOGNISED trailing extension (the same _has_extension
+        # gate the image lookup uses). For the jpg/jpeg/png images objdet ships
+        # (FileTypeValidator enforces that set) this equals the image file's
+        # Path.stem — what File Pairing / Pascal VOC XML pair on — so validation
+        # and transfer resolve the same annotation. This is deliberately NOT
+        # Path.stem: a value with no recognised extension — a bare stem, or an
+        # internal dot like ``image.001`` — is kept whole, so we never strip a
+        # non-extension segment (Path.stem would wrongly turn ``image.001`` into
+        # ``image``). The two only diverge for a non-recognised final suffix
+        # (e.g. ``a.tar.gz``), which objdet images can't have.
         stem = filename.rsplit(".", 1)[0] if _has_extension(filename) else filename
         filename_with_ext = f"{stem}{extension}"
     else:

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -122,7 +122,12 @@ def _has_extension(filename: str) -> bool:
 
 
 def _find_src(
-    subdirectory: str, filename: str, extension: str, cfg: Optional[Config] = None
+    subdirectory: str,
+    filename: str,
+    extension: str,
+    cfg: Optional[Config] = None,
+    *,
+    force_extension: bool = False,
 ):
     """Resolve a source file in `SRC_PATH/<subdirectory>/`.
 
@@ -136,11 +141,38 @@ def _find_src(
     ``cfg`` is the run's resolved Config, threaded from ``map_file_transfer``
     (P4c); ``None`` falls back to the module-global ``config`` for direct
     callers / tests.
+
+    ``force_extension`` selects how ``extension`` is applied:
+
+    - ``False`` (default): the manifest ``filename`` names *this very file*, so
+      keep its own extension when it already has one and only append
+      ``extension`` when it doesn't — the image / text case (``a.jpg`` stays
+      ``a.jpg``; bare ``a`` becomes ``a.jpg``).
+    - ``True``: the manifest ``filename`` names a DIFFERENT file that merely
+      shares the stem — a sidecar whose extension is fixed and differs from the
+      image's. Object detection annotations are always ``<stem>.xml`` (the
+      documented ``{image_name}.xml`` convention), so strip a recognised
+      trailing extension off ``filename`` and append ``extension``: both the
+      extension-bearing ``a.jpg`` and the bare stem ``a`` resolve to ``a.xml``.
+      Without this, an extension-bearing manifest value kept its ``.jpg`` and
+      the annotation lookup searched ``annotations/a.jpg`` — which never exists
+      — so every record was silently skipped even though the File Pairing
+      validator (which pairs by on-disk stem) had passed. The manifest format
+      is documented as working "with or without extension"; this keeps the
+      annotation side of the transfer honouring that contract.
     """
     cfg = cfg or config
-    filename_with_ext = (
-        filename if _has_extension(filename) else f"{filename}{extension}"
-    )
+    if force_extension:
+        # Mirror _has_extension's rsplit so the stem matches Path.stem exactly
+        # (what FilePairingValidator pairs on). A value with no recognised
+        # extension — a bare stem, or an internal dot like ``image.001`` — is
+        # kept whole so we never strip a non-extension segment.
+        stem = filename.rsplit(".", 1)[0] if _has_extension(filename) else filename
+        filename_with_ext = f"{stem}{extension}"
+    else:
+        filename_with_ext = (
+            filename if _has_extension(filename) else f"{filename}{extension}"
+        )
     # _safe_join raises on a traversal/absolute filename (#239); a genuinely
     # missing file still returns None below (skip), so a malicious manifest
     # value is rejected loudly while an absent sidecar is tolerated.
@@ -242,8 +274,12 @@ def annotation_transfer(
             return None
 
         if src_path is None:
+            # force_extension: the annotation is <stem>.xml, derived from the
+            # image filename's stem — never the image's own extension. See
+            # _find_src for why an extension-bearing manifest value would
+            # otherwise miss the annotation (object_detection skip bug).
             src_path, filename_with_ext = _find_src(
-                "annotations", filename, extension, cfg=cfg
+                "annotations", filename, extension, cfg=cfg, force_extension=True
             )
             if src_path is None:
                 logger.error(

--- a/tracebloc_ingestor/modalities/transfer.py
+++ b/tracebloc_ingestor/modalities/transfer.py
@@ -72,8 +72,15 @@ def object_detection(
             f"{RED}Source image not found: {os.path.join(cfg.SRC_PATH, 'images', image_filename)} — skipping record{RESET}"
         )
         return None
+    # force_extension: the annotation is <stem>.xml (the documented
+    # {image_name}.xml convention), derived from the image filename's stem
+    # regardless of whether the manifest value carries the image extension.
+    # A manifest `filename` of `a.jpg` must resolve to `annotations/a.xml`,
+    # not `annotations/a.jpg` — the latter never exists, so every record was
+    # skipped (exit 9, 0 ingested) while every validator, including File
+    # Pairing (which pairs by on-disk stem), had passed.
     annotation_src_path, annotation_filename = _find_src(
-        "annotations", filename, ".xml", cfg=cfg
+        "annotations", filename, ".xml", cfg=cfg, force_extension=True
     )
     if annotation_src_path is None:
         logger.error(


### PR DESCRIPTION
## Summary

`object_detection` ingestion silently **skipped every record** (Job exits 9, 0 ingested) whenever the manifest `filename` column carried the image extension (e.g. `a.jpg`) — the exact format the CLI parity fixture `objdet-ok/labels.csv` ships and the template README documents as supported. The dry-run and **all** cluster validators passed first, so the failure only surfaced mid-Job as `Source annotation not found: …/annotations/a.jpg`.

Root cause: `_find_src("annotations", filename, ".xml")` kept the recognised `.jpg` extension instead of swapping to `.xml`, so it looked for `annotations/a.jpg` (never present; the annotation is `a.xml`). The **File Pairing validator pairs image↔XML by on-disk stem** (`Path.stem`), so validation passed while transfer failed — a validation/transfer inconsistency, and a violation of the README's documented *"with or without extension"* contract.

Fix: add a `force_extension` mode to `_find_src` that strips a recognised trailing extension off the manifest value and appends the sidecar's fixed extension, used at both annotation-resolution sites (the `object_detection` factory and `annotation_transfer`). Both `a.jpg` and the bare stem `a` now resolve to `annotations/a.xml`, matching `Path.stem` and the documented contract. The default (non-force) branch is byte-for-byte identical, so image / text / mask / keypoint / semseg lookups are unchanged.

Scope note: only the object_detection **annotation** sidecar was affected. `semantic_segmentation` masks already strip via `_find_mask_src`; image lookups correctly keep the manifest extension. No docs or fixture change needed — the code was the only thing wrong (docs and the `objdet-ok` fixture were already correct).

## Related

Closes #379. Same class as the image_classification `filename`-vs-`image_id` gap (separate chip), where the CLI local walk green-lights a dataset the cluster then rejects for a file-resolution reason it could surface up front.

## Type of change
- [x] Bug fix

## Test plan

- Reproduced the bug: seeded `images/a.jpg` + `annotations/a.xml`, drove `map_file_transfer(OBJECT_DETECTION, {"filename": "a.jpg"}, {"extension": ".jpg"})` → pre-fix skipped with `Source annotation not found: …/annotations/a.jpg`; post-fix stages both `a.jpg` and `a.xml`. The bare-stem workaround (`filename="a"`) still works.
- New regression tests (all confirmed to **fail on pre-fix code, pass post-fix**):
  - `test_map_object_detection_extension_bearing_filename` — end-to-end objdet with `x.jpg`, asserts both files staged **and** the stored record is identical to the bare-stem form (`filename="x"`, `extension=".jpg"` — no `.jpg` leaks into the DB row).
  - `test_map_object_detection_extension_bearing_filename_jpeg` — same for a non-`.jpg` recognised extension (`.jpeg`).
  - `test_annotation_transfer_resolves_stem_from_extension_bearing_filename` — standalone `annotation_transfer` path.
  - `test_find_src_force_extension_{swaps_real_extension,bare_stem,keeps_non_extension_dot}` — the `_find_src` stem/bare/internal-dot (`image.001`) edges.
- Full suite: `1784 passed, 1 xfailed` (the pre-existing leading-zeros INT xfail). `black --check` clean.
- Adversarially verified the #239 path-traversal guard is preserved in the `force_extension` branch (`_safe_join` still runs on the transformed value; absolute/`..` inputs still raise).

## Deployment notes

Ships in the ingestor image. Existing installs pick up the fix on the next ingestion run once `images.ingestor.tag` is moved to the new digest (see `RELEASING.md`) — no chart change required.

## Checklist
- [x] Tests added / updated and passing locally
- [x] Docs updated if behavior or config changed — N/A (fix makes code match the already-correct docs)
- [x] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested — N/A (path-traversal guard verified preserved)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core file-resolution for object-detection annotation staging; scope is narrow (annotation sidecar only) with extensive tests and no change to default image lookups.
> 
> **Overview**
> Fixes **object detection** ingestion when manifest `filename` includes the image extension (e.g. `x.jpg`): annotation lookup now resolves **`annotations/<stem>.xml`** instead of incorrectly looking for `annotations/x.jpg`, which caused every record to be skipped after validators passed.
> 
> Adds **`force_extension`** to `_find_src`: for sidecars it strips only a **recognised** image extension from the manifest value, then appends the sidecar extension (`.xml`). Values like `image.001` stay intact so annotations remain `image.001.xml`. Wired into **`object_detection`** transfer pre-check and **`annotation_transfer`** when the source path is unresolved; default `_find_src` behaviour for images/text/masks is unchanged.
> 
> Regression tests cover `_find_src` edge cases, standalone `annotation_transfer`, and end-to-end `map_file_transfer` for `.jpg` / `.jpeg` with extension-bearing filenames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f363b2d12c58a73edf705b01df6850b5766ac927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->