### PR TITLE
feat(backfill): metadata backfill runner — GET dataset → recompute → send to backend (#378 send side)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,10 @@ setup(
         # schema/ingest.v1.json, and dispatches to the right ingestor.
         "console_scripts": [
             "tracebloc-ingest = tracebloc_ingestor.cli.run:main",
+            # One-time pre-cutover metadata backfill (backend#1166/#1198): reads
+            # DB + backend creds from the same env as the ingestor (no
+            # ingest.yaml) and sweeps this client's registered datasets.
+            "tracebloc-backfill = tracebloc_ingestor.metadata_backfill_runner:main",
         ],
     },
     classifiers=[

--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -263,3 +263,85 @@ def test_refresh_token_false_when_reauth_raises():
     client.token = "old_token"
     with patch.object(client, "authenticate", side_effect=RuntimeError("auth down")):
         assert client._refresh_token() is False
+
+
+# ---------------------------------------------------------------------------
+# get_dataset_metadata() — read-by-ingestor_id (backend#1198)
+# ---------------------------------------------------------------------------
+
+
+def test_get_dataset_metadata_success():
+    client = _client()
+    body = {"table_name": "tb", "category": "tabular_classification", "meta_data": {}}
+    with patch.object(client.session, "get", return_value=_resp(200, body)):
+        result = client.get_dataset_metadata("ing-1")
+    assert result == body
+
+
+def test_get_dataset_metadata_404_returns_none():
+    """A 404 (no dataset for this ingestor_id owned by this edge) is a skip
+    signal for the sweep, not an error — return None rather than raise."""
+    client = _client()
+    with patch.object(client.session, "get", return_value=_resp(404, text="nope")):
+        assert client.get_dataset_metadata("missing") is None
+
+
+def test_get_dataset_metadata_http_error_raises():
+    client = _client()
+    with patch.object(client.session, "get", return_value=_resp(500, text="boom")):
+        with pytest.raises(requests.exceptions.RequestException):
+            client.get_dataset_metadata("ing-1")
+
+
+def test_get_dataset_metadata_local_mode():
+    client = _client(EDGE_ENV="local")
+    with patch.object(client.session, "get") as get:
+        assert client.get_dataset_metadata("ing-1") is None
+    get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# send_metadata_backfill() — upsert recomputed metadata (backend#1166/#1198)
+# ---------------------------------------------------------------------------
+
+
+def test_send_metadata_backfill_success():
+    client = _client()
+    body = {"table_name": "tb", "created": True, "competitions_refolded": 2}
+    with patch.object(client.session, "post", return_value=_resp(201, body)):
+        result = client.send_metadata_backfill("tb", {"x": {"dtype": "int"}}, {})
+    assert result == body
+
+
+def test_send_metadata_backfill_http_error_raises():
+    client = _client()
+    with patch.object(client.session, "post", return_value=_resp(404, text="no table")):
+        with pytest.raises(requests.exceptions.RequestException):
+            client.send_metadata_backfill("tb", {"x": {"dtype": "int"}}, {})
+
+
+def test_send_metadata_backfill_local_mode():
+    client = _client(EDGE_ENV="local")
+    with patch.object(client.session, "post") as post:
+        result = client.send_metadata_backfill("tb", {"x": {"dtype": "int"}}, {})
+    post.assert_not_called()
+    assert result["table_name"] == "tb"
+
+
+def test_send_metadata_backfill_payload_shape():
+    import json as _json
+
+    client = _client()
+    captured = {}
+
+    def _capture(url, **kwargs):
+        captured["url"] = url
+        captured["data"] = kwargs.get("data")
+        return _resp(201, {"table_name": "tb", "created": False, "competitions_refolded": 0})
+
+    with patch.object(client.session, "post", side_effect=_capture):
+        client.send_metadata_backfill("tb", {"x": {"dtype": "int"}}, {"attributes": {}})
+
+    assert captured["url"].endswith("/global_meta/metadata_backfill/tb/")
+    sent = _json.loads(captured["data"])
+    assert sent == {"schema": {"x": {"dtype": "int"}}, "meta_data": {"attributes": {}}}

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1004,3 +1004,28 @@ def test_create_table_rejects_reserved_bookkeeping_tables(reserved):
     db = Database.__new__(Database)
     with pytest.raises(ValueError, match="reserved"):
         db.create_table(reserved, {"feature_0": "FLOAT"})
+
+
+# ---------------------------------------------------------------------------
+# Run journal: enumeration for the metadata backfill sweep
+# ---------------------------------------------------------------------------
+
+
+def test_list_registered_runs_returns_registered_only(db, mock_engine_factory):
+    """The backfill sweep enumerates only REGISTERED runs, one row each, mapped
+    to {ingestor_id, table_name, task}. A NULL task (pre-task-column run) is
+    preserved as None."""
+    _, _, conn = mock_engine_factory
+    conn.execute.return_value.fetchall.return_value = [
+        ("run-a", "ta", "tabular_classification"),
+        ("run-b", "tb", None),
+    ]
+    result = db.list_registered_runs()
+    assert result == [
+        {"ingestor_id": "run-a", "table_name": "ta", "task": "tabular_classification"},
+        {"ingestor_id": "run-b", "table_name": "tb", "task": None},
+    ]
+    select = next(
+        s for s in _executed_sql(conn) if "SELECT ingestor_id, table_name, task" in s
+    )
+    assert "WHERE registered = 1" in select

--- a/tests/test_metadata_backfill_runner.py
+++ b/tests/test_metadata_backfill_runner.py
@@ -176,5 +176,6 @@ def test_backfill_datasets_continues_past_a_failing_dataset():
     with patch.object(runner, "build_dataset_metadata", return_value=_PAYLOAD):
         results = backfill_datasets(MagicMock(), api, ["a", "b"])
     assert results[0].status == STATUS_ERROR
-    assert results[0].error == "boom"
+    # Exception TYPE only — never the raw message (may embed customer cell values).
+    assert results[0].error == "RuntimeError"
     assert results[1].status == STATUS_OK  # sweep continued

--- a/tests/test_metadata_backfill_runner.py
+++ b/tests/test_metadata_backfill_runner.py
@@ -1,0 +1,180 @@
+"""Tests for the metadata backfill runner — the GET → recompute → POST sweep
+that wires build_dataset_metadata to the backend metadata-backfill endpoint.
+
+build_dataset_metadata and the APIClient are the units-under-test's collaborators
+and are exercised elsewhere; here they are mocked so the runner's own
+orchestration/skip/guard logic is what's covered.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from tracebloc_ingestor import metadata_backfill_runner as runner
+from tracebloc_ingestor.metadata_backfill_runner import (
+    STATUS_ERROR,
+    STATUS_NOT_FOUND,
+    STATUS_OK,
+    STATUS_SKIPPED_COMPETITION,
+    STATUS_SKIPPED_CURRENT,
+    backfill_dataset,
+    backfill_datasets,
+)
+
+# A pre-cutover plain dataset record as the GET returns it — no new-shape
+# attributes yet, not a competition.
+_PLAIN_RECORD = {
+    "id": 1,
+    "table_name": "tb",
+    "category": "tabular_classification",
+    "data_format": "tabular",
+    "intent": "train",
+    "ingestor_id": "ing-1",
+    "is_competition": False,
+    "source_dataset_ids": [],
+    "schema": {"x": "INT"},
+    "meta_data": {},
+}
+
+_PAYLOAD = {
+    "schema": {"x": {"dtype": "int"}},
+    "meta_data": {"attributes": {"feature_stats": {"x": {"count": 5}}}},
+}
+
+
+def _api(record=None, send_result=None):
+    api = MagicMock()
+    api.get_dataset_metadata.return_value = record
+    api.send_metadata_backfill.return_value = send_result or {
+        "table_name": "tb",
+        "created": True,
+        "competitions_refolded": 2,
+    }
+    return api
+
+
+# ---------------------------------------------------------------------------
+# backfill_dataset — single dataset
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_dataset_happy_path_gets_builds_and_posts():
+    api = _api(record=dict(_PLAIN_RECORD))
+    db = MagicMock()
+    with patch.object(runner, "build_dataset_metadata", return_value=_PAYLOAD) as build:
+        result = backfill_dataset(db, api, "ing-1")
+
+    # GET by ingestor_id, build keyed on the backend's category/data_format,
+    # then POST the recomputed payload back.
+    api.get_dataset_metadata.assert_called_once_with("ing-1")
+    build.assert_called_once()
+    assert build.call_args.kwargs["category"] == "tabular_classification"
+    assert build.call_args.kwargs["data_format"] == "tabular"
+    api.send_metadata_backfill.assert_called_once_with(
+        "tb", _PAYLOAD["schema"], _PAYLOAD["meta_data"]
+    )
+    assert result.status == STATUS_OK
+    assert result.created is True
+    assert result.competitions_refolded == 2
+
+
+def test_backfill_dataset_not_found_returns_status_and_skips_build():
+    api = _api(record=None)  # GET 404 → None
+    db = MagicMock()
+    with patch.object(runner, "build_dataset_metadata") as build:
+        result = backfill_dataset(db, api, "missing")
+    assert result.status == STATUS_NOT_FOUND
+    build.assert_not_called()
+    api.send_metadata_backfill.assert_not_called()
+
+
+def test_backfill_dataset_skips_competition():
+    record = dict(_PLAIN_RECORD, is_competition=True)
+    api = _api(record=record)
+    db = MagicMock()
+    with patch.object(runner, "build_dataset_metadata") as build:
+        result = backfill_dataset(db, api, "ing-1")
+    assert result.status == STATUS_SKIPPED_COMPETITION
+    build.assert_not_called()
+    api.send_metadata_backfill.assert_not_called()
+
+
+def test_backfill_dataset_skips_merged_with_source_ids():
+    record = dict(_PLAIN_RECORD, source_dataset_ids=[7, 8])
+    api = _api(record=record)
+    with patch.object(runner, "build_dataset_metadata") as build:
+        result = backfill_dataset(MagicMock(), api, "ing-1")
+    assert result.status == STATUS_SKIPPED_COMPETITION
+    build.assert_not_called()
+
+
+def test_backfill_dataset_skips_when_already_new_shape():
+    record = dict(
+        _PLAIN_RECORD,
+        meta_data={"attributes": {"feature_stats": {"x": {"count": 1}}}},
+    )
+    api = _api(record=record)
+    with patch.object(runner, "build_dataset_metadata") as build:
+        result = backfill_dataset(MagicMock(), api, "ing-1")
+    assert result.status == STATUS_SKIPPED_CURRENT
+    build.assert_not_called()
+    api.send_metadata_backfill.assert_not_called()
+
+
+def test_backfill_dataset_reprocesses_current_when_skip_disabled():
+    record = dict(
+        _PLAIN_RECORD,
+        meta_data={"attributes": {"feature_stats": {"x": {"count": 1}}}},
+    )
+    api = _api(record=record)
+    with patch.object(runner, "build_dataset_metadata", return_value=_PAYLOAD):
+        result = backfill_dataset(MagicMock(), api, "ing-1", skip_if_current=False)
+    assert result.status == STATUS_OK
+    api.send_metadata_backfill.assert_called_once()
+
+
+def test_backfill_dataset_error_when_record_missing_category():
+    record = dict(_PLAIN_RECORD, category=None)
+    api = _api(record=record)
+    with patch.object(runner, "build_dataset_metadata") as build:
+        result = backfill_dataset(MagicMock(), api, "ing-1")
+    assert result.status == STATUS_ERROR
+    build.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# backfill_datasets — the sweep
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_datasets_enumerates_registered_runs_when_ids_omitted():
+    db = MagicMock()
+    db.list_registered_runs.return_value = [
+        {"ingestor_id": "a", "table_name": "ta", "task": "tabular_classification"},
+        {"ingestor_id": "b", "table_name": "tb", "task": "tabular_classification"},
+    ]
+    api = _api(record=dict(_PLAIN_RECORD))
+    with patch.object(runner, "build_dataset_metadata", return_value=_PAYLOAD):
+        results = backfill_datasets(db, api)
+    db.list_registered_runs.assert_called_once()
+    assert [r.ingestor_id for r in results] == ["a", "b"]
+    assert all(r.status == STATUS_OK for r in results)
+
+
+def test_backfill_datasets_continues_past_a_failing_dataset():
+    api = MagicMock()
+    # First GET raises (e.g. transient), second succeeds.
+    api.get_dataset_metadata.side_effect = [
+        RuntimeError("boom"),
+        dict(_PLAIN_RECORD, ingestor_id="b"),
+    ]
+    api.send_metadata_backfill.return_value = {
+        "table_name": "tb",
+        "created": False,
+        "competitions_refolded": 0,
+    }
+    with patch.object(runner, "build_dataset_metadata", return_value=_PAYLOAD):
+        results = backfill_datasets(MagicMock(), api, ["a", "b"])
+    assert results[0].status == STATUS_ERROR
+    assert results[0].error == "boom"
+    assert results[1].status == STATUS_OK  # sweep continued

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -356,8 +356,13 @@ class APIClient:
             )
             return None
         if response.status_code >= 400:
+            # Status only in the message — NOT response.text. A backend error
+            # body can echo the dataset's metadata (categorical vocab = customer
+            # cell values), and this exception surfaces in the backfill runner's
+            # install-log output. The response object is attached for a caller
+            # that needs to inspect it deliberately. (bugbot)
             raise requests.exceptions.HTTPError(
-                f"HTTP {response.status_code}: {response.text}", response=response
+                f"HTTP {response.status_code}", response=response
             )
         return self._parse_json(response, required=True)
 
@@ -401,8 +406,12 @@ class APIClient:
             timeout=API_TIMEOUT,
         )
         if response.status_code >= 400:
+            # Status only — NOT response.text (see get_dataset_metadata): the
+            # POST body carries this table's categorical vocab, so a backend
+            # error echoing it back would embed customer cell values in the
+            # runner's install-log output. (bugbot)
             raise requests.exceptions.HTTPError(
-                f"HTTP {response.status_code}: {response.text}", response=response
+                f"HTTP {response.status_code}", response=response
             )
         result = self._parse_json(response, required=True)
         logger.info(

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -322,6 +322,96 @@ class APIClient:
                 logger.error(f"{RED}Error sending ingest summary: {str(e)[:500]}{RESET}")
             raise
 
+    def get_dataset_metadata(self, ingestor_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch a dataset's backend record by ``ingestor_id`` (backend#1198).
+
+        Returns the core fields — ``table_name`` / ``category`` / ``data_format``
+        / ``intent`` / ``is_competition`` / ``source_dataset_ids`` — plus the
+        currently-stored ``schema`` / ``meta_data``. Backs the pre-cutover
+        backfill runner: ``category`` and ``data_format`` drive the recompute and
+        are not recoverable from the table alone, so the runner reads them here
+        first.
+
+        Returns ``None`` when the backend has no dataset for this ``ingestor_id``
+        owned by this edge (404) so a sweep can skip it rather than crash.
+
+        Raises:
+            requests.exceptions.HTTPError: on any non-404 error status.
+        """
+        if self.config.EDGE_ENV == "local":
+            logger.info(
+                f"Mock: would fetch dataset metadata for ingestor_id={ingestor_id}"
+            )
+            return None
+
+        url = (
+            f"{self.config.API_ENDPOINT}"
+            f"/global_meta/metadata_backfill/by-ingestor/{ingestor_id}/"
+        )
+        response = self._authed_request("GET", url, timeout=API_TIMEOUT)
+        if response.status_code == 404:
+            logger.warning(
+                f"{YELLOW}No backend dataset for ingestor_id={ingestor_id} "
+                f"owned by this edge (404); skipping.{RESET}"
+            )
+            return None
+        if response.status_code >= 400:
+            raise requests.exceptions.HTTPError(
+                f"HTTP {response.status_code}: {response.text}", response=response
+            )
+        return self._parse_json(response, required=True)
+
+    def send_metadata_backfill(
+        self,
+        table_name: str,
+        schema: Dict[str, Any],
+        meta_data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Upsert recomputed ``{schema, meta_data}`` for a PRE-EXISTING table via
+        the metadata-backfill endpoint (backend#1166/#1198).
+
+        Metadata-only: never creates a dataset (the table must already exist
+        backend-side — 404 otherwise). The POST also propagates the refresh into
+        any competition built from the table (re-fold). Idempotent, so a re-run
+        is a safe overwrite.
+
+        Returns:
+            The backend body — ``{"table_name", "created", "competitions_refolded"}``.
+
+        Raises:
+            requests.exceptions.HTTPError: If the API call fails after retries.
+        """
+        if self.config.EDGE_ENV == "local":
+            logger.info(
+                f"Mock: would backfill metadata for {table_name} "
+                f"({len(schema)} schema column(s))"
+            )
+            return {
+                "table_name": table_name,
+                "created": False,
+                "competitions_refolded": 0,
+            }
+
+        payload = json.dumps({"schema": schema, "meta_data": meta_data or {}})
+        response = self._authed_request(
+            "POST",
+            f"{self.config.API_ENDPOINT}/global_meta/metadata_backfill/{table_name}/",
+            extra_headers={"Content-Type": "application/json"},
+            data=payload,
+            timeout=API_TIMEOUT,
+        )
+        if response.status_code >= 400:
+            raise requests.exceptions.HTTPError(
+                f"HTTP {response.status_code}: {response.text}", response=response
+            )
+        result = self._parse_json(response, required=True)
+        logger.info(
+            f"{GREEN}Backfilled metadata for {table_name}: "
+            f"created={result.get('created')}, "
+            f"competitions_refolded={result.get('competitions_refolded')}{RESET}"
+        )
+        return result
+
     def __del__(self):
         """Cleanup when the client is destroyed"""
         if hasattr(self, "session"):

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -862,6 +862,34 @@ class Database:
             )
         return reclaimed
 
+    def list_registered_runs(self) -> List[Dict[str, str]]:
+        """Return the REGISTERED ingest runs journalled on this client, one per
+        dataset: ``[{"ingestor_id", "table_name", "task"}, ...]``.
+
+        The run journal (``record_ingest_started`` / ``mark_ingest_registered``)
+        is the authoritative local list of datasets this edge has ingested and
+        successfully registered with the backend — exactly the set the
+        pre-cutover metadata backfill sweeps. Only ``registered = 1`` rows are
+        returned, so a started-but-never-registered (dead) run is never
+        backfilled. ``task`` is the recorded category (may be NULL on runs
+        journalled before the column existed); the backfill runner re-reads the
+        authoritative category from the backend anyway.
+        """
+        with self.engine.connect() as connection:
+            self._ensure_runs_table(connection)
+            rows = _execute_with_retry(
+                connection,
+                text(
+                    f"SELECT ingestor_id, table_name, task "
+                    f"FROM `{self.RUNS_TABLE}` WHERE registered = 1 "
+                    f"ORDER BY started_at"
+                ),
+            ).fetchall()
+        return [
+            {"ingestor_id": iid, "table_name": tname, "task": task}
+            for (iid, tname, task) in rows
+        ]
+
     def get_label_counts(self, table_name: str, ingestor_id: str) -> Dict[str, int]:
         """
         Return ``{label: row_count}`` for every label inserted by *ingestor_id*.

--- a/tracebloc_ingestor/metadata_backfill_runner.py
+++ b/tracebloc_ingestor/metadata_backfill_runner.py
@@ -1,0 +1,225 @@
+"""Pre-cutover metadata backfill runner (backend#1166 / #1198 — the send side
+of #378).
+
+Ties the backfill pieces together into a one-time, per-client sweep of datasets
+ingested BEFORE the federated-alignment cutover. For each dataset it:
+
+  1. **GETs the backend record** by ``ingestor_id``
+     (:meth:`APIClient.get_dataset_metadata`). The authoritative ``category`` and
+     ``data_format`` drive the recompute and are not recoverable from the table
+     alone, so they are read from the backend first.
+  2. **Recomputes** the enriched ``{schema, meta_data}`` from the persisted rows
+     via :func:`build_dataset_metadata` — SQL aggregates, no row re-ingest —
+     keyed on that category.
+  3. **POSTs** it back (:meth:`APIClient.send_metadata_backfill`), which upserts
+     ``GlobalMetaData`` and re-folds any competition built from the table.
+
+The set of datasets to sweep is the client's REGISTERED ingest journal
+(:meth:`Database.list_registered_runs`); explicit ``ingestor_id``\\ s can be
+passed instead.
+
+**Rollout, not always-on.** New ingests already emit the new-shape metadata
+(#361), so this runs once per client during rollout. It is idempotent: a dataset
+already carrying new-shape metadata is skipped, and the backend upsert is itself
+a safe overwrite, so a re-run converges.
+
+**Scope.** Only plain/source datasets are recomputed. Competition/merged
+datasets have no client-side raw table to read — their fold is rebuilt
+backend-side by the re-fold this POST triggers — so they are skipped here
+(detected via the backend record's ``is_competition`` / ``source_dataset_ids``).
+``label_column`` and the uploader-declared scalar attributes are not persisted
+backend-side, so they are not passed; the SQL-derivable enriched schema +
+``feature_stats`` (the backfill's primary value) are recomputed regardless. See
+:func:`build_dataset_metadata` for the per-fact limitations.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from .api.client import APIClient
+from .config import Config
+from .database import Database
+from .metadata_backfill import build_dataset_metadata
+from .utils.logging import setup_logging
+
+logger = logging.getLogger(__name__)
+
+
+# Outcome statuses for a single dataset's backfill attempt.
+STATUS_OK = "ok"
+STATUS_NOT_FOUND = "not_found"
+STATUS_SKIPPED_COMPETITION = "skipped_competition"
+STATUS_SKIPPED_CURRENT = "skipped_current"
+STATUS_ERROR = "error"
+
+
+@dataclass
+class BackfillResult:
+    """The outcome of backfilling one dataset (see the ``STATUS_*`` constants)."""
+
+    ingestor_id: str
+    table_name: Optional[str] = None
+    status: str = STATUS_OK
+    created: Optional[bool] = None
+    competitions_refolded: Optional[int] = None
+    error: Optional[str] = None
+
+
+def _already_new_shape(record: Dict[str, Any]) -> bool:
+    """Whether the backend record already carries new-shape metadata, so the
+    recompute + POST can be skipped.
+
+    Marker: a non-empty ``meta_data.attributes`` — the typed alignment contract
+    that only the post-cutover ingest (#361) / a prior backfill writes. A
+    pre-cutover row has no ``attributes``, so it is not skipped. Conservative: if
+    a category legitimately has empty attributes we simply re-POST (idempotent).
+    """
+    meta_data = record.get("meta_data") or {}
+    return bool(meta_data.get("attributes"))
+
+
+def backfill_dataset(
+    database: Database,
+    api_client: APIClient,
+    ingestor_id: str,
+    *,
+    skip_if_current: bool = True,
+) -> BackfillResult:
+    """GET → recompute → POST for a single dataset. Never raises for an expected
+    skip/not-found; those are returned as a :class:`BackfillResult` status.
+    Unexpected failures (SQL / network) propagate to the caller.
+    """
+    record = api_client.get_dataset_metadata(ingestor_id)
+    if record is None:
+        return BackfillResult(ingestor_id, status=STATUS_NOT_FOUND)
+
+    table_name = record.get("table_name")
+
+    # Competition/merged datasets have no client-side raw table for the SQL
+    # recompute; their reconciled fold is rebuilt backend-side (the re-fold this
+    # backfill triggers on source POSTs), so never recompute them here.
+    if record.get("is_competition") or record.get("source_dataset_ids"):
+        return BackfillResult(
+            ingestor_id, table_name, status=STATUS_SKIPPED_COMPETITION
+        )
+
+    if skip_if_current and _already_new_shape(record):
+        return BackfillResult(ingestor_id, table_name, status=STATUS_SKIPPED_CURRENT)
+
+    category = record.get("category")
+    if not category or not table_name:
+        return BackfillResult(
+            ingestor_id,
+            table_name,
+            status=STATUS_ERROR,
+            error="backend record missing category/table_name",
+        )
+
+    payload = build_dataset_metadata(
+        database,
+        table_name,
+        category=category,
+        data_format=record.get("data_format"),
+    )
+    result = api_client.send_metadata_backfill(
+        table_name, payload["schema"], payload.get("meta_data")
+    )
+    return BackfillResult(
+        ingestor_id,
+        table_name,
+        status=STATUS_OK,
+        created=result.get("created"),
+        competitions_refolded=result.get("competitions_refolded"),
+    )
+
+
+def backfill_datasets(
+    database: Database,
+    api_client: APIClient,
+    ingestor_ids: Optional[List[str]] = None,
+    *,
+    skip_if_current: bool = True,
+) -> List[BackfillResult]:
+    """Backfill every dataset in ``ingestor_ids``, or — when ``None`` — every
+    REGISTERED run in this client's ingest journal.
+
+    Per-dataset guarded: an unexpected failure on one dataset is logged and
+    recorded as an ``error`` result, and the sweep continues to the next (a
+    single bad table can't abort the rollout). Returns one
+    :class:`BackfillResult` per dataset.
+    """
+    if ingestor_ids is None:
+        ingestor_ids = [run["ingestor_id"] for run in database.list_registered_runs()]
+
+    logger.info("Metadata backfill: %d dataset(s) to process.", len(ingestor_ids))
+
+    results: List[BackfillResult] = []
+    for ingestor_id in ingestor_ids:
+        try:
+            result = backfill_dataset(
+                database, api_client, ingestor_id, skip_if_current=skip_if_current
+            )
+        except Exception as exc:  # noqa: BLE001 — one bad table must not abort the sweep
+            logger.exception(
+                "Metadata backfill failed for ingestor_id=%s", ingestor_id
+            )
+            result = BackfillResult(
+                ingestor_id, status=STATUS_ERROR, error=str(exc)[:500]
+            )
+        results.append(result)
+        _log_result(result)
+
+    _log_summary(results)
+    return results
+
+
+def _log_result(result: BackfillResult) -> None:
+    if result.status == STATUS_OK:
+        logger.info(
+            "  ✓ %s (%s): created=%s, competitions_refolded=%s",
+            result.table_name,
+            result.ingestor_id,
+            result.created,
+            result.competitions_refolded,
+        )
+    elif result.status == STATUS_ERROR:
+        logger.error(
+            "  ✗ %s (%s): %s", result.table_name, result.ingestor_id, result.error
+        )
+    else:
+        logger.info(
+            "  – %s (%s): %s", result.table_name, result.ingestor_id, result.status
+        )
+
+
+def _log_summary(results: List[BackfillResult]) -> None:
+    counts: Dict[str, int] = {}
+    for result in results:
+        counts[result.status] = counts.get(result.status, 0) + 1
+    logger.info(
+        "Metadata backfill complete: %s",
+        ", ".join(f"{status}={count}" for status, count in sorted(counts.items()))
+        or "nothing to do",
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:  # pragma: no cover - thin shell
+    """Console-script entrypoint (``tracebloc-backfill``).
+
+    Reads DB + backend credentials from the environment via :class:`Config` (the
+    same env the ingestor uses — ``MYSQL_HOST``, ``BACKEND_TOKEN``, ``EDGE_ENV``,
+    …); no ``ingest.yaml`` is needed. Returns a non-zero exit code iff any
+    dataset errored, so a rollout job surfaces failures.
+    """
+    config = Config()
+    setup_logging(config)
+
+    database = Database(config)
+    api_client = APIClient(config)  # triggers config.validate()
+
+    results = backfill_datasets(database, api_client)
+    errored = sum(1 for result in results if result.status == STATUS_ERROR)
+    return 1 if errored else 0

--- a/tracebloc_ingestor/metadata_backfill_runner.py
+++ b/tracebloc_ingestor/metadata_backfill_runner.py
@@ -163,11 +163,18 @@ def backfill_datasets(
                 database, api_client, ingestor_id, skip_if_current=skip_if_current
             )
         except Exception as exc:  # noqa: BLE001 — one bad table must not abort the sweep
-            logger.exception(
-                "Metadata backfill failed for ingestor_id=%s", ingestor_id
+            # Record/log the exception TYPE only — never str(exc) or a traceback.
+            # A SQL driver error or backend response body can embed customer cell
+            # values (e.g. categorical vocab), and this runs in a Helm-hook Job
+            # whose output lands in install logs. (bugbot)
+            error_type = type(exc).__name__
+            logger.error(
+                "Metadata backfill failed for ingestor_id=%s (%s)",
+                ingestor_id,
+                error_type,
             )
             result = BackfillResult(
-                ingestor_id, status=STATUS_ERROR, error=str(exc)[:500]
+                ingestor_id, status=STATUS_ERROR, error=error_type
             )
         results.append(result)
         _log_result(result)


### PR DESCRIPTION
> **Draft** — the send side of the pre-cutover metadata backfill (piece #2 of the #378 plan). Opening for review of the orchestration + entrypoint; the backend endpoints it calls (#1166 POST, #1198 GET) are already merged to `develop`.

## What & why

Datasets ingested **before** the federated-alignment cutover carry no enriched schema and no per-column `feature_stats` on the global-metadata channel, so the backend combine-time alignment checks and the edge metadata API can't reconcile them. #378 (`build_dataset_metadata`) recomputes that `{schema, meta_data}` for a table from its persisted rows — but deliberately stopped before sending. **This PR is the runner that ties it to the backend.**

For each dataset it does exactly what was asked — *get data from backend → based on category compute all attributes → send updated attributes back*:

1. **GET** the backend record by `ingestor_id` (`GET global_meta/metadata_backfill/by-ingestor/<id>/`, #1198). The authoritative `category` + `data_format` drive the recompute and aren't recoverable from the table alone.
2. **Recompute** the enriched `{schema, meta_data}` from persisted rows via `build_dataset_metadata` (SQL aggregates, no row re-ingest), keyed on that category.
3. **POST** it back (`POST global_meta/metadata_backfill/<table>/`, #1166) — the endpoint upserts `GlobalMetaData` and re-folds any competition built from the table (#1198).

## What this PR adds

| Piece | What |
|---|---|
| `APIClient.get_dataset_metadata(ingestor_id)` | GET the dataset record; `None` on 404 (skip, not error); local-mode mock |
| `APIClient.send_metadata_backfill(table, schema, meta_data)` | POST the recomputed payload; returns `{table_name, created, competitions_refolded}` |
| `Database.list_registered_runs()` | Enumerate the client's **registered** ingest journal — the datasets to sweep |
| `metadata_backfill_runner.backfill_dataset` | GET → build → POST for one dataset |
| `metadata_backfill_runner.backfill_datasets` | The per-dataset-guarded sweep (one bad table can't abort the rollout) |
| `tracebloc-backfill` console script | Entrypoint reading DB/backend creds from the **same env** as the ingestor — no `ingest.yaml` |

## Skips & guards

- **Competitions / merged datasets are skipped** (detected via the backend record's `is_competition` / `source_dataset_ids`): they have no client-side raw table to read, and their reconciled fold is rebuilt backend-side by the re-fold the source POSTs trigger.
- **Already-new-shape datasets are skipped** (`meta_data.attributes` present) so a re-run is cheap; disable with `skip_if_current=False`.
- **Idempotent / re-runnable** — the backend upsert is a safe overwrite; new ingests already emit the new shape, so this is a **one-time rollout step, not always-on**.

## Scope / non-goals

- Covers **plain / source** datasets — the per-table metadata #378 computes.
- `label_column` and the uploader-declared scalar attributes (`color_mode`, `language`, …) aren't persisted backend-side, so they aren't passed; the **SQL-derivable enriched schema + `feature_stats`** (the backfill's primary value) are recomputed regardless. Same per-fact limitations as `build_dataset_metadata`'s docstring.

## What reviewers should focus on

1. **Enumeration source** — `list_registered_runs()` (registered ingest journal) as the set to sweep. Right boundary, or should the operator pass an explicit `ingestor_id` list?
2. **Competition/merged skip** — is `is_competition or source_dataset_ids` the right detector for "no local table to recompute"?
3. **`skip_if_current` marker** — using non-empty `meta_data.attributes` as "already new-shape." Conservative (a category with legitimately-empty attributes re-POSTs, idempotently). Acceptable?
4. **Entrypoint** — separate `tracebloc-backfill` console script (vs. a subcommand on `tracebloc-ingest`), reading creds from env.

## Tests

- `test_metadata_backfill_runner.py` — happy path (GET→build→POST with category/data_format threaded), not-found, competition/merged skip, already-current skip (+ `skip_if_current=False` reprocess), missing-category error, journal enumeration, and per-dataset guard (a failing dataset doesn't abort the sweep).
- `test_api_client_methods.py` — the two new methods: success / 404→None / HTTP-error / local-mode / payload shape.
- `test_database.py` — `list_registered_runs` returns registered-only, mapped, NULL task preserved.

Full suite green (1866 passed).

## Rollout / pairing

- Independently deployable; dead until run. Pairs with backend #1166/#1198 (already on `develop`).
- Run once per client during rollout: `tracebloc-backfill` in the ingestor image's env. Non-zero exit iff any dataset errored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rollout job mutates global metadata on the backend for every registered dataset; failures are isolated but a bad recompute or POST could affect alignment/competition folds until re-run (idempotent).
> 
> **Overview**
> Adds a **one-time rollout sweep** for pre-cutover datasets: for each registered ingest, **GET** backend metadata by `ingestor_id`, **recompute** `{schema, meta_data}` via `build_dataset_metadata` from local MySQL, then **POST** to the metadata-backfill API (upsert + competition re-fold).
> 
> New pieces: `APIClient.get_dataset_metadata` / `send_metadata_backfill` (404 → skip; HTTP errors omit response bodies in messages for log safety), `Database.list_registered_runs` (`registered = 1` journal rows), `metadata_backfill_runner` with skip rules (competition/merged, already has `meta_data.attributes`), per-dataset error isolation, and **`tracebloc-backfill`** entrypoint using the same env as the ingestor (no `ingest.yaml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1aa20ecc9967b38b2c75613c71e17484ca556a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->