### PR TITLE
ci: add fr-pass-comment caller workflow (#963)

### DIFF
--- a/.github/workflows/fr-pass-comment-caller.yml
+++ b/.github/workflows/fr-pass-comment-caller.yml
@@ -1,0 +1,14 @@
+name: FR pass comment
+
+# Per-repo caller. Listens for /fr-pass comments and advances kanban items
+# from "FR on dev" → "Ready for staging" or "FR on staging" → "Ready for prod".
+# All logic lives in tracebloc/.github/.github/workflows/fr-pass-comment.yml.
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  advance:
+    uses: tracebloc/.github/.github/workflows/fr-pass-comment.yml@main
+    secrets: inherit


### PR DESCRIPTION
Part of tracebloc/backend#963 (kanban caller rollout).

Adds the byte-identical `fr-pass-comment-caller.yml` so `/fr-pass` comments advance kanban items in this repo instead of silently no-opping. All logic lives in `tracebloc/.github`; this is the per-repo caller only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin CI wrapper only; behavior lives in the shared reusable workflow and follows established caller patterns in this repo.
> 
> **Overview**
> **Enables `/fr-pass` on issues/PR comments in this repository** as part of the kanban caller rollout, so comments no longer no-op here.
> 
> Adds `.github/workflows/fr-pass-comment-caller.yml`, matching the existing per-repo caller pattern (e.g. `fr-gate-caller.yml`). It runs on `issue_comment` `created` and delegates to `tracebloc/.github/.github/workflows/fr-pass-comment.yml@main` with `secrets: inherit`, advancing items from **FR on dev** → **Ready for staging** or **FR on staging** → **Ready for prod**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42854c47056396d34721cff61667681099039a90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->