### PR TITLE
chore: clear the ruff backlog (E4,E7,E9,F)

### DIFF
--- a/debug_csv_processing.py
+++ b/debug_csv_processing.py
@@ -8,7 +8,6 @@ how the CSV data is being processed and identifying potential issues.
 
 import pandas as pd
 import logging
-from pathlib import Path
 import re
 
 # Setup logging
@@ -144,7 +143,7 @@ def diagnose_csv_issues(csv_path):
                 "feature_018",
             ]
             available_cols = [col for col in test_cols if col in df.columns]
-            subset_df = df[available_cols]
+            df[available_cols]  # exercise subset selection; result unused
             print(f"   ✅ Column subset selection works: {len(available_cols)} columns")
         except Exception as e:
             print(f"   ❌ Column subset selection failed: {e}")
@@ -152,7 +151,7 @@ def diagnose_csv_issues(csv_path):
         try:
             # Test column renaming
             rename_dict = {col: col.strip() for col in df.columns}
-            renamed_df = df.rename(columns=rename_dict)
+            df.rename(columns=rename_dict)  # exercise renaming; result unused
             print("   ✅ Column renaming works")
         except Exception as e:
             print(f"   ❌ Column renaming failed: {e}")

--- a/e2e/test_semseg_client_contract_e2e.py
+++ b/e2e/test_semseg_client_contract_e2e.py
@@ -33,7 +33,6 @@ from pathlib import Path
 
 import mysql.connector
 import pandas as pd
-import pytest
 import yaml
 
 from tracebloc_ingestor.cli import run

--- a/examples/json_ingestor.py
+++ b/examples/json_ingestor.py
@@ -7,7 +7,6 @@ that normalizes data types and formats.
 
 import logging
 from pathlib import Path
-from typing import Dict, Any
 
 from tracebloc_ingestor import Config, Database, APIClient, JSONIngestor
 from tracebloc_ingestor.utils.logging import setup_logging

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,15 @@
+# Ruff configuration for the org code-quality gate (tracebloc/.github
+# code-quality.yml, adopted repo-wide via tracebloc/backend#1303). The shared
+# workflow uses a repo's own ruff config when one exists, so keep the
+# selection identical to the org default: the real-bug families only
+# (pyflakes + the pycodestyle errors), no formatting-opinion rules.
+
+[lint]
+select = ["E4", "E7", "E9", "F"]
+
+[lint.per-file-ignores]
+# templates/ ships byte-exact, user-facing sample scripts — pre-commit's
+# end-of-file-fixer excludes them for the same reason. They must never be
+# rewritten to satisfy lint; their only findings are unused imports (F401),
+# which are part of the copy-me template surface.
+"templates/**" = ["F401"]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages
-import os
 import re
 
 # read the contents of your README file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,8 @@ shell environment can't leak into a run.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 from unittest.mock import MagicMock
 
 import pandas as pd

--- a/tests/test_api_client_failure_modes.py
+++ b/tests/test_api_client_failure_modes.py
@@ -20,7 +20,6 @@ import requests
 from tracebloc_ingestor.api import client as client_mod
 from tracebloc_ingestor.api.client import APIClient
 from tracebloc_ingestor.config import Config
-from tracebloc_ingestor.utils.constants import TaskCategory
 
 
 class _Program:

--- a/tests/test_batch_send_failure_accounting.py
+++ b/tests/test_batch_send_failure_accounting.py
@@ -33,7 +33,7 @@ import requests
 from tracebloc_ingestor.config import Config
 from tracebloc_ingestor.api.client import APIClient
 from tracebloc_ingestor.ingestors import base as base_mod
-from tracebloc_ingestor.ingestors.base import BaseIngestor, IngestionSummary
+from tracebloc_ingestor.ingestors.base import BaseIngestor
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_category_congruence.py
+++ b/tests/test_category_congruence.py
@@ -35,7 +35,7 @@ from tracebloc_ingestor.cli.conventions import (
 )
 from tracebloc_ingestor.ingestors.base import _FILE_BEARING_CATEGORIES
 from tracebloc_ingestor.modalities import spec_for
-from tracebloc_ingestor.utils.constants import DataFormat, TaskCategory
+from tracebloc_ingestor.utils.constants import DataFormat
 from tracebloc_ingestor.utils.validators_mapping import map_validators
 
 

--- a/tests/test_content_hash_data_id.py
+++ b/tests/test_content_hash_data_id.py
@@ -7,7 +7,6 @@ duplicating them. The per-table salt keeps ids unlinkable across tables and
 never leaves the cluster.
 """
 
-import json
 
 import pytest
 

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -21,7 +21,6 @@ What they cover:
 
 from __future__ import annotations
 
-from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict
 

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import importlib
 import logging
-import sys
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -73,7 +72,8 @@ def test_build_ingestor_unknown_source_type_raises():
 # validators/base: BaseValidator helpers
 # ===========================================================================
 
-from tracebloc_ingestor.validators.base import BaseValidator, ValidationResult
+# E402: deliberate per-section import — the unit under test lives with its tests.
+from tracebloc_ingestor.validators.base import BaseValidator  # noqa: E402
 
 
 class _Concrete(BaseValidator):
@@ -148,7 +148,8 @@ def test_mlm_with_schema_adds_data_validator():
 # data_validator: edge branches
 # ===========================================================================
 
-from tracebloc_ingestor.validators.data_validator import DataValidator
+# E402: deliberate per-section import — the unit under test lives with its tests.
+from tracebloc_ingestor.validators.data_validator import DataValidator  # noqa: E402
 
 
 def test_data_validator_load_non_csv_returns_none():
@@ -190,7 +191,10 @@ def test_data_validator_date_exception(monkeypatch):
 # duplicate_validator: exception fallbacks
 # ===========================================================================
 
-from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
+# E402: deliberate per-section import — the unit under test lives with its tests.
+from tracebloc_ingestor.validators.duplicate_validator import (  # noqa: E402
+    DuplicateValidator,
+)
 
 
 def test_duplicate_validate_exception(monkeypatch):
@@ -385,7 +389,8 @@ def test_image_validator_list_with_non_path_item():
 # api/client: error-response branches + LoggingRetry
 # ===========================================================================
 
-from tracebloc_ingestor.api.client import APIClient, LoggingRetry
+# E402: deliberate per-section import — the unit under test lives with its tests.
+from tracebloc_ingestor.api.client import APIClient, LoggingRetry  # noqa: E402
 
 
 def _client(**ov):
@@ -433,7 +438,8 @@ def test_send_ingest_summary_error_with_response_text():
 # file_transfer: copy-failure except branches
 # ===========================================================================
 
-from tracebloc_ingestor import file_transfer
+# E402: deliberate per-section import — the unit under test lives with its tests.
+from tracebloc_ingestor import file_transfer  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/test_coverage_gaps2.py
+++ b/tests/test_coverage_gaps2.py
@@ -297,7 +297,10 @@ def test_json_ingest_method_propagates_error():
 # XML validator: sub-element branches (called directly on crafted elements)
 # ===========================================================================
 
-from tracebloc_ingestor.validators.xml_validator import PascalVOCXMLValidator
+# E402: deliberate per-section import — the unit under test lives with its tests.
+from tracebloc_ingestor.validators.xml_validator import (  # noqa: E402
+    PascalVOCXMLValidator,
+)
 
 
 def _obj(

--- a/tests/test_csv_ingestor_scale.py
+++ b/tests/test_csv_ingestor_scale.py
@@ -14,7 +14,6 @@ import datetime
 
 from unittest.mock import MagicMock
 
-import pandas as pd
 
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
 from tracebloc_ingestor.utils.constants import TaskCategory

--- a/tests/test_file_transfer_has_extension.py
+++ b/tests/test_file_transfer_has_extension.py
@@ -23,7 +23,6 @@ These tests pin the three classes of input that need to be handled:
 
 from __future__ import annotations
 
-import pytest
 
 from tracebloc_ingestor.file_transfer import _has_extension
 

--- a/tests/test_file_transfer_reclaim.py
+++ b/tests/test_file_transfer_reclaim.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import os
 
-import pytest
 
 from tracebloc_ingestor import file_transfer
 from tracebloc_ingestor.config import Config

--- a/tests/test_file_transfer_summary.py
+++ b/tests/test_file_transfer_summary.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import io
 import logging
-import os
 from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_file_transfer_transfers.py
+++ b/tests/test_file_transfer_transfers.py
@@ -7,7 +7,6 @@ source resolution helpers, and the multi-file map_file_transfer branches.
 
 from __future__ import annotations
 
-import os
 
 import pytest
 

--- a/tests/test_file_validator.py
+++ b/tests/test_file_validator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any, Dict, Generator, List
+from typing import Any, Dict, Generator
 from unittest.mock import MagicMock, patch
 
 import pandas as pd

--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -274,7 +274,6 @@ def test_read_data_streams_array_does_not_materialise_whole_file(tmp_path):
     ``next()`` returns without reading the trailing records first).
     """
     import ijson as _ijson
-    import os
 
     # Write a moderate-size array so the test is fast but the streaming
     # behaviour is observable. We assert by checking that ijson.items is

--- a/tests/test_label_diversity_validator.py
+++ b/tests/test_label_diversity_validator.py
@@ -9,7 +9,6 @@ landed in MySQL. Issue #251.
 from __future__ import annotations
 
 import pandas as pd
-import pytest
 
 from tracebloc_ingestor.validators.label_diversity_validator import (
     LabelDiversityValidator,

--- a/tests/test_metadata_backfill.py
+++ b/tests/test_metadata_backfill.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 from collections import Counter
 from decimal import Decimal
 
-import pytest
 from sqlalchemy import (
     Column,
     Float,

--- a/tests/test_numeric_columns_validator.py
+++ b/tests/test_numeric_columns_validator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from tracebloc_ingestor.validators.numeric_columns_validator import (
     NumericColumnsValidator,

--- a/tests/test_schema_bundled.py
+++ b/tests/test_schema_bundled.py
@@ -29,8 +29,6 @@ from __future__ import annotations
 
 import importlib
 
-import pytest
-
 
 def test_schema_subpackage_is_importable():
     """The marker __init__.py exists and the subpackage imports cleanly.

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -21,7 +21,6 @@ This file's job is to lock the shape of the YAML surface in isolation.
 from __future__ import annotations
 
 import json
-from copy import deepcopy
 from pathlib import Path
 
 import pytest

--- a/tests/test_time_validators.py
+++ b/tests/test_time_validators.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pandas as pd
-import pytest
 
 from tracebloc_ingestor.validators.time_format_validator import TimeFormatValidator
 from tracebloc_ingestor.validators.time_ordered_validator import TimeOrderedValidator

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from tracebloc_ingestor.config import Config
 from tracebloc_ingestor.utils.validators_mapping import map_validators

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -1,6 +1,7 @@
 from typing import List, Dict, Any, Optional
 import os
-import requests, json
+import requests
+import json
 import logging
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -42,7 +42,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, NoReturn, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 import yaml
 from jsonschema import Draft7Validator, ValidationError

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -16,6 +16,12 @@ import ijson
 import pandas as pd
 
 from ..utils import redaction
+from .base import BaseIngestor
+from ..database import Database
+from ..api.client import APIClient
+from ..utils.constants import RESET, RED, YELLOW
+from ..utils import label_policy as label_policy_module
+from ..utils import coercion
 
 
 def _peek_json_shape(path: Path) -> Optional[str]:
@@ -57,12 +63,6 @@ def _peek_json_shape(path: Path) -> Optional[str]:
                 return None
     return None
 
-from .base import BaseIngestor
-from ..database import Database
-from ..api.client import APIClient
-from ..utils.constants import RESET, RED, YELLOW
-from ..utils import label_policy as label_policy_module
-from ..utils import coercion
 
 logger = logging.getLogger(__name__)
 

--- a/tracebloc_ingestor/modalities/layout.py
+++ b/tracebloc_ingestor/modalities/layout.py
@@ -27,8 +27,9 @@ than independent logic:
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 # Bump when the contract's SHAPE changes (fields added/removed/reinterpreted),
 # not when a task's values change — those are caught by the drift test.
@@ -166,8 +167,6 @@ def build_layout_contract() -> Dict[str, Any]:
 # Path of the committed, machine-readable contract the CLI vendors + mirrors.
 # Kept next to ingest.v1.json (both are the CLI's contract surface).
 def contract_path() -> "os.PathLike[str]":
-    import os
-
     return os.path.join(
         os.path.dirname(os.path.dirname(__file__)), "schema", "layout.v1.json"
     )

--- a/tracebloc_ingestor/validators/base.py
+++ b/tracebloc_ingestor/validators/base.py
@@ -5,13 +5,17 @@ for implementing data validation before ingestion.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, TYPE_CHECKING
 from dataclasses import dataclass
 from pathlib import Path
 import json
 import logging
 
 from tqdm import tqdm
+
+if TYPE_CHECKING:  # pragma: no cover
+    # Typing-only: pandas stays a lazy runtime import (see _load_data).
+    import pandas as pd
 
 from tracebloc_ingestor.config import Config
 

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -10,8 +10,7 @@ import json
 import logging
 import re
 from pathlib import Path
-from typing import Any, List, Dict, Optional, Union
-from datetime import datetime
+from typing import Any, Dict, Optional
 
 import numpy as np
 from ..utils import redaction
@@ -969,7 +968,7 @@ class DataValidator(BaseValidator):
                 errors.append(
                     f"Column '{column_name}' contains {invalid_dates} invalid date values"
                 )
-        except:
+        except Exception:
             errors.append(f"Column '{column_name}' contains invalid date values")
 
         return {"is_valid": len(errors) == 0, "errors": errors, "warnings": warnings}

--- a/tracebloc_ingestor/validators/duplicate_validator.py
+++ b/tracebloc_ingestor/validators/duplicate_validator.py
@@ -4,7 +4,6 @@ This module provides validation to check if the destination directory exists,
 raising errors if it does to prevent accidental overwrites.
 """
 
-import os
 from pathlib import Path
 from typing import Any, List, Optional
 import logging

--- a/tracebloc_ingestor/validators/keypoint_visibility_validator.py
+++ b/tracebloc_ingestor/validators/keypoint_visibility_validator.py
@@ -6,7 +6,7 @@ match the corresponding annotation keypoint names.
 """
 
 import logging
-from typing import Any, List, Optional
+from typing import Any, List
 
 import pandas as pd
 


### PR DESCRIPTION
## Summary

Clears the repo's ruff backlog for the org code-quality gate selection (`E4,E7,E9,F`, ruff `0.15.20`) so the gate's `soft-fail: false` flip can proceed. **77 findings at develop HEAD → 0.**

| Rule | Count | Resolution |
|---|---:|---|
| F401 unused-import | 59 | 36 removed (safe autofix); 23 live under `templates/` → per-file-ignore (below) |
| E402 import-not-at-top | 12 | 6 real fixes, 6 deliberate per-section test imports → `# noqa: E402` with reason |
| F821 undefined-name | 2 | **real-bug family — see below** |
| F841 unused-variable | 2 | bindings dropped, exercised expressions kept (`debug_csv_processing.py`) |
| E401 multiple-imports-on-one-line | 1 | autofix |
| E722 bare-except | 1 | `except:` → `except Exception:` |

## F821 — real-bug candidates (investigated)

Both are quoted type annotations that reference modules imported only *inside* the function body, i.e. undefined at module scope. Nothing evaluates these annotations today, so there is no runtime crash on the current paths — but anything that resolves type hints (`typing.get_type_hints`, doc tooling, pydantic-style introspection) would raise `NameError`:

- `tracebloc_ingestor/modalities/layout.py` — `contract_path() -> "os.PathLike[str]"` with `import os` inside the function. Fix: module-level `import os` (stdlib, side-effect-free), function-local import removed.
- `tracebloc_ingestor/validators/base.py` — `_load_data(...) -> Optional["pd.DataFrame"]` with pandas imported lazily in the body. Fix: `if TYPE_CHECKING: import pandas as pd`, so the deliberate lazy runtime import stays exactly as it was.

## templates/ carve-out (new `ruff.toml`)

`templates/` ships byte-exact, user-facing sample scripts (pre-commit's `end-of-file-fixer` already excludes them for the same reason) — they must not be edited to satisfy lint. All 23 of their findings are F401. The new `ruff.toml` mirrors the org gate's selection (`E4,E7,E9,F`) and adds `per-file-ignores: "templates/**" = ["F401"]`. The shared `code-quality.yml` explicitly honors a repo's own ruff config, so the gate semantics stay identical everywhere else.

## Other notes

- `json_ingestor.py` had a 6-line import block stranded *below* a helper function (E402 ×6); moved up. Only a pure `def` sat between, so import order/side effects are unchanged.
- `except: → except Exception:` in `data_validator._validate_date` no longer swallows `KeyboardInterrupt`/`SystemExit`; all real error paths behave as before.
- No file under `templates/` is touched (verified: `git diff --name-only` has no `templates/` entry).
- Changed files stay black-parity with develop HEAD (black `26.3.1 --check`: no newly failing files).

## Test plan

- `ruff check .` (repo config) → clean; `ruff check . --isolated --select E4,E7,E9,F` → only the 23 `templates/` F401s remain, which the repo config suppresses for the CI gate.
- Local run of the CI test job (python 3.12): `pytest --cov=tracebloc_ingestor --cov-fail-under=95` → **1902 passed, 1 xfailed, coverage 96.29%**.

Part of tracebloc/backend#1303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and import hygiene with two typing-only annotation fixes; the bare-except change only stops swallowing BaseException subclasses like KeyboardInterrupt in date validation error paths.
> 
> **Overview**
> **Clears the ruff backlog** for the org code-quality gate (`E4`, `E7`, `E9`, `F`) so CI can run with `soft-fail: false`. A new **`ruff.toml`** mirrors the shared workflow rule set and **`per-file-ignores`** `F401` under `templates/**` so byte-exact sample scripts are not edited for unused imports.
> 
> **Lint fixes** are mostly mechanical: drop unused imports across tests, examples, and `setup.py`; split `import requests, json` in `api/client.py`; move stranded imports to the top of `json_ingestor.py`; narrow typing imports in validators; replace bare `except:` with `except Exception:` in `data_validator._validate_date`; and mark intentional mid-file test imports with `# noqa: E402`.
> 
> **Two F821 fixes** for quoted annotations that referenced names only imported inside functions: module-level `import os` in `modalities/layout.py` for `contract_path()`, and `TYPE_CHECKING` + `pandas as pd` in `validators/base.py` while keeping lazy pandas at runtime.
> 
> **Minor behavior-neutral tweaks:** `debug_csv_processing.py` exercises pandas subset/rename without assigning unused variables; `cli/run.py` drops an unused `NoReturn` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072c1930b69be1195df6de94b8f3025a2e8736af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->