### PR TITLE
feat(ingestor): per-ingestion immutable tables ds_<uuid4().hex> behind PER_INGESTION_TABLES (backend#1205)

### DIFF
--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -713,8 +713,10 @@ def test_ingest_creates_table_after_validation_passes():
         ing.ingest("src", batch_size=10)
     # index_columns=None: only grouped categories (ModalitySpec.grouping)
     # request the composite secondary index (backend#1054 WS1).
+    # must_not_exist=False: legacy shared-table ingests keep the
+    # reflect/append behavior (RFC-0003 D16 flag off — backend#1205).
     ing.database.create_table.assert_called_once_with(
-        "tbl", {"a": "INT"}, index_columns=None
+        "tbl", {"a": "INT"}, index_columns=None, must_not_exist=False
     )
     assert ing.table is not None
 

--- a/tests/test_per_ingestion_tables.py
+++ b/tests/test_per_ingestion_tables.py
@@ -85,6 +85,45 @@ def test_flag_on_physical_name_is_hex_of_ingestor_id():
     assert ing.table_name == "my_dataset"
 
 
+def test_flag_on_rejects_file_bearing_categories():
+    """v1 boundary (Bugbot): the flag isolates the row store only — assets of
+    file-bearing categories still land under the shared label tree, where a
+    later same-label ingest would overwrite an earlier dataset's files. Fail
+    at construction, before any validation or DDL; per-dataset file isolation
+    ships with tracebloc/client-runtime#203 phase 2."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    database = MagicMock(name="Database")
+    database.config.PER_INGESTION_TABLES = True
+    with pytest.raises(ValueError, match="file-bearing"):
+        CSVIngestor(
+            database=database,
+            api_client=MagicMock(),
+            table_name="imgs",
+            schema={"filename": "VARCHAR(255)", "label": "VARCHAR(50)"},
+            label_column="label",
+            category=TaskCategory.IMAGE_CLASSIFICATION,
+        )
+
+
+def test_flag_on_accepts_row_only_categories():
+    """Tabular / time-series families — the RFC-0003 v1 rollout target —
+    construct normally under the flag."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    database = MagicMock(name="Database")
+    database.config.PER_INGESTION_TABLES = True
+    ing = CSVIngestor(
+        database=database,
+        api_client=MagicMock(),
+        table_name="rows",
+        schema={"feature": "FLOAT", "label": "VARCHAR(50)"},
+        label_column="label",
+        category=TaskCategory.TABULAR_CLASSIFICATION,
+    )
+    assert ing.physical_table_name.startswith("ds_")
+
+
 def test_truthy_mock_config_does_not_flip_the_storage_model():
     """Bare MagicMock config (the fixture default across this suite) must
     read as flag OFF — a truthy Mock silently flipping every mocked test

--- a/tests/test_per_ingestion_tables.py
+++ b/tests/test_per_ingestion_tables.py
@@ -10,6 +10,7 @@ ingest summary carries the physical handle so the backend can persist it
 """
 
 import json
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -70,12 +71,16 @@ def test_flag_off_physical_name_is_the_label():
     assert ing.table_name == "my_dataset"
 
 
-def test_flag_on_physical_name_is_ds_ingestor_id():
+def test_flag_on_physical_name_is_hex_of_ingestor_id():
     ing = _make_ingestor(per_ingestion=True)
     assert ing.per_ingestion_tables is True
-    assert ing.physical_table_name == f"ds_{ing.ingestor_id}"
-    # 'ds_' + uuid4 = 39 chars, inside MySQL's 64-char identifier cap.
-    assert len(ing.physical_table_name) == 39
+    # ds_<uuid4().hex>: a pure function of ingestor_id, hyphen-free because
+    # SQL table grammars (trainer _SQL_IDENTIFIER_RE, this package's
+    # TableNameValidator) forbid hyphens — D3 amendment on backend#1204.
+    assert ing.physical_table_name == f"ds_{uuid.UUID(ing.ingestor_id).hex}"
+    assert "-" not in ing.physical_table_name
+    # 'ds_' + 32 hex chars = 35, inside MySQL's 64-char identifier cap.
+    assert len(ing.physical_table_name) == 35
     # The label survives untouched for the user-facing surfaces.
     assert ing.table_name == "my_dataset"
 

--- a/tests/test_per_ingestion_tables.py
+++ b/tests/test_per_ingestion_tables.py
@@ -1,0 +1,180 @@
+"""RFC-0003 D16/D19 (tracebloc/backend#1205): per-ingestion immutable tables.
+
+Flag OFF (the default) must be byte-for-byte today's behavior: the physical
+table IS the user label, the summary payload has no ``physical_table`` key,
+and existing tables are reflected (append). Flag ON: every run writes its own
+``ds_<ingestor_id>`` table, the reflect/append path is a hard error, and the
+ingest summary carries the physical handle so the backend can persist it
+(tracebloc/backend#1206). The label keeps serving the user-facing surfaces
+(summary URL segment, staging dirs, table lock, default title).
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tracebloc_ingestor import database as db_mod
+from tracebloc_ingestor.api.client import APIClient
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.database import Database
+from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+
+
+# ── Config flag ──────────────────────────────────────────────────────────────
+
+
+def test_flag_defaults_off(monkeypatch):
+    monkeypatch.delenv("PER_INGESTION_TABLES", raising=False)
+    assert Config(EDGE_ENV="local").PER_INGESTION_TABLES is False
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("1", True), ("true", True), ("YES", True), ("on", True),
+     ("0", False), ("", False), ("no", False), ("off", False)],
+)
+def test_flag_env_parsing(monkeypatch, raw, expected):
+    monkeypatch.setenv("PER_INGESTION_TABLES", raw)
+    assert Config(EDGE_ENV="local").PER_INGESTION_TABLES is expected
+
+
+def test_flag_override_beats_env(monkeypatch):
+    monkeypatch.setenv("PER_INGESTION_TABLES", "1")
+    assert Config(EDGE_ENV="local", PER_INGESTION_TABLES=False).PER_INGESTION_TABLES is False
+    monkeypatch.delenv("PER_INGESTION_TABLES", raising=False)
+    assert Config(EDGE_ENV="local", PER_INGESTION_TABLES=True).PER_INGESTION_TABLES is True
+
+
+# ── Ingestor naming ─────────────────────────────────────────────────────────
+
+
+def _make_ingestor(per_ingestion):
+    database = MagicMock(name="Database")
+    # Real bool, not a truthy Mock — BaseIngestor compares `is True`.
+    database.config.PER_INGESTION_TABLES = per_ingestion
+    api_client = MagicMock(name="APIClient")
+    return CSVIngestor(
+        database=database,
+        api_client=api_client,
+        table_name="my_dataset",
+        schema={"feature": "FLOAT", "label": "VARCHAR(50)"},
+        label_column="label",
+    )
+
+
+def test_flag_off_physical_name_is_the_label():
+    ing = _make_ingestor(per_ingestion=False)
+    assert ing.per_ingestion_tables is False
+    assert ing.physical_table_name == "my_dataset"
+    assert ing.table_name == "my_dataset"
+
+
+def test_flag_on_physical_name_is_ds_ingestor_id():
+    ing = _make_ingestor(per_ingestion=True)
+    assert ing.per_ingestion_tables is True
+    assert ing.physical_table_name == f"ds_{ing.ingestor_id}"
+    # 'ds_' + uuid4 = 39 chars, inside MySQL's 64-char identifier cap.
+    assert len(ing.physical_table_name) == 39
+    # The label survives untouched for the user-facing surfaces.
+    assert ing.table_name == "my_dataset"
+
+
+def test_truthy_mock_config_does_not_flip_the_storage_model():
+    """Bare MagicMock config (the fixture default across this suite) must
+    read as flag OFF — a truthy Mock silently flipping every mocked test
+    onto per-ingestion naming would invalidate the whole legacy suite."""
+    database = MagicMock(name="Database")  # config.PER_INGESTION_TABLES is a Mock
+    ing = CSVIngestor(
+        database=database,
+        api_client=MagicMock(),
+        table_name="t",
+        schema={"feature": "FLOAT", "label": "VARCHAR(50)"},
+        label_column="label",
+    )
+    assert ing.per_ingestion_tables is False
+    assert ing.physical_table_name == "t"
+
+
+# ── create_table immutability guard ─────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_engine_factory():
+    with patch.object(db_mod, "create_engine") as ce:
+        engine = MagicMock(name="engine")
+        conn = MagicMock(name="connection")
+        engine.connect.return_value.__enter__.return_value = conn
+        ce.return_value = engine
+        yield ce, engine, conn
+
+
+@pytest.fixture
+def db(mock_engine_factory):
+    return Database(Config(EDGE_ENV="local"))
+
+
+def test_create_table_must_not_exist_rejects_cached_table(db):
+    db.tables["ds_deadbeef"] = MagicMock(name="table")
+    with pytest.raises(ValueError, match="immutable"):
+        db.create_table("ds_deadbeef", {"feature": "FLOAT"}, must_not_exist=True)
+
+
+def test_create_table_must_not_exist_rejects_existing_db_table(db):
+    inspector = MagicMock()
+    inspector.get_table_names.return_value = ["ds_deadbeef"]
+    with patch.object(db_mod, "inspect", return_value=inspector):
+        with pytest.raises(ValueError, match="immutable"):
+            db.create_table("ds_deadbeef", {"feature": "FLOAT"}, must_not_exist=True)
+
+
+def test_create_table_default_still_reflects_existing(db):
+    """Legacy path unchanged: without the flag, an existing cached table is
+    returned (the append behavior)."""
+    sentinel = MagicMock(name="table")
+    db.tables["legacy"] = sentinel
+    assert db.create_table("legacy", {"feature": "FLOAT"}) is sentinel
+
+
+# ── summary payload ──────────────────────────────────────────────────────────
+
+
+def _resp(status_code, body=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.text = json.dumps(body or {})
+    r.json.return_value = body or {}
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def _client():
+    cfg = Config(BACKEND_TOKEN="tok", EDGE_ENV="prod")
+    with patch.object(APIClient, "authenticate", return_value="tok"):
+        return APIClient(cfg)
+
+
+def _send_and_capture(client, **extra):
+    """POST a summary against a mocked transport; return the JSON payload."""
+    with patch.object(
+        client.session, "post",
+        return_value=_resp(201, {"dataset_id": 1, "dataset_key": "k"}),
+    ) as post:
+        client.send_ingest_summary(
+            table_name="my_dataset", ingestor_id="ing-1", labels={"cat": 2},
+            dataset_title="T", data_format="tabular", data_intent="train",
+            category="tabular_classification", schema={}, samples=[], **extra,
+        )
+        _, kwargs = post.call_args
+    return json.loads(kwargs["data"])
+
+
+def test_summary_payload_carries_physical_table_when_given():
+    payload = _send_and_capture(_client(), physical_table="ds_ing-1")
+    assert payload["physical_table"] == "ds_ing-1"
+
+
+def test_summary_payload_omits_physical_table_by_default():
+    """Legacy payload stays byte-identical: no key at all, not a null."""
+    payload = _send_and_capture(_client())
+    assert "physical_table" not in payload

--- a/tests/test_per_ingestion_tables.py
+++ b/tests/test_per_ingestion_tables.py
@@ -19,6 +19,8 @@ from tracebloc_ingestor import database as db_mod
 from tracebloc_ingestor.api.client import APIClient
 from tracebloc_ingestor.config import Config
 from tracebloc_ingestor.database import Database
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
 
 
@@ -222,3 +224,72 @@ def test_summary_payload_omits_physical_table_by_default():
     """Legacy payload stays byte-identical: no key at all, not a null."""
     payload = _send_and_capture(_client())
     assert "physical_table" not in payload
+
+
+# -- flag-ON end-to-end (review #1, Saqlain) ---------------------------------
+
+
+class _EndToEndIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records --
+    mirrors tests/test_ingestor_base.FakeIngestor, kept local so this file
+    stays self-contained."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source):
+        yield from self._records
+
+
+def test_flag_on_threads_the_physical_name_end_to_end():
+    """The connective tissue in ``_ingest_with_lock`` -- not just the units:
+    a full flag-ON ingest must hand ``physical_table_name`` to EVERY row-store
+    call (salt, create, reclaim, journal, counts, samples, schema, batch
+    insert) while the summary keeps the label as its URL identity and carries
+    the handle in the payload. A regression that passed ``self.table_name``
+    to any one of these would pass the unit tests and fail only here."""
+    db = MagicMock(name="Database")
+    db.get_or_create_table_salt.return_value = "0" * 64
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
+    db.get_table_schema.return_value = {"a": "INT"}
+    db.get_label_counts.return_value = {"cat": 2}
+    db.get_samples.return_value = []
+    db.config.PER_INGESTION_TABLES = True
+    api = MagicMock(name="APIClient")
+    api.send_ingest_summary.return_value = {"dataset_id": 1, "dataset_key": "k"}
+
+    ing = _EndToEndIngestor(
+        [{"a": "1", "filename": "f1"}],
+        database=db,
+        api_client=api,
+        table_name="tbl",
+        schema={"a": "INT"},
+        intent="train",
+        category=None,
+    )
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        ing.ingest("src", batch_size=10)
+
+    phys = ing.physical_table_name
+    assert phys == f"ds_{uuid.UUID(ing.ingestor_id).hex}"
+
+    # Row store: every table-taking call got the physical name.
+    db.get_or_create_table_salt.assert_called_once_with(phys)
+    db.create_table.assert_called_once_with(
+        phys, {"a": "INT"}, index_columns=None, must_not_exist=True
+    )
+    db.reclaim_dead_run_rows.assert_called_once_with(phys, ing.ingestor_id)
+    db.record_ingest_started.assert_called_once_with(phys, ing.ingestor_id, None)
+    db.get_label_counts.assert_called_once_with(phys, ing.ingestor_id)
+    db.get_samples.assert_called_once_with(phys, ing.ingestor_id)
+    db.get_table_schema.assert_called_once_with(phys)
+    db.mark_ingest_registered.assert_called_once_with(phys, ing.ingestor_id)
+    assert db.insert_batch.call_args.args[0] == phys
+
+    # Summary: the label stays the URL identity; the handle rides the payload.
+    summary_kwargs = api.send_ingest_summary.call_args.kwargs
+    assert summary_kwargs["table_name"] == "tbl"
+    assert summary_kwargs["physical_table"] == phys

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -241,8 +241,9 @@ class APIClient:
             schema: Column schema written to GlobalMetaData
             samples: Small list of representative records shown in the UI
             physical_table: RFC-0003 D16 (tracebloc/backend#1205) — the
-                per-ingestion physical table (``ds_<ingestor_id>``) this run
-                wrote into, reported so the backend persists the handle
+                per-ingestion physical table (``ds_<uuid4().hex>``, derived
+                from ingestor_id) this run wrote into, reported so the
+                backend persists the handle
                 (tracebloc/backend#1206). ``None`` (legacy shared-table
                 ingests) omits the field entirely, keeping the payload
                 byte-identical to today's.

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -223,6 +223,7 @@ class APIClient:
         schema: Dict[str, Any],
         samples: List[Dict[str, Any]],
         meta_data: Optional[Dict[str, Any]] = None,
+        physical_table: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Send a single ingest summary to the backend, creating the UserDataSet in one
@@ -239,6 +240,12 @@ class APIClient:
             category: TaskCategory value, e.g. "image_classification"
             schema: Column schema written to GlobalMetaData
             samples: Small list of representative records shown in the UI
+            physical_table: RFC-0003 D16 (tracebloc/backend#1205) — the
+                per-ingestion physical table (``ds_<ingestor_id>``) this run
+                wrote into, reported so the backend persists the handle
+                (tracebloc/backend#1206). ``None`` (legacy shared-table
+                ingests) omits the field entirely, keeping the payload
+                byte-identical to today's.
 
         Returns:
             ``{"dataset_id": ..., "dataset_key": ...}``
@@ -254,19 +261,20 @@ class APIClient:
             return {"dataset_id": "mock_dataset_id", "dataset_key": "mock_dataset_key"}
 
         try:
-            payload = json.dumps(
-                {
-                    "ingestor_id": ingestor_id,
-                    "labels": labels,
-                    "dataset_title": dataset_title,
-                    "data_format": data_format,
-                    "data_intent": data_intent,
-                    "category": category,
-                    "schema": schema,
-                    "samples": samples,
-                    "meta_data": meta_data or {},
-                }
-            )
+            payload_fields = {
+                "ingestor_id": ingestor_id,
+                "labels": labels,
+                "dataset_title": dataset_title,
+                "data_format": data_format,
+                "data_intent": data_intent,
+                "category": category,
+                "schema": schema,
+                "samples": samples,
+                "meta_data": meta_data or {},
+            }
+            if physical_table:
+                payload_fields["physical_table"] = physical_table
+            payload = json.dumps(payload_fields)
             logger.info(
                 f"Sending ingest summary for {table_name}: "
                 f"{len(labels)} label(s), {sum(labels.values())} total rows"

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -219,10 +219,11 @@ class Config:
     @property
     def PER_INGESTION_TABLES(self) -> bool:
         """RFC-0003 D16/D19 (tracebloc/backend#1205): when true, every ingest
-        run creates its own immutable physical table ``ds_<ingestor_id>``
-        instead of appending to the label-named shared table, and reports the
-        handle in the ingest summary (``physical_table``) so the backend can
-        persist it (tracebloc/backend#1206).
+        run creates its own immutable physical table ``ds_<uuid4().hex>``
+        (derived from ingestor_id; hex because SQL table grammars forbid
+        hyphens) instead of appending to the label-named shared table, and
+        reports the handle in the ingest summary (``physical_table``) so the
+        backend can persist it (tracebloc/backend#1206).
 
         Defaults to **off** — today's shared-table behavior, byte for byte.
         Flipping it is coordinated with the backend resolution path and the

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -44,6 +44,7 @@ class Config:
         "LOG_LEVEL",
         "CATEGORICAL_MIN_COUNT",
         "EMIT_ENRICHED_SCHEMA",
+        "PER_INGESTION_TABLES",
     })
 
     # Env values (case-insensitive) that read as boolean true; anything else
@@ -214,6 +215,27 @@ class Config:
         if ov is not _MISSING:
             return ov if isinstance(ov, int) else LogLevel.get_level_code(ov)
         return LogLevel.get_level_code(os.environ.get("LOG_LEVEL", "WARNING"))
+
+    @property
+    def PER_INGESTION_TABLES(self) -> bool:
+        """RFC-0003 D16/D19 (tracebloc/backend#1205): when true, every ingest
+        run creates its own immutable physical table ``ds_<ingestor_id>``
+        instead of appending to the label-named shared table, and reports the
+        handle in the ingest summary (``physical_table``) so the backend can
+        persist it (tracebloc/backend#1206).
+
+        Defaults to **off** — today's shared-table behavior, byte for byte.
+        Flipping it is coordinated with the backend resolution path and the
+        training read path (tracebloc/backend#1208); an edge flipped early
+        would ingest datasets the current training path cannot locate.
+        """
+        ov = self._override("PER_INGESTION_TABLES")
+        if ov is not _MISSING:
+            return ov if isinstance(ov, bool) else str(ov).strip().lower() in self._TRUE_STRINGS
+        env = os.environ.get("PER_INGESTION_TABLES")
+        if env is None:
+            return False
+        return env.strip().lower() in self._TRUE_STRINGS
 
     @property
     def EMIT_ENRICHED_SCHEMA(self) -> bool:

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -320,7 +320,7 @@ class Database:
                     f"Table '{table_name}' already exists but was created as "
                     f"a per-ingestion table (RFC-0003 D16: one immutable "
                     f"table per ingest run, append disabled). This should be "
-                    f"impossible for a fresh ds_<uuid4> name; a collision "
+                    f"impossible for a fresh ds_<uuid4 hex> name; a collision "
                     f"means ingestor_id reuse within one process."
                 )
             return self.tables[table_name]
@@ -333,7 +333,7 @@ class Database:
                     f"Table '{table_name}' already exists in the database, "
                     f"but per-ingestion tables are immutable (RFC-0003 D16/"
                     f"D19 — one table per ingest run, append disabled). A "
-                    f"leftover ds_ table under a fresh uuid4 ingestor_id "
+                    f"leftover ds_ table under a fresh uuid4-derived name "
                     f"should be impossible; drop it and re-run."
                 )
             # Reflect existing table using MetaData

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -218,6 +218,7 @@ class Database:
         table_name: str,
         schema: Dict[str, str],
         index_columns: Optional[List[str]] = None,
+        must_not_exist: bool = False,
     ):
         """
         Creates a table if it doesn't exist, or returns existing table
@@ -225,6 +226,13 @@ class Database:
         Args:
             table_name: Name of the table
             schema: Dictionary defining the table schema
+            must_not_exist: RFC-0003 D16/D19 (tracebloc/backend#1205) —
+                per-ingestion tables are immutable, so reusing or reflecting
+                an existing table is a contract violation, never a
+                convenience. When True, an existing table (cached or in the
+                database) raises instead of being returned. Callers pass the
+                per-ingestion flag here; legacy shared-table ingests keep the
+                reflect/append behavior below.
             index_columns: Optional list of schema columns to compose into a
                 secondary (non-unique) index. Used by the sequence-grouped
                 categories to create the composite ``(sequence_id,
@@ -307,11 +315,27 @@ class Database:
 
         # Return existing table if already created
         if table_name in self.tables:
+            if must_not_exist:
+                raise ValueError(
+                    f"Table '{table_name}' already exists but was created as "
+                    f"a per-ingestion table (RFC-0003 D16: one immutable "
+                    f"table per ingest run, append disabled). This should be "
+                    f"impossible for a fresh ds_<uuid4> name; a collision "
+                    f"means ingestor_id reuse within one process."
+                )
             return self.tables[table_name]
 
         # Check if table exists in database
         inspector = inspect(self.engine)
         if table_name in inspector.get_table_names():
+            if must_not_exist:
+                raise ValueError(
+                    f"Table '{table_name}' already exists in the database, "
+                    f"but per-ingestion tables are immutable (RFC-0003 D16/"
+                    f"D19 — one table per ingest run, append disabled). A "
+                    f"leftover ds_ table under a fresh uuid4 ingestor_id "
+                    f"should be impossible; drop it and re-run."
+                )
             # Reflect existing table using MetaData
             self.metadata.reflect(self.engine, only=[table_name])
             table = self.metadata.tables[table_name]

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -924,6 +924,10 @@ class BaseIngestor(ABC):
             and not self.unique_id_column
             and self._table_salt is None
         ):
+            # Per-ingestion mode mints a fresh salt row per run (each
+            # immutable table gets its own salt); the I6 delete sweep
+            # (tracebloc/backend#1209) reaps salt rows together with their
+            # ds_ tables, so they don't accumulate indefinitely.
             self._table_salt = self.database.get_or_create_table_salt(
                 self.physical_table_name
             )
@@ -959,6 +963,11 @@ class BaseIngestor(ABC):
         # this run's own counts are unaffected because every summary query
         # is scoped to its ingestor_id.
         try:
+            # Under per-ingestion tables this is a guaranteed no-op (the
+            # table was created fresh this run; a retry is a NEW table, so
+            # reclaim never protects per-ingestion runs); dead-run husk
+            # tables are I6's sweep instead (tracebloc/backend#1209). Kept
+            # unconditional to preserve a single code path for legacy.
             self.database.reclaim_dead_run_rows(
                 self.physical_table_name, self.ingestor_id
             )

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -300,6 +300,21 @@ class BaseIngestor(ABC):
         self.engine: Engine = database.engine
         self.api_client = api_client
         self.table_name = table_name
+        # RFC-0003 D16/D19 (tracebloc/backend#1205): under per-ingestion
+        # storage every run writes its own immutable table ds_<ingestor_id>;
+        # ``table_name`` stays the user-facing dataset label (summary URL
+        # segment, staging dirs, table lock, default title). The row store —
+        # create/insert/count/schema/journal/compensating-delete — sees ONLY
+        # ``physical_table_name``. Flag off => both names are the label and
+        # behavior is byte-for-byte today's. The ``is True`` comparison is
+        # deliberate: test doubles use bare MagicMocks for config, and a
+        # truthy Mock must not silently flip the storage model.
+        self.per_ingestion_tables = (
+            database.config.PER_INGESTION_TABLES is True
+        )
+        self.physical_table_name = (
+            f"ds_{self.ingestor_id}" if self.per_ingestion_tables else table_name
+        )
         self.schema = schema
         self.unique_id_column = unique_id_column
         self.label_column = label_column
@@ -881,7 +896,9 @@ class BaseIngestor(ABC):
             and not self.unique_id_column
             and self._table_salt is None
         ):
-            self._table_salt = self.database.get_or_create_table_salt(self.table_name)
+            self._table_salt = self.database.get_or_create_table_salt(
+                self.physical_table_name
+            )
 
         if self.table is None:
             # Grouped categories get a composite (group, time) secondary
@@ -894,7 +911,10 @@ class BaseIngestor(ABC):
                 else None
             )
             self.table = self.database.create_table(
-                self.table_name, self._table_schema, index_columns=index_columns
+                self.physical_table_name,
+                self._table_schema,
+                index_columns=index_columns,
+                must_not_exist=self.per_ingestion_tables,
             )
 
         # Reconcile-on-start (backend#1028 item 2): a prior attempt that died
@@ -911,11 +931,13 @@ class BaseIngestor(ABC):
         # this run's own counts are unaffected because every summary query
         # is scoped to its ingestor_id.
         try:
-            self.database.reclaim_dead_run_rows(self.table_name, self.ingestor_id)
+            self.database.reclaim_dead_run_rows(
+                self.physical_table_name, self.ingestor_id
+            )
         except Exception as reclaim_error:
             logger.critical(
                 f"Orphan-row reconciliation failed for table "
-                f"{self.table_name!r}: {redaction.safe_db_error(reclaim_error)}. "
+                f"{self.physical_table_name!r}: {redaction.safe_db_error(reclaim_error)}. "
                 f"Continuing the ingest — rows left by a previous hard-killed "
                 f"run may remain in the table (backend#1028)."
             )
@@ -927,7 +949,7 @@ class BaseIngestor(ABC):
         # now, before any row lands, than to insert rows the journal never
         # heard about.
         self.database.record_ingest_started(
-            self.table_name, self.ingestor_id, self.category
+            self.physical_table_name, self.ingestor_id, self.category
         )
 
         batch = []
@@ -1096,7 +1118,7 @@ class BaseIngestor(ABC):
                     partial_ids = sorted(partial_id_set)
                     if partial_ids and stats["inserted_records"]:
                         removed = self.database.delete_sequences(
-                            self.table_name,
+                            self.physical_table_name,
                             self.ingestor_id,
                             partial_ids,
                             group_column=grouping.group_column,
@@ -1121,7 +1143,7 @@ class BaseIngestor(ABC):
                 # standard row counts like every non-grouped category.
                 if grouping is not None and grouping.count_unit == "sequences":
                     label_counts = self.database.get_label_sequence_counts(
-                        self.table_name,
+                        self.physical_table_name,
                         self.ingestor_id,
                         group_column=grouping.group_column,
                     )
@@ -1134,7 +1156,7 @@ class BaseIngestor(ABC):
                     )
                 else:
                     label_counts = self.database.get_label_counts(
-                        self.table_name, self.ingestor_id
+                        self.physical_table_name, self.ingestor_id
                     )
 
                 if not stats["inserted_records"]:
@@ -1158,13 +1180,15 @@ class BaseIngestor(ABC):
                     )
                 else:
                     samples = self.database.get_samples(
-                        self.table_name, self.ingestor_id
+                        self.physical_table_name, self.ingestor_id
                     )
                     dataset_title = (
                         self.api_client.config.TITLE
                         or f"{self.table_name} - {self.ingestor_id[:8]}"
                     )
-                    schema_dict = self.database.get_table_schema(self.table_name)
+                    schema_dict = self.database.get_table_schema(
+                        self.physical_table_name
+                    )
 
                     if self.category in _NLP_CATEGORIES:
                         text_profile = compute_text_profile(self.database.config)
@@ -1196,11 +1220,16 @@ class BaseIngestor(ABC):
                     # except-branch undoes this flip (mark_ingest_unregistered)
                     # so reclaim can still recover the rows.
                     self.database.mark_ingest_registered(
-                        self.table_name, self.ingestor_id
+                        self.physical_table_name, self.ingestor_id
                     )
 
                     self.api_client.send_ingest_summary(
                         table_name=self.table_name,
+                        physical_table=(
+                            self.physical_table_name
+                            if self.per_ingestion_tables
+                            else None
+                        ),
                         ingestor_id=self.ingestor_id,
                         labels=label_counts,
                         dataset_title=dataset_title,
@@ -1261,13 +1290,13 @@ class BaseIngestor(ABC):
                     # mask the original error or skip the delete.
                     try:
                         self.database.mark_ingest_unregistered(
-                            self.table_name, self.ingestor_id
+                            self.physical_table_name, self.ingestor_id
                         )
                     except Exception as journal_reset_error:
                         logger.critical(
                             f"Failed to reset the run journal to unregistered "
                             f"for ingestor_id={self.ingestor_id!r} in table "
-                            f"{self.table_name!r}: "
+                            f"{self.physical_table_name!r}: "
                             f"{redaction.safe_db_error(journal_reset_error)}. "
                             f"If the compensating delete also fails, these "
                             f"rows may not be reclaimed automatically "
@@ -1275,7 +1304,7 @@ class BaseIngestor(ABC):
                         )
                     try:
                         deleted = self.database.delete_by_ingestor_id(
-                            self.table_name, self.ingestor_id
+                            self.physical_table_name, self.ingestor_id
                         )
                         logger.error(
                             f"Compensating delete removed {deleted} "
@@ -1287,7 +1316,7 @@ class BaseIngestor(ABC):
                         logger.critical(
                             f"Compensating delete FAILED for "
                             f"ingestor_id={self.ingestor_id!r} in table "
-                            f"{self.table_name!r}: "
+                            f"{self.physical_table_name!r}: "
                             f"{redaction.safe_db_error(cleanup_error)}. "
                             f"{stats.get('inserted_records', 0)} unregistered "
                             "row(s) remain orphaned (#227)."
@@ -1324,7 +1353,7 @@ class BaseIngestor(ABC):
         failure accounting; built from the run's database / table. A fresh
         instance per access is fine — it just holds those refs."""
         return BatchWriter(
-            self.database, self.api_client, self.table_name, self.ingestor_id
+            self.database, self.api_client, self.physical_table_name, self.ingestor_id
         )
 
     def _log_summary(self, summary: IngestionSummary):

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -301,19 +301,28 @@ class BaseIngestor(ABC):
         self.api_client = api_client
         self.table_name = table_name
         # RFC-0003 D16/D19 (tracebloc/backend#1205): under per-ingestion
-        # storage every run writes its own immutable table ds_<ingestor_id>;
-        # ``table_name`` stays the user-facing dataset label (summary URL
-        # segment, staging dirs, table lock, default title). The row store —
-        # create/insert/count/schema/journal/compensating-delete — sees ONLY
-        # ``physical_table_name``. Flag off => both names are the label and
-        # behavior is byte-for-byte today's. The ``is True`` comparison is
-        # deliberate: test doubles use bare MagicMocks for config, and a
-        # truthy Mock must not silently flip the storage model.
+        # storage every run writes its own immutable table — named
+        # ds_<uuid4().hex> (35 chars), a pure function of ingestor_id.
+        # HEX, not the hyphenated uuid (D3 amendment on backend#1204): the
+        # trainer's strict table grammar (_SQL_IDENTIFIER_RE) and this
+        # package's own TableNameValidator both forbid hyphens in TABLE
+        # names, and loosening two security validators would be worse than
+        # deriving a hyphen-free name. ingestor_id itself keeps its
+        # hyphenated format everywhere. ``table_name`` stays the user-facing
+        # dataset label (summary URL segment, staging dirs, table lock,
+        # default title). The row store — create/insert/count/schema/journal/
+        # compensating-delete — sees ONLY ``physical_table_name``. Flag off
+        # => both names are the label and behavior is byte-for-byte today's.
+        # The ``is True`` comparison is deliberate: test doubles use bare
+        # MagicMocks for config, and a truthy Mock must not silently flip
+        # the storage model.
         self.per_ingestion_tables = (
             database.config.PER_INGESTION_TABLES is True
         )
         self.physical_table_name = (
-            f"ds_{self.ingestor_id}" if self.per_ingestion_tables else table_name
+            f"ds_{uuid.UUID(self.ingestor_id).hex}"
+            if self.per_ingestion_tables
+            else table_name
         )
         self.schema = schema
         self.unique_id_column = unique_id_column

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -324,6 +324,25 @@ class BaseIngestor(ABC):
             if self.per_ingestion_tables
             else table_name
         )
+        # v1 boundary (Bugbot on the PR): the flag isolates the ROW STORE
+        # only. File-bearing categories also persist assets under the shared
+        # label tree (STORAGE_PATH/<label>), where a later same-label ingest
+        # would overwrite an earlier dataset's files while both ds_ tables
+        # keep referencing them — silent cross-dataset corruption. The file
+        # tree's isolation unit moves to the same handle with the
+        # per-dataset-mount work (tracebloc/client-runtime#203 phase 2);
+        # until then, refuse loudly instead of corrupting quietly. Row-only
+        # categories (tabular / time-series families) are the RFC-0003 v1
+        # rollout target and are unaffected.
+        if self.per_ingestion_tables and category in _FILE_BEARING_CATEGORIES:
+            raise ValueError(
+                f"PER_INGESTION_TABLES does not support file-bearing "
+                f"category {category!r} yet: assets would land in the shared "
+                f"label tree and be overwritten by a later ingest under the "
+                f"same label (per-dataset file isolation ships with "
+                f"tracebloc/client-runtime#203 phase 2). Run this ingest "
+                f"with the flag off."
+            )
         self.schema = schema
         self.unique_id_column = unique_id_column
         self.label_column = label_column


### PR DESCRIPTION
## Summary

Implements **I2** of the RFC-0003 D-series (tracebloc/backend#1205), per the I1 design signed off 2026-07-28 (decision record + D3 amendment on tracebloc/backend#1204).

Behind a new config flag `PER_INGESTION_TABLES` (env/override, **default off**):

- Every ingest run creates its own **immutable** physical table `ds_<uuid4().hex>` (35 chars, hyphen-free — the D3 amendment: the trainer's `_SQL_IDENTIFIER_RE` and this package's `TableNameValidator` both forbid hyphens in table names, so the name is the hex form of `ingestor_id`, still a pure function of it; `ingestor_id` itself keeps its hyphenated format everywhere). The per-run uuid makes immutability natural: a fresh run is a fresh table, so the reflect/append branch is **unreachable — and now a hard error** (`create_table(..., must_not_exist=True)`), implementing "disable append" (D19).
- The ingest summary payload gains `physical_table` (only when the flag is on — the legacy payload stays byte-identical, no key at all). Backend-side persistence + the `ds_<hex(ingestor_id)>` integrity check land with I3 (tracebloc/backend#1300).
- **The physical/label split is surgical**: the row store (create/insert via BatchWriter, counts, samples, schema read-back, run journal, orphan reclaim, compensating delete) sees only `physical_table_name`; the user label keeps serving the summary URL segment, staging dirs (`.tracebloc-staging/<label>`), the table lock, and the default dataset title. Flag off ⇒ both names are the label.
- **File-bearing categories are refused under the flag** (Bugbot finding): their assets land in the shared label tree, where a later same-label ingest would overwrite an earlier dataset's files. Loud refusal at construction until per-dataset file isolation ships with the mount work (tracebloc/client-runtime#203 phase 2). Row-only categories (tabular/time-series — the v1 rollout target) are unaffected.
- Deliberate detail: the flag is read `is True`, so the suite's bare `MagicMock` configs can never silently flip the storage model (covered by a dedicated test).

## Sequencing / safety

Merging this is inert: the flag defaults off and nothing in any environment sets it. Enablement is coordinated with I3 (backend resolution, tracebloc/backend#1300) and I5 (training read path, tracebloc/tracebloc-engine#543) — an edge flipped early would ingest datasets the current training path cannot locate, which is why the flag ships dark. Retry semantics under the flag: a k8s Job retry gets a fresh uuid ⇒ a fresh table; a dead run's unregistered `ds_` table is invisible to the platform and is I6's cleanup target (tracebloc/backend#1209) via the existing run journal (which now records physical names — as do the per-table salt rows, which I6 sweeps alongside the tables).

## Test plan

- 21 tests in `tests/test_per_ingestion_tables.py`: flag parsing/override/default-off, hex naming + strict-validator rationale, MagicMock-truthiness guard, `must_not_exist` (cached + existing tables; legacy default still reflects), summary payload with/without the handle, file-bearing refusal + row-only acceptance, and a **flag-ON end-to-end ingest** asserting every row-store call receives the physical name while the summary keeps the label identity and carries the handle (review #1).
- One existing exact-args assertion updated for the new kwarg (`must_not_exist=False` documents the legacy default).
- **Full suite: 1902 passed, 1 xfailed** (pre-existing) — flag-off is behavior-neutral.

Epic: tracebloc/backend#1151 · Design + D3 amendment: tracebloc/backend#1204 · Backend half: tracebloc/backend#1300 · Read path: tracebloc/tracebloc-engine#543 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
