### PR TITLE
feat(journal): record each run's task in the ingest-run journal

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -849,6 +849,71 @@ def test_ensure_runs_table_skips_alter_when_task_column_present(
     assert not any("ADD COLUMN task" in s for s in _executed_sql(conn))
 
 
+def test_ensure_runs_table_swallows_lost_alter_race(db, mock_engine_factory):
+    """A concurrent ingestor can add the column between our absence check and
+    our own ALTER, so the ALTER fails duplicate-column. The handler must roll
+    back the (now pending-rollback) connection BEFORE re-checking — else the
+    re-check hits PendingRollbackError (#219) — then swallow the race once the
+    column is confirmed present."""
+    from sqlalchemy.exc import DBAPIError
+
+    _, _, conn = mock_engine_factory
+    events = []
+    conn.rollback.side_effect = lambda *a, **k: events.append("rollback")
+    altered = {"attempted": False}
+
+    def execute_side_effect(stmt, *a, **k):
+        sql = str(stmt)
+        events.append(sql)
+        if "ADD COLUMN task" in sql:
+            altered["attempted"] = True
+            raise DBAPIError(sql, {}, Exception("Duplicate column name 'task'"))
+        result = MagicMock()
+        if "information_schema.columns" in sql:
+            # Absent on the pre-ALTER check; present on the re-check (the
+            # racing ingestor's ALTER has landed). Our ALTER attempt is the
+            # ordering marker between the two.
+            result.scalar.return_value = 1 if altered["attempted"] else 0
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    # Must NOT raise: the lost race is swallowed once the column is present.
+    db.record_ingest_started("tbl", "run-a", "tabular_classification")
+
+    # A rollback ran between the failed ALTER and the re-check.
+    alter_idx = next(i for i, e in enumerate(events) if "ADD COLUMN task" in e)
+    recheck_idx = next(
+        i
+        for i, e in enumerate(events)
+        if i > alter_idx and "information_schema.columns" in e
+    )
+    assert "rollback" in events[alter_idx:recheck_idx]
+
+
+def test_ensure_runs_table_reraises_non_race_alter_failure(db, mock_engine_factory):
+    """When the ALTER fails and the column is STILL absent afterwards (a genuine
+    DDL failure, not a lost race), the error propagates rather than being
+    silently swallowed."""
+    from sqlalchemy.exc import DBAPIError
+
+    _, _, conn = mock_engine_factory
+    conn.rollback.side_effect = lambda *a, **k: None
+
+    def execute_side_effect(stmt, *a, **k):
+        sql = str(stmt)
+        if "ADD COLUMN task" in sql:
+            raise DBAPIError(sql, {}, Exception("some other DDL error"))
+        result = MagicMock()
+        if "information_schema.columns" in sql:
+            result.scalar.return_value = 0  # still absent -> not a race
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    with pytest.raises(DBAPIError):
+        db.record_ingest_started("tbl", "run-a", "tabular_classification")
+    conn.rollback.assert_called()
+
+
 def test_mark_ingest_registered_flips_journal_flag(db, mock_engine_factory):
     """Marking registration must UPDATE the run's journal row to
     registered=1, scoped to this (ingestor_id, table_name)."""

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -780,17 +780,73 @@ def _executed_sql(conn):
 
 
 def test_record_ingest_started_journals_idempotently(db, mock_engine_factory):
-    """Journaling a run's start must lazily create the journal table and use
-    INSERT IGNORE (idempotent re-entry), then commit — mirroring the salt
-    store's lazy-creation pattern (#225)."""
+    """Journaling a run's start must lazily create the journal table (with the
+    task column) and use INSERT IGNORE (idempotent re-entry), then commit —
+    mirroring the salt store's lazy-creation pattern (#225)."""
     _, _, conn = mock_engine_factory
     db.record_ingest_started("tbl", "run-a")
     sql = _executed_sql(conn)
-    assert any(
-        "CREATE TABLE IF NOT EXISTS `tracebloc_ingest_runs`" in s for s in sql
+    create = next(
+        s for s in sql if "CREATE TABLE IF NOT EXISTS `tracebloc_ingest_runs`" in s
     )
+    assert "task VARCHAR(64)" in create
     assert any("INSERT IGNORE INTO `tracebloc_ingest_runs`" in s for s in sql)
     conn.commit.assert_called()
+
+
+def test_record_ingest_started_persists_task(db, mock_engine_factory):
+    """The run's task (ingest category) is written into the journal so a
+    cluster-local reader can report it without a backend round-trip."""
+    _, _, conn = mock_engine_factory
+    db.record_ingest_started("tbl", "run-a", "image_classification")
+    insert = next(
+        c.args[0]
+        for c in conn.execute.call_args_list
+        if "INSERT IGNORE INTO `tracebloc_ingest_runs`" in str(c.args[0])
+    )
+    assert "task" in str(insert)
+    assert insert.compile().params == {
+        "ingestor_id": "run-a",
+        "table_name": "tbl",
+        "task": "image_classification",
+    }
+
+
+def test_record_ingest_started_task_defaults_null(db, mock_engine_factory):
+    """An older caller that omits the task still journals the run (task NULL),
+    so registration/reclaim keep working across the rollout."""
+    _, _, conn = mock_engine_factory
+    db.record_ingest_started("tbl", "run-a")
+    insert = next(
+        c.args[0]
+        for c in conn.execute.call_args_list
+        if "INSERT IGNORE INTO `tracebloc_ingest_runs`" in str(c.args[0])
+    )
+    assert insert.compile().params["task"] is None
+
+
+def test_ensure_runs_table_adds_task_column_when_missing(db, mock_engine_factory):
+    """A runs table created before the task column existed is migrated in
+    place: information_schema reports it absent, so an ALTER adds it."""
+    _, _, conn = mock_engine_factory
+    conn.execute.return_value.scalar.return_value = 0  # column absent
+    db.record_ingest_started("tbl", "run-a", "tabular_classification")
+    sql = _executed_sql(conn)
+    assert any(
+        "ALTER TABLE `tracebloc_ingest_runs`" in s and "ADD COLUMN task" in s
+        for s in sql
+    )
+
+
+def test_ensure_runs_table_skips_alter_when_task_column_present(
+    db, mock_engine_factory
+):
+    """When the column already exists, no ALTER runs (the common steady-state
+    path — a bare check, no DDL)."""
+    _, _, conn = mock_engine_factory
+    conn.execute.return_value.scalar.return_value = 1  # column present
+    db.record_ingest_started("tbl", "run-a", "tabular_classification")
+    assert not any("ADD COLUMN task" in s for s in _executed_sql(conn))
 
 
 def test_mark_ingest_registered_flips_journal_flag(db, mock_engine_factory):

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -1653,7 +1653,7 @@ def test_reconcile_and_start_journal_run_before_first_insert():
         ing.table_name, ing.ingestor_id
     )
     ing.database.record_ingest_started.assert_called_once_with(
-        ing.table_name, ing.ingestor_id
+        ing.table_name, ing.ingestor_id, ing.category
     )
     names = [name for name, _, _ in ing.database.mock_calls]
     assert names.index("create_table") < names.index("reclaim_dead_run_rows")

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -658,7 +658,8 @@ class Database:
     RUNS_TABLE = "tracebloc_ingest_runs"
 
     def _ensure_runs_table(self, connection) -> None:
-        """Create the run-journal table if missing. Idempotent DDL, mirroring
+        """Create the run-journal table if missing, then add the ``task``
+        column to a table created before it existed. Idempotent DDL, mirroring
         the salt store's lazy creation (#225) — no migration step needed."""
         _execute_with_retry(
             connection,
@@ -667,16 +668,62 @@ class Database:
                 "  ingestor_id VARCHAR(64) NOT NULL PRIMARY KEY,"
                 "  table_name VARCHAR(64) NOT NULL,"
                 "  registered TINYINT(1) NOT NULL DEFAULT 0,"
+                "  task VARCHAR(64) NULL,"
                 "  started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,"
                 "  registered_at TIMESTAMP NULL DEFAULT NULL,"
                 "  KEY ix_tracebloc_ingest_runs_table (table_name)"
                 ")"
             ),
         )
+        self._ensure_runs_task_column(connection)
 
-    def record_ingest_started(self, table_name: str, ingestor_id: str) -> None:
+    def _runs_has_task_column(self, connection) -> bool:
+        """Whether the runs table already carries the ``task`` column."""
+        return bool(
+            _execute_with_retry(
+                connection,
+                text(
+                    "SELECT COUNT(*) FROM information_schema.columns "
+                    "WHERE table_schema = DATABASE() "
+                    "AND table_name = :t AND column_name = 'task'"
+                ).bindparams(t=self.RUNS_TABLE),
+            ).scalar()
+        )
+
+    def _ensure_runs_task_column(self, connection) -> None:
+        """Add ``task`` to a runs table created before the column existed
+        (clusters that journalled runs under the pre-task schema). MySQL has no
+        portable ``ADD COLUMN IF NOT EXISTS``, so check information_schema first
+        and ALTER only when it's missing; a concurrent ingestor winning the race
+        surfaces as a duplicate-column error, which is re-checked and swallowed.
+        New tables already carry the column, so this is a no-op there."""
+        if self._runs_has_task_column(connection):
+            return
+        try:
+            # Not via _execute_with_retry: a duplicate-column failure is
+            # deterministic, so retrying it would only burn the backoff before
+            # the re-check below handles the race.
+            connection.execute(
+                text(
+                    f"ALTER TABLE `{self.RUNS_TABLE}` "
+                    "ADD COLUMN task VARCHAR(64) NULL"
+                )
+            )
+        except DBAPIError:
+            if not self._runs_has_task_column(connection):
+                raise
+
+    def record_ingest_started(
+        self, table_name: str, ingestor_id: str, task: Optional[str] = None
+    ) -> None:
         """Journal that *ingestor_id* is about to insert rows into
-        *table_name* (backend#1028 item 2).
+        *table_name* (backend#1028 item 2), tagging the run with its *task*
+        (the ingest category, e.g. ``image_classification``).
+
+        The task is otherwise known only to the backend; recording it here lets
+        a cluster-local reader (``tb data list``) report each dataset's real
+        task instead of inferring it. ``task`` is optional so an older caller
+        keeps working (the run is journalled with a NULL task).
 
         Must be called before the run's first ``insert_batch`` so that a hard
         kill at ANY later point leaves a started-but-unregistered journal
@@ -690,9 +737,9 @@ class Database:
                 connection,
                 text(
                     f"INSERT IGNORE INTO `{self.RUNS_TABLE}` "
-                    "(ingestor_id, table_name) "
-                    "VALUES (:ingestor_id, :table_name)"
-                ).bindparams(ingestor_id=ingestor_id, table_name=table_name),
+                    "(ingestor_id, table_name, task) "
+                    "VALUES (:ingestor_id, :table_name, :task)"
+                ).bindparams(ingestor_id=ingestor_id, table_name=table_name, task=task),
             )
             connection.commit()
 

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -710,6 +710,18 @@ class Database:
                 )
             )
         except DBAPIError:
+            # SQLAlchemy leaves the connection in a pending-rollback state
+            # after the failed ALTER, so the re-check below would raise
+            # PendingRollbackError instead of running — the same #219 failure
+            # mode _execute_with_retry guards against. Reset the transactional
+            # state first; then re-check. A lost race (a concurrent ingestor
+            # added the column) is swallowed; any other ALTER failure re-raises.
+            try:
+                connection.rollback()
+            except Exception as rb_exc:
+                # A rollback on a truly dead connection may itself fail; let
+                # the re-check (or the re-raise) surface the real problem.
+                logger.debug(f"connection.rollback() failed after ALTER: {rb_exc}")
             if not self._runs_has_task_column(connection):
                 raise
 

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -907,7 +907,9 @@ class BaseIngestor(ABC):
         # insert, the batch inserts below would fail anyway — better to fail
         # now, before any row lands, than to insert rows the journal never
         # heard about.
-        self.database.record_ingest_started(self.table_name, self.ingestor_id)
+        self.database.record_ingest_started(
+            self.table_name, self.ingestor_id, self.category
+        )
 
         batch = []
         failed_records = []


### PR DESCRIPTION
## Summary

Persists each ingest run's **task** (the category, e.g. `image_classification`) into the cluster-local run journal so a reader like `tb data list` can report the *real* task instead of inferring modality from file extensions / column shapes.

The task is chosen at ingest time and travels in the spec as `category`, but it was only ever sent to the backend — the cluster DB never stored it. This closes that gap at the cheapest point: `tracebloc_ingest_runs` is already per-table and indexed by `table_name`, the natural join target.

## Changes

- **`tracebloc_ingest_runs` schema:** add a nullable `task VARCHAR(64)` column to the `CREATE`, plus an **idempotent guarded `ALTER`** for tables created before the column existed. MySQL has no portable `ADD COLUMN IF NOT EXISTS`, so we check `information_schema` and `ALTER` only when missing; a concurrent ingestor winning the race surfaces as a duplicate-column error, which is re-checked and swallowed.
- **`record_ingest_started(table_name, ingestor_id, task=None)`** writes the task. `task` is optional, so an older caller still journals the run (NULL task) and registration/reclaim are unaffected — safe across the rollout.
- **`BaseIngestor`** passes `self.category` at the existing journal-start call site (no new DB round-trips; same statement).

## Why it's safe

- Nullable column + `INSERT IGNORE` preserve the journal's existing idempotency and the orphan-reclaim contract (backend#1028) — `reclaim`/`mark_registered` don't touch `task`.
- Existing clusters migrate in place on the next ingest; legacy datasets simply carry a NULL task (the CLI falls back to inferred modality for those).

## Test plan

- `task` is persisted with the right bindparams; defaults to NULL when omitted.
- Migration `ALTER` fires **only** when the column is absent (and is skipped in steady state).
- `CREATE` carries the column; the journal call-order test asserts the category is threaded through `BaseIngestor.ingest`.
- Full suite green (1819 passed, 1 xfail) on 3.11/3.12.

Foundation for the `tb data list` real-task display (CLI side, tracebloc/cli#376). Forward-looking: newly ingested datasets get the exact task; the CLI degrades to inferred modality for pre-existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runs DDL (ALTER) on the ingest path during rollout and touches journal setup, though nullable task and unchanged reclaim/register paths limit impact to metadata for local CLI display.
> 
> **Overview**
> Adds a nullable **`task`** column to the cluster-local **`tracebloc_ingest_runs`** journal so tools like **`tb data list`** can show the real ingest category instead of inferring it.
> 
> **`record_ingest_started`** now accepts an optional **`task`** and writes it on **`INSERT IGNORE`**. **`BaseIngestor`** passes **`self.category`** at the existing journal-start call. Older callers that omit **`task`** still journal runs with **NULL**, so registration and orphan reclaim behavior stay the same.
> 
> New tables get **`task`** in **`CREATE TABLE`**. Existing journals are upgraded lazily via **`information_schema`** plus **`ALTER TABLE … ADD COLUMN`**, with rollback and re-check when concurrent ingestors race on the same DDL (duplicate-column errors swallowed only if the column is present afterward).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29253124a040d49537343576bb9a59e030990fd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->