### PR TITLE
chore(release): bump version to 0.7.9

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.7.8"
+__version__ = "0.7.9"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
Bugbot (HIGH) on promotion #413: `__version__` is `0.7.8` but `v0.7.8` is already tagged, so the auto-release on the next master push would silently skip tagging the released commit. Bump to 0.7.9 so the master publish actually releases. **Note for the same conversation (#402 comment):** even with the bump, the auto-release's tag creation will 403 against the `v*` ruleset (github-actions isn't in the bypass) — the standing recommendation is to hand tagging to the release train (`version_file: tracebloc_ingestor/__init__.py` in repos.yml) and drop the workflow's tag step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version constant change with no runtime or security impact; release/tag workflow behavior only.
> 
> **Overview**
> Bumps the package **`__version__`** in `tracebloc_ingestor/__init__.py` from **0.7.8** to **0.7.9**. `setup.py` still reads the version from that literal via `_read_version()`, so no other files change.
> 
> The bump unblocks tagging for the next master publish: **0.7.8** already has a **`v0.7.8`** tag, so leaving the version unchanged would cause auto-release to skip creating a new tag for the released commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d5dea47fe9a4a1f9505a6bf150ec656798b3eea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->