### PR TITLE
fix(backfill): honor the tabular-family alignment gate in metadata backfill (bugbot High on #383)

### DIFF
--- a/tests/test_metadata_backfill.py
+++ b/tests/test_metadata_backfill.py
@@ -225,3 +225,24 @@ def test_build_dataset_metadata_classification_excludes_label_from_stats():
     assert "label" not in fs  # class label is not a feature
     assert set(fs) == {"feat"}
     assert out["schema"]["label"]["role"] == "target"
+
+
+def test_build_dataset_metadata_manifest_category_emits_no_alignment_stats():
+    # Same gate as the live cast pass (#385, bugbot High on #383): for a
+    # manifest-style category the table's cells are bookkeeping, not features
+    # — a keypoint Visibility TEXT column must not ship as vocab. The SQL
+    # scans are skipped entirely and the payload matches a fresh ingest.
+    engine = create_engine("sqlite://")
+    with engine.begin() as c:
+        c.execute(text("CREATE TABLE t (id INTEGER, width REAL, Visibility TEXT)"))
+        c.execute(
+            text("INSERT INTO t (id, width, Visibility) VALUES (1, 640.0, '[1,1]')")
+        )
+    schema = {"id": "BIGINT", "width": "FLOAT", "Visibility": "TEXT"}
+    db = _FakeDB(engine, schema)
+
+    out = mb.build_dataset_metadata(db, "t", category="keypoint_detection")
+
+    # Enriched schema still ships; no alignment stats are fabricated.
+    assert out["schema"]["width"]["dtype"] == "float"
+    assert out["meta_data"] == {}

--- a/tracebloc_ingestor/metadata_backfill.py
+++ b/tracebloc_ingestor/metadata_backfill.py
@@ -135,12 +135,20 @@ def build_dataset_metadata(
         file_options=dict(file_options or {}),
     )
 
-    table = Table(table_name, MetaData(), autoload_with=database.engine)
-    with database.engine.connect() as conn:
-        ingestor._feature_stats_acc = _numeric_feature_stats(
-            conn, table, schema, category
-        )
-        ingestor._categorical_acc = _categorical_counts(conn, table, schema)
+    # Same gate as the live cast pass (#385): alignment stats describe cell
+    # values as FEATURES, which is only true for tabular-family categories.
+    # Injecting the SQL-built accumulators directly would bypass that
+    # accumulation-time gate and ship a manifest table's TEXT cell values as
+    # vocab (bugbot High on #383). Honor the ingestor's own flag — derived
+    # from the category in __init__ — and skip the table scans entirely,
+    # mirroring what a fresh ingest of the same table would emit.
+    if ingestor._emit_alignment_stats:
+        table = Table(table_name, MetaData(), autoload_with=database.engine)
+        with database.engine.connect() as conn:
+            ingestor._feature_stats_acc = _numeric_feature_stats(
+                conn, table, schema, category
+            )
+            ingestor._categorical_acc = _categorical_counts(conn, table, schema)
 
     enriched_schema = ingestor._schema_payload(schema)
     run_meta = ingestor._collect_run_metadata()


### PR DESCRIPTION
## Summary
Bugbot round 3 on release PR #383 (learned rule from #385): `build_dataset_metadata` injects SQL-built `_feature_stats_acc` / `_categorical_acc` directly, bypassing the accumulation-time tabular-family gate #385 added on the live path — a backfill of a manifest-style table (keypoint `Visibility` TEXT) could ship raw cell values as vocab that a fresh ingest suppresses.

Fix: gate on the ingestor's own `_emit_alignment_stats` flag (single source of truth, derived from category in `__init__`) and skip the table scans entirely for non-tabular categories — the backfilled payload now mirrors a fresh ingest's exactly.

## Related
Resolves Bugbot thread "Backfill skips tabular stats gate" on #383. Ref #378, #385, di#360.

## Type of change
- [x] Bug fix

## Test plan
- Full suite: 1848 passed, 1 xfailed locally.
- New integration test: keypoint backfill over SQLite emits enriched schema but `meta_data == {}` — no fabricated stats/vocab.

## Checklist
- [x] Tests added / updated and passing locally
- [x] No secrets / credentials in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted bug fix aligning backfill with existing ingest behavior; limited to metadata computation with regression coverage.
> 
> **Overview**
> **Metadata backfill** no longer always runs SQL numeric/categorical scans and injects those accumulators into `CSVIngestor`. It now checks `ingestor._emit_alignment_stats` (same tabular-family gate as live ingest #385) and **skips table scans** for manifest-style categories such as `keypoint_detection`, so TEXT bookkeeping columns (e.g. keypoint `Visibility`) are not emitted as categorical vocab.
> 
> Backfilled payloads for non-tabular datasets should match a fresh ingest: enriched `schema` still builds, but `meta_data` stays empty when no alignment attributes apply.
> 
> A new integration test asserts keypoint backfill returns `meta_data == {}` while schema enrichment remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1dc637fd2c15b35665012dfe7f6e557edf681e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

