### PR TITLE
fix(ingest): resolve filename column case-/whitespace-insensitively end-to-end (#372)

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -17,6 +17,7 @@ from tracebloc_ingestor.ingestors import base as base_mod
 from tracebloc_ingestor.ingestors import preflight
 from tracebloc_ingestor.ingestors.base import BaseIngestor, IngestionSummary
 from tracebloc_ingestor.validators.base import ValidationResult
+from tracebloc_ingestor.utils.constants import TaskCategory
 
 
 class FakeIngestor(BaseIngestor):
@@ -312,6 +313,96 @@ def test_ingest_label_resolves_on_later_record_for_sparse_json():
     _table, batch = ing.database.insert_batch.call_args.args
     assert [r.get("label") for r in batch] == [None, "dog"], (
         f"expected [None, 'dog']; got {[r.get('label') for r in batch]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_filename_key (#372)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "record,expected",
+    [
+        ({"a": "1", "Filename": "f1"}, "f1"),      # case mismatch -> canonical
+        ({"a": "1", "FileName": "f1"}, "f1"),      # mixed case -> canonical
+        ({"a": "1", " filename ": "f1"}, "f1"),    # whitespace -> canonical
+        ({"a": "1", "filename": "f1"}, "f1"),       # exact -> unchanged
+    ],
+)
+def test_resolve_filename_key_remaps_to_canonical(record, expected):
+    """#372: a file-pointer header that only differs in case/whitespace is
+    remapped to the literal ``filename`` key the transfer read path uses."""
+    ing = make_ingestor(category=TaskCategory.IMAGE_CLASSIFICATION)
+    ing._resolve_filename_key(record)
+    assert record.get("filename") == expected
+
+
+def test_resolve_filename_key_noop_when_absent():
+    """An ``image_id``-only manifest is a genuinely different column, not a case
+    variant (cli#371 territory) — leave it untouched so it still fails at
+    transfer as the contract intends, rather than silently aliasing it."""
+    rec = {"a": "1", "image_id": "f1"}
+    ing = make_ingestor(category=TaskCategory.IMAGE_CLASSIFICATION)
+    ing._resolve_filename_key(rec)
+    assert "filename" not in rec
+
+
+def test_resolve_filename_key_noop_for_non_file_bearing():
+    """A tabular dataset may legitimately carry an unrelated ``FileName`` data
+    column that must NOT be hijacked as a file pointer."""
+    rec = {"a": "1", "FileName": "not-a-file-pointer"}
+    ing = make_ingestor(category=None)
+    ing._resolve_filename_key(rec)
+    assert "filename" not in rec
+
+
+def test_resolve_filename_key_resolves_on_later_record_for_sparse_json():
+    """Mirrors the #340 label edge: a leading (file-column-less) JSON object
+    must not stop resolution — the source column is resolved on the first
+    record that carries it and then applied to every subsequent record."""
+    ing = make_ingestor(category=TaskCategory.IMAGE_CLASSIFICATION)
+    r1 = {"a": "1"}                       # no file column at all
+    r2 = {"a": "2", "Filename": "f2"}     # mis-cased file column
+    r3 = {"a": "3", "Filename": "f3"}
+    ing._resolve_filename_key(r1)
+    ing._resolve_filename_key(r2)
+    ing._resolve_filename_key(r3)
+    assert "filename" not in r1
+    assert r2["filename"] == "f2"
+    assert r3["filename"] == "f3"
+    assert ing._filename_source_key == "Filename"
+
+
+def test_ingest_filename_case_mismatch_reaches_transfer():
+    """#372 end-to-end: an image manifest with a ``Filename`` header passes the
+    case-insensitive preflight; the ingest loop must remap it to the canonical
+    ``filename`` key or every record reaches file transfer with filename=None
+    and fails after upload ("No filename found in record", exit 9)."""
+    records = [
+        {"a": "1", "Filename": "img1", "label": "cat"},
+        {"a": "2", "Filename": "img2", "label": "dog"},
+    ]
+    ing = make_ingestor(
+        records=records,
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="label",
+        schema={"a": "INT", "label": "VARCHAR(10)"},
+    )
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod, "map_file_transfer", side_effect=lambda cat, rec, *a, **k: rec
+    ) as mft:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+    # Every record the transfer received carries a non-None canonical filename.
+    transferred = [c.kwargs.get("source_record") for c in mft.call_args_list]
+    assert [r.get("filename") for r in transferred] == ["img1", "img2"]
+    # And the cleaned records that reach the DB batch carry it too.
+    _table, batch = ing.database.insert_batch.call_args.args
+    assert [r.get("filename") for r in batch] == ["img1", "img2"], (
+        f"filenames nulled by case mismatch: {[r.get('filename') for r in batch]}"
     )
 
 

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -249,6 +249,10 @@ class BaseIngestor(ABC):
         self.intent = intent
         self.annotation_column = annotation_column
         self.category = category
+        # #372: the actual header spelling of the file-pointer column, resolved
+        # once per run to the canonical ``filename`` key (see
+        # ``_resolve_filename_key``). None until the first record that carries it.
+        self._filename_source_key: Optional[str] = None
         self.data_format = data_format
         self.file_options = file_options or {}
         self.label_policy = label_policy
@@ -412,6 +416,54 @@ class BaseIngestor(ABC):
             )
             self.label_column = resolved
         return True
+
+    def _resolve_filename_key(self, record: Dict[str, Any]) -> None:
+        """Remap the record's file-pointer column to the canonical ``filename`` key (#372).
+
+        The filename column is validated case-/whitespace-insensitively
+        (``IngestableRecordsValidator._resolve_filename_column`` via the shared
+        ``resolve_column`` rule), but the transfer read path pulls it out of each
+        record by the exact literal key — ``record.get("filename")`` in
+        ``file_transfer`` / ``modalities.transfer``, and ``RecordProcessor`` copies
+        it forward the same way. So a header like ``Filename`` / ``FileName`` /
+        ``" filename "`` passes preflight and then reads ``None`` for every row:
+        every file transfer fails ("No filename found in record", exit 9) AFTER
+        the upload. This is the #340 class already fixed for the label column,
+        still open for ``filename``.
+
+        Unlike the label column — whose configured NAME is pinned once on the
+        ingestor (``_resolve_label_column``) and read back via that name — the
+        filename read target is the fixed literal ``"filename"`` used everywhere
+        in transfer. So the fix normalises the RECORD instead: the source column
+        is resolved once (cached on ``self._filename_source_key``) using the SAME
+        ``resolve_column`` rule the validators use, then copied onto the canonical
+        ``filename`` key of every record so the read path and the validators agree.
+
+        Scoped to file-bearing categories — a tabular dataset may legitimately
+        carry an unrelated ``FileName`` data column that must NOT be hijacked as a
+        file pointer. No-ops when the record already carries a literal
+        ``filename`` key (the common lowercase case) or when nothing resolves:
+        an ``image_id``-only manifest is a genuinely different column, not a case
+        variant (cli#371 territory), and is left to fail at transfer as the
+        contract intends. Sparse JSON whose leading object omits the column is
+        retried on later records, mirroring ``_resolve_label_column``.
+        """
+        if self.category not in _FILE_BEARING_CATEGORIES:
+            return
+        if "filename" in record:
+            return
+        source = self._filename_source_key
+        if source is None:
+            source = resolve_column(record.keys(), "filename")
+            if source is None:
+                return
+            self._filename_source_key = source
+            logger.info(
+                f"Resolved filename column {source!r} to canonical 'filename' "
+                f"(case/whitespace-insensitive match)."
+            )
+        if source in record:
+            record["filename"] = record[source]
 
     @property
     def _grouping(self):
@@ -886,8 +938,19 @@ class BaseIngestor(ABC):
                 pbar = tqdm(total=total, desc="Ingesting records", unit="records")
 
                 _label_resolved = False
+                self._filename_source_key = None
                 for record in self.read_data(source):
                     stats["total_records"] += 0 if total else 1
+
+                    # #372: remap the file-pointer column to the canonical
+                    # ``filename`` key before the record is processed or
+                    # transferred. The validators matched the filename column
+                    # case-/whitespace-insensitively, so a header like ``Filename``
+                    # passed preflight; without this the transfer read path
+                    # (exact key ``record.get("filename")``) would then read None
+                    # for every row and fail after upload. No-op for the common
+                    # lowercase header and for non-file-bearing categories.
+                    self._resolve_filename_key(record)
 
                     # #340: pin the label column to the actual header spelling
                     # before it is processed. The validators matched the label


### PR DESCRIPTION
Fixes tracebloc/cli#372. Follow-up from tracebloc/cli#371 (Theme D — preflight parity, epic tracebloc/backend#1142).

## Problem

The image `filename` column had a case-sensitivity asymmetry between the ingestor's preflight and its transfer read — the same #340 class already fixed for the *label* column, still open for `filename`:

- **Preflight accepts case-insensitively.** `IngestableRecordsValidator._resolve_filename_column` matches via the shared `resolve_column` rule (case/whitespace-insensitive), so a header like `Filename` / `FileName` / `" filename "` passes the dry-run.
- **Transfer reads case-sensitively.** The value only ever enters the cleaned record via `RecordProcessor` (`record.get("filename")`), and every downstream read (`file_transfer.py`, `modalities/transfer.py`) uses the exact literal key. A non-lowercase header resolves to `None`.

Net: a `Filename`-header image dataset passes preflight but is doomed at transfer — every row fails with `No filename found in record`, exit 9, **after** the upload. #340 fixed exactly this class for the label column via a resolver in `ingestors/base.py`; no equivalent existed for `filename`.

## Fix (ingestor-side, per the issue's preferred approach)

Mirror the #340 label resolver so preflight and transfer agree for every client, not just the CLI:

- Add `BaseIngestor._resolve_filename_key`, wired into the ingest loop right next to the existing `_resolve_label_column` call. It resolves the file-pointer column once per run using the **same** `resolve_column` rule the validators use, then copies it onto the canonical literal `filename` key every downstream read expects.
- Normalizing upstream fixes all read sites at once: `record_processor.py` (`:175` content-hash `data_id` and `:279`), both `modalities/transfer.py` paths, and `file_transfer.py`.

### Deliberately scoped

- **File-bearing categories only** — a tabular dataset may legitimately carry an unrelated `FileName` data column that must not be hijacked as a file pointer.
- **No-op when nothing resolves** — an `image_id`-only manifest is a genuinely *different* column, not a case variant (cli#371's concern), and is left to fail at transfer as the contract intends. This change is strictly about case/whitespace variants.
- **Sparse-JSON safe** — resolution retries on later records if a leading object omits the column, matching `_resolve_label_column`.

### CLI note

cli#371 added `CheckImageFilenameColumn`, which already matches case-insensitively — consistent with this end-to-end behavior, so no CLI change is needed once this lands.

## Tests

+8 in `tests/test_ingestor_base.py`:
- Parametrized case/whitespace remapping to the canonical key (`Filename`, `FileName`, `" filename "`, exact).
- `image_id`-only manifest → no-op (still fails at transfer, as intended).
- Non-file-bearing category with a `FileName` data column → no-op.
- Sparse-JSON retry: source column resolved on the first record that carries it, applied to subsequent records.
- End-to-end: a `Filename`-header image manifest reaches file transfer with a non-None canonical filename and lands in the DB batch.

Full suite green: 1786 passed, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the per-record ingest path for all file-bearing categories, but behavior is narrowly scoped and mirrors the already-shipped #340 label resolver with dedicated tests.
> 
> **Overview**
> Fixes **#372**: manifests whose file-pointer header differs only by case or whitespace (e.g. `Filename`) passed preflight but failed at transfer because downstream code reads **`record.get("filename")`** exactly.
> 
> **`BaseIngestor._resolve_filename_key`** uses the same **`resolve_column`** rule as validators, caches the source header on **`_filename_source_key`**, and copies the value onto the canonical **`filename`** key for each row in the ingest loop (next to the existing label resolver). It runs only for **file-bearing** categories, skips when **`filename`** is already present, and does not alias unrelated columns like **`image_id`** or tabular **`FileName`** data fields.
> 
> New tests cover remapping, no-ops, sparse JSON, and an end-to-end path through file transfer and DB batch insert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e070b6e866c38355043ce8f1f7972ea74d71a7b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->