### PR TITLE
chore(release): bump version to 0.7.5

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.7.4"
+__version__ = "0.7.5"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
Version bump ahead of the v0.7.5 release.

Follows [RELEASING.md](RELEASING.md) step 2 — single-sourced in `tracebloc_ingestor/__init__.py`; `setup.py` derives it. Once this lands on `develop`, the open develop→master sync PR #383 picks it up so PyPI and the image-baked version stay aligned.

**Verified**
- `git diff` is version-only (0.7.4 → 0.7.5)
- `python setup.py --version` → `0.7.5`
- `tests/test_version_single_source.py` → 2 passed

## Checklist
- [x] Tests added / updated and passing locally
- [x] No secrets / credentials in the diff

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no runtime or behavioral impact.
> 
> **Overview**
> Prepares the **v0.7.5** release by updating the package version from **0.7.4** to **0.7.5** in `tracebloc_ingestor/__init__.py`, which remains the single source of truth for versioning (`setup.py` reads it via `_read_version()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9422b78da354864edd3903cd721fdc25a021c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->