### PR TITLE
ci(release): auto-tag + image release after master publish

### DIFF
--- a/.github/workflows/auto-release-on-master.yml
+++ b/.github/workflows/auto-release-on-master.yml
@@ -1,0 +1,116 @@
+# Close the release loop: tag + image release, automatically, after a
+# develop→master sync publishes the PyPI package.
+#
+# Flow:
+#   merge sync PR → master
+#     → publish-master.yml  (builds sdist/wheel, runs the schema smoke
+#       probe, uploads to PyPI)
+#         → THIS workflow    (only if that publish succeeded)
+#             → tag vX.Y.Z from the single-sourced __version__
+#             → dispatch release-image.yml → signed image + GitHub Release
+#
+# Design notes:
+#
+#   * Chained on `publish-master` via `workflow_run`, not on `push: master`,
+#     so the image release only cuts for a build that actually published
+#     cleanly. publish-master only succeeds if the sdist installs and
+#     schema/ingest.v1.json is present (the v0.3.0-rc1 regression class), so
+#     a packaging break never reaches the image/release step. The PR-level
+#     checks (fr-gate, pii, pytest, e2e) already had to pass for the sync PR
+#     to merge under branch protection — by the time code is on master, the
+#     checks have passed.
+#
+#   * Idempotent on the tag. If vX.Y.Z already exists (a re-run, or a
+#     version someone pre-tagged out of band), we log and exit 0 — we never
+#     move or re-cut an existing tag.
+#
+#   * We push the tag AND explicitly dispatch release-image.yml, rather than
+#     relying on the tag-push event to trigger it. A tag pushed with the
+#     default GITHUB_TOKEN does NOT trigger another workflow (GitHub's
+#     recursion guard). `workflow_dispatch` and `repository_dispatch` are the
+#     two documented exceptions, so dispatching works under GITHUB_TOKEN with
+#     no PAT. release-image.yml's workflow_dispatch reads `inputs.ref`, which
+#     must already exist on origin — hence tag first, then dispatch.
+#
+# Manual `git push` of a tag and a manual `workflow_dispatch` on
+# release-image.yml both still work as fallbacks; this only automates the
+# common path. Takes effect once it lives on the default branch (master) —
+# workflow_run workflows are read from the default branch.
+
+name: Auto-release on master
+
+on:
+  workflow_run:
+    workflows: ['Publish Master Package to GitHub Packages']
+    types: [completed]
+
+permissions:
+  contents: write # create + push the tag
+  actions: write # dispatch release-image.yml
+
+concurrency:
+  group: auto-release-on-master
+  cancel-in-progress: false
+
+jobs:
+  tag-and-release:
+    # Only after a *successful* master publish. head_branch guards against a
+    # publish run that somehow fired for a non-master ref.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout the published master commit
+        uses: actions/checkout@v4
+        with:
+          # Pin to the exact commit publish-master built from, not master's
+          # tip — so the tag lands on the released code even if master moved.
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Read single-sourced version
+        id: ver
+        run: |
+          set -euo pipefail
+          # Same literal setup.py parses (RELEASING.md: version is
+          # single-sourced in tracebloc_ingestor/__init__.py). Dependency-free
+          # so we don't need setup-python just to read a string.
+          version=$(python3 -c "import re,pathlib; \
+            print(re.search(r'^__version__\s*=\s*[\"\x27]([^\"\x27]+)[\"\x27]', \
+            pathlib.Path('tracebloc_ingestor/__init__.py').read_text(), re.M).group(1))")
+          if [ -z "${version}" ]; then
+            echo "::error::could not parse __version__ from tracebloc_ingestor/__init__.py" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version ${version} → tag v${version}"
+
+      - name: Tag and dispatch image release (idempotent)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          # Never re-cut an existing tag. Check the remote (authoritative),
+          # not just the local fetch.
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin — version unchanged or pre-tagged. Nothing to release."
+            exit 0
+          fi
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" "${SHA}" -m "${TAG}"
+          git push origin "${TAG}"
+          echo "Pushed ${TAG} at ${SHA}."
+
+          # workflow_dispatch runs under GITHUB_TOKEN (recursion-guard
+          # exception), so this actually triggers the image build.
+          gh workflow run release-image.yml -f ref="${TAG}"
+          echo "Dispatched release-image.yml for ${TAG}."

--- a/.github/workflows/auto-release-on-master.yml
+++ b/.github/workflows/auto-release-on-master.yml
@@ -20,9 +20,17 @@
 #     to merge under branch protection — by the time code is on master, the
 #     checks have passed.
 #
-#   * Idempotent on the tag. If vX.Y.Z already exists (a re-run, or a
-#     version someone pre-tagged out of band), we log and exit 0 — we never
-#     move or re-cut an existing tag.
+#   * Idempotent on the *artifact*, not just the tag. The tag is pushed
+#     before release-image.yml is dispatched, so "tag exists" alone is not
+#     "release done": a run that pushed the tag but died before/at the
+#     dispatch would leave the tag with no signed image or GitHub Release,
+#     and a naive tag-only skip would exit 0 on re-run and never build it.
+#     So we exit 0 early only when the tag exists AND its GitHub Release
+#     resolves; if the tag exists but the Release is missing, we re-dispatch
+#     release-image.yml against the existing tag (release-image is itself
+#     tag-idempotent — it edits or creates the Release and re-signs the same
+#     digest). We never move or re-cut an existing tag, only create a
+#     missing one.
 #
 #   * We push the tag AND explicitly dispatch release-image.yml, rather than
 #     relying on the tag-push event to trigger it. A tag pushed with the
@@ -97,20 +105,39 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Never re-cut an existing tag. Check the remote (authoritative),
-          # not just the local fetch.
+          # Does the tag already exist on origin? (Authoritative check — the
+          # remote, not just the local fetch.)
+          tag_exists=false
           if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "Tag ${TAG} already exists on origin — version unchanged or pre-tagged. Nothing to release."
+            tag_exists=true
+          fi
+
+          # "Done" = the GitHub Release exists, not merely the tag. The tag is
+          # pushed before release-image.yml is dispatched, so a tag with no
+          # Release means an earlier run pushed the tag but never completed the
+          # image/release step. Only skip when BOTH the tag and its Release are
+          # present; otherwise fall through and (re-)dispatch.
+          if [ "${tag_exists}" = true ] && gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} and its GitHub Release already exist — nothing to release."
             exit 0
           fi
 
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${TAG}" "${SHA}" -m "${TAG}"
-          git push origin "${TAG}"
-          echo "Pushed ${TAG} at ${SHA}."
+          if [ "${tag_exists}" = true ]; then
+            # Never move or re-cut an existing tag (it may point at a commit a
+            # human tagged out of band); just re-drive the image release for it.
+            echo "Tag ${TAG} exists but its GitHub Release is missing — re-dispatching release-image.yml for the existing tag."
+          else
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "${TAG}" "${SHA}" -m "${TAG}"
+            git push origin "${TAG}"
+            echo "Pushed ${TAG} at ${SHA}."
+          fi
 
           # workflow_dispatch runs under GITHUB_TOKEN (recursion-guard
-          # exception), so this actually triggers the image build.
+          # exception), so this actually triggers the image build. Dispatching
+          # against an already-released tag is safe: release-image.yml is
+          # tag-idempotent (edits or creates the Release, re-signs the same
+          # digest).
           gh workflow run release-image.yml -f ref="${TAG}"
           echo "Dispatched release-image.yml for ${TAG}."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -97,9 +97,13 @@ gh run watch --repo tracebloc/data-ingestors \
 
 If the smoke probe inside that workflow fails, the package will not be uploaded. Fix the regression and reopen a new sync PR — do **not** force the upload.
 
-## 5. Tag the release
+## 5. Tag the release (automatic)
 
-After the master publish is green:
+**This step now happens on its own.** Once the step-4 master publish is green, `auto-release-on-master.yml` (chained on `publish-master.yml` via `workflow_run`) reads the single-sourced `__version__`, and — if the `vX.Y.Z` tag doesn't already exist — creates and pushes it on the published master commit, then dispatches `release-image.yml`. So a normal release needs no manual tag: merge the sync PR, watch the master publish go green, and the image + GitHub Release follow automatically.
+
+It's idempotent — if `vX.Y.Z` already exists (a re-run, or a version someone pre-tagged out of band) it's a no-op; the workflow never moves or re-cuts an existing tag.
+
+**Manual fallback.** If the automation is disabled, or you're re-cutting an image for an existing tag, tag by hand after the master publish is green:
 
 ```bash
 git checkout master && git pull --ff-only
@@ -107,7 +111,9 @@ git tag -a v${VERSION} -m "v${VERSION}"
 git push origin v${VERSION}
 ```
 
-That tag push triggers `release-image.yml`, which:
+> **Don't tag from `develop`.** The tag must sit on the master commit that PyPI published, or the signed image's pip-reported version leads the PyPI package until the sync lands (v0.7.6–v0.7.8 were tagged off develop this way). The automation always tags the published master commit; hand-tagging should too.
+
+Either path triggers `release-image.yml`, which:
 
 1. builds the image,
 2. runs the digest-level smoke probes (`_load_schema()` and a bare `tracebloc-ingest` invocation via `--entrypoint`),


### PR DESCRIPTION
Closes #401.

Closes the release loop so a normal release needs no manual tag. New `auto-release-on-master.yml` chains on **Publish Master Package** via `workflow_run`:

```
merge sync PR → master → publish-master.yml (PyPI + schema smoke probe) ──success──▶
   auto-release-on-master: read __version__ → if vX.Y.Z tag absent,
   create+push it on the published commit → dispatch release-image.yml
```

### Why these choices
- **Chained on the master publish, not `push: master`** — the image only cuts for a build that published cleanly (sdist install + `schema/ingest.v1.json` probe). PR-level checks (fr-gate/pii/pytest/e2e) already had to pass for the sync PR to merge.
- **Dispatches `release-image.yml` explicitly** — a tag pushed by the default `GITHUB_TOKEN` won't trigger another workflow (recursion guard); `workflow_dispatch` is the documented exception, so **no PAT needed** (`contents: write` + `actions: write`).
- **Idempotent** — if `vX.Y.Z` already exists (re-run, or a pre-tagged version like today's v0.7.8) it's a no-op; never moves or re-cuts a tag.

### Fixes
The out-of-order pattern where v0.7.6–v0.7.8 were tagged **off develop** before the master sync, leaving the signed image's pip-reported version ahead of PyPI. RELEASING.md step 5 rewritten: automatic path is the norm; hand-tagging is the fallback and must tag the master commit, never develop.

### Notes
- **Non-breaking**: tag-push and `workflow_dispatch` on `release-image.yml` still work.
- **Takes effect once merged to master** — `workflow_run` workflows are read from the default branch, so it governs 0.7.9+ (0.7.8 is already tagged/released).
- YAML validated; the `__version__` parse verified against the current file (→ `0.7.8`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation (tag creation and image dispatch) on the critical master publish path; mistakes could cut releases or skip image builds, though idempotency and publish gating limit blast radius.
> 
> **Overview**
> Adds **`auto-release-on-master.yml`**, which runs after a successful **Publish Master Package** run and closes the release loop without a manual tag step.
> 
> On success it checks out the **published commit** (not moving `master` tip), parses **`__version__`** from `tracebloc_ingestor/__init__.py`, and creates/pushes **`vX.Y.Z`** only when missing. It then **`workflow_dispatch`**es `release-image.yml` (because `GITHUB_TOKEN` tag pushes do not trigger other workflows). **Idempotency** skips only when both the remote tag and its GitHub Release exist; if the tag exists without a Release, it re-dispatches the image workflow without moving the tag.
> 
> **`RELEASING.md`** step 5 is updated: automatic tagging is the default path, manual tagging is documented as fallback, with a warning not to tag from **`develop`** (PyPI vs image version skew).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a9f5b319e898d5a95f810ff606c8ec453e70f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->