### PR TITLE
ci: arm the code-quality gate (soft-fail off) + all-files dispatch

### DIFF
--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -3,6 +3,14 @@ name: Code quality
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+  # Manual whole-tree scan (gitleaks baseline etc.) -- runs every enabled
+  # job in all-files mode instead of a PR diff.
+  workflow_dispatch:
+    inputs:
+      all-files:
+        description: "Scan the whole repo, not a diff"
+        type: boolean
+        default: true
 
 # Supersede the previous run when a branch is pushed again. Measured:
 # workflows missing this stack ~10-minute duplicate runs per push.
@@ -19,4 +27,7 @@ jobs:
     with:
       python: true          # repos with Python
       shell: true           # repos with shell scripts
-      # soft-fail: false    # flip once the backlog is clear
+      # The gate is armed: findings fail the job. Backlog cleared to zero
+      # fleet-wide + advisory soak done (backend#1303).
+      soft-fail: false
+      all-files: ${{ inputs.all-files || false }}


### PR DESCRIPTION
The #1303 flip: `soft-fail: false` — from this merge on, ruff/shellcheck/gitleaks/house-rules findings **fail the check** (which is already marked required on develop). This repo's backlog is at zero, so only *new* findings can ever block. Also adds `workflow_dispatch(all-files)` for whole-tree scans (the gitleaks baseline run follows the merge).

This PR is its own proof-run: the armed configuration must pass on this very diff.

Part of tracebloc/backend#1303

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turns advisory scans into a required blocking gate on PRs; scope is CI config only with no runtime code changes, but misconfiguration or new findings will block merges.
> 
> **Overview**
> **Arms the shared code-quality workflow** so ruff, shellcheck, gitleaks, and house-rules findings **fail the job** (`soft-fail: false`), completing the backend#1303 rollout after fleet-wide backlog cleanup and advisory soak.
> 
> Adds **`workflow_dispatch`** with an **`all-files`** boolean (default `true`) so operators can trigger a **whole-repo scan** instead of a PR diff; PR runs still pass `all-files: false` via `inputs.all-files || false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4b7272c4fa4eea7c2a7465cc80433632537bf59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->