### PR TITLE
fix(validators): require an exact lowercase "filename" column at preflight (#372, supersedes #382)

### DIFF
--- a/tests/test_ingestable_records_validator.py
+++ b/tests/test_ingestable_records_validator.py
@@ -210,6 +210,9 @@ def test_missing_filename_column_message_is_capped(clean_env, tmp_path, make_csv
     result = IngestableRecordsValidator(file_subdir="images").validate(str(path))
     assert not result.is_valid
     assert "more of 40)" in result.errors[0]  # capped preview, not all 40 names
+    # ...but the FULL header set is retained in metadata (learned Bugbot rule).
+    assert len(result.metadata["columns"]) == 40
+    assert result.metadata["columns"][0] == "c0"
 
 
 def test_absolute_or_traversal_path_is_not_counted_as_found(

--- a/tests/test_ingestable_records_validator.py
+++ b/tests/test_ingestable_records_validator.py
@@ -9,6 +9,7 @@ with a misleading "rows already in the database" message.
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 
 from tracebloc_ingestor.validators.ingestable_records_validator import (
     IngestableRecordsValidator,
@@ -160,6 +161,55 @@ def test_exact_filename_column_with_whitespace_is_accepted(
     path = make_csv([{" filename ": "doc1"}])
     result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
     assert result.is_valid, result.errors
+
+
+def test_semicolon_manifest_not_false_rejected_with_csv_options(clean_env, tmp_path):
+    # #376/#372: a non-comma manifest must be tokenized with the run's dialect.
+    # Without it the header reads as one column ("filename;label"), the exact-
+    # filename check finds nothing, and a VALID dataset is false-rejected —
+    # defeating the purpose of the check. With csv_options it parses correctly.
+    src = tmp_path / "src"
+    seq = src / "sequences"
+    seq.mkdir(parents=True)
+    _write(seq / "doc1.txt", "x")
+    clean_env.setenv("SRC_PATH", str(src))
+    path = _write(tmp_path / "m.csv", "filename;label\ndoc1;cat\n")
+    result = IngestableRecordsValidator(
+        file_subdir="sequences", csv_options={"delimiter": ";"}
+    ).validate(str(path))
+    assert result.is_valid, result.errors
+
+
+def test_semicolon_manifest_mis_tokenized_without_dialect(clean_env, tmp_path):
+    # The failure mode the dialect threading prevents: comma-tokenized, the
+    # semicolon header is one mashed column with no exact `filename`.
+    src = tmp_path / "src"
+    seq = src / "sequences"
+    seq.mkdir(parents=True)
+    _write(seq / "doc1.txt", "x")
+    clean_env.setenv("SRC_PATH", str(src))
+    path = _write(tmp_path / "m.csv", "filename;label\ndoc1;cat\n")
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert not result.is_valid  # mashed header -> no exact filename column
+
+
+def test_malformed_csv_options_rejected_at_construction():
+    # Mirrors the grouped validators (#376): fail fast at construction.
+    with pytest.raises(ValueError):
+        IngestableRecordsValidator(csv_options={"delimiter": 123})
+
+
+def test_missing_filename_column_message_is_capped(clean_env, tmp_path, make_csv):
+    # #372 fix-2: a wide manifest must not produce an unbounded column list in
+    # the error (redaction.column_preview caps it).
+    src = tmp_path / "src"
+    (src / "images").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    wide = {f"c{i}": "v" for i in range(40)}  # 40 columns, none named filename
+    path = make_csv([wide])
+    result = IngestableRecordsValidator(file_subdir="images").validate(str(path))
+    assert not result.is_valid
+    assert "more of 40)" in result.errors[0]  # capped preview, not all 40 names
 
 
 def test_absolute_or_traversal_path_is_not_counted_as_found(

--- a/tests/test_ingestable_records_validator.py
+++ b/tests/test_ingestable_records_validator.py
@@ -8,6 +8,8 @@ with a misleading "rows already in the database" message.
 
 from __future__ import annotations
 
+import json
+
 import pandas as pd
 import pytest
 
@@ -18,6 +20,12 @@ from tracebloc_ingestor.validators.ingestable_records_validator import (
 
 def _write(path, text):
     path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_json(tmp_path, obj, name="manifest.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps(obj), encoding="utf-8")
     return path
 
 
@@ -233,3 +241,56 @@ def test_absolute_or_traversal_path_is_not_counted_as_found(
     result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
     assert not result.is_valid
     assert "No referenced data files" in result.errors[0]
+
+
+# --- JSON manifests: same exact-`filename` contract as CSV (#384 / #3) --------
+# Removing BaseIngestor._resolve_filename_key dropped the ingest-time case/
+# whitespace remap; the preflight now enforces the exact key for JSON too, so a
+# case-variant no longer passes preflight and fails late cluster-side (exit 9).
+
+
+def test_json_file_bearing_with_exact_filename_passes(tmp_path):
+    path = _write_json(tmp_path, [{"filename": "a.txt", "label": "x"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert result.is_valid
+
+
+def test_json_file_bearing_case_variant_filename_is_rejected(tmp_path):
+    # The cluster reads case-sensitive record.get("filename") for JSON too, so a
+    # `Filename` key would upload then fail late — reject up front.
+    path = _write_json(tmp_path, [{"Filename": "a.txt", "label": "x"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert not result.is_valid
+    assert "must be lowercase 'filename'" in result.errors[0]
+    assert result.metadata["reason"] == "filename_column_case_variant"
+
+
+def test_json_file_bearing_missing_filename_is_rejected(tmp_path):
+    path = _write_json(tmp_path, [{"image_id": "a", "label": "x"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert not result.is_valid
+    assert result.metadata["reason"] == "filename_column_missing"
+
+
+def test_json_single_object_form_is_checked(tmp_path):
+    # Object form (not an array) is read via json.load; its keys are checked.
+    path = _write_json(tmp_path, {"Filename": "a.txt"})
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert not result.is_valid
+    assert result.metadata["reason"] == "filename_column_case_variant"
+
+
+def test_json_non_file_bearing_passes(tmp_path):
+    # No file_subdir → no filename contract to enforce.
+    path = _write_json(tmp_path, [{"anything": 1}])
+    result = IngestableRecordsValidator(file_subdir=None).validate(str(path))
+    assert result.is_valid
+
+
+def test_malformed_json_is_skipped_not_rejected(tmp_path):
+    # A parse error is the JSON-structure validators' concern — the filename
+    # preflight must skip (not false-reject) when it can't read the keys.
+    path = _write(tmp_path / "bad.json", "{ this is not valid json")
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert result.is_valid
+    assert result.metadata.get("checked") is False

--- a/tests/test_ingestable_records_validator.py
+++ b/tests/test_ingestable_records_validator.py
@@ -257,12 +257,38 @@ def test_json_file_bearing_with_exact_filename_passes(tmp_path):
 
 def test_json_file_bearing_case_variant_filename_is_rejected(tmp_path):
     # The cluster reads case-sensitive record.get("filename") for JSON too, so a
-    # `Filename` key would upload then fail late — reject up front.
+    # `Filename` key would upload then fail late — reject up front. JSON keys are
+    # matched verbatim, so the hint says "exactly" (not "lowercase" like CSV).
     path = _write_json(tmp_path, [{"Filename": "a.txt", "label": "x"}])
     result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
     assert not result.is_valid
-    assert "must be lowercase 'filename'" in result.errors[0]
+    assert "must be exactly 'filename'" in result.errors[0]
+    assert "'Filename'" in result.errors[0]
     assert result.metadata["reason"] == "filename_column_case_variant"
+
+
+def test_json_padded_filename_key_is_rejected(tmp_path):
+    # Bugbot #384: unlike CSV (pandas strips headers), JSON keys are NOT
+    # stripped, so a padded `" filename "` key fails the cluster's
+    # record.get("filename") at transfer — must be rejected up front, not
+    # accepted as the CSV whitespace-lenient path does.
+    path = _write_json(tmp_path, [{" filename ": "a.txt", "label": "x"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert not result.is_valid
+    assert "must be exactly 'filename'" in result.errors[0]
+    assert result.metadata["reason"] == "filename_column_case_variant"
+
+
+def test_json_sparse_first_record_missing_filename_still_passes(tmp_path):
+    # Bugbot #384: a leading object may omit `filename` while later records carry
+    # it (the transfer reads each row independently, so those rows ingest).
+    # Preflight must union keys across records, not judge on the first alone.
+    path = _write_json(
+        tmp_path,
+        [{"label": "x"}, {"filename": "a.txt", "label": "y"}],
+    )
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert result.is_valid, result.errors
 
 
 def test_json_file_bearing_missing_filename_is_rejected(tmp_path):

--- a/tests/test_ingestable_records_validator.py
+++ b/tests/test_ingestable_records_validator.py
@@ -82,15 +82,19 @@ def test_filename_with_extension_resolves_without_double_suffix(
     assert result.is_valid, result.errors
 
 
-def test_filename_column_is_case_insensitive(clean_env, tmp_path, make_csv):
+def test_filename_column_case_variant_is_rejected(clean_env, tmp_path, make_csv):
+    # #372: the cluster's transfer read is case-sensitive record.get("filename"),
+    # so a `FileName` case variant is doomed after upload. It must be rejected up
+    # front with a targeted "rename to lowercase" hint (NOT accepted as before).
     src = tmp_path / "src"
     (src / "sequences").mkdir(parents=True)
     clean_env.setenv("SRC_PATH", str(src))
     path = make_csv([{"FileName": "doc1"}])  # header cased differently
     result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
-    # column resolves, file is missing -> rejected (not a no-op)
     assert not result.is_valid
-    assert "No referenced data files" in result.errors[0]
+    assert "must be lowercase 'filename'" in result.errors[0]
+    assert "'FileName'" in result.errors[0]
+    assert result.metadata["reason"] == "filename_column_case_variant"
 
 
 def test_tabular_style_no_subdir_only_checks_rows(make_csv):
@@ -112,16 +116,50 @@ def test_valid_dataset_with_files_passes(clean_env, tmp_path, make_csv):
     assert result.is_valid, result.errors
 
 
-def test_file_bearing_but_no_filename_column_is_noop(clean_env, tmp_path, make_csv):
-    # Rows present, file_subdir set, but the CSV has no filename column to
-    # cross-check -> not this validator's error to raise (pass through).
+def test_file_bearing_but_no_filename_column_is_rejected(clean_env, tmp_path, make_csv):
+    # #372: rows present, file_subdir set, but the CSV names its file column
+    # something other than `filename` (e.g. image_id / text_col). The cluster
+    # can't resolve it and drops every row after upload, so reject up front
+    # instead of deferring (the pre-#372 no-op).
     src = tmp_path / "src"
     (src / "sequences").mkdir(parents=True)
     clean_env.setenv("SRC_PATH", str(src))
     path = make_csv([{"text_col": "hi"}, {"text_col": "yo"}])
     result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
-    assert result.is_valid
-    assert result.metadata["reason"] == "no_filename_column"
+    assert not result.is_valid
+    assert "No 'filename' column" in result.errors[0]
+    assert "text_col" in result.errors[0]  # lists the actual columns
+    assert result.metadata["reason"] == "filename_column_missing"
+
+
+def test_image_id_filename_column_is_rejected(clean_env, tmp_path, make_csv):
+    # #371/#372 image case: labels.csv uses `image_id` instead of `filename`.
+    # Doomed at the cluster's case-sensitive transfer read -> reject up front.
+    src = tmp_path / "src"
+    (src / "images").mkdir(parents=True)
+    clean_env.setenv("SRC_PATH", str(src))
+    path = make_csv([{"image_id": "001", "label": "cat"}])
+    result = IngestableRecordsValidator(
+        file_subdir="images", extension=".jpg"
+    ).validate(str(path))
+    assert not result.is_valid
+    assert "No 'filename' column" in result.errors[0]
+    assert result.metadata["reason"] == "filename_column_missing"
+
+
+def test_exact_filename_column_with_whitespace_is_accepted(
+    clean_env, tmp_path, make_csv
+):
+    # `" filename "` resolves at transfer (pandas strips header whitespace), so
+    # it must pass the column check too — only case, not whitespace, is strict.
+    src = tmp_path / "src"
+    seq = src / "sequences"
+    seq.mkdir(parents=True)
+    _write(seq / "doc1.txt", "x")
+    clean_env.setenv("SRC_PATH", str(src))
+    path = make_csv([{" filename ": "doc1"}])
+    result = IngestableRecordsValidator(file_subdir="sequences").validate(str(path))
+    assert result.is_valid, result.errors
 
 
 def test_absolute_or_traversal_path_is_not_counted_as_found(

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -17,7 +17,6 @@ from tracebloc_ingestor.ingestors import base as base_mod
 from tracebloc_ingestor.ingestors import preflight
 from tracebloc_ingestor.ingestors.base import BaseIngestor, IngestionSummary
 from tracebloc_ingestor.validators.base import ValidationResult
-from tracebloc_ingestor.utils.constants import TaskCategory
 
 
 class FakeIngestor(BaseIngestor):
@@ -313,96 +312,6 @@ def test_ingest_label_resolves_on_later_record_for_sparse_json():
     _table, batch = ing.database.insert_batch.call_args.args
     assert [r.get("label") for r in batch] == [None, "dog"], (
         f"expected [None, 'dog']; got {[r.get('label') for r in batch]}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# _resolve_filename_key (#372)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "record,expected",
-    [
-        ({"a": "1", "Filename": "f1"}, "f1"),      # case mismatch -> canonical
-        ({"a": "1", "FileName": "f1"}, "f1"),      # mixed case -> canonical
-        ({"a": "1", " filename ": "f1"}, "f1"),    # whitespace -> canonical
-        ({"a": "1", "filename": "f1"}, "f1"),       # exact -> unchanged
-    ],
-)
-def test_resolve_filename_key_remaps_to_canonical(record, expected):
-    """#372: a file-pointer header that only differs in case/whitespace is
-    remapped to the literal ``filename`` key the transfer read path uses."""
-    ing = make_ingestor(category=TaskCategory.IMAGE_CLASSIFICATION)
-    ing._resolve_filename_key(record)
-    assert record.get("filename") == expected
-
-
-def test_resolve_filename_key_noop_when_absent():
-    """An ``image_id``-only manifest is a genuinely different column, not a case
-    variant (cli#371 territory) — leave it untouched so it still fails at
-    transfer as the contract intends, rather than silently aliasing it."""
-    rec = {"a": "1", "image_id": "f1"}
-    ing = make_ingestor(category=TaskCategory.IMAGE_CLASSIFICATION)
-    ing._resolve_filename_key(rec)
-    assert "filename" not in rec
-
-
-def test_resolve_filename_key_noop_for_non_file_bearing():
-    """A tabular dataset may legitimately carry an unrelated ``FileName`` data
-    column that must NOT be hijacked as a file pointer."""
-    rec = {"a": "1", "FileName": "not-a-file-pointer"}
-    ing = make_ingestor(category=None)
-    ing._resolve_filename_key(rec)
-    assert "filename" not in rec
-
-
-def test_resolve_filename_key_resolves_on_later_record_for_sparse_json():
-    """Mirrors the #340 label edge: a leading (file-column-less) JSON object
-    must not stop resolution — the source column is resolved on the first
-    record that carries it and then applied to every subsequent record."""
-    ing = make_ingestor(category=TaskCategory.IMAGE_CLASSIFICATION)
-    r1 = {"a": "1"}                       # no file column at all
-    r2 = {"a": "2", "Filename": "f2"}     # mis-cased file column
-    r3 = {"a": "3", "Filename": "f3"}
-    ing._resolve_filename_key(r1)
-    ing._resolve_filename_key(r2)
-    ing._resolve_filename_key(r3)
-    assert "filename" not in r1
-    assert r2["filename"] == "f2"
-    assert r3["filename"] == "f3"
-    assert ing._filename_source_key == "Filename"
-
-
-def test_ingest_filename_case_mismatch_reaches_transfer():
-    """#372 end-to-end: an image manifest with a ``Filename`` header passes the
-    case-insensitive preflight; the ingest loop must remap it to the canonical
-    ``filename`` key or every record reaches file transfer with filename=None
-    and fails after upload ("No filename found in record", exit 9)."""
-    records = [
-        {"a": "1", "Filename": "img1", "label": "cat"},
-        {"a": "2", "Filename": "img2", "label": "dog"},
-    ]
-    ing = make_ingestor(
-        records=records,
-        category=TaskCategory.IMAGE_CLASSIFICATION,
-        label_column="label",
-        schema={"a": "INT", "label": "VARCHAR(10)"},
-    )
-    with patch.object(base_mod, "Session") as Sess, patch.object(
-        ing, "validate_data", return_value=True
-    ), patch.object(
-        base_mod, "map_file_transfer", side_effect=lambda cat, rec, *a, **k: rec
-    ) as mft:
-        Sess.return_value.__enter__.return_value = MagicMock()
-        ing.ingest("src", batch_size=10)
-    # Every record the transfer received carries a non-None canonical filename.
-    transferred = [c.kwargs.get("source_record") for c in mft.call_args_list]
-    assert [r.get("filename") for r in transferred] == ["img1", "img2"]
-    # And the cleaned records that reach the DB batch carry it too.
-    _table, batch = ing.database.insert_batch.call_args.args
-    assert [r.get("filename") for r in batch] == ["img1", "img2"], (
-        f"filenames nulled by case mismatch: {[r.get('filename') for r in batch]}"
     )
 
 

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -249,10 +249,6 @@ class BaseIngestor(ABC):
         self.intent = intent
         self.annotation_column = annotation_column
         self.category = category
-        # #372: the actual header spelling of the file-pointer column, resolved
-        # once per run to the canonical ``filename`` key (see
-        # ``_resolve_filename_key``). None until the first record that carries it.
-        self._filename_source_key: Optional[str] = None
         self.data_format = data_format
         self.file_options = file_options or {}
         self.label_policy = label_policy
@@ -416,54 +412,6 @@ class BaseIngestor(ABC):
             )
             self.label_column = resolved
         return True
-
-    def _resolve_filename_key(self, record: Dict[str, Any]) -> None:
-        """Remap the record's file-pointer column to the canonical ``filename`` key (#372).
-
-        The filename column is validated case-/whitespace-insensitively
-        (``IngestableRecordsValidator._resolve_filename_column`` via the shared
-        ``resolve_column`` rule), but the transfer read path pulls it out of each
-        record by the exact literal key — ``record.get("filename")`` in
-        ``file_transfer`` / ``modalities.transfer``, and ``RecordProcessor`` copies
-        it forward the same way. So a header like ``Filename`` / ``FileName`` /
-        ``" filename "`` passes preflight and then reads ``None`` for every row:
-        every file transfer fails ("No filename found in record", exit 9) AFTER
-        the upload. This is the #340 class already fixed for the label column,
-        still open for ``filename``.
-
-        Unlike the label column — whose configured NAME is pinned once on the
-        ingestor (``_resolve_label_column``) and read back via that name — the
-        filename read target is the fixed literal ``"filename"`` used everywhere
-        in transfer. So the fix normalises the RECORD instead: the source column
-        is resolved once (cached on ``self._filename_source_key``) using the SAME
-        ``resolve_column`` rule the validators use, then copied onto the canonical
-        ``filename`` key of every record so the read path and the validators agree.
-
-        Scoped to file-bearing categories — a tabular dataset may legitimately
-        carry an unrelated ``FileName`` data column that must NOT be hijacked as a
-        file pointer. No-ops when the record already carries a literal
-        ``filename`` key (the common lowercase case) or when nothing resolves:
-        an ``image_id``-only manifest is a genuinely different column, not a case
-        variant (cli#371 territory), and is left to fail at transfer as the
-        contract intends. Sparse JSON whose leading object omits the column is
-        retried on later records, mirroring ``_resolve_label_column``.
-        """
-        if self.category not in _FILE_BEARING_CATEGORIES:
-            return
-        if "filename" in record:
-            return
-        source = self._filename_source_key
-        if source is None:
-            source = resolve_column(record.keys(), "filename")
-            if source is None:
-                return
-            self._filename_source_key = source
-            logger.info(
-                f"Resolved filename column {source!r} to canonical 'filename' "
-                f"(case/whitespace-insensitive match)."
-            )
-        if source in record:
-            record["filename"] = record[source]
 
     @property
     def _grouping(self):
@@ -938,19 +886,8 @@ class BaseIngestor(ABC):
                 pbar = tqdm(total=total, desc="Ingesting records", unit="records")
 
                 _label_resolved = False
-                self._filename_source_key = None
                 for record in self.read_data(source):
                     stats["total_records"] += 0 if total else 1
-
-                    # #372: remap the file-pointer column to the canonical
-                    # ``filename`` key before the record is processed or
-                    # transferred. The validators matched the filename column
-                    # case-/whitespace-insensitively, so a header like ``Filename``
-                    # passed preflight; without this the transfer read path
-                    # (exact key ``record.get("filename")``) would then read None
-                    # for every row and fail after upload. No-op for the common
-                    # lowercase header and for non-file-bearing categories.
-                    self._resolve_filename_key(record)
 
                     # #340: pin the label column to the actual header spelling
                     # before it is processed. The validators matched the label

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -53,6 +53,11 @@ def map_validators(
         IngestableRecordsValidator(
             file_subdir=spec.file_subdir,
             extension=options.get("extension", FileExtension.TXT),
+            # Thread the run's dialect so the manifest reads (header probe,
+            # referenced-files scan) tokenize like the ingest write path —
+            # else a non-comma / BOM manifest false-rejects the exact-filename
+            # check (#372/#376). Mirrors the grouped validators.
+            csv_options=options.get("csv_options"),
         )
     ]
     # Thread the spec's grouping trait into the factory options so the

--- a/tracebloc_ingestor/validators/ingestable_records_validator.py
+++ b/tracebloc_ingestor/validators/ingestable_records_validator.py
@@ -190,7 +190,9 @@ class IngestableRecordsValidator(BaseValidator):
         src_root = (self._config or config).SRC_PATH
         subdir = os.path.join(src_root, self.file_subdir)
 
-        filename_col = self._exact_filename_column(self._read_header(path))
+        filename_col = self._exact_filename_column(
+            self._read_header(path), trim=True
+        )
         checked = 0
         try:
             chunks = pd.read_csv(
@@ -256,21 +258,28 @@ class IngestableRecordsValidator(BaseValidator):
         except Exception:  # noqa: BLE001 — header probe is best-effort
             return []
 
-    def _exact_filename_column(self, header: list) -> Optional[str]:
-        """The header naming each file, matched EXACTLY — whitespace-trimmed but
-        case-SENSITIVE (#372).
+    def _exact_filename_column(self, header: list, *, trim: bool) -> Optional[str]:
+        """The header/key naming each file, matched case-SENSITIVELY (#372).
 
         The cluster reads each file with a case-sensitive
-        ``record.get("filename")`` at transfer, over a record whose keys are the
-        CSV header after pandas strips surrounding whitespace
-        (``chunk.columns.str.strip()``). So ``filename`` and ``" filename "``
-        resolve, but ``Filename`` / ``FILENAME`` do NOT — matching what the
-        transfer will actually find, and the CLI's ``imageFileColIndex``
-        (cli#373). Returns the raw header (un-stripped) so callers can index the
-        frame with it; ``None`` when no exact column is present.
+        ``record.get("filename")`` at transfer. What surrounding whitespace it
+        tolerates depends on the source, so the match must too:
+
+        - **CSV** (``trim=True``): pandas strips header whitespace on read
+          (``chunk.columns.str.strip()``), so the record key is already trimmed
+          — ``filename`` and ``" filename "`` both resolve at transfer, and must
+          resolve here. Matches the CLI's ``imageFileColIndex`` (cli#373).
+        - **JSON** (``trim=False``): keys are NEVER stripped, so ``" filename "``
+          stays padded and ``record.get("filename")`` misses it — it is doomed at
+          transfer and must be rejected here. Only a byte-exact ``filename`` key
+          resolves.
+
+        Returns the raw header (un-stripped) so callers can index the frame with
+        it; ``None`` when no exact match is present.
         """
         for col in header:
-            if str(col).strip() == self.filename_column:
+            candidate = str(col).strip() if trim else str(col)
+            if candidate == self.filename_column:
                 return col
         return None
 
@@ -289,36 +298,51 @@ class IngestableRecordsValidator(BaseValidator):
         ingestor's own preflight agree with its transfer read for every client,
         and mirrors the CLI's up-front ``CheckImageFilenameColumn`` (cli#373).
         """
-        return self._filename_column_result(self._read_header(path))
+        return self._filename_column_result(self._read_header(path), trim=True)
 
-    def _filename_column_result(self, header: list) -> ValidationResult:
+    def _filename_column_result(
+        self, header: list, *, trim: bool
+    ) -> ValidationResult:
         """Accept iff ``header`` (CSV columns or JSON record keys) carries an
-        EXACT lowercase ``filename``; else reject with a targeted message
-        (case-variant vs missing). Shared by the CSV and JSON paths so the
-        contract and its user-facing message live in ONE place."""
-        if self._exact_filename_column(header) is not None:
+        EXACT ``filename``; else reject with a targeted message (case/whitespace
+        variant vs missing). Shared by the CSV and JSON paths so the contract and
+        its user-facing message live in ONE place.
+
+        ``trim`` selects the source's whitespace rule (see
+        :meth:`_exact_filename_column`): CSV tolerates surrounding whitespace,
+        JSON does not. The message's noun (``column`` vs ``key``) follows it.
+        """
+        if self._exact_filename_column(header, trim=trim) is not None:
             return self._create_result(is_valid=True, metadata={"checked": True})
 
-        # Cap the column list in the MESSAGE (redaction.column_preview, as #372
-        # did for mask_id_validator) but keep the FULL header in metadata so
+        unit = "column" if trim else "key"
+        # Cap the list in the MESSAGE (redaction.column_preview, as #372 did for
+        # mask_id_validator) but keep the FULL header in metadata so
         # CLI/programmatic consumers don't lose it — the learned Bugbot rule
         # ("cap the list, keep the full set in metadata").
         full_columns = [str(c) for c in header]
         cols = redaction.column_preview(header) if header else "<none>"
-        # A case variant (``Filename``) still resolves case-insensitively — give
-        # a targeted "rename to lowercase" hint rather than "no column at all".
+        # A near-miss (case variant ``Filename``, or for JSON a padded key)
+        # resolves case-/whitespace-insensitively — give a targeted "rename it"
+        # hint rather than "no column at all".
         variant = self._match_column(header, self.filename_column)
         if variant is not None:
-            variant = str(variant).strip()
+            variant = str(variant) if not trim else str(variant).strip()
+            requirement = (
+                f"must be lowercase '{self.filename_column}'"
+                if trim
+                else f"must be exactly '{self.filename_column}' (case- and "
+                f"whitespace-sensitive — JSON keys are read verbatim)"
+            )
             return self._create_result(
                 is_valid=False,
                 errors=[
-                    f"Column {variant!r} must be lowercase "
-                    f"'{self.filename_column}': the cluster reads each file with "
-                    f"a case-sensitive record.get('{self.filename_column}') at "
-                    f"transfer, so {variant!r} would upload, then fail with 'No "
-                    f"filename found in record'. Rename it to "
-                    f"'{self.filename_column}' and re-run."
+                    f"{unit.capitalize()} {variant!r} {requirement}: the cluster "
+                    f"reads each file with a case-sensitive "
+                    f"record.get('{self.filename_column}') at transfer, so "
+                    f"{variant!r} would upload, then fail with 'No filename found "
+                    f"in record'. Rename it to '{self.filename_column}' and "
+                    f"re-run."
                 ],
                 metadata={
                     "reason": "filename_column_case_variant",
@@ -328,10 +352,10 @@ class IngestableRecordsValidator(BaseValidator):
         return self._create_result(
             is_valid=False,
             errors=[
-                f"No '{self.filename_column}' column in the manifest (columns: "
+                f"No '{self.filename_column}' {unit} in the manifest ({unit}s: "
                 f"{cols}) — file-bearing tasks match each row to its file by "
-                f"that column, and the cluster drops every row without it ('No "
-                f"filename found in record'). Rename your file column to "
+                f"that {unit}, and the cluster drops every row without it ('No "
+                f"filename found in record'). Rename your file {unit} to "
                 f"'{self.filename_column}' and re-run."
             ],
             metadata={"reason": "filename_column_missing", "columns": full_columns},
@@ -351,47 +375,48 @@ class IngestableRecordsValidator(BaseValidator):
         keys = self._read_json_keys(path)
         if keys is None:
             return self._create_result(is_valid=True, metadata={"checked": False})
-        return self._filename_column_result(keys)
+        return self._filename_column_result(keys, trim=False)
 
     def _read_json_keys(self, path: Path) -> Optional[List[str]]:
-        """The manifest's record keys — the first record's keys, mirroring the
-        single header a CSV carries. An array is streamed via ``ijson`` (first
-        item only); a single object is loaded directly. Returns ``None`` when the
-        file can't be parsed (best-effort probe; other validators own JSON
-        validity) and ``[]`` for an empty array / non-object record.
+        """The UNION of keys across the manifest's records, in first-seen order.
+
+        JSON records may be sparse — a leading object can omit ``filename`` while
+        later ones carry it (the transfer reads each row independently, so those
+        later rows ingest). Inspecting only the first record would false-reject
+        such a manifest, so the array is streamed via ``ijson`` and keys are
+        unioned; the scan short-circuits as soon as a record carries the exact
+        ``filename`` key (the common valid case costs one record). Mirrors the
+        retry semantics of ``BaseIngestor._resolve_label_column`` (#340).
+
+        Returns ``None`` when the file can't be parsed (best-effort probe; the
+        JSON-structure validators own validity) and ``[]`` for an empty array /
+        non-object records.
         """
+        # Lazy import: json_ingestor -> base -> validators_mapping ->
+        # modalities.validators -> the validators -> this module, so a top-level
+        # import would cycle. Reuse the ingestor's shape probe rather than a
+        # second copy that could drift (Bugbot #384).
+        from ..ingestors.json_ingestor import _peek_json_shape
+
         try:
-            shape = self._json_shape(path)
-            if shape == "array":
-                with open(path, "rb") as f:
-                    for item in ijson.items(f, "item"):
-                        return list(item.keys()) if isinstance(item, dict) else []
-                return []
+            shape = _peek_json_shape(path)
             if shape == "object":
                 with open(path, "r", encoding="utf-8") as f:
                     obj = json.load(f)
                 return list(obj.keys()) if isinstance(obj, dict) else []
+            if shape == "array":
+                seen: Dict[str, None] = {}
+                with open(path, "rb") as f:
+                    for item in ijson.items(f, "item"):
+                        if not isinstance(item, dict):
+                            continue
+                        for k in item.keys():
+                            seen.setdefault(k, None)
+                        # Exact key present in this record -> the union already
+                        # contains it and the result is settled; stop scanning.
+                        if self.filename_column in item:
+                            break
+                return list(seen)
             return None
         except Exception:  # noqa: BLE001 — key probe is best-effort
             return None
-
-    @staticmethod
-    def _json_shape(path: Path) -> Optional[str]:
-        """``"array"`` / ``"object"`` from the first non-whitespace byte, or
-        ``None`` for neither (malformed — left to the JSON validators)."""
-        with open(path, "rb") as f:
-            buf = b""
-            while True:
-                chunk = f.read(1024)
-                if not chunk:
-                    return None
-                buf += chunk
-                stripped = buf.lstrip()
-                if stripped:
-                    if stripped[:1] == b"[":
-                        return "array"
-                    if stripped[:1] == b"{":
-                        return "object"
-                    return None
-                if len(buf) > 65536:
-                    return None

--- a/tracebloc_ingestor/validators/ingestable_records_validator.py
+++ b/tracebloc_ingestor/validators/ingestable_records_validator.py
@@ -275,8 +275,11 @@ class IngestableRecordsValidator(BaseValidator):
         if self._exact_filename_column(header) is not None:
             return self._create_result(is_valid=True, metadata={"checked": True})
 
-        # Cap the column list so a wide manifest can't produce an unbounded
-        # message (redaction.column_preview, as #372 did for mask_id_validator).
+        # Cap the column list in the MESSAGE (redaction.column_preview, as #372
+        # did for mask_id_validator) but keep the FULL header in metadata so
+        # CLI/programmatic consumers don't lose it — the learned Bugbot rule
+        # ("cap the list, keep the full set in metadata").
+        full_columns = [str(c) for c in header]
         cols = redaction.column_preview(header) if header else "<none>"
         # A case variant (``Filename``) still resolves case-insensitively — give
         # a targeted "rename to lowercase" hint rather than "no column at all".
@@ -293,7 +296,10 @@ class IngestableRecordsValidator(BaseValidator):
                     f"filename found in record'. Rename it to "
                     f"'{self.filename_column}' and re-run."
                 ],
-                metadata={"reason": "filename_column_case_variant"},
+                metadata={
+                    "reason": "filename_column_case_variant",
+                    "columns": full_columns,
+                },
             )
         return self._create_result(
             is_valid=False,
@@ -304,5 +310,5 @@ class IngestableRecordsValidator(BaseValidator):
                 f"filename found in record'). Rename your file column to "
                 f"'{self.filename_column}' and re-run."
             ],
-            metadata={"reason": "filename_column_missing"},
+            metadata={"reason": "filename_column_missing", "columns": full_columns},
         )

--- a/tracebloc_ingestor/validators/ingestable_records_validator.py
+++ b/tracebloc_ingestor/validators/ingestable_records_validator.py
@@ -30,13 +30,15 @@ Two distinct ways a CSV manifest yields zero records, both caught here:
 import logging
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import pandas as pd
 
 from ..config import Config
 from ..file_transfer import _has_extension, _safe_join
+from ..utils import redaction
 from ..utils.constants import FileExtension
+from ..utils.csv_dialect import read_dialect_kwargs, validate_csv_options
 from .base import BaseValidator, ValidationResult
 
 config = Config()
@@ -56,7 +58,13 @@ class IngestableRecordsValidator(BaseValidator):
         extension: Expected file extension, appended to a CSV filename that
             carries none (same rule the transfer uses).
         filename_column: CSV column naming each sample's file (default
-            ``"filename"``; resolved case-insensitively).
+            ``"filename"``; required as an EXACT lowercase match, #372).
+        csv_options: the run's pandas read options (delimiter / encoding /
+            quoting). Threaded so every read here tokenizes the manifest the
+            SAME way the ingest write path does — otherwise a non-comma / BOM
+            manifest reads as one mashed column and the exact-``filename`` check
+            (#372) false-rejects a valid dataset. Mirrors the grouped validators
+            (#376). A malformed value is rejected at construction.
     """
 
     def __init__(
@@ -65,12 +73,24 @@ class IngestableRecordsValidator(BaseValidator):
         extension: str = FileExtension.TXT,
         filename_column: str = "filename",
         name: str = "Ingestable Records",
+        csv_options: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(name)
         self.file_subdir = file_subdir
         ext = extension or FileExtension.TXT
         self.extension = ext if ext.startswith(".") else f".{ext}"
         self.filename_column = filename_column
+        self._csv_options = csv_options or {}
+        # Fail fast at construction on a malformed dialect, not mid-scan —
+        # same contract as the grouped validators (#376).
+        validate_csv_options(self._csv_options)
+
+    def _dialect_kwargs(self) -> Dict[str, Any]:
+        """pandas ``read_csv`` dialect kwargs (sep / encoding / quoting) matching
+        the ingest write path, via the shared :func:`read_dialect_kwargs` (#376).
+        Callers merge their own read-shape kwargs (``nrows`` / ``usecols`` / …)
+        on top."""
+        return read_dialect_kwargs(self._csv_options)
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         try:
@@ -118,8 +138,8 @@ class IngestableRecordsValidator(BaseValidator):
             # keep the read cheap and inference-free — we only count rows here.
             head = pd.read_csv(
                 path,
+                **self._dialect_kwargs(),
                 nrows=1,
-                encoding="utf-8",
                 dtype=str,
                 keep_default_na=False,
             )
@@ -157,8 +177,8 @@ class IngestableRecordsValidator(BaseValidator):
         try:
             chunks = pd.read_csv(
                 path,
+                **self._dialect_kwargs(),
                 usecols=[filename_col],
-                encoding="utf-8",
                 chunksize=50_000,
                 dtype=str,
                 keep_default_na=False,
@@ -212,7 +232,9 @@ class IngestableRecordsValidator(BaseValidator):
         """The CSV header as a plain list of raw column names; ``[]`` if the
         header can't be read (best-effort probe)."""
         try:
-            return list(pd.read_csv(path, nrows=0, encoding="utf-8").columns)
+            return list(
+                pd.read_csv(path, **self._dialect_kwargs(), nrows=0).columns
+            )
         except Exception:  # noqa: BLE001 — header probe is best-effort
             return []
 
@@ -253,7 +275,9 @@ class IngestableRecordsValidator(BaseValidator):
         if self._exact_filename_column(header) is not None:
             return self._create_result(is_valid=True, metadata={"checked": True})
 
-        cols = ", ".join(str(c) for c in header) or "<none>"
+        # Cap the column list so a wide manifest can't produce an unbounded
+        # message (redaction.column_preview, as #372 did for mask_id_validator).
+        cols = redaction.column_preview(header) if header else "<none>"
         # A case variant (``Filename``) still resolves case-insensitively — give
         # a targeted "rename to lowercase" hint rather than "no column at all".
         variant = self._match_column(header, self.filename_column)

--- a/tracebloc_ingestor/validators/ingestable_records_validator.py
+++ b/tracebloc_ingestor/validators/ingestable_records_validator.py
@@ -27,11 +27,13 @@ Two distinct ways a CSV manifest yields zero records, both caught here:
    mirrors the CLI's ``CheckImageFilenameColumn`` (cli#373).
 """
 
+import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
+import ijson
 import pandas as pd
 
 from ..config import Config
@@ -94,33 +96,49 @@ class IngestableRecordsValidator(BaseValidator):
 
     def validate(self, data: Any, **kwargs) -> ValidationResult:
         try:
-            # Only CSV manifests are checked here. Non-CSV inputs (e.g. JSON)
-            # are covered by their own validators; a non-path input is a direct
-            # caller we don't second-guess.
-            if not isinstance(data, (str, Path)) or Path(data).suffix.lower() != ".csv":
+            # A non-path input is a direct caller we don't second-guess.
+            if not isinstance(data, (str, Path)):
                 return self._create_result(is_valid=True, metadata={"checked": False})
 
             path = Path(data)
+            suffix = path.suffix.lower()
 
-            # 1) Header-only / empty CSV -> zero data rows.
-            row_result = self._check_has_rows(path)
-            if not row_result.is_valid:
-                return row_result
+            if suffix == ".csv":
+                # 1) Header-only / empty CSV -> zero data rows.
+                row_result = self._check_has_rows(path)
+                if not row_result.is_valid:
+                    return row_result
 
-            # 2) File-bearing: enforce the filename-column contract, then the
-            #    all-referenced-files-missing check.
-            if self.file_subdir:
-                # 2a) No EXACT lowercase `filename` column -> doomed at the
-                #     cluster's case-sensitive transfer read; reject up front
-                #     (#372) rather than let it fail late after upload.
-                col_result = self._check_filename_column(path)
-                if not col_result.is_valid:
-                    return col_result
-                # 2b) Column present but every referenced file missing -> zero
-                #     ingestable records.
-                return self._check_referenced_files(path)
+                # 2) File-bearing: enforce the filename-column contract, then the
+                #    all-referenced-files-missing check.
+                if self.file_subdir:
+                    # 2a) No EXACT lowercase `filename` column -> doomed at the
+                    #     cluster's case-sensitive transfer read; reject up front
+                    #     (#372) rather than let it fail late after upload.
+                    col_result = self._check_filename_column(path)
+                    if not col_result.is_valid:
+                        return col_result
+                    # 2b) Column present but every referenced file missing -> zero
+                    #     ingestable records.
+                    return self._check_referenced_files(path)
 
-            return self._create_result(is_valid=True, metadata={"checked": True})
+                return self._create_result(is_valid=True, metadata={"checked": True})
+
+            if suffix == ".json":
+                # A file-bearing JSON manifest is read at transfer with the SAME
+                # case-sensitive record.get("filename") as CSV (cli#373), so it
+                # gets the same exact-`filename` contract up front — else a
+                # `Filename` / padded key passes preflight and fails late after
+                # upload (exit 9). This is the JSON half of the #372 check that
+                # would otherwise be lost with _resolve_filename_key gone
+                # (review #384). Non-file-bearing JSON has nothing to enforce.
+                if self.file_subdir:
+                    return self._check_filename_key_json(path)
+                # Non-file-bearing JSON has no filename contract to enforce here.
+                return self._create_result(is_valid=True, metadata={"checked": False})
+
+            # Other inputs are covered by their own validators.
+            return self._create_result(is_valid=True, metadata={"checked": False})
 
         except Exception as e:  # noqa: BLE001 — mirror sibling validators
             logger.error(f"Error during ingestable-records validation: {str(e)}")
@@ -271,7 +289,13 @@ class IngestableRecordsValidator(BaseValidator):
         ingestor's own preflight agree with its transfer read for every client,
         and mirrors the CLI's up-front ``CheckImageFilenameColumn`` (cli#373).
         """
-        header = self._read_header(path)
+        return self._filename_column_result(self._read_header(path))
+
+    def _filename_column_result(self, header: list) -> ValidationResult:
+        """Accept iff ``header`` (CSV columns or JSON record keys) carries an
+        EXACT lowercase ``filename``; else reject with a targeted message
+        (case-variant vs missing). Shared by the CSV and JSON paths so the
+        contract and its user-facing message live in ONE place."""
         if self._exact_filename_column(header) is not None:
             return self._create_result(is_valid=True, metadata={"checked": True})
 
@@ -312,3 +336,62 @@ class IngestableRecordsValidator(BaseValidator):
             ],
             metadata={"reason": "filename_column_missing", "columns": full_columns},
         )
+
+    def _check_filename_key_json(self, path: Path) -> ValidationResult:
+        """Reject a file-bearing JSON manifest whose records carry no EXACT
+        lowercase ``filename`` key, before any upload — the JSON analogue of
+        :meth:`_check_filename_column` (#372 / review #384).
+
+        The cluster's transfer read is the same case-sensitive
+        ``record.get("filename")`` for JSON as for CSV, so ``Filename`` / padded
+        keys fail late (exit 9); reject at preflight instead. Only the record
+        keys are needed. A malformed / unreadable manifest is left to the
+        JSON-structure validators — we skip rather than false-reject.
+        """
+        keys = self._read_json_keys(path)
+        if keys is None:
+            return self._create_result(is_valid=True, metadata={"checked": False})
+        return self._filename_column_result(keys)
+
+    def _read_json_keys(self, path: Path) -> Optional[List[str]]:
+        """The manifest's record keys — the first record's keys, mirroring the
+        single header a CSV carries. An array is streamed via ``ijson`` (first
+        item only); a single object is loaded directly. Returns ``None`` when the
+        file can't be parsed (best-effort probe; other validators own JSON
+        validity) and ``[]`` for an empty array / non-object record.
+        """
+        try:
+            shape = self._json_shape(path)
+            if shape == "array":
+                with open(path, "rb") as f:
+                    for item in ijson.items(f, "item"):
+                        return list(item.keys()) if isinstance(item, dict) else []
+                return []
+            if shape == "object":
+                with open(path, "r", encoding="utf-8") as f:
+                    obj = json.load(f)
+                return list(obj.keys()) if isinstance(obj, dict) else []
+            return None
+        except Exception:  # noqa: BLE001 — key probe is best-effort
+            return None
+
+    @staticmethod
+    def _json_shape(path: Path) -> Optional[str]:
+        """``"array"`` / ``"object"`` from the first non-whitespace byte, or
+        ``None`` for neither (malformed — left to the JSON validators)."""
+        with open(path, "rb") as f:
+            buf = b""
+            while True:
+                chunk = f.read(1024)
+                if not chunk:
+                    return None
+                buf += chunk
+                stripped = buf.lstrip()
+                if stripped:
+                    if stripped[:1] == b"[":
+                        return "array"
+                    if stripped[:1] == b"{":
+                        return "object"
+                    return None
+                if len(buf) > 65536:
+                    return None

--- a/tracebloc_ingestor/validators/ingestable_records_validator.py
+++ b/tracebloc_ingestor/validators/ingestable_records_validator.py
@@ -18,6 +18,13 @@ Two distinct ways a CSV manifest yields zero records, both caught here:
    referenced filenames against what's actually staged; the per-directory
    ``FileTypeValidator`` only checks the *extension* of files that ARE present,
    not whether the CSV's filenames resolve to any of them.
+3. **No EXACT ``filename`` column** (file-bearing categories, #372) — the file
+   column is misnamed (``image_id``) or only a case variant (``Filename``). The
+   cluster's transfer read is a case-sensitive ``record.get("filename")``, so it
+   resolves to no key and every row is dropped cluster-side with "No filename
+   found in record" (exit 9) AFTER the full upload. Rejected up front here so
+   the ingestor's own preflight agrees with its transfer read for every client;
+   mirrors the CLI's ``CheckImageFilenameColumn`` (cli#373).
 """
 
 import logging
@@ -80,8 +87,17 @@ class IngestableRecordsValidator(BaseValidator):
             if not row_result.is_valid:
                 return row_result
 
-            # 2) File-bearing: every referenced file missing -> zero records.
+            # 2) File-bearing: enforce the filename-column contract, then the
+            #    all-referenced-files-missing check.
             if self.file_subdir:
+                # 2a) No EXACT lowercase `filename` column -> doomed at the
+                #     cluster's case-sensitive transfer read; reject up front
+                #     (#372) rather than let it fail late after upload.
+                col_result = self._check_filename_column(path)
+                if not col_result.is_valid:
+                    return col_result
+                # 2b) Column present but every referenced file missing -> zero
+                #     ingestable records.
                 return self._check_referenced_files(path)
 
             return self._create_result(is_valid=True, metadata={"checked": True})
@@ -128,19 +144,15 @@ class IngestableRecordsValidator(BaseValidator):
         Early-exits on the first file that resolves, so a healthy dataset costs
         one ``stat``; only an all-missing dataset walks the whole column — which
         is exactly the zero-records case we want to surface up front.
+
+        Runs only after the manifest is confirmed to carry an EXACT lowercase
+        filename column (:meth:`_check_filename_column`), so ``filename_col`` is
+        always present here.
         """
         src_root = (self._config or config).SRC_PATH
         subdir = os.path.join(src_root, self.file_subdir)
 
-        filename_col = self._resolve_filename_column(path)
-        if filename_col is None:
-            # No filename column to cross-check — not this validator's error to
-            # raise (the read/transfer path surfaces a missing column). Pass.
-            return self._create_result(
-                is_valid=True,
-                metadata={"checked": False, "reason": "no_filename_column"},
-            )
-
+        filename_col = self._exact_filename_column(self._read_header(path))
         checked = 0
         try:
             chunks = pd.read_csv(
@@ -196,10 +208,77 @@ class IngestableRecordsValidator(BaseValidator):
             metadata={"referenced_files_checked": checked, "found_at_least_one": False},
         )
 
-    def _resolve_filename_column(self, path: Path) -> Optional[str]:
-        """Case-insensitively resolve the filename column from the CSV header."""
+    def _read_header(self, path: Path) -> list:
+        """The CSV header as a plain list of raw column names; ``[]`` if the
+        header can't be read (best-effort probe)."""
         try:
-            header = pd.read_csv(path, nrows=0, encoding="utf-8").columns
+            return list(pd.read_csv(path, nrows=0, encoding="utf-8").columns)
         except Exception:  # noqa: BLE001 — header probe is best-effort
-            return None
-        return self._match_column(header, self.filename_column)
+            return []
+
+    def _exact_filename_column(self, header: list) -> Optional[str]:
+        """The header naming each file, matched EXACTLY — whitespace-trimmed but
+        case-SENSITIVE (#372).
+
+        The cluster reads each file with a case-sensitive
+        ``record.get("filename")`` at transfer, over a record whose keys are the
+        CSV header after pandas strips surrounding whitespace
+        (``chunk.columns.str.strip()``). So ``filename`` and ``" filename "``
+        resolve, but ``Filename`` / ``FILENAME`` do NOT — matching what the
+        transfer will actually find, and the CLI's ``imageFileColIndex``
+        (cli#373). Returns the raw header (un-stripped) so callers can index the
+        frame with it; ``None`` when no exact column is present.
+        """
+        for col in header:
+            if str(col).strip() == self.filename_column:
+                return col
+        return None
+
+    def _check_filename_column(self, path: Path) -> ValidationResult:
+        """Reject a file-bearing manifest with no EXACT lowercase filename
+        column, before any upload (#372).
+
+        File-bearing tasks match each row to its file by the ``filename`` column,
+        and the cluster's transfer read is case-sensitive — a wrong name
+        (``image_id``) or a case variant (``Filename``) resolves to no key, so
+        every row is dropped cluster-side with "No filename found in record"
+        (exit 9) AFTER the full upload. Previously this validator matched the
+        column case-insensitively and DEFERRED when it was absent ("not this
+        validator's error to raise"), which let both cases pass preflight and
+        fail late. Rejecting here — fail-fast, in the dry-run — makes the
+        ingestor's own preflight agree with its transfer read for every client,
+        and mirrors the CLI's up-front ``CheckImageFilenameColumn`` (cli#373).
+        """
+        header = self._read_header(path)
+        if self._exact_filename_column(header) is not None:
+            return self._create_result(is_valid=True, metadata={"checked": True})
+
+        cols = ", ".join(str(c) for c in header) or "<none>"
+        # A case variant (``Filename``) still resolves case-insensitively — give
+        # a targeted "rename to lowercase" hint rather than "no column at all".
+        variant = self._match_column(header, self.filename_column)
+        if variant is not None:
+            variant = str(variant).strip()
+            return self._create_result(
+                is_valid=False,
+                errors=[
+                    f"Column {variant!r} must be lowercase "
+                    f"'{self.filename_column}': the cluster reads each file with "
+                    f"a case-sensitive record.get('{self.filename_column}') at "
+                    f"transfer, so {variant!r} would upload, then fail with 'No "
+                    f"filename found in record'. Rename it to "
+                    f"'{self.filename_column}' and re-run."
+                ],
+                metadata={"reason": "filename_column_case_variant"},
+            )
+        return self._create_result(
+            is_valid=False,
+            errors=[
+                f"No '{self.filename_column}' column in the manifest (columns: "
+                f"{cols}) — file-bearing tasks match each row to its file by "
+                f"that column, and the cluster drops every row without it ('No "
+                f"filename found in record'). Rename your file column to "
+                f"'{self.filename_column}' and re-run."
+            ],
+            metadata={"reason": "filename_column_missing"},
+        )


### PR DESCRIPTION
Fixes tracebloc/cli#372 (correctly this time). Follow-up to #382, which resolved the asymmetry the **wrong** way.

## Context — why this supersedes #382

#382 fixed the #372 preflight/transfer asymmetry by making the ingestor **accept** `Filename` case-insensitively end-to-end. Per the **"filename only"** contract decision (the cluster's transfer read stays a case-sensitive `record.get("filename")`, and cli#373 already enforces exact lowercase `filename` in the CLI dry-run), that was the wrong direction: it left the ingestor **accepting** datasets the CLI **rejects**, an inverted parity gap.

This PR **reverts #382** (`e070b6e`) and fixes the asymmetry the other way — by tightening the ingestor's **preflight to reject** a non-exact filename column, so preflight agrees with the case-sensitive transfer read.

## Problem

`IngestableRecordsValidator` matched the filename column **case-insensitively** and **deferred** (passed) when it was absent — *"not this validator's error to raise."* So a file-bearing manifest whose file column was:
- a **wrong name** (`image_id`, `data_id`), or
- a **case variant** (`Filename`, `FILENAME`)

passed the dry-run, then failed **cluster-side with exit 9** (`No filename found in record`, 0 records ingested) **after the full upload** — because the transfer read `record.get("filename")` is case-sensitive and never aliases another column.

## Fix

`IngestableRecordsValidator` now enforces the filename-column contract **up front** for file-bearing categories (`_check_filename_column`), rejecting before any upload with actionable messages:

- **case variant** → *"Column 'Filename' must be lowercase 'filename': the cluster reads … a case-sensitive `record.get('filename')` at transfer, so 'Filename' would upload, then fail … Rename it to 'filename' and re-run."*
- **wrong/missing name** → *"No 'filename' column in the manifest (columns: image_id, label) — … the cluster drops every row without it … Rename your file column to 'filename' and re-run."*

Matching detail:
- **Case-sensitive, whitespace-lenient.** `filename` and `" filename "` pass (pandas strips header whitespace before the transfer read); `Filename`/`FILENAME` are rejected. Mirrors the CLI's `imageFileColIndex` / `CheckImageFilenameColumn` (cli#373).
- **All file-bearing categories** (image **and** text) — the transfer read is case-sensitive for all of them, so this closes the same latent gap for text, not just image.
- Makes the ingestor's **own** preflight agree with its transfer read for **every client**, not only the CLI — the stated goal of #372, and it also closes the ingestor-side gap cli#371 left open (`image_id` now rejected at ingestor preflight too).

## Tests

`tests/test_ingestable_records_validator.py`:
- `test_filename_column_case_variant_is_rejected` — `FileName` → rejected with the lowercase hint (replaces the old `…is_case_insensitive` test that asserted the now-wrong accept).
- `test_file_bearing_but_no_filename_column_is_rejected` — `text_col` → rejected (replaces the old `…is_noop` test).
- `test_image_id_filename_column_is_rejected` — the #371/#372 image case.
- `test_exact_filename_column_with_whitespace_is_accepted` — `" filename "` still passes.
- Existing missing-files / valid-dataset / traversal cases unchanged.

Full suite green: **1780 passed, 1 xfailed**.

## Note

This does not touch the CLI. cli#373 is already correct for this contract. If the team later wants the CLI's *text*-family filename check to also preview this (it currently matches case-insensitively via `matchColumnIndex`), that's a separate CLI-side follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Bugbot review resolutions

- **1 (HIGH) — non-comma manifests false-rejected:** fixed. `IngestableRecordsValidator` now takes `csv_options` (wired in `validators_mapping`) and routes all three reads through `csv_dialect.read_dialect_kwargs`, matching the ingest write path and the grouped validators (#376). Dialect validated at construction. Tests: semicolon manifest passes with dialect / is mis-tokenized without it; malformed dialect rejected at construction.
- **2 (MEDIUM) — uncapped columns in error:** fixed. Missing-filename message uses `redaction.column_preview` (as #372 did for `mask_id_validator`). Test asserts the capped `(+N more of M)` preview.
- **3 (MEDIUM) — JSON path not covered:** scoped to a follow-up — **tracebloc/cli#382**. `IngestableRecordsValidator` is CSV-only by design (every check no-ops on JSON) and the CLI has no JSON filename preflight either, so this is a pre-existing gap, not a regression this PR introduces. Keeping the remap for JSON (Bugbot's alternative) would contradict the "filename only" contract, so the follow-up adds a JSON *reject* at preflight instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preflight acceptance for all file-bearing ingests (CSV and JSON) and removes runtime filename aliasing—datasets that passed under #382 will fail earlier; behavior is intentional but user-facing.
> 
> **Overview**
> Reverts the **#382** ingest-time filename remapping and instead **tightens preflight** so file-bearing manifests must expose an exact **`filename`** field before upload—matching the cluster’s case-sensitive `record.get("filename")` transfer read.
> 
> **`IngestableRecordsValidator`** now rejects wrong or variant file columns up front (e.g. `image_id`, `Filename`) with targeted errors; CSV headers may still use surrounding whitespace (`" filename "`). It threads **`csv_options`** through manifest reads so non-comma dialects are not false-rejected, and applies the same contract to **JSON** manifests (verbatim keys; unions keys across sparse records). **`BaseIngestor._resolve_filename_key`** and its ingest-loop call are removed.
> 
> Tests are updated accordingly: old remap/e2e cases dropped; broad CSV/JSON and dialect coverage added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 157a8e436d99b5ed79a5847d967030118eacfa61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->