### PR TITLE
chore(release): bump version to 0.7.8

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.7.7"
+__version__ = "0.7.8"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
Release bump so a `v0.7.8` tag can be cut to build the next ingestor image.

## Why
`develop`/`master` are one commit ahead of the v0.7.7 release image: the validator log-label normalization fix (#397). No image contains it yet because the image is built only by `release-image.yml` on a `v*.*.*` tag push.

## What
- `tracebloc_ingestor/__init__.py`: `0.7.7` → `0.7.8`

## After merge
Tag `v0.7.8` on `develop` → `release-image.yml` builds & pushes `ghcr.io/tracebloc/ingestor:0.7.8` (+ `:0.7`, `:0`), signs it, and writes the digest to the GitHub release. Prod stays on 0.7.7 until `images.ingestor.prodDigest` in the client chart is updated to the new digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version string change with no behavioral impact; production stays on 0.7.7 until the chart digest is updated.
> 
> **Overview**
> **Release version bump** from `0.7.7` to `0.7.8` in `tracebloc_ingestor/__init__.py` (`__version__`), the package’s single source of truth that `setup.py` reads at build time.
> 
> No runtime or ingestor logic changes in this PR—it only prepares cutting a `v0.7.8` tag so `release-image.yml` can build and publish the next ingestor image (including the validator log-label fix from #397 that isn’t in the `0.7.7` image yet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd82a7b46dcd863895a75235ca56f9895af33bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->