### PR TITLE
fix(ingest): resolve the two Bugbot findings on the #383 release (alignment-stats gating + descriptor wire leak)

### DIFF
--- a/tests/test_enriched_schema.py
+++ b/tests/test_enriched_schema.py
@@ -243,3 +243,43 @@ def test_target_source_column_stripped_from_schema_under_case_drift():
     assert set(ing._table_schema) == {"feat"}
     # ...and from the sanitized schema shipped to the backend in meta_data.
     assert "price" not in ing.file_options["schema"]
+
+
+# ---- the meta_data payload (bugbot on #383) -------------------------------
+
+
+def test_meta_data_payload_strips_internal_bridges():
+    # ``schema`` (validator artifact — the canonical schema ships as the
+    # top-level arg) and ``column_descriptors`` (already merged onto the
+    # enriched schema's columns by _schema_payload) are ingestor-internal;
+    # neither may ship in meta_data. Everything else passes through.
+    ing = make_ingestor(
+        enriched=True,
+        label_column="y",
+        file_options={
+            "column_descriptors": {"a": {"unit": "years"}},
+            "target_size": [512, 512],
+            "attributes": {"color_mode": "RGB"},
+        },
+    )
+    # The label-stripped internal schema copy base.py maintains is present...
+    assert "schema" in ing.file_options
+
+    meta = ing._meta_data_payload()
+    assert "schema" not in meta
+    assert "column_descriptors" not in meta
+    # ...while genuine wire payload is untouched.
+    assert meta["target_size"] == [512, 512]
+    assert meta["attributes"] == {"color_mode": "RGB"}
+
+
+def test_descriptors_still_reach_enriched_schema_after_meta_data_strip():
+    # The strip must not starve _schema_payload: the uploader's unit/ordinal
+    # declarations still land on the enriched schema columns.
+    ing = make_ingestor(
+        enriched=True,
+        file_options={"column_descriptors": {"a": {"unit": "kg"}}},
+    )
+    enriched = ing._schema_payload({"a": "INT"})
+    assert enriched["a"]["unit"] == "kg"
+    assert "column_descriptors" not in ing._meta_data_payload()

--- a/tests/test_feature_stats.py
+++ b/tests/test_feature_stats.py
@@ -32,7 +32,10 @@ def make_csv_ingestor(schema=None, categorical_min_count=1, **overrides):
         table_name="tbl",
         schema=schema if schema is not None else {"a": "INT"},
         intent="train",
-        category=None,
+        # Alignment stats only accumulate for the tabular family
+        # (TABULAR_FAMILY_CATEGORIES), so the factory defaults to a tabular
+        # category; the gating tests below override it.
+        category=TaskCategory.TABULAR_CLASSIFICATION,
     )
     kwargs.update(overrides)
     return CSVIngestor(**kwargs)
@@ -466,3 +469,60 @@ def test_feature_stats_keeps_feature_that_case_matches_role_name(make_csv):
     stats = ing.feature_stats()
     assert set(stats) == {"feat", "Label"}
     assert "label" not in stats
+
+
+# ---- category gating (bugbot on #383) --------------------------------------
+# feature_stats / categorical vocab are tabular alignment facts. For every
+# category whose CSV is a manifest (image/objdet/keypoint/text pointer files)
+# the cells are bookkeeping, not features — a keypoint Visibility JSON column
+# must not ship as a "vocab" — so the accumulators stay off entirely.
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        TaskCategory.IMAGE_CLASSIFICATION,
+        TaskCategory.OBJECT_DETECTION,
+        TaskCategory.KEYPOINT_DETECTION,
+        TaskCategory.SEMANTIC_SEGMENTATION,
+        TaskCategory.TEXT_CLASSIFICATION,
+        TaskCategory.EMBEDDINGS,
+    ],
+)
+def test_alignment_stats_off_for_manifest_categories(make_csv, category):
+    path = make_csv(
+        {
+            "filename": ["a.jpg", "b.jpg", "c.jpg"],
+            "width": [640, 480, 640],
+            "Visibility": ['[1, 1]', '[0, 1]', '[1, 0]'],
+        }
+    )
+    ing = make_csv_ingestor(
+        schema={"filename": "VARCHAR(255)", "width": "INT", "Visibility": "TEXT"},
+        category=category,
+    )
+    list(ing.read_data(str(path)))
+
+    assert ing.feature_stats() == {}
+    assert ing.categorical_vocab() == {}
+    # No alignment stats reach the emitted attributes. (The base hook may
+    # still contribute scalar facts — e.g. text categories emit ``encoding``
+    # — so only the feature_stats key must be absent.)
+    run_meta = ing._collect_run_metadata()
+    assert "feature_stats" not in run_meta.get("attributes", {})
+
+
+def test_alignment_stats_on_for_time_series_classification(make_csv):
+    # time_series_classification is tabular-family (CSV rows ARE the data):
+    # numeric features accumulate; its label is classification-class, excluded.
+    path = make_csv({"reading": [1.0, 2.0, 3.0], "label": ["a", "b", "a"]})
+    ing = make_csv_ingestor(
+        schema={"reading": "FLOAT", "label": "VARCHAR(255)"},
+        label_column="label",
+        category=TaskCategory.TIME_SERIES_CLASSIFICATION,
+    )
+    list(ing.read_data(str(path)))
+
+    stats = ing.feature_stats()
+    assert set(stats) == {"reading"}
+    assert stats["reading"]["count"] == 3

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -82,6 +82,15 @@ _TEXT_CATEGORIES = _NLP_CATEGORIES - {TaskCategory.EMBEDDINGS}
 # Survival (time-to-event) duration units the combine-time contract accepts.
 _TIME_UNITS = ("days", "weeks", "months", "years")
 
+# file_options keys that are ingestor-internal bridges, never wire payload:
+# the label-stripped ``schema`` copy is a validator artifact (the canonical
+# schema ships as the top-level ``schema`` arg), and ``column_descriptors``
+# only carries the uploader's ``unit``/``ordinal`` declarations from config
+# resolution to ``_schema_payload``, which merges them onto the enriched
+# schema's columns — the raw map, keyed by CSV source names, duplicates
+# those facts under names the backend can't correlate (bugbot on #383).
+_META_DATA_INTERNAL_KEYS = frozenset({"schema", "column_descriptors"})
+
 
 def _valid_event_indicator(v: Any) -> bool:
     """A survival ``event_indicator`` is ``{event: int, censored: int}`` — the
@@ -782,6 +791,19 @@ class BaseIngestor(ABC):
                 enriched[target]["ordinal"] = desc["ordinal"]
         return enriched
 
+    def _meta_data_payload(self) -> Dict[str, Any]:
+        """The ``meta_data`` value shipped on the global-metadata channel:
+        ``file_options`` minus the ingestor-internal bridges
+        (``_META_DATA_INTERNAL_KEYS``), so a single, unambiguous copy of the
+        schema and the per-column descriptors is on the wire (G8, #360).
+        Split out from ``_ingest`` so the filter is unit-testable without a
+        full ingest run."""
+        return {
+            k: v
+            for k, v in self.file_options.items()
+            if k not in _META_DATA_INTERNAL_KEYS
+        }
+
     def _count_records(self, source: Any) -> Optional[int]:
         """
         Try to count total records in the source for progress tracking.
@@ -1200,14 +1222,7 @@ class BaseIngestor(ABC):
                         category=self.category,
                         schema=self._schema_payload(schema_dict),
                         samples=samples,
-                        # The internal, label-stripped ``schema`` copy in
-                        # file_options is a validator artifact; the canonical
-                        # schema ships as the top-level ``schema`` arg above
-                        # (enriched, target-bearing). Drop the duplicate so a
-                        # single, unambiguous schema is on the wire (G8, #360).
-                        meta_data={
-                            k: v for k, v in self.file_options.items() if k != "schema"
-                        },
+                        meta_data=self._meta_data_payload(),
                     )
                     dataset_registered = True
                     stats["api_sent_records"] = stats["inserted_records"]

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -19,6 +19,7 @@ from .base import BaseIngestor
 from ..database import Database
 from ..api.client import APIClient
 from ..cli.conventions import REGRESSION_CLASS_CATEGORIES
+from ..modalities.registry import TABULAR_FAMILY_CATEGORIES
 from ..utils.constants import RESET, RED, YELLOW, TaskCategory
 from ..utils import label_policy as label_policy_module
 from ..utils import coercion
@@ -229,6 +230,14 @@ class CSVIngestor(BaseIngestor):
             data_id_strategy=data_id_strategy,
         )
         self.csv_options = csv_options or {}
+
+        # Alignment stats treat the CSV's cell values as FEATURES, which is
+        # only true when the rows are the data (ModalitySpec's
+        # is_tabular_family). For manifest-style categories (image/objdet/
+        # keypoint/text pointer files) the cells are bookkeeping — and a TEXT
+        # column's vocab would ship raw cell content — so both accumulators
+        # stay off entirely (bugbot medium on #383).
+        self._emit_alignment_stats = category in TABULAR_FAMILY_CATEGORIES
 
         # Per numeric-feature-column sufficient statistics, accumulated in the
         # cast pass (_validate_csv) and emitted on the global-metadata channel
@@ -507,7 +516,11 @@ class CSVIngestor(BaseIngestor):
         Non-feature columns (label/target, row-id, annotation) are skipped — see
         ``_feature_stats_excluded``. An all-null column contributes nothing and
         never appears in the emitted stats (min/max would be undefined).
+        Manifest-style categories accumulate nothing at all — see
+        ``_emit_alignment_stats``.
         """
+        if not self._emit_alignment_stats:
+            return
         # Exclude by exact membership against the resolved exclusion set (the
         # configured label/id/annotation names pinned to their real headers in
         # _validate_csv). This drops a case-/whitespace-drifted role header but
@@ -610,8 +623,11 @@ class CSVIngestor(BaseIngestor):
         configured names pinned to their real headers in ``_validate_csv``, #340),
         so a header spelled ``Label`` / ``" label "`` is still excluded for a
         config that says ``label`` — while a distinct feature that only case-
-        matches a role name is kept, not dropped.
+        matches a role name is kept, not dropped. Manifest-style categories
+        accumulate nothing at all — see ``_emit_alignment_stats``.
         """
+        if not self._emit_alignment_stats:
+            return
         if (
             column in self._categorical_over_cap
             or column in (self._categorical_excluded_resolved or ())


### PR DESCRIPTION
## Summary
Fixes the two unresolved medium-severity Bugbot findings on release PR #383, both in the #360 enriched-schema work:

1. **Stats emitted for non-tabular CSV** — `feature_stats` / categorical vocab accumulated for every CSV category, so manifest-style ingests (e.g. keypoint_detection with a `Visibility` JSON TEXT column) shipped raw cell values off-premise as a "vocab". Both accumulators are now gated on the registry's `TABULAR_FAMILY_CATEGORIES` (rows-are-the-data family: tabular_*, time_series_*, time_to_event_prediction).
2. **Internal descriptors leak on wire** — `column_descriptors` (the config-resolution → `_schema_payload` bridge for uploader `unit`/`ordinal`) shipped in `meta_data` even though its facts are already merged onto the enriched schema columns. The send filter now strips both internal bridges via `_META_DATA_INTERNAL_KEYS`, extracted into a unit-testable `_meta_data_payload()`.

## Related
Resolves the two Bugbot review threads on #383. Ref #360, backend#1037.

## Type of change
- [x] Bug fix

## Test plan
- Full suite: 1824 passed, 1 xfailed locally.
- New: gating off for 6 manifest categories (incl. keypoint Visibility case), gating on for time_series_classification, `_meta_data_payload` strips `schema` + `column_descriptors` while passing genuine payload, descriptors still reach the enriched schema after the strip.
- Checked `e2e/` asserts nothing about `feature_stats` / `column_descriptors` / `meta_data`.

## Checklist
- [x] Tests added / updated and passing locally
- [x] No secrets / credentials in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what metadata leaves the client for non-tabular CSVs and tightens meta_data shape; behavior is covered by new tests but affects backend-facing registration payloads.
> 
> **Overview**
> Addresses two Bugbot findings from the enriched-schema (#360) work.
> 
> **Alignment stats gating:** `feature_stats` and categorical vocab accumulation now run only when `category` is in `TABULAR_FAMILY_CATEGORIES`. Manifest-style CSV ingests (image, object detection, keypoint, segmentation, text, embeddings) no longer treat bookkeeping columns as features—e.g. a keypoint `Visibility` TEXT column will not ship cell content as a vocab. Tabular-family categories such as `time_series_classification` still accumulate stats as before.
> 
> **meta_data wire cleanup:** Registration `meta_data` is built via `_meta_data_payload()`, which drops ingestor-internal keys `schema` and `column_descriptors` (defined in `_META_DATA_INTERNAL_KEYS`). The canonical schema still goes on the top-level `schema` argument; `unit`/`ordinal` from descriptors still merge in `_schema_payload()`—only the duplicate raw maps are removed from the wire payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6dbf557a00162edfe477880759395a4f1a8b585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->