### PR TITLE
fix(objdet): default data_id to uuid — content_hash collapses per-object rows (bugbot High on #383)

### DIFF
--- a/templates/object_detection/object_detection.py
+++ b/templates/object_detection/object_detection.py
@@ -70,6 +70,10 @@ def main():
         file_options=object_detection_options,
         label_column="image_label",
         intent=Intent.TRAIN,  # Is the data for training or testing
+        # Objdet manifests carry one row per object; duplicate
+        # (filename, label) rows are real objects, so per-row UUIDs —
+        # a content hash would collapse them (bugbot on #383).
+        data_id_strategy="uuid",
     )
 
     # Ingest data with validation

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -467,3 +467,29 @@ def test_positive_definition_bridged():
     config["positive_definition"] = "same-question paraphrase"
     r = resolve(config)
     assert r.file_options["positive_definition"] == "same-question paraphrase"
+
+
+# ---------------------------------------------------------------------------
+# data_id — object_detection category default (bugbot High on #383)
+# ---------------------------------------------------------------------------
+
+
+def test_objdet_defaults_to_uuid():
+    # Objdet manifests list one row per object, so duplicate (filename, label)
+    # rows are real objects — the bundled VisDrone sample has three `car` rows
+    # for one image. A content digest is identical across those duplicates and
+    # the UNIQUE upsert would collapse them, so absent an explicit choice the
+    # objdet default stays uuid.
+    r = resolve(_load("object_detection.yaml"))
+    assert r.unique_id_column is None
+    assert r.data_id_strategy == "uuid"
+
+
+def test_objdet_explicit_content_hash_is_honored():
+    # The category default only fills the ABSENT case — an uploader who
+    # explicitly asks for content_hash (e.g. a one-row-per-image manifest)
+    # keeps it.
+    config = _load("object_detection.yaml")
+    config["data_id"] = {"strategy": "content_hash"}
+    r = resolve(config)
+    assert r.data_id_strategy == "content_hash"

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -6,6 +6,7 @@ SQLAlchemy Session is patched out so no real engine is touched.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any, Dict, Generator, List
 from unittest.mock import MagicMock, patch
@@ -1789,3 +1790,21 @@ def test_zero_record_run_journals_start_but_not_registered():
     _run_happy_ingest(ing)
     ing.database.record_ingest_started.assert_called_once()
     ing.database.mark_ingest_registered.assert_not_called()
+
+
+def test_objdet_content_hash_constructor_warns(caplog):
+    # The YAML resolver defaults object_detection to uuid, but the direct-
+    # constructor path (templates, custom scripts) can't distinguish an
+    # explicit content_hash from the signature default — so the constructor
+    # warns loudly about the duplicate-row collapse instead of overriding
+    # (bugbot High on #383).
+    with caplog.at_level(logging.WARNING):
+        make_ingestor(category=TaskCategory.OBJECT_DETECTION)
+    assert any("collapse" in r.getMessage() for r in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        make_ingestor(
+            category=TaskCategory.OBJECT_DETECTION, data_id_strategy="uuid"
+        )
+    assert not any("collapse" in r.getMessage() for r in caplog.records)

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -1798,6 +1798,11 @@ def test_objdet_content_hash_constructor_warns(caplog):
     # explicit content_hash from the signature default — so the constructor
     # warns loudly about the duplicate-row collapse instead of overriding
     # (bugbot High on #383).
+    # Local import: develop's copy of this file has no module-level
+    # TaskCategory import, so the PR merge-ref loses it — the test must be
+    # self-contained (same convention as every other test here).
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
     with caplog.at_level(logging.WARNING):
         make_ingestor(category=TaskCategory.OBJECT_DETECTION)
     assert any("collapse" in r.getMessage() for r in caplog.records)

--- a/tests/test_template_equivalence.py
+++ b/tests/test_template_equivalence.py
@@ -133,6 +133,10 @@ CASES = [
             "label_column": "image_label",
             "label_policy": PASSTHROUGH,
             "unique_id_column": None,
+            # Objdet manifests are one-row-per-object; the category defaults
+            # to per-row UUIDs so duplicate (filename, label) rows don't
+            # collapse under a content digest (bugbot on #383).
+            "data_id_strategy": "uuid",
             "annotation_column": None,
             "file_options": {
                 "target_size": [1920, 1080],

--- a/tracebloc_ingestor/cli/conventions.py
+++ b/tracebloc_ingestor/cli/conventions.py
@@ -302,9 +302,22 @@ def resolve(config: Dict[str, Any]) -> ResolvedConfig:
     #    content_hash. The explicit ``uuid`` branch below is the opt-out: without
     #    it, ``strategy: uuid`` would fall through and silently stay content_hash.
     data_id = config.get("data_id") or {}
-    if data_id.get("strategy") == "column":
+    strategy = data_id.get("strategy")
+    if strategy == "column":
         resolved.unique_id_column = data_id["column"]
-    elif data_id.get("strategy") == "uuid":
+    elif strategy == "uuid":
+        resolved.data_id_strategy = "uuid"
+    elif strategy is None and category == TaskCategory.OBJECT_DETECTION:
+        # Object-detection manifests list one row PER OBJECT, so duplicate
+        # (filename, label) rows are the norm — the bundled VisDrone sample
+        # has three identical `car` rows for one image. Those rows hash to
+        # the SAME content digest and the data_id UNIQUE upsert would keep a
+        # single stored row, silently under-counting objects (bugbot High on
+        # #383). Absent an explicit choice, objdet therefore keeps
+        # fresh-per-row UUIDs; an explicit `strategy: content_hash` is
+        # honored (and #227 cleans up retry duplicates either way). Restoring
+        # retry idempotency for objdet needs a row-ordinal-salted hash — a
+        # follow-up, not a default.
         resolved.data_id_strategy = "uuid"
     # else (content_hash, or absent): leave default ⇒ content_hash
 

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -247,6 +247,24 @@ class BaseIngestor(ABC):
         # run leaves no salt row behind. get_or_create is atomic
         # (INSERT IGNORE), so it needs no table lock even then.
         self.data_id_strategy = data_id_strategy
+        if (
+            category == TaskCategory.OBJECT_DETECTION
+            and data_id_strategy == "content_hash"
+            and not unique_id_column
+        ):
+            # Objdet manifests list one row PER OBJECT: duplicate
+            # (filename, label) rows are distinct objects, but they produce
+            # identical content digests, so the data_id UNIQUE upsert keeps
+            # only one of them (bugbot High on #383). The YAML resolver
+            # defaults objdet to uuid; this guards the direct-constructor
+            # path, which can't distinguish an explicit choice from the
+            # signature default — hence a warning, not an override.
+            logger.warning(
+                "object_detection with data_id_strategy='content_hash': "
+                "duplicate (filename, label) manifest rows collapse into one "
+                "stored row. If each row is one object (the usual manifest "
+                "shape), pass data_id_strategy='uuid'."
+            )
         self._table_salt: Optional[str] = None
         self.database = database
         self.engine: Engine = database.engine


### PR DESCRIPTION
## Summary
Bugbot flagged (High) on release PR #383: the #350 `content_hash` default flip collapses object-detection rows. Objdet manifests are one-row-per-object, so duplicate `(filename, label)` rows are distinct objects — the bundled VisDrone sample literally has three identical `car` rows for one image. Identical rows → identical digest → the `data_id` UNIQUE upsert keeps one stored row, silently under-counting objects. The e2e characterization fixtures already pin `uuid` to dodge this, which is the smoking gun.

**Fix (minimal, preserves explicit choice):**
- `conventions.resolve`: absent `data_id` block + `object_detection` → `uuid`; explicit `strategy: content_hash` stays honored
- objdet template passes `data_id_strategy="uuid"` explicitly
- `BaseIngestor` warns loudly when objdet runs under `content_hash` via the direct-constructor path (an explicit kwarg is indistinguishable from the signature default there, so warn — don't override)

**Deliberately NOT here:** restoring retry-idempotency for objdet via a row-ordinal-salted digest (deterministic across retries — same manifest, same order — yet unique per duplicate row). That changes the #350 hash contract and deserves its own ticket + review rather than a release hotfix. Happy to file/build it as a follow-up.

## Related
Resolves Bugbot thread "Content-hash default collapses object rows" on #383. Ref #350, #375.

## Type of change
- [x] Bug fix

## Test plan
- Full suite: 1833 passed, 1 xfailed locally.
- New: resolver defaults objdet→uuid; explicit content_hash honored; constructor warning fires for objdet+content_hash and not for uuid; template-equivalence pins `data_id_strategy="uuid"` for the objdet case.

## Checklist
- [x] Tests added / updated and passing locally
- [x] No secrets / credentials in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default `data_id` behavior for object-detection ingestion and affects how rows dedupe on upsert; explicit `content_hash` remains opt-in with a warning.
> 
> **Overview**
> Fixes **silent object under-counting** when object-detection manifests use the global **`content_hash`** default: one row per object often repeats the same `(filename, label)`, so identical digests collide on the `data_id` UNIQUE upsert and only one row is kept.
> 
> **YAML / resolver:** `conventions.resolve` now defaults **`object_detection`** to **`data_id_strategy: uuid`** when no `data_id` block is present; an explicit **`strategy: content_hash`** is still honored.
> 
> **Template & direct construction:** The object-detection template passes **`data_id_strategy="uuid"`** explicitly. **`BaseIngestor`** logs a **warning** (does not override) when objdet is built with **`content_hash`** and no `unique_id_column`, covering scripts that bypass the resolver.
> 
> Tests pin the resolver default, explicit `content_hash`, the constructor warning, and template-equivalence expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfcfa83ec745c83e5082db55e8e42d0fe711e5de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->