### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,144 @@
+# Bugbot guide — tracebloc/data-ingestors
+
+## Context
+
+Public Python package (`tracebloc_ingestor` on PyPI) plus a signed GHCR image. It validates,
+preprocesses, and ingests datasets (image, text, tabular, time series — 16 task categories)
+inside a customer's Kubernetes environment: raw data stays on-premise, only metadata syncs
+to the tracebloc backend.
+
+Three properties shape most real defects here:
+
+1. **It runs inside the customer's cluster, on the customer's data.** Anything written to a
+   log, error message, or API payload can egress via install logs and failure reports —
+   redaction is a product guarantee, not cosmetics (`tracebloc_ingestor/utils/redaction.py`).
+2. **It deletes and mutates shared storage.** The MySQL tables and the shared PVC hold the
+   customer's staged data; a wrong `rmtree` or row purge destroys data tracebloc does not
+   own.
+3. **Validation is a promise about ingest.** Preflight validators exist so a dataset that
+   passes dry-run also ingests and trains; any drift between what a validator reads and what
+   the ingestor reads breaks that promise in one direction or the other.
+
+Release flow: this repo rides the org release train `develop → staging → master`. A develop
+push publishes a dev pre-release (`publish-dev.yml`), a master push publishes the package
+(`publish-master.yml`), and a `vX.Y.Z` tag builds the signed multi-arch image + GitHub
+Release (`release-image.yml`). Package and image release independently; `RELEASING.md`
+documents how they stay aligned.
+
+## Always flag
+
+- **A cell value that can reach a log, error message, or the wire.** The policy line
+  (`utils/redaction.py` docstring): cell VALUES never appear in errors/logs; column names,
+  file names, counts, dtypes, and row indices may. The two recurring leak shapes are
+  interpolating a raw exception — `str(exc)` / `logger.exception`; MySQL driver errors embed
+  bound parameter values — and echoing an HTTP `response.text` whose request body carried
+  vocab or stats. The house pattern logs `type(exc).__name__` only, with a "message
+  suppressed" note (`ingestors/csv_ingestor.py:508`,
+  `validators/per_group_time_ordered_validator.py:219`, `metadata_backfill_runner.py:195`).
+
+- **A validator that reads data differently from the ingestor.** Preflight readers must
+  honor the run's `csv_options` via `utils/csv_dialect.read_dialect_kwargs` — a hardcoded
+  `pd.read_csv(..., sep=",", encoding="utf-8")` passes or rejects manifests the real ingest
+  treats the opposite way (#371 → #376, #384). Same class: a contract enforced only on the
+  `.csv` path while `json_ingestor.py` accepts the same manifest shape, so the JSON dataset
+  fails late, cluster-side (#384); and column-name comparisons that skip the case- and
+  whitespace-insensitive resolution the read path uses (`utils/columns.resolve_column`, #367).
+
+- **Config validated mid-scan instead of at construction** (learned rule). A bad YAML value
+  must fail loudly in the validator's `__init__`, not raise inside the per-file loop where
+  it gets caught and misreported as corrupt data (#364, #365, #376).
+
+- **A new key on `meta_data` that isn't consciously wire-facing.** Internal bridges hung on
+  `file_options`/`meta_data` for combine-time plumbing must be listed in
+  `_META_DATA_INTERNAL_KEYS` so `_meta_data_payload()` strips them before send
+  (`ingestors/base.py:96,793`); the canonical copies ship under `attributes` only. This leak
+  class recurred three times in one release (#383 → fixed in #385, #387).
+
+- **`feature_stats` / categorical vocab accumulated outside the tabular family.** Stats
+  accumulation gates on `TABULAR_FAMILY_CATEGORIES` (`modalities/registry.py`) because a
+  manifest category's TEXT column (e.g. keypoint `Visibility` JSON) under the cardinality
+  cap would ship raw cell values as vocabulary. The gate must hold on *every* emit path —
+  live ingest and `metadata_backfill.py` alike (#385, #389).
+
+- **A filesystem delete that can't prove the target is ours.** `reclaim_source`
+  (`file_transfer.py:519`) is the reference: opt-in exact `realpath` match on
+  `STORAGE_PATH/.tracebloc-staging/<TABLE_NAME>`, never a blocklist; symlinks resolved
+  before every check and before the delete (PVC mounts are symlinks); refuses `/`, the PVC
+  root, sibling staging dirs, and anything overlapping the table dir. #381 collected four
+  findings against the first draft of exactly this function.
+
+- **Anything that can make the run journal lie about registration.**
+  `reclaim_dead_run_rows` (`database.py:808`) purges rows of runs the journal says never
+  registered — so a swallowed `mark_ingest_registered` failure (`database.py:758`) turns an
+  already-registered dataset into the next run's "orphan" and deletes its rows (#371).
+  Journal writes that follow a successful registration must not fail silently.
+
+- **A `data_id` semantics change that collapses or duplicates rows.** `data_id` has a
+  UNIQUE upsert. The default strategy is `content_hash` (#350) *except* object detection,
+  which stays `uuid`: objdet manifests list one row per object, duplicate
+  `(filename, label)` rows are the norm, and content-hashing them silently under-counts
+  objects (`cli/conventions.py:293-322`; #383 → #388). Flag any new category or code path
+  that changes `data_id` behavior without reasoning about row collapse vs retry
+  re-insertion.
+
+- **Reusing a SQLAlchemy connection after a failed statement without a rollback.** The next
+  execute raises `PendingRollbackError` and masks the intended handling (#386; same class
+  as #219's `_execute_with_retry`). Relatedly, sweep loops (e.g. backfill discovery) need a
+  per-item guard — one bad table logged (type only) and skipped, never aborting the whole
+  rollout (#395).
+
+- **A release step that self-creates a `v*` tag, or gates "done" on the tag.** `v*` tags
+  are ruleset-protected (org admins + release-managers only) — a workflow tagging under
+  `github-actions` 403s on its first real run (#402); tags are cut by the release train's
+  prod hop. Idempotency checks must gate on the actual artifact (GitHub Release / signed
+  image), not tag existence (#402). The version is single-sourced in
+  `tracebloc_ingestor/__init__.py` (`setup.py` parses it; the two drifted once — #171/#175),
+  and every publisher keeps the `_load_schema()` smoke probe (the v0.3.0-rc1
+  missing-schema bug).
+
+- **Validator UX regressions on wide manifests** (learned rules). Column lists in messages
+  are capped via `redaction.column_preview` with the full set kept in result *metadata* for
+  programmatic consumers (#371, #384); log labels derive from `validator.name` normalized
+  at the log site — names do not all end in "Validator" (#396 → #397).
+
+## Known non-issues — do not flag
+
+- **`reclaim_source` swallowing every exception is deliberate.** It runs only after the
+  load is durable (rows committed + dataset registered); a reclaim hiccup must never fail a
+  successful ingest (`file_transfer.py:519` docstring; call site
+  `ingestors/base.py:1303-1310`). Best-effort here was reviewed and kept on purpose.
+- **`type(e).__name__` with "message suppressed" is not information loss** — it is the
+  redaction policy above. Don't suggest logging the exception message or full traceback on
+  paths that reach install logs.
+- **Label values in `LabelDiversityValidator` diagnostics are exempt by policy** — labels
+  egress by design in the ingest summary's label counts (`utils/redaction.py` docstring).
+- **Object detection defaulting to `uuid` while everything else defaults to `content_hash`
+  is intentional**, documented at `cli/conventions.py:310` with the row-collapse rationale.
+  The known cost (a retried objdet run re-inserts rows) is accepted; the row-ordinal-salted
+  hash is a tracked follow-up, not a bug in the default.
+- **`\x27` inside a *Python* `re` pattern is a valid escape for `'`** — verified false
+  positive on #407. The "broken escape" claim applies to POSIX grep/sed character classes,
+  not Python's `re` engine.
+- **The e2e suite drives a real MySQL service container** (`e2e/`, `e2e.yml`) while the
+  unit suite mocks DB + API (`tests.yml`) — the split is by design, and the
+  characterization e2e pins `data_id: uuid` where content-hash would collapse its repeated
+  fixture rows (`e2e/test_characterization.py:107,215`).
+- `debug_csv_processing.py` at the repo root is a tracked debugging scratch script — only
+  `tracebloc_ingestor/` ships in the package.
+
+## Tone
+
+Direct. Name the file and line. Give a concrete fix, not "consider". Lead with the
+customer-visible consequence — what egresses, what gets deleted, which dataset silently
+mis-ingests.
+
+This repo is **public**: never put a customer name, internal hostname, or internal-only
+ticket detail in a finding. A bare `tracebloc/backend#NNNN` reference is fine.
+
+## Working with Bugbot findings (team norm)
+
+Every Bugbot review thread gets a reply, then gets resolved:
+- **Fixed**: say what changed and in which commit.
+- **False positive**: say why, with evidence (file/line, measured behavior).
+Unresolved cursor threads HOLD release-train promotions (soft gate) — an
+unaddressed finding blocks the fleet, not just this PR.

--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -1,0 +1,22 @@
+name: Code quality
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+# Supersede the previous run when a branch is pushed again. Measured:
+# workflows missing this stack ~10-minute duplicate runs per push.
+concurrency:
+  group: code-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    uses: tracebloc/.github/.github/workflows/code-quality.yml@main
+    with:
+      python: true          # repos with Python
+      shell: true           # repos with shell scripts
+      # soft-fail: false    # flip once the backlog is clear

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# File used for configuring project pre-commit hooks.
+# Layer 0: an optional local lint guard — CI remains the enforcement layer.
+# Mirrors the org pattern in tracebloc/backend.
+repos:
+- repo: https://github.com/psf/black
+  rev: 26.3.1
+  hooks:
+  - id: black
+    args: [
+      --check
+    ]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.1.0
+  hooks:
+  - id: check-json
+  - id: check-xml
+  - id: check-yaml
+  - id: debug-statements
+  - id: end-of-file-fixer
+    # templates/ ships user-facing sample files byte-for-byte — never rewrite.
+    exclude: ^templates/

--- a/Readme.md
+++ b/Readme.md
@@ -215,3 +215,9 @@ Maintainers: see [RELEASING.md](RELEASING.md) for the release procedure.
 Apache 2.0 — see [LICENSE](LICENSE).
 
 **Questions?** [support@tracebloc.io](mailto:support@tracebloc.io) or [open an issue](https://github.com/tracebloc/data-ingestors/issues).
+
+## Pre-commit
+
+Optional but recommended: `pip install pre-commit && pre-commit install` sets up the git hooks from [`.pre-commit-config.yaml`](.pre-commit-config.yaml).
+The hooks run automatically on each commit, only on the files you touch.
+They are a fast local guard — CI remains the guarantee.

--- a/debug_csv_processing.py
+++ b/debug_csv_processing.py
@@ -8,7 +8,6 @@ how the CSV data is being processed and identifying potential issues.
 
 import pandas as pd
 import logging
-from pathlib import Path
 import re
 
 # Setup logging
@@ -144,7 +143,7 @@ def diagnose_csv_issues(csv_path):
                 "feature_018",
             ]
             available_cols = [col for col in test_cols if col in df.columns]
-            subset_df = df[available_cols]
+            df[available_cols]  # exercise subset selection; result unused
             print(f"   ✅ Column subset selection works: {len(available_cols)} columns")
         except Exception as e:
             print(f"   ❌ Column subset selection failed: {e}")
@@ -152,7 +151,7 @@ def diagnose_csv_issues(csv_path):
         try:
             # Test column renaming
             rename_dict = {col: col.strip() for col in df.columns}
-            renamed_df = df.rename(columns=rename_dict)
+            df.rename(columns=rename_dict)  # exercise renaming; result unused
             print("   ✅ Column renaming works")
         except Exception as e:
             print(f"   ❌ Column renaming failed: {e}")

--- a/e2e/test_semseg_client_contract_e2e.py
+++ b/e2e/test_semseg_client_contract_e2e.py
@@ -33,7 +33,6 @@ from pathlib import Path
 
 import mysql.connector
 import pandas as pd
-import pytest
 import yaml
 
 from tracebloc_ingestor.cli import run

--- a/examples/json_ingestor.py
+++ b/examples/json_ingestor.py
@@ -7,7 +7,6 @@ that normalizes data types and formats.
 
 import logging
 from pathlib import Path
-from typing import Dict, Any
 
 from tracebloc_ingestor import Config, Database, APIClient, JSONIngestor
 from tracebloc_ingestor.utils.logging import setup_logging

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ types-requests
 types-urllib3
 
 # Linting / formatting
-black>=23.0.0
+black>=26,<27  # keep in step with the pre-commit hook (26.3.1) — same 2026 stable style
 isort>=5.12.0
 flake8>=6.0.0
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,15 @@
+# Ruff configuration for the org code-quality gate (tracebloc/.github
+# code-quality.yml, adopted repo-wide via tracebloc/backend#1303). The shared
+# workflow uses a repo's own ruff config when one exists, so keep the
+# selection identical to the org default: the real-bug families only
+# (pyflakes + the pycodestyle errors), no formatting-opinion rules.
+
+[lint]
+select = ["E4", "E7", "E9", "F"]
+
+[lint.per-file-ignores]
+# templates/ ships byte-exact, user-facing sample scripts — pre-commit's
+# end-of-file-fixer excludes them for the same reason. They must never be
+# rewritten to satisfy lint; their only findings are unused imports (F401),
+# which are part of the copy-me template surface.
+"templates/**" = ["F401"]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages
-import os
 import re
 
 # read the contents of your README file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,8 @@ shell environment can't leak into a run.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 from unittest.mock import MagicMock
 
 import pandas as pd

--- a/tests/test_api_client_failure_modes.py
+++ b/tests/test_api_client_failure_modes.py
@@ -20,7 +20,6 @@ import requests
 from tracebloc_ingestor.api import client as client_mod
 from tracebloc_ingestor.api.client import APIClient
 from tracebloc_ingestor.config import Config
-from tracebloc_ingestor.utils.constants import TaskCategory
 
 
 class _Program:

--- a/tests/test_batch_send_failure_accounting.py
+++ b/tests/test_batch_send_failure_accounting.py
@@ -33,7 +33,7 @@ import requests
 from tracebloc_ingestor.config import Config
 from tracebloc_ingestor.api.client import APIClient
 from tracebloc_ingestor.ingestors import base as base_mod
-from tracebloc_ingestor.ingestors.base import BaseIngestor, IngestionSummary
+from tracebloc_ingestor.ingestors.base import BaseIngestor
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_category_congruence.py
+++ b/tests/test_category_congruence.py
@@ -35,7 +35,7 @@ from tracebloc_ingestor.cli.conventions import (
 )
 from tracebloc_ingestor.ingestors.base import _FILE_BEARING_CATEGORIES
 from tracebloc_ingestor.modalities import spec_for
-from tracebloc_ingestor.utils.constants import DataFormat, TaskCategory
+from tracebloc_ingestor.utils.constants import DataFormat
 from tracebloc_ingestor.utils.validators_mapping import map_validators
 
 

--- a/tests/test_content_hash_data_id.py
+++ b/tests/test_content_hash_data_id.py
@@ -7,7 +7,6 @@ duplicating them. The per-table salt keeps ids unlinkable across tables and
 never leaves the cluster.
 """
 
-import json
 
 import pytest
 

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -21,7 +21,6 @@ What they cover:
 
 from __future__ import annotations
 
-from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict
 

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import importlib
 import logging
-import sys
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -73,7 +72,8 @@ def test_build_ingestor_unknown_source_type_raises():
 # validators/base: BaseValidator helpers
 # ===========================================================================
 
-from tracebloc_ingestor.validators.base import BaseValidator, ValidationResult
+# E402: deliberate per-section import — the unit under test lives with its tests.
+from tracebloc_ingestor.validators.base import BaseValidator  # noqa: E402
 
 
 class _Concrete(BaseValidator):
@@ -148,7 +148,8 @@ def test_mlm_with_schema_adds_data_validator():
 # data_validator: edge branches
 # ===========================================================================
 
-from tracebloc_ingestor.validators.data_validator import DataValidator
+# E402: deliberate per-section import — the unit under test lives with its tests.
+from tracebloc_ingestor.validators.data_validator import DataValidator  # noqa: E402
 
 
 def test_data_validator_load_non_csv_returns_none():
@@ -190,7 +191,10 @@ def test_data_validator_date_exception(monkeypatch):
 # duplicate_validator: exception fallbacks
 # ===========================================================================
 
-from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
+# E402: deliberate per-section import — the unit under test lives with its tests.
+from tracebloc_ingestor.validators.duplicate_validator import (  # noqa: E402
+    DuplicateValidator,
+)
 
 
 def test_duplicate_validate_exception(monkeypatch):
@@ -385,7 +389,8 @@ def test_image_validator_list_with_non_path_item():
 # api/client: error-response branches + LoggingRetry
 # ===========================================================================
 
-from tracebloc_ingestor.api.client import APIClient, LoggingRetry
+# E402: deliberate per-section import — the unit under test lives with its tests.
+from tracebloc_ingestor.api.client import APIClient, LoggingRetry  # noqa: E402
 
 
 def _client(**ov):
@@ -433,7 +438,8 @@ def test_send_ingest_summary_error_with_response_text():
 # file_transfer: copy-failure except branches
 # ===========================================================================
 
-from tracebloc_ingestor import file_transfer
+# E402: deliberate per-section import — the unit under test lives with its tests.
+from tracebloc_ingestor import file_transfer  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/test_coverage_gaps2.py
+++ b/tests/test_coverage_gaps2.py
@@ -297,7 +297,10 @@ def test_json_ingest_method_propagates_error():
 # XML validator: sub-element branches (called directly on crafted elements)
 # ===========================================================================
 
-from tracebloc_ingestor.validators.xml_validator import PascalVOCXMLValidator
+# E402: deliberate per-section import — the unit under test lives with its tests.
+from tracebloc_ingestor.validators.xml_validator import (  # noqa: E402
+    PascalVOCXMLValidator,
+)
 
 
 def _obj(

--- a/tests/test_csv_ingestor_scale.py
+++ b/tests/test_csv_ingestor_scale.py
@@ -14,7 +14,6 @@ import datetime
 
 from unittest.mock import MagicMock
 
-import pandas as pd
 
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
 from tracebloc_ingestor.utils.constants import TaskCategory

--- a/tests/test_file_transfer_has_extension.py
+++ b/tests/test_file_transfer_has_extension.py
@@ -23,7 +23,6 @@ These tests pin the three classes of input that need to be handled:
 
 from __future__ import annotations
 
-import pytest
 
 from tracebloc_ingestor.file_transfer import _has_extension
 

--- a/tests/test_file_transfer_reclaim.py
+++ b/tests/test_file_transfer_reclaim.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import os
 
-import pytest
 
 from tracebloc_ingestor import file_transfer
 from tracebloc_ingestor.config import Config

--- a/tests/test_file_transfer_summary.py
+++ b/tests/test_file_transfer_summary.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import io
 import logging
-import os
 from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_file_transfer_transfers.py
+++ b/tests/test_file_transfer_transfers.py
@@ -7,7 +7,6 @@ source resolution helpers, and the multi-file map_file_transfer branches.
 
 from __future__ import annotations
 
-import os
 
 import pytest
 

--- a/tests/test_file_validator.py
+++ b/tests/test_file_validator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any, Dict, Generator, List
+from typing import Any, Dict, Generator
 from unittest.mock import MagicMock, patch
 
 import pandas as pd

--- a/tests/test_json_ingestor.py
+++ b/tests/test_json_ingestor.py
@@ -274,7 +274,6 @@ def test_read_data_streams_array_does_not_materialise_whole_file(tmp_path):
     ``next()`` returns without reading the trailing records first).
     """
     import ijson as _ijson
-    import os
 
     # Write a moderate-size array so the test is fast but the streaming
     # behaviour is observable. We assert by checking that ijson.items is

--- a/tests/test_label_diversity_validator.py
+++ b/tests/test_label_diversity_validator.py
@@ -9,7 +9,6 @@ landed in MySQL. Issue #251.
 from __future__ import annotations
 
 import pandas as pd
-import pytest
 
 from tracebloc_ingestor.validators.label_diversity_validator import (
     LabelDiversityValidator,

--- a/tests/test_metadata_backfill.py
+++ b/tests/test_metadata_backfill.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 from collections import Counter
 from decimal import Decimal
 
-import pytest
 from sqlalchemy import (
     Column,
     Float,

--- a/tests/test_numeric_columns_validator.py
+++ b/tests/test_numeric_columns_validator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from tracebloc_ingestor.validators.numeric_columns_validator import (
     NumericColumnsValidator,

--- a/tests/test_schema_bundled.py
+++ b/tests/test_schema_bundled.py
@@ -29,8 +29,6 @@ from __future__ import annotations
 
 import importlib
 
-import pytest
-
 
 def test_schema_subpackage_is_importable():
     """The marker __init__.py exists and the subpackage imports cleanly.

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -21,7 +21,6 @@ This file's job is to lock the shape of the YAML surface in isolation.
 from __future__ import annotations
 
 import json
-from copy import deepcopy
 from pathlib import Path
 
 import pytest

--- a/tests/test_time_validators.py
+++ b/tests/test_time_validators.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pandas as pd
-import pytest
 
 from tracebloc_ingestor.validators.time_format_validator import TimeFormatValidator
 from tracebloc_ingestor.validators.time_ordered_validator import TimeOrderedValidator

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from tracebloc_ingestor.config import Config
 from tracebloc_ingestor.utils.validators_mapping import map_validators

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -1,6 +1,7 @@
 from typing import List, Dict, Any, Optional
 import os
-import requests, json
+import requests
+import json
 import logging
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -42,7 +42,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, NoReturn, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 import yaml
 from jsonschema import Draft7Validator, ValidationError

--- a/tracebloc_ingestor/ingestors/json_ingestor.py
+++ b/tracebloc_ingestor/ingestors/json_ingestor.py
@@ -16,6 +16,12 @@ import ijson
 import pandas as pd
 
 from ..utils import redaction
+from .base import BaseIngestor
+from ..database import Database
+from ..api.client import APIClient
+from ..utils.constants import RESET, RED, YELLOW
+from ..utils import label_policy as label_policy_module
+from ..utils import coercion
 
 
 def _peek_json_shape(path: Path) -> Optional[str]:
@@ -57,12 +63,6 @@ def _peek_json_shape(path: Path) -> Optional[str]:
                 return None
     return None
 
-from .base import BaseIngestor
-from ..database import Database
-from ..api.client import APIClient
-from ..utils.constants import RESET, RED, YELLOW
-from ..utils import label_policy as label_policy_module
-from ..utils import coercion
 
 logger = logging.getLogger(__name__)
 

--- a/tracebloc_ingestor/modalities/layout.py
+++ b/tracebloc_ingestor/modalities/layout.py
@@ -27,8 +27,9 @@ than independent logic:
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 # Bump when the contract's SHAPE changes (fields added/removed/reinterpreted),
 # not when a task's values change — those are caught by the drift test.
@@ -166,8 +167,6 @@ def build_layout_contract() -> Dict[str, Any]:
 # Path of the committed, machine-readable contract the CLI vendors + mirrors.
 # Kept next to ingest.v1.json (both are the CLI's contract surface).
 def contract_path() -> "os.PathLike[str]":
-    import os
-
     return os.path.join(
         os.path.dirname(os.path.dirname(__file__)), "schema", "layout.v1.json"
     )

--- a/tracebloc_ingestor/validators/base.py
+++ b/tracebloc_ingestor/validators/base.py
@@ -5,13 +5,17 @@ for implementing data validation before ingestion.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, TYPE_CHECKING
 from dataclasses import dataclass
 from pathlib import Path
 import json
 import logging
 
 from tqdm import tqdm
+
+if TYPE_CHECKING:  # pragma: no cover
+    # Typing-only: pandas stays a lazy runtime import (see _load_data).
+    import pandas as pd
 
 from tracebloc_ingestor.config import Config
 

--- a/tracebloc_ingestor/validators/data_validator.py
+++ b/tracebloc_ingestor/validators/data_validator.py
@@ -10,8 +10,7 @@ import json
 import logging
 import re
 from pathlib import Path
-from typing import Any, List, Dict, Optional, Union
-from datetime import datetime
+from typing import Any, Dict, Optional
 
 import numpy as np
 from ..utils import redaction
@@ -969,7 +968,7 @@ class DataValidator(BaseValidator):
                 errors.append(
                     f"Column '{column_name}' contains {invalid_dates} invalid date values"
                 )
-        except:
+        except Exception:
             errors.append(f"Column '{column_name}' contains invalid date values")
 
         return {"is_valid": len(errors) == 0, "errors": errors, "warnings": warnings}

--- a/tracebloc_ingestor/validators/duplicate_validator.py
+++ b/tracebloc_ingestor/validators/duplicate_validator.py
@@ -4,7 +4,6 @@ This module provides validation to check if the destination directory exists,
 raising errors if it does to prevent accidental overwrites.
 """
 
-import os
 from pathlib import Path
 from typing import Any, List, Optional
 import logging

--- a/tracebloc_ingestor/validators/keypoint_visibility_validator.py
+++ b/tracebloc_ingestor/validators/keypoint_visibility_validator.py
@@ -6,7 +6,7 @@ match the corresponding annotation keypoint names.
 """
 
 import logging
-from typing import Any, List, Optional
+from typing import Any, List
 
 import pandas as pd
 


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI/docs, lint config, and non-functional import/exception-handling cleanup; ingest behavior is unchanged aside from narrowing a bare `except` to `Exception` in date validation.
> 
> **Overview**
> **Release-train promotion** bundling org-wide **code quality** wiring and a large **lint/import hygiene** pass, with no new ingest features.
> 
> Adds **`.github/workflows/code-quality-caller.yml`** to run the shared `tracebloc/.github` code-quality workflow on PRs (with concurrency cancel-in-progress), plus **`ruff.toml`** aligned to the org default (pyflakes + pycodestyle errors; `templates/**` ignores unused imports). Introduces **`.pre-commit-config.yaml`** (Black 26.3.1 check, JSON/XML/YAML, EOF fixer excluding `templates/`) and documents optional local hooks in **`Readme.md`**. **`requirements-dev.txt`** pins Black `>=26,<27` to match pre-commit.
> 
> Adds **`.cursor/BUGBOT.md`** — maintainer/Bugbot guidance for this repo (redaction, validator/ingest parity, reclaim safety, etc.).
> 
> Production code tweaks are mechanical: import reordering in **`json_ingestor.py`** / **`api/client.py`**, **`TYPE_CHECKING`** for pandas in **`validators/base.py`**, **`except Exception`** in **`data_validator`**, unused import removals across **`cli/run.py`**, **`modalities/layout.py`**, and validators. Tests and examples drop unused imports; **`test_coverage_gaps*.py`** adds `# noqa: E402` for deliberate mid-file imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ff47f1bdb9244d8c53312e19c5944a65b4589b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->