### PR TITLE
fix(ingest): reclaim staged source after verified load (~2x PVC)

### DIFF
--- a/tests/test_file_transfer_reclaim.py
+++ b/tests/test_file_transfer_reclaim.py
@@ -1,0 +1,152 @@
+"""Tests for ``file_transfer.reclaim_source`` (#346).
+
+The ingestor COPIES staged sidecars from ``SRC_PATH`` into the final table
+dir, so without a reclaim every file-bearing ingest left two copies on the
+shared PVC (~2x disk). ``reclaim_source`` removes the staging tree after a
+verified, clean load — but only when it can prove the delete won't take the
+freshly-written table (or another tenant's data) with it. These pin both the
+happy path and every SAFETY guard.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tracebloc_ingestor import file_transfer
+from tracebloc_ingestor.config import Config
+
+
+def _cfg(src, storage, table="tbl"):
+    """Config pointing SRC_PATH at ``src`` and DEST at ``storage/<table>``.
+
+    STORAGE_PATH is a class-level constant (not env-driven), so shadow it on
+    the instance — ``DEST_PATH`` reads ``self.STORAGE_PATH``.
+    """
+    cfg = Config(SRC_PATH=str(src), TABLE_NAME=table)
+    cfg.STORAGE_PATH = str(storage)
+    return cfg
+
+
+def _seed(root, subdir, name="cat.jpg", content=b"data"):
+    d = os.path.join(str(root), subdir)
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, name), "wb") as fh:
+        fh.write(content)
+
+
+# ---------------------------------------------------------------------------
+# happy path — the real staging layout (SharedRoot/.tracebloc-staging/<table>)
+# ---------------------------------------------------------------------------
+
+
+def test_reclaims_staging_dir_after_verified_load(tmp_path):
+    storage = tmp_path / "shared"
+    src = storage / ".tracebloc-staging" / "tbl"  # isolated staging copy
+    dest = storage / "tbl"  # the table dir the ingest just wrote
+    src.mkdir(parents=True)
+    dest.mkdir(parents=True)
+    _seed(src, "images")
+    (dest / "cat.jpg").write_bytes(b"data")  # the copied-in table file
+
+    cfg = _cfg(src, storage)
+    assert file_transfer.reclaim_source(cfg) is True
+    assert not src.exists()  # staging copy reclaimed
+    assert dest.exists() and (dest / "cat.jpg").exists()  # table untouched
+
+
+# ---------------------------------------------------------------------------
+# guards — every path that must NOT delete
+# ---------------------------------------------------------------------------
+
+
+def test_skips_when_src_path_unset(tmp_path):
+    cfg = Config(SRC_PATH="", TABLE_NAME="tbl")
+    cfg.STORAGE_PATH = str(tmp_path)
+    assert file_transfer.reclaim_source(cfg) is False
+
+
+def test_skips_when_src_missing(tmp_path):
+    storage = tmp_path / "shared"
+    storage.mkdir()
+    cfg = _cfg(tmp_path / "ghost-staging", storage)
+    assert file_transfer.reclaim_source(cfg) is False
+
+
+def test_refuses_when_src_equals_dest(tmp_path):
+    storage = tmp_path / "shared"
+    dest = storage / "tbl"
+    dest.mkdir(parents=True)
+    _seed(dest, "images")
+    # SRC_PATH set to the table dir itself.
+    cfg = _cfg(dest, storage)
+    assert file_transfer.reclaim_source(cfg) is False
+    assert dest.exists()
+
+
+def test_refuses_when_dest_lives_inside_src(tmp_path):
+    # Helm-direct layout: data staged straight under the storage root, so
+    # SRC (a parent) CONTAINS the table dir. Deleting SRC would take the
+    # table (and siblings) with it — must skip.
+    storage = tmp_path / "data" / "shared"
+    storage.mkdir(parents=True)
+    src = tmp_path / "data"  # parent of storage -> contains DEST
+    dest = storage / "tbl"
+    dest.mkdir()
+    _seed(dest, "images")
+    cfg = _cfg(src, storage)
+    assert file_transfer.reclaim_source(cfg) is False
+    assert src.exists() and dest.exists()
+
+
+def test_refuses_when_src_lives_inside_dest(tmp_path):
+    # Degenerate: SRC nested under the table dir itself. Skip rather than
+    # delete a subtree of the freshly-written table.
+    storage = tmp_path / "shared"
+    dest = storage / "tbl"
+    src = dest / "substaging"
+    src.mkdir(parents=True)
+    _seed(src, "images")
+    cfg = _cfg(src, storage)
+    assert file_transfer.reclaim_source(cfg) is False
+    assert src.exists()
+
+
+def test_refuses_when_src_is_storage_root(tmp_path):
+    storage = tmp_path / "shared"
+    storage.mkdir()
+    cfg = _cfg(storage, storage)  # SRC == STORAGE_PATH (shared-PVC root)
+    assert file_transfer.reclaim_source(cfg) is False
+    assert storage.exists()
+
+
+def test_best_effort_swallows_rmtree_error(tmp_path, monkeypatch):
+    # A filesystem error while removing the staging tree must never fail an
+    # already-successful load: log + return False, don't raise.
+    storage = tmp_path / "shared"
+    src = storage / ".tracebloc-staging" / "tbl"
+    src.mkdir(parents=True)
+    _seed(src, "images")
+
+    def boom(*_a, **_k):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(file_transfer.shutil, "rmtree", boom)
+    cfg = _cfg(src, storage)
+    assert file_transfer.reclaim_source(cfg) is False
+    assert src.exists()  # untouched because the delete failed
+
+
+def test_default_cfg_falls_back_to_module_config(tmp_path, monkeypatch):
+    # Called with no cfg -> uses the module-global ``config`` (env-driven),
+    # mirroring the other file_transfer helpers.
+    storage = tmp_path / "shared"
+    src = storage / ".tracebloc-staging" / "tbl"
+    src.mkdir(parents=True)
+    _seed(src, "images")
+    monkeypatch.setenv("SRC_PATH", str(src))
+    monkeypatch.setenv("TABLE_NAME", "tbl")
+    monkeypatch.setattr(file_transfer.config, "STORAGE_PATH", str(storage))
+    assert file_transfer.reclaim_source() is True
+    assert not src.exists()

--- a/tests/test_file_transfer_reclaim.py
+++ b/tests/test_file_transfer_reclaim.py
@@ -260,3 +260,44 @@ def test_skips_when_table_name_unset(tmp_path):
     cfg = _cfg(src, storage, table="")
     assert file_transfer.reclaim_source(cfg) is False
     assert src.exists()
+
+
+# ---------------------------------------------------------------------------
+# best-effort contract (3rd Bugbot round, PR #381): reclaim runs AFTER the load
+# is durable + registered, so NO error in it — guards, realpath, or logging,
+# not just rmtree — may propagate and turn a green ingest red.
+# ---------------------------------------------------------------------------
+
+
+def test_internal_error_never_fails_the_ingest(tmp_path, monkeypatch):
+    # An unexpected raise in a guard (here _is_within) must be swallowed, not
+    # propagated — the delete never happens and the load stays green.
+    storage = tmp_path / "shared"
+    src = storage / ".tracebloc-staging" / "tbl"
+    src.mkdir(parents=True)
+    _seed(src, "images")
+
+    def boom(*_a, **_k):
+        raise RuntimeError("unexpected guard failure")
+
+    monkeypatch.setattr(file_transfer, "_is_within", boom)
+    cfg = _cfg(src, storage)
+    assert file_transfer.reclaim_source(cfg) is False  # must NOT raise
+    assert src.exists()  # never reached rmtree
+
+
+def test_logging_failure_never_fails_the_ingest(tmp_path, monkeypatch):
+    # Even a broken logger inside reclaim must not propagate (Bugbot flagged
+    # logging as a raise path). A skip-path log that throws is swallowed.
+    storage = tmp_path / "shared"
+    other = storage / ".tracebloc-staging" / "other"
+    other.mkdir(parents=True)
+    _seed(other, "images")
+
+    def boom(*_a, **_k):
+        raise RuntimeError("logger down")
+
+    monkeypatch.setattr(file_transfer.logger, "info", boom)
+    cfg = _cfg(other, storage, table="tbl")  # mismatch → gate logs .info → boom
+    assert file_transfer.reclaim_source(cfg) is False  # must NOT raise
+    assert other.exists()

--- a/tests/test_file_transfer_reclaim.py
+++ b/tests/test_file_transfer_reclaim.py
@@ -150,3 +150,67 @@ def test_default_cfg_falls_back_to_module_config(tmp_path, monkeypatch):
     monkeypatch.setattr(file_transfer.config, "STORAGE_PATH", str(storage))
     assert file_transfer.reclaim_source() is True
     assert not src.exists()
+
+
+# ---------------------------------------------------------------------------
+# guards added for the Bugbot review (PR #381): sibling user dir, symlink
+# escape, and a root SRC_PATH — none of which the original blocklist caught.
+# ---------------------------------------------------------------------------
+
+
+def test_refuses_sibling_user_dataset_dir(tmp_path):
+    # Helm layout: _resolve_config sets SRC_PATH to the parent of images:, e.g.
+    # /data/shared/cats-dogs — a SIBLING of the table dir, and the user's OWN
+    # data. It is not an isolated .tracebloc-staging dir, so reclaim must leave
+    # it alone (the original guards deleted it on a clean load — the #381 bug).
+    storage = tmp_path / "shared"
+    src = storage / "cats-dogs"  # user's mounted dataset dir
+    dest = storage / "cats_dogs_train"  # the table dir (sibling)
+    src.mkdir(parents=True)
+    dest.mkdir(parents=True)
+    _seed(src, "images")
+    cfg = _cfg(src, storage, table="cats_dogs_train")
+    assert file_transfer.reclaim_source(cfg) is False
+    assert src.exists() and (src / "images" / "cat.jpg").exists()
+
+
+def test_refuses_symlinked_src_resolving_outside_staging(tmp_path):
+    # A SRC_PATH whose path looks like a staging dir but is a SYMLINK to the
+    # user's data must not be reclaimed: guards resolve symlinks (realpath) so
+    # the real target is judged, not the innocent-looking link path.
+    storage = tmp_path / "shared"
+    user_data = storage / "cats-dogs"
+    user_data.mkdir(parents=True)
+    _seed(user_data, "images")
+    staging = storage / ".tracebloc-staging"
+    staging.mkdir(parents=True)
+    link = staging / "tbl"  # path is under .tracebloc-staging …
+    os.symlink(user_data, link)  # … but resolves to the user's data
+    cfg = _cfg(link, storage)
+    assert file_transfer.reclaim_source(cfg) is False
+    assert user_data.exists() and (user_data / "images" / "cat.jpg").exists()
+
+
+def test_refuses_root_src(tmp_path):
+    # A truthy SRC_PATH of "/" must never reach rmtree: it is outside the
+    # staging subtree, so the opt-in gate skips it (a string-prefix guard
+    # mishandled the "//" root case — the #381 medium finding).
+    storage = tmp_path / "shared"
+    storage.mkdir()
+    cfg = _cfg("/", storage)
+    assert file_transfer.reclaim_source(cfg) is False
+
+
+def test_reclaims_through_symlinked_storage_mount(tmp_path):
+    # Realistic PVC: STORAGE_PATH is a symlink to the real mount. A legit
+    # staging dir under it must STILL be reclaimed (realpath resolves both
+    # sides consistently) — the symlink handling must not over-skip.
+    real_storage = tmp_path / "real-shared"
+    real_src = real_storage / ".tracebloc-staging" / "tbl"
+    real_src.mkdir(parents=True)
+    _seed(real_src, "images")
+    storage_link = tmp_path / "shared"  # symlink -> real-shared
+    os.symlink(real_storage, storage_link)
+    cfg = _cfg(storage_link / ".tracebloc-staging" / "tbl", storage_link)
+    assert file_transfer.reclaim_source(cfg) is True
+    assert not real_src.exists()

--- a/tests/test_file_transfer_reclaim.py
+++ b/tests/test_file_transfer_reclaim.py
@@ -214,3 +214,49 @@ def test_reclaims_through_symlinked_storage_mount(tmp_path):
     cfg = _cfg(storage_link / ".tracebloc-staging" / "tbl", storage_link)
     assert file_transfer.reclaim_source(cfg) is True
     assert not real_src.exists()
+
+
+# ---------------------------------------------------------------------------
+# guard added for the 2nd Bugbot round (PR #381): reclaim must be bound to
+# THIS table's staging dir, not just "somewhere under .tracebloc-staging".
+# ---------------------------------------------------------------------------
+
+
+def test_refuses_another_tables_staging_dir(tmp_path):
+    # SRC_PATH points at a DIFFERENT table's staging dir under the same
+    # .tracebloc-staging tree. Deleting it would take a sibling dataset's
+    # staging with it — must skip (gate binds to cfg.TABLE_NAME).
+    storage = tmp_path / "shared"
+    other = storage / ".tracebloc-staging" / "other_table"
+    other.mkdir(parents=True)
+    _seed(other, "images")
+    cfg = _cfg(other, storage, table="tbl")  # our table is 'tbl', not 'other_table'
+    assert file_transfer.reclaim_source(cfg) is False
+    assert other.exists() and (other / "images" / "cat.jpg").exists()
+
+
+def test_refuses_symlink_into_another_tables_staging(tmp_path):
+    # Our per-table path is a symlink that realpaths to ANOTHER table's staging
+    # under the same tree. The literal-path equality (src resolves elsewhere)
+    # skips it — the sibling's data survives.
+    storage = tmp_path / "shared"
+    other = storage / ".tracebloc-staging" / "other_table"
+    other.mkdir(parents=True)
+    _seed(other, "images")
+    link = storage / ".tracebloc-staging" / "tbl"
+    os.symlink(other, link)
+    cfg = _cfg(link, storage, table="tbl")
+    assert file_transfer.reclaim_source(cfg) is False
+    assert other.exists() and (other / "images" / "cat.jpg").exists()
+
+
+def test_skips_when_table_name_unset(tmp_path):
+    # A well-formed staging dir but no TABLE_NAME to bind it to → skip (we can't
+    # prove which table this staging belongs to).
+    storage = tmp_path / "shared"
+    src = storage / ".tracebloc-staging" / "tbl"
+    src.mkdir(parents=True)
+    _seed(src, "images")
+    cfg = _cfg(src, storage, table="")
+    assert file_transfer.reclaim_source(cfg) is False
+    assert src.exists()

--- a/tests/test_file_transfer_reclaim.py
+++ b/tests/test_file_transfer_reclaim.py
@@ -301,3 +301,54 @@ def test_logging_failure_never_fails_the_ingest(tmp_path, monkeypatch):
     cfg = _cfg(other, storage, table="tbl")  # mismatch → gate logs .info → boom
     assert file_transfer.reclaim_source(cfg) is False  # must NOT raise
     assert other.exists()
+
+
+# ---------------------------------------------------------------------------
+# observability (Asad review, PR #381): the gate silently couples us to the
+# CLI staging layout. A source that lands UNDER .tracebloc-staging but not at
+# this table's dir (a CLI layout drift, or a cross-table SRC) must WARN, so the
+# #346 leak can't return invisibly on a green ingest. A source OUTSIDE the tree
+# (a helm user dir) is a deliberate skip and stays quiet.
+# ---------------------------------------------------------------------------
+
+
+def _count_logs(monkeypatch):
+    calls = {"warning": 0, "info": 0}
+    monkeypatch.setattr(
+        file_transfer.logger,
+        "warning",
+        lambda *a, **k: calls.__setitem__("warning", calls["warning"] + 1),
+    )
+    monkeypatch.setattr(
+        file_transfer.logger,
+        "info",
+        lambda *a, **k: calls.__setitem__("info", calls["info"] + 1),
+    )
+    return calls
+
+
+def test_warns_loudly_on_staging_layout_drift(tmp_path, monkeypatch):
+    # Deeper than the expected .tracebloc-staging/<table> (as if the CLI staged
+    # images under .../<table>/data/images/) → under the tree but unbindable.
+    storage = tmp_path / "shared"
+    drifted = storage / ".tracebloc-staging" / "tbl" / "nested"
+    drifted.mkdir(parents=True)
+    _seed(drifted, "images")
+    calls = _count_logs(monkeypatch)
+    cfg = _cfg(drifted, storage, table="tbl")  # expected .../tbl, got .../tbl/nested
+    assert file_transfer.reclaim_source(cfg) is False
+    assert drifted.exists()
+    assert calls["warning"] == 1 and calls["info"] == 0  # loud, not silent
+
+
+def test_user_dir_skip_stays_quiet(tmp_path, monkeypatch):
+    # A helm user-data dir OUTSIDE .tracebloc-staging is a deliberate skip — no
+    # false-alarm warning every ingest.
+    storage = tmp_path / "shared"
+    userdir = storage / "cats-dogs"
+    userdir.mkdir(parents=True)
+    _seed(userdir, "images")
+    calls = _count_logs(monkeypatch)
+    cfg = _cfg(userdir, storage, table="cats_dogs_train")
+    assert file_transfer.reclaim_source(cfg) is False
+    assert calls["info"] == 1 and calls["warning"] == 0  # deliberate, quiet

--- a/tests/test_ingest_source_reclaim.py
+++ b/tests/test_ingest_source_reclaim.py
@@ -1,0 +1,107 @@
+"""Gate tests: BaseIngestor reclaims its staged source only on a verified,
+clean load (#346).
+
+``reclaim_source`` itself (and all its safety guards) is unit-tested in
+test_file_transfer_reclaim.py. Here we patch it out and assert only the GATE
+in ``_ingest_with_lock``: it fires after a fully-registered, failure-free run
+and stays quiet on any partial/failed run — matching the compensating-delete
+branch, which deliberately leaves staged files in place for retry/inspection.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor
+from tracebloc_ingestor.validators.base import ValidationResult
+
+
+class _FakeIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records and whose
+    record processing is a pass-through — we exercise the reclaim GATE, not the
+    (separately tested) content-hash / record-cleaning path."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source: Any) -> Generator[Dict[str, Any], None, None]:
+        yield from self._records
+
+    def process_record(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        return dict(record)
+
+
+def _make_ingestor(records=None, insert_return=([1], []), **overrides):
+    db = MagicMock(name="Database")
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = insert_return  # (inserted_ids, db_failures)
+    db.get_table_schema.return_value = {"a": "INT"}
+    db.get_label_counts.return_value = {"x": 1}  # truthy -> summary is sent
+    api = MagicMock(name="APIClient")
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=None,
+    )
+    kwargs.update(overrides)
+    return _FakeIngestor(
+        records if records is not None else [{"a": "1", "filename": "f"}], **kwargs
+    )
+
+
+def _run(ing):
+    """Drive a full ingest with validation stubbed to pass and the DB Session
+    mocked, returning the patched ``reclaim_source`` mock for assertions."""
+    ok = MagicMock()
+    ok.name = "OK"
+    ok.validate.return_value = ValidationResult(True, [], [], {})
+    with patch.object(base_mod, "map_validators", return_value=[ok]), patch.object(
+        base_mod, "Session"
+    ) as Sess, patch.object(base_mod, "reclaim_source") as reclaim:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest("src", batch_size=10)
+    return reclaim, failed
+
+
+def test_reclaim_called_on_clean_success():
+    ing = _make_ingestor()
+    reclaim, failed = _run(ing)
+    assert failed == []
+    reclaim.assert_called_once_with(ing.database.config)
+
+
+def test_reclaim_not_called_when_a_record_fails_but_dataset_registers():
+    # A DB failure on part of the batch: the dataset still registers (some
+    # rows inserted, summary sent) but failed_records is non-empty -> the run
+    # is "partial", so the source must be KEPT for retry/inspection.
+    ing = _make_ingestor(
+        insert_return=([1], [{"record": {"a": "2"}, "error": "boom"}]),
+    )
+    reclaim, failed = _run(ing)
+    assert failed  # non-empty
+    reclaim.assert_not_called()
+
+
+def test_reclaim_not_called_when_summary_send_fails():
+    # send_ingest_summary raising drops into the compensating-delete branch:
+    # dataset_registered stays False and the run re-raises -> no reclaim.
+    ing = _make_ingestor()
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("5xx")
+    ok = MagicMock()
+    ok.name = "OK"
+    ok.validate.return_value = ValidationResult(True, [], [], {})
+    with patch.object(base_mod, "map_validators", return_value=[ok]), patch.object(
+        base_mod, "Session"
+    ) as Sess, patch.object(base_mod, "reclaim_source") as reclaim:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError):
+            ing.ingest("src", batch_size=10)
+    reclaim.assert_not_called()

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -440,10 +440,19 @@ def map_file_transfer(
             record.pop(key, None)
 
 
-# The isolated, tracebloc-created staging subtree the CLI stage pod writes to
-# (SharedRoot/.tracebloc-staging/<table>; tracebloc/cli teardown.py). It is the
-# ONLY location reclaim_source will delete — a hidden, tracebloc-owned dir that
-# is provably a throwaway copy, never a customer's own data.
+# The isolated, tracebloc-created staging subtree the CLI stage pod writes to:
+# SharedRoot/.tracebloc-staging/<table>/ (tracebloc/cli internal/push/teardown.go
+# + data_ingest_cluster.go). reclaim_source deletes ONLY that per-table dir — a
+# hidden, tracebloc-owned throwaway copy, never a customer's own data.
+#
+# CROSS-REPO CONTRACT: this name — and the per-table layout the gate below
+# expects (SRC_PATH == SharedRoot/.tracebloc-staging/<TABLE_NAME>, which the CLI
+# realises by staging images: under .../<table>/images/) — is shared with the
+# CLI and nothing here pins it. If the CLI's staging layout changes, this must
+# change in lockstep or reclaim silently no-ops and the #346 ~2x-disk leak
+# returns on a green ingest. Mitigation until a shared constant / cross-repo
+# integration check exists (PR #381 review): the gate WARNs when a source lands
+# under this tree but not at the expected per-table path, so drift is loud.
 STAGING_DIRNAME = ".tracebloc-staging"
 
 
@@ -565,19 +574,39 @@ def _reclaim_source(cfg: Config) -> bool:
     staging_root = os.path.normpath(os.path.join(storage_real, STAGING_DIRNAME))
     table = (cfg.TABLE_NAME or "").strip()
     expected = os.path.normpath(os.path.join(staging_root, table))
-    if (
-        not table
-        or src_real != expected
-        or expected == staging_root
-        or not _is_within(expected, staging_root)
+    if not (
+        table
+        and src_real == expected
+        and expected != staging_root
+        and _is_within(expected, staging_root)
     ):
-        logger.info(
-            f"{YELLOW}Not reclaiming staged source {src_real}: it is not this "
-            f"table's own {STAGING_DIRNAME}/{table or '<table>'} dir under "
-            f"{storage_real} (a helm user dir, another table's staging, the "
-            f"storage root, or a symlink resolving elsewhere). Leaving it in "
-            f"place (#346).{RESET}"
-        )
+        # Didn't resolve to THIS table's staging dir — skip. Two very different
+        # reasons, logged at very different volumes:
+        #   - src IS under .tracebloc-staging but not this table's dir: a
+        #     tracebloc-staged copy we could NOT bind to this table — a CLI
+        #     staging-layout drift (the contract is cross-repo + unpinned, see
+        #     STAGING_DIRNAME) or a cross-table SRC_PATH. Silently no-oping here
+        #     would let the #346 ~2x-disk leak return on a GREEN ingest, so WARN.
+        #   - src is OUTSIDE .tracebloc-staging (a helm user-data dir, the
+        #     storage root, a symlink resolving away): we deliberately never
+        #     touch it — info is enough.
+        if _is_within(src_real, staging_root):
+            logger.warning(
+                f"{YELLOW}Staged source {src_real} is under {staging_root} but is "
+                f"not this table's expected dir {expected} — NOT reclaiming, so "
+                f"the ~2x-disk staging copy (#346) may persist even though the "
+                f"ingest succeeded. If this is the CLI-staged path, its staging "
+                f"layout (SharedRoot/{STAGING_DIRNAME}/<TABLE_NAME>/) has drifted "
+                f"from what reclaim expects; otherwise SRC_PATH is pointed at "
+                f"another table.{RESET}"
+            )
+        else:
+            logger.info(
+                f"{YELLOW}Not reclaiming staged source {src_real}: it is not under "
+                f"this table's {STAGING_DIRNAME}/{table or '<table>'} staging dir "
+                f"(e.g. a user-mounted dataset dir in the helm layout, or the "
+                f"storage root) — left in place (#346).{RESET}"
+            )
         return False
 
     # Backstop: never delete the freshly-written table dir or anything that

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -505,13 +505,41 @@ def reclaim_source(cfg: Optional[Config] = None) -> bool:
     directory. A final backstop still refuses if the resolved source overlaps
     the table dir at all.
 
-    Best-effort: a filesystem error while removing the tree is logged and
-    swallowed — the load already succeeded, so a leftover staging copy (the
-    pre-#346 status quo) must never turn a green ingest red.
+    Best-effort: ANY error — deriving the guards or the delete itself — is
+    logged and swallowed (returns False). The load has already succeeded when
+    this is called, so a leftover staging copy (the pre-#346 status quo) must
+    never turn a green ingest red.
 
     Returns ``True`` iff the staging tree was removed.
     """
     cfg = cfg or config
+    # Best-effort wrapper: reclaim runs AFTER the load is durable + registered
+    # (see _ingest_with_lock), so NOTHING here — realpath, isdir, the guards,
+    # rmtree, even a logging failure — may turn a green ingest red (Bugbot #381).
+    # Any error is swallowed and the leftover staging copy (the pre-#346 status
+    # quo) is left for manual cleanup.
+    try:
+        return _reclaim_source(cfg)
+    except Exception as e:
+        try:
+            logger.warning(
+                f"{YELLOW}Could not reclaim staged source (SRC_PATH="
+                f"{cfg.SRC_PATH!r}): {e}. The load succeeded; the leftover "
+                f"staging copy is the pre-#346 status quo and can be removed "
+                f"manually.{RESET}"
+            )
+        except Exception:
+            pass  # a broken logger must not fail a green ingest either
+        return False
+
+
+def _reclaim_source(cfg: Config) -> bool:
+    """The guarded reclaim decision + delete (contract: see ``reclaim_source``).
+
+    Split out so ``reclaim_source`` can wrap the WHOLE thing in one best-effort
+    guard — a raise anywhere here (a bad ``realpath`` / ``isdir``, an overlap
+    check, a logging failure, or ``rmtree``) must never propagate to the ingest.
+    """
     src = cfg.SRC_PATH
     if not src:
         return False
@@ -562,17 +590,9 @@ def reclaim_source(cfg: Optional[Config] = None) -> bool:
         )
         return False
 
-    try:
-        shutil.rmtree(src_real)
-        logger.info(
-            f"{GREEN}Reclaimed staged source {src_real} after a verified, clean "
-            f"load — no duplicate copy left on the PVC (#346).{RESET}"
-        )
-        return True
-    except OSError as e:
-        logger.warning(
-            f"{YELLOW}Could not reclaim staged source {src_real}: {e}. The load "
-            f"succeeded; the leftover staging copy is the pre-#346 status quo "
-            f"and can be removed manually.{RESET}"
-        )
-        return False
+    shutil.rmtree(src_real)
+    logger.info(
+        f"{GREEN}Reclaimed staged source {src_real} after a verified, clean "
+        f"load — no duplicate copy left on the PVC (#346).{RESET}"
+    )
+    return True

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -22,6 +22,7 @@ from tracebloc_ingestor import Config
 from tracebloc_ingestor.utils.constants import (
     GREEN,
     RED,
+    YELLOW,
     RESET,
     RETRY_MAX_ATTEMPTS,
     RETRY_WAIT_MAX,
@@ -437,3 +438,85 @@ def map_file_transfer(
     finally:
         for key in lent:
             record.pop(key, None)
+
+
+def reclaim_source(cfg: Optional[Config] = None) -> bool:
+    """Delete the staged ``SRC_PATH`` tree after a VERIFIED, clean load (#346).
+
+    Every ``*_transfer`` above **copies** a file-bearing dataset's staged
+    sidecars from ``SRC_PATH/<subdir>/`` into the final table dir
+    ``DEST_PATH`` (see ``_copy_file_with_retry``) but historically never
+    removed the staging copy — so each ingest left two copies of the data on
+    the shared PVC (~2x disk for image / detection / segmentation datasets).
+    This reclaims the staging tree, replacing the CLI's extra ``rm -rf`` pod
+    (tracebloc/cli#167) and closing the leak for the helm-driven path too.
+
+    The caller MUST invoke this only once the load is fully durable (DB rows
+    committed + dataset registered with the backend) AND clean (no failed
+    records). On a partial/failed load the source is deliberately kept so the
+    operator can retry or inspect it — mirroring the compensating-delete branch
+    in ``BaseIngestor._ingest_with_lock``, which leaves staged files in place.
+
+    SAFETY — the delete is a no-op (returns ``False``) unless ``SRC_PATH`` is a
+    real, standalone staging directory that provably does NOT contain the table
+    just written:
+
+      - unset / empty ``SRC_PATH`` (tabular etc. stage nothing) — skip;
+      - ``SRC_PATH`` is not an existing directory — nothing to reclaim;
+      - ``SRC_PATH`` == ``STORAGE_PATH`` (the shared-PVC root) — never delete it;
+      - ``SRC_PATH`` == ``DEST_PATH``, or ``DEST_PATH`` lives INSIDE ``SRC_PATH``
+        — deleting SRC would take the freshly-written table (and, for a shared
+        root, every other tenant's data) with it. This is the helm-direct
+        layout where data was staged straight into the shared root rather than
+        an isolated ``.tracebloc-staging/<table>`` dir; leaving it untouched is
+        strictly no worse than the pre-#346 status quo;
+      - ``SRC_PATH`` lives inside ``DEST_PATH`` — degenerate, skip.
+
+    Best-effort: a filesystem error while removing the tree is logged and
+    swallowed — the load already succeeded, so a leftover staging copy (the
+    pre-#346 status quo) must never turn a green ingest red.
+
+    Returns ``True`` iff the staging tree was removed.
+    """
+    cfg = cfg or config
+    src = cfg.SRC_PATH
+    if not src:
+        return False
+
+    src_abs = os.path.abspath(src)
+    dest_abs = os.path.abspath(cfg.DEST_PATH)
+    storage_abs = os.path.abspath(cfg.STORAGE_PATH)
+
+    if not os.path.isdir(src_abs):
+        return False
+    if src_abs == storage_abs:
+        logger.warning(
+            f"{YELLOW}Not reclaiming staged source {src_abs}: it is the shared "
+            f"storage root (STORAGE_PATH) — refusing to delete it (#346).{RESET}"
+        )
+        return False
+    if src_abs == dest_abs or dest_abs.startswith(src_abs + os.sep):
+        logger.warning(
+            f"{YELLOW}Not reclaiming staged source {src_abs}: the table dir "
+            f"{dest_abs} lives inside it, so removing SRC would delete the "
+            f"freshly-written table. Data was staged into the storage root "
+            f"rather than an isolated staging dir; skipping reclaim (#346).{RESET}"
+        )
+        return False
+    if src_abs.startswith(dest_abs + os.sep):
+        return False
+
+    try:
+        shutil.rmtree(src_abs)
+        logger.info(
+            f"{GREEN}Reclaimed staged source {src_abs} after a verified, clean "
+            f"load — no duplicate copy left on the PVC (#346).{RESET}"
+        )
+        return True
+    except OSError as e:
+        logger.warning(
+            f"{YELLOW}Could not reclaim staged source {src_abs}: {e}. The load "
+            f"succeeded; the leftover staging copy is the pre-#346 status quo "
+            f"and can be removed manually.{RESET}"
+        )
+        return False

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -482,19 +482,22 @@ def reclaim_source(cfg: Optional[Config] = None) -> bool:
     in ``BaseIngestor._ingest_with_lock``, which leaves staged files in place.
 
     SAFETY — reclaim is OPT-IN, not blocklist. We delete a directory only when
-    we can PROVE it is a throwaway copy tracebloc itself staged: the resolved
-    ``SRC_PATH`` must live strictly inside ``STORAGE_PATH/.tracebloc-staging``
-    (``SharedRoot/.tracebloc-staging/<table>`` — what the CLI stage pod writes).
-    Every other layout is left untouched — no worse than the pre-#346 status
-    quo — because it is not provably ours to delete:
+    we can PROVE it is a throwaway copy tracebloc itself staged FOR THIS TABLE:
+    the resolved ``SRC_PATH`` must equal EXACTLY
+    ``STORAGE_PATH/.tracebloc-staging/<TABLE_NAME>`` — the per-table dir the CLI
+    stage pod writes. Binding to ``cfg.TABLE_NAME`` (not merely "somewhere under
+    ``.tracebloc-staging``") means a stray or symlinked ``SRC_PATH`` cannot reach
+    a SIBLING dataset's staging. Every other layout is left untouched — no worse
+    than the pre-#346 status quo — because it is not provably ours to delete:
 
-      - unset / empty ``SRC_PATH`` (tabular etc. stage nothing);
+      - unset / empty ``SRC_PATH`` or ``TABLE_NAME`` (tabular etc. stage nothing);
       - ``SRC_PATH`` is not an existing directory — nothing to reclaim;
       - a customer's OWN mounted dataset dir in the helm layout, where
         ``_resolve_config`` derives ``SRC_PATH`` as the parent of ``images:``
         (e.g. ``/data/shared/cats-dogs``, a SIBLING of the table dir) — deleting
         that would destroy the user's data;
-      - the shared-PVC root, ``/``, or anything that resolves outside staging.
+      - another table's ``.tracebloc-staging/<other>`` dir, the shared-PVC root,
+        ``/``, or anything that resolves outside this table's staging dir.
 
     Paths are resolved with ``os.path.realpath`` before every check AND before
     the delete, so a symlinked ``SRC_PATH`` (PVC mounts are symlinks) cannot
@@ -522,15 +525,30 @@ def reclaim_source(cfg: Optional[Config] = None) -> bool:
     if not os.path.isdir(src_real):
         return False
 
-    # Opt-in gate: reclaim ONLY an isolated SharedRoot/.tracebloc-staging/<table>
-    # dir (strictly inside the staging subtree — not the staging root itself).
-    staging_root = os.path.join(storage_real, STAGING_DIRNAME)
-    if src_real == staging_root or not _is_within(src_real, staging_root):
+    # Opt-in gate: reclaim ONLY THIS table's own staging dir — exactly
+    # STORAGE_PATH/.tracebloc-staging/<TABLE_NAME>, what the CLI stage pod writes.
+    # Binding to cfg.TABLE_NAME (not merely "somewhere under .tracebloc-staging")
+    # stops a stray SRC_PATH — another dataset's staging, or a <table> symlink
+    # that realpaths into the tree — from rmtree'ing a sibling's data on the
+    # shared PVC (Bugbot #381). `expected` is the literal per-table path (NOT
+    # realpath'd), so a `<table>` that is itself a symlink elsewhere fails the
+    # equality against the fully-resolved src and is left alone. A blank table
+    # name, or one that escapes the staging subtree, skips.
+    staging_root = os.path.normpath(os.path.join(storage_real, STAGING_DIRNAME))
+    table = (cfg.TABLE_NAME or "").strip()
+    expected = os.path.normpath(os.path.join(staging_root, table))
+    if (
+        not table
+        or src_real != expected
+        or expected == staging_root
+        or not _is_within(expected, staging_root)
+    ):
         logger.info(
-            f"{YELLOW}Not reclaiming staged source {src_real}: it is not an "
-            f"isolated {STAGING_DIRNAME}/<table> dir under {storage_real} — e.g. "
-            f"a user-mounted dataset dir (helm layout), the storage root, or a "
-            f"symlink resolving outside staging. Leaving it in place (#346).{RESET}"
+            f"{YELLOW}Not reclaiming staged source {src_real}: it is not this "
+            f"table's own {STAGING_DIRNAME}/{table or '<table>'} dir under "
+            f"{storage_real} (a helm user dir, another table's staging, the "
+            f"storage root, or a symlink resolving elsewhere). Leaving it in "
+            f"place (#346).{RESET}"
         )
         return False
 

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -440,16 +440,40 @@ def map_file_transfer(
             record.pop(key, None)
 
 
+# The isolated, tracebloc-created staging subtree the CLI stage pod writes to
+# (SharedRoot/.tracebloc-staging/<table>; tracebloc/cli teardown.py). It is the
+# ONLY location reclaim_source will delete — a hidden, tracebloc-owned dir that
+# is provably a throwaway copy, never a customer's own data.
+STAGING_DIRNAME = ".tracebloc-staging"
+
+
+def _is_within(child: str, parent: str) -> bool:
+    """True if ``child`` is ``parent`` or a path inside it.
+
+    Compares fully resolved (symlinks followed) absolute paths COMPONENT-WISE
+    via ``os.path.commonpath`` — never a raw ``startswith`` string prefix. That
+    dodges two traps a string compare falls into: a ``parent`` of ``/`` becoming
+    a ``//`` prefix that matches nothing, and ``/data/shared-2`` looking
+    "within" ``/data/shared``.
+    """
+    child = os.path.realpath(child)
+    parent = os.path.realpath(parent)
+    try:
+        return os.path.commonpath([child, parent]) == parent
+    except ValueError:
+        # Mixed absolute/relative, or (on Windows) different drives — not within.
+        return False
+
+
 def reclaim_source(cfg: Optional[Config] = None) -> bool:
     """Delete the staged ``SRC_PATH`` tree after a VERIFIED, clean load (#346).
 
     Every ``*_transfer`` above **copies** a file-bearing dataset's staged
-    sidecars from ``SRC_PATH/<subdir>/`` into the final table dir
-    ``DEST_PATH`` (see ``_copy_file_with_retry``) but historically never
-    removed the staging copy — so each ingest left two copies of the data on
-    the shared PVC (~2x disk for image / detection / segmentation datasets).
-    This reclaims the staging tree, replacing the CLI's extra ``rm -rf`` pod
-    (tracebloc/cli#167) and closing the leak for the helm-driven path too.
+    sidecars from ``SRC_PATH/<subdir>/`` into the final table dir ``DEST_PATH``
+    (see ``_copy_file_with_retry``) but historically never removed the staging
+    copy — so each ingest left two copies of the data on the shared PVC (~2x
+    disk for image / detection / segmentation datasets). This reclaims the
+    staging tree, replacing the CLI's extra ``rm -rf`` pod (tracebloc/cli#167).
 
     The caller MUST invoke this only once the load is fully durable (DB rows
     committed + dataset registered with the backend) AND clean (no failed
@@ -457,20 +481,26 @@ def reclaim_source(cfg: Optional[Config] = None) -> bool:
     operator can retry or inspect it — mirroring the compensating-delete branch
     in ``BaseIngestor._ingest_with_lock``, which leaves staged files in place.
 
-    SAFETY — the delete is a no-op (returns ``False``) unless ``SRC_PATH`` is a
-    real, standalone staging directory that provably does NOT contain the table
-    just written:
+    SAFETY — reclaim is OPT-IN, not blocklist. We delete a directory only when
+    we can PROVE it is a throwaway copy tracebloc itself staged: the resolved
+    ``SRC_PATH`` must live strictly inside ``STORAGE_PATH/.tracebloc-staging``
+    (``SharedRoot/.tracebloc-staging/<table>`` — what the CLI stage pod writes).
+    Every other layout is left untouched — no worse than the pre-#346 status
+    quo — because it is not provably ours to delete:
 
-      - unset / empty ``SRC_PATH`` (tabular etc. stage nothing) — skip;
+      - unset / empty ``SRC_PATH`` (tabular etc. stage nothing);
       - ``SRC_PATH`` is not an existing directory — nothing to reclaim;
-      - ``SRC_PATH`` == ``STORAGE_PATH`` (the shared-PVC root) — never delete it;
-      - ``SRC_PATH`` == ``DEST_PATH``, or ``DEST_PATH`` lives INSIDE ``SRC_PATH``
-        — deleting SRC would take the freshly-written table (and, for a shared
-        root, every other tenant's data) with it. This is the helm-direct
-        layout where data was staged straight into the shared root rather than
-        an isolated ``.tracebloc-staging/<table>`` dir; leaving it untouched is
-        strictly no worse than the pre-#346 status quo;
-      - ``SRC_PATH`` lives inside ``DEST_PATH`` — degenerate, skip.
+      - a customer's OWN mounted dataset dir in the helm layout, where
+        ``_resolve_config`` derives ``SRC_PATH`` as the parent of ``images:``
+        (e.g. ``/data/shared/cats-dogs``, a SIBLING of the table dir) — deleting
+        that would destroy the user's data;
+      - the shared-PVC root, ``/``, or anything that resolves outside staging.
+
+    Paths are resolved with ``os.path.realpath`` before every check AND before
+    the delete, so a symlinked ``SRC_PATH`` (PVC mounts are symlinks) cannot
+    slip a non-staging target past the gate, and ``rmtree`` acts on the real
+    directory. A final backstop still refuses if the resolved source overlaps
+    the table dir at all.
 
     Best-effort: a filesystem error while removing the tree is logged and
     swallowed — the load already succeeded, so a leftover staging copy (the
@@ -483,39 +513,47 @@ def reclaim_source(cfg: Optional[Config] = None) -> bool:
     if not src:
         return False
 
-    src_abs = os.path.abspath(src)
-    dest_abs = os.path.abspath(cfg.DEST_PATH)
-    storage_abs = os.path.abspath(cfg.STORAGE_PATH)
+    # Resolve symlinks up front: every guard below — and the delete itself —
+    # must act on the REAL target, so a symlinked SRC_PATH can't bypass them.
+    src_real = os.path.realpath(src)
+    dest_real = os.path.realpath(cfg.DEST_PATH)
+    storage_real = os.path.realpath(cfg.STORAGE_PATH)
 
-    if not os.path.isdir(src_abs):
+    if not os.path.isdir(src_real):
         return False
-    if src_abs == storage_abs:
-        logger.warning(
-            f"{YELLOW}Not reclaiming staged source {src_abs}: it is the shared "
-            f"storage root (STORAGE_PATH) — refusing to delete it (#346).{RESET}"
+
+    # Opt-in gate: reclaim ONLY an isolated SharedRoot/.tracebloc-staging/<table>
+    # dir (strictly inside the staging subtree — not the staging root itself).
+    staging_root = os.path.join(storage_real, STAGING_DIRNAME)
+    if src_real == staging_root or not _is_within(src_real, staging_root):
+        logger.info(
+            f"{YELLOW}Not reclaiming staged source {src_real}: it is not an "
+            f"isolated {STAGING_DIRNAME}/<table> dir under {storage_real} — e.g. "
+            f"a user-mounted dataset dir (helm layout), the storage root, or a "
+            f"symlink resolving outside staging. Leaving it in place (#346).{RESET}"
         )
         return False
-    if src_abs == dest_abs or dest_abs.startswith(src_abs + os.sep):
+
+    # Backstop: never delete the freshly-written table dir or anything that
+    # overlaps it, even if the staging root were somehow mis-derived.
+    if _is_within(src_real, dest_real) or _is_within(dest_real, src_real):
         logger.warning(
-            f"{YELLOW}Not reclaiming staged source {src_abs}: the table dir "
-            f"{dest_abs} lives inside it, so removing SRC would delete the "
-            f"freshly-written table. Data was staged into the storage root "
-            f"rather than an isolated staging dir; skipping reclaim (#346).{RESET}"
+            f"{YELLOW}Not reclaiming staged source {src_real}: it overlaps the "
+            f"table dir {dest_real}; refusing to risk the freshly-written table "
+            f"(#346).{RESET}"
         )
-        return False
-    if src_abs.startswith(dest_abs + os.sep):
         return False
 
     try:
-        shutil.rmtree(src_abs)
+        shutil.rmtree(src_real)
         logger.info(
-            f"{GREEN}Reclaimed staged source {src_abs} after a verified, clean "
+            f"{GREEN}Reclaimed staged source {src_real} after a verified, clean "
             f"load — no duplicate copy left on the PVC (#346).{RESET}"
         )
         return True
     except OSError as e:
         logger.warning(
-            f"{YELLOW}Could not reclaim staged source {src_abs}: {e}. The load "
+            f"{YELLOW}Could not reclaim staged source {src_real}: {e}. The load "
             f"succeeded; the leftover staging copy is the pre-#346 status quo "
             f"and can be removed manually.{RESET}"
         )

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -25,7 +25,7 @@ from ..utils import redaction
 from ..utils.columns import resolve_column
 from ..utils.correlation import resolve_correlation_id
 from ..utils.validators_mapping import map_validators
-from ..file_transfer import map_file_transfer
+from ..file_transfer import map_file_transfer, reclaim_source
 from ..text_profile import compute_text_profile
 from ..schema_inference import canonical_dtype
 from ..reporting import ConsoleRenderer
@@ -1228,6 +1228,21 @@ class BaseIngestor(ABC):
                             "row(s) remain orphaned (#227)."
                         )
                 raise e
+
+        # Reclaim the staged source tree now that the load is fully verified
+        # (rows committed + dataset registered above) AND clean (no failed
+        # records). The per-record copies in ``map_file_transfer`` leave a
+        # second copy of every file-bearing dataset on the shared PVC; without
+        # this each ingest ~doubled PVC usage (#346). Gated on a CLEAN success
+        # so a partial/failed run keeps its source for retry/inspection —
+        # matching the compensating-delete branch above, which deliberately
+        # leaves staged files in place ("overwritten on re-run"). Still inside
+        # the table lock (released in ``ingest``'s finally), so it can't race a
+        # concurrent ingest of the same table. ``reclaim_source`` is fully
+        # guarded + best-effort: it never deletes a dir that contains the table
+        # dir and never fails an already-successful load.
+        if dataset_registered and not failed_records:
+            reclaim_source(self.database.config)
 
         return failed_records
 


### PR DESCRIPTION
## What

The ingestor **copies** each file-bearing dataset's staged sidecars from `SRC_PATH/<subdir>/` into the final table dir `DEST_PATH` (`_copy_file_with_retry`) but never removed the staging copy afterward. So every image / detection / segmentation ingest left **two** copies of the data on the shared PVC — ~2× disk per ingest (#346).

- New `file_transfer.reclaim_source(cfg)` — `rmtree`s the `SRC_PATH` staging tree.
- `BaseIngestor._ingest_with_lock` calls it right before returning, **only** when `dataset_registered is True` **and** `failed_records` is empty.

This closes the leak at the source and replaces the CLI's extra `rm -rf` cleanup pod (tracebloc/cli#167), and also covers the helm-driven ingest path (which never went through the CLI reclaim).

## Why it's safe

- **Reclaim only after a fully verified, clean load.** `dataset_registered` flips `True` only after DB rows are committed **and** the backend summary registration succeeds. On any failure/partial run the source is deliberately kept for retry/inspection — mirroring the existing compensating-delete branch, whose comment already says staged files stay and are "overwritten on re-run". No per-file `shutil.move` (that would delete source mid-load, before verification — unsafe).
- **Runs under the table lock** (released in `ingest()`'s `finally`), so it can't race a concurrent ingest of the same table.
- **Heavily guarded** — `reclaim_source` refuses to delete a directory that *is* or *contains* the freshly-written table, and never touches the shared root:
  - unset/empty `SRC_PATH` (tabular etc.) → no-op;
  - `SRC_PATH` not an existing dir → no-op;
  - `SRC_PATH == STORAGE_PATH` (shared-PVC root) → skip;
  - `SRC_PATH == DEST_PATH`, or `DEST_PATH` **inside** `SRC_PATH` (the helm-direct "staged straight into the root" layout) → skip — strictly no worse than today;
  - `SRC_PATH` inside `DEST_PATH` → skip.
- **Best-effort:** a filesystem error while removing the tree is logged and swallowed — a leftover staging copy must never turn a green ingest red.

## Files

- `tracebloc_ingestor/file_transfer.py` — `reclaim_source` helper (+ `YELLOW` import).
- `tracebloc_ingestor/ingestors/base.py` — gated call before `return failed_records`.
- `tests/test_file_transfer_reclaim.py` — unit tests for the helper (happy path + every guard + best-effort).
- `tests/test_ingest_source_reclaim.py` — gate tests: reclaim fires on clean success, and is skipped when a record fails (dataset still registers) or the summary send fails.

## Test plan

- `pytest tests/test_file_transfer_reclaim.py tests/test_ingest_source_reclaim.py` → **12 passed**; `reclaim_source` is fully covered (no missing lines).
- Full unit suite: **1785 passed, 1 xfailed**, plus the 4 new gate/helper tests. The only failures locally are 4 pre-existing `float/int overflow` message-assertion tests, which fail identically on `origin/develop` without this change (a Python 3.9-local vs CI 3.11+ pandas/numpy artifact — CI runs 3.11/3.12).
- `black --check` clean on all changed/added files. (`base.py` shows two unrelated pre-existing formatting hunks from a newer local black; left untouched to avoid churn — CI does not run black.)

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes directories on the shared PVC, but only via a strict opt-in path gate; residual risk is CLI staging-layout drift or a guard bug deleting the wrong tree.
> 
> **Overview**
> Fixes **~2× PVC usage** (#346) by removing the CLI staging tree after ingest copies sidecars into the table directory.
> 
> Adds **`file_transfer.reclaim_source`**, which deletes only when resolved `SRC_PATH` exactly matches `STORAGE_PATH/.tracebloc-staging/<TABLE_NAME>`. It uses **`realpath` + `commonpath`** guards (symlinks, sibling user dirs, other tables, overlap with `DEST_PATH`), **warns** on staging-layout drift under `.tracebloc-staging`, and is **best-effort** so failures never fail a successful ingest.
> 
> **`BaseIngestor._ingest_with_lock`** invokes reclaim after registration when **`dataset_registered` and `failed_records` is empty** (still under the table lock).
> 
> New tests cover reclaim guards/observability and the ingest gate (success vs partial vs summary failure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b407b9bfcaab5ed71159c9b68dc47c5f43ffbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->