### PR TITLE
fix(ingest): strip the scalar alignment bridges from meta_data (bugbot round 2 on #383)

### DIFF
--- a/tests/test_enriched_schema.py
+++ b/tests/test_enriched_schema.py
@@ -283,3 +283,31 @@ def test_descriptors_still_reach_enriched_schema_after_meta_data_strip():
     enriched = ing._schema_payload({"a": "INT"})
     assert enriched["a"]["unit"] == "kg"
     assert "column_descriptors" not in ing._meta_data_payload()
+
+
+def test_meta_data_payload_strips_scalar_alignment_bridges():
+    # Second bugbot round on #383: the scalar alignment facts bridged onto
+    # file_options (7c-7g in conventions.resolve) are copied under
+    # ``attributes`` by _scalar_attribute_metadata — the only channel the
+    # backend reads. The raw top-level copies must not ship beside them.
+    bridged = {
+        "color_mode": "RGB",
+        "bit_depth": 8,
+        "language": "en",
+        "normalization": "lowercase",
+        "time_unit": "days",
+        "event_indicator": {"event": 1, "censored": 0},
+        "positive_definition": "same-document pairs",
+    }
+    ing = make_ingestor(
+        enriched=True,
+        file_options={**bridged, "target_size": [512, 512]},
+    )
+    meta = ing._meta_data_payload()
+    for key in bridged:
+        assert key not in meta, key
+    # Genuine file_options and the canonical attributes channel still ship.
+    assert meta["target_size"] == [512, 512]
+
+    ing.file_options.setdefault("attributes", {})["color_mode"] = "RGB"
+    assert ing._meta_data_payload()["attributes"]["color_mode"] == "RGB"

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -82,14 +82,30 @@ _TEXT_CATEGORIES = _NLP_CATEGORIES - {TaskCategory.EMBEDDINGS}
 # Survival (time-to-event) duration units the combine-time contract accepts.
 _TIME_UNITS = ("days", "weeks", "months", "years")
 
-# file_options keys that are ingestor-internal bridges, never wire payload:
-# the label-stripped ``schema`` copy is a validator artifact (the canonical
-# schema ships as the top-level ``schema`` arg), and ``column_descriptors``
-# only carries the uploader's ``unit``/``ordinal`` declarations from config
-# resolution to ``_schema_payload``, which merges them onto the enriched
-# schema's columns — the raw map, keyed by CSV source names, duplicates
-# those facts under names the backend can't correlate (bugbot on #383).
-_META_DATA_INTERNAL_KEYS = frozenset({"schema", "column_descriptors"})
+# file_options keys that are ingestor-internal bridges, never wire payload.
+# ``schema`` is a validator artifact (the canonical schema ships as the
+# top-level ``schema`` arg). The rest are alignment facts bridged from config
+# resolution onto file_options ONLY so the emit hooks can place them on their
+# canonical channels: ``column_descriptors`` (unit/ordinal) merges onto the
+# enriched schema's columns (``_schema_payload``); the scalar facts are
+# copied under ``attributes`` (``_scalar_attribute_metadata``) — the only
+# place the backend reads them (dataset_validators reads
+# ``meta_data.attributes``). Shipping the raw keys beside the canonical
+# copies duplicated them at meta_data top level (bugbot on #383, both
+# rounds).
+_META_DATA_INTERNAL_KEYS = frozenset(
+    {
+        "schema",
+        "column_descriptors",
+        "color_mode",
+        "bit_depth",
+        "language",
+        "normalization",
+        "time_unit",
+        "event_indicator",
+        "positive_definition",
+    }
+)
 
 
 def _valid_event_indicator(v: Any) -> bool:


### PR DESCRIPTION
## Summary
Bugbot's re-review of release PR #383 flagged the remaining internal-bridge leak, same class #385 closed for `schema`/`column_descriptors`: the seven scalar alignment facts (`color_mode`, `bit_depth`, `language`, `normalization`, `time_unit`, `event_indicator`, `positive_definition`) bridged onto `file_options` still shipped raw at `meta_data` top level beside their canonical `attributes` copies. `_META_DATA_INTERNAL_KEYS` now covers all bridged facts.

Verified the backend only reads these from `meta_data.attributes` (`dataset_validators._dataset_attributes`, backend develop c9e14ef9) — the top-level copies have no consumer.

## Related
Resolves Bugbot thread "Alignment bridges leak into meta_data" on #383. Ref #360, #385, backend#1037.

## Type of change
- [x] Bug fix

## Test plan
- Full suite: 1831 passed, 1 xfailed locally.
- New test: all seven bridges stripped from `_meta_data_payload()`; genuine `file_options` (`target_size`) and the `attributes` channel still ship.

## Checklist
- [x] Tests added / updated and passing locally
- [x] No secrets / credentials in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata shaping only; no ingest, auth, or data-path changes beyond omitting duplicate top-level keys the backend does not consume.
> 
> **Overview**
> Fixes a **meta_data wire leak** (bugbot round 2 on #383): seven config-resolved alignment facts on `file_options` (`color_mode`, `bit_depth`, `language`, `normalization`, `time_unit`, `event_indicator`, `positive_definition`) were still copied to **`meta_data` top level** even though `_scalar_attribute_metadata` already places them under **`meta_data.attributes`**, which is what the backend reads.
> 
> **`_META_DATA_INTERNAL_KEYS`** in `base.py` now treats those keys like `schema` and `column_descriptors`—filtered out of `_meta_data_payload()` so only the canonical channels ship. Genuine `file_options` (e.g. `target_size`) and explicit `attributes` are unchanged.
> 
> A new test asserts all seven bridges are stripped while `target_size` and `attributes` still pass through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0392b8f91a142b9831daeb04de08382e1d3bf4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->