### PR TITLE
Add pre-commit hooks (Layer 0 local lint guard)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# File used for configuring project pre-commit hooks.
+# Layer 0: an optional local lint guard — CI remains the enforcement layer.
+# Mirrors the org pattern in tracebloc/backend.
+repos:
+- repo: https://github.com/psf/black
+  rev: 26.3.1
+  hooks:
+  - id: black
+    args: [
+      --check
+    ]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.1.0
+  hooks:
+  - id: check-json
+  - id: check-xml
+  - id: check-yaml
+  - id: debug-statements
+  - id: end-of-file-fixer
+    # templates/ ships user-facing sample files byte-for-byte — never rewrite.
+    exclude: ^templates/
+default_language_version:
+  python: python3.11

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,5 +19,3 @@ repos:
   - id: end-of-file-fixer
     # templates/ ships user-facing sample files byte-for-byte — never rewrite.
     exclude: ^templates/
-default_language_version:
-  python: python3.11

--- a/Readme.md
+++ b/Readme.md
@@ -215,3 +215,9 @@ Maintainers: see [RELEASING.md](RELEASING.md) for the release procedure.
 Apache 2.0 — see [LICENSE](LICENSE).
 
 **Questions?** [support@tracebloc.io](mailto:support@tracebloc.io) or [open an issue](https://github.com/tracebloc/data-ingestors/issues).
+
+## Pre-commit
+
+Optional but recommended: `pip install pre-commit && pre-commit install` sets up the git hooks from [`.pre-commit-config.yaml`](.pre-commit-config.yaml).
+The hooks run automatically on each commit, only on the files you touch.
+They are a fast local guard — CI remains the guarantee.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ types-requests
 types-urllib3
 
 # Linting / formatting
-black>=23.0.0
+black>=26,<27  # keep in step with the pre-commit hook (26.3.1) — same 2026 stable style
 isort>=5.12.0
 flake8>=6.0.0
 


### PR DESCRIPTION
## What

Adds `.pre-commit-config.yaml` — Layer 0, an optional local lint guard — and appends a short Pre-commit section to `Readme.md`.

Hooks (mirroring `tracebloc/backend`'s config, revs pinned to tags):

- `black --check` @ `26.3.1` — lint-only, never rewrites code (black is already in `requirements-dev.txt`; its floor is bumped to `>=26,<27` here so a local run satisfies the hook's check)
- `check-json`, `check-xml`, `check-yaml`, `debug-statements` @ pre-commit-hooks `v4.1.0`
- `end-of-file-fixer` @ `v4.1.0`, with `templates/` excluded — those are user-facing sample files shipped byte-for-byte, so nothing may rewrite them

## Why

One consistent Layer 0 across the org: catch lint at commit time instead of in review. Installing the hooks is opt-in (`pre-commit install`); CI is unchanged and remains the guarantee (Layer 1).

## Notes

- The repo is not fully black-clean today (~77 of 185 files would reformat under black 26.3.1). The hook only checks files staged in a commit, so debt is paid down file-by-file — nothing is mass-reformatted by this PR.
- No `default_language_version` pin: the repo supports Python 3.11 and 3.12 (CI tests both), so hooks build against whatever Python pre-commit finds. (Bugbot round 1 caught both this and the black floor — fixed.)
- backend's `gitlint` hook was deliberately not carried over: it runs at the commit-msg stage, which a plain `pre-commit install` does not install, so it would be dead config.

Part of tracebloc/backend#1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and documentation only; no runtime, CI, or application logic changes.
> 
> **Overview**
> Introduces an **optional Layer 0** local guard via [`.pre-commit-config.yaml`](.pre-commit-config.yaml), aligned with `tracebloc/backend`: **`black --check`** at `26.3.1` (check-only, no auto-format) plus **pre-commit-hooks** for JSON/XML/YAML validity, `debug-statements`, and **`end-of-file-fixer`** with **`templates/` excluded** so sample files are not rewritten.
> 
> The README gains a **Pre-commit** section describing `pip install pre-commit && pre-commit install`; hooks run on staged files only, with **CI unchanged** as the enforcement layer.
> 
> **`requirements-dev.txt`** raises the **`black`** floor from `>=23` to **`>=26,<27`** so local dev installs satisfy the same Black version the hook uses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d46fc2b0cb863e9b7dbb9568816d7f07ca0c7d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->