### PR TITLE
chore: add redacted gitleaks history baseline

### DIFF
--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -31,3 +31,4 @@ jobs:
       # fleet-wide + advisory soak done (backend#1303).
       soft-fail: false
       all-files: ${{ inputs.all-files || false }}
+      gitleaks-baseline: .gitleaks-baseline.json

--- a/.gitleaks-baseline.json
+++ b/.gitleaks-baseline.json
@@ -1,0 +1,23 @@
+[
+ {
+  "RuleID": "generic-api-key",
+  "Description": "Detected a Generic API Key, potentially exposing access to various services and sensitive operations.",
+  "StartLine": 34,
+  "EndLine": 34,
+  "StartColumn": 2,
+  "EndColumn": 51,
+  "Match": "CLI_STYLE_KEY = \"REDACTED\"",
+  "Secret": "REDACTED",
+  "File": "tests/test_correlation_id.py",
+  "SymlinkFile": "",
+  "Commit": "8f89aece1e0c249a28644eb6cdec47b7572bbec6",
+  "Link": "https://github.com/tracebloc/data-ingestors/blob/8f89aece1e0c249a28644eb6cdec47b7572bbec6/tests/test_correlation_id.py#L34",
+  "Entropy": 3.9528196,
+  "Author": "lukasWuttke",
+  "Email": "54042461+LukasWodka@users.noreply.github.com",
+  "Date": "2026-07-13T13:26:54Z",
+  "Message": "feat(ingest): end-to-end ingest correlation id — honour the Job env (backend#1028 item 3) (#368)\n\n* feat(ingest): honour TRACEBLOC_INGEST_CORRELATION_ID as the end-to-end run id (backend#1028 item 3)\n\njobs-manager (client-runtime) stamps the CLI's idempotency key onto the\nspawned ingestor Job as TRACEBLOC_INGEST_CORRELATION_ID — the same string\nits Job name and tracebloc.io/ingestion-run label already derive from.\nPick it up here:\n\n- utils/correlation.py: resolve + validate the env value (1-64 chars of\n  [A-Za-z0-9._-], mirroring jobs-manager's key cap and label alphabet).\n  Absent -\u003e None; malformed -\u003e WARNING + None. Observability must never\n  fail an ingest.\n- BaseIngestor: keep the id ALONGSIDE the per-process ingestor_id (row\n  scoping — label counts, the #227 compensating delete — must stay\n  per-process across Job retries, or a hard-killed attempt's orphan rows\n  would be counted into the retry's dataset). Riding file_options puts it\n  in the registration payload's meta_data, so the backend dataset row\n  carries it verbatim (DictField, no backend change needed).\n- cli/run.py: print the always-visible link line\n  \"Correlation id: \u003cid\u003e (ingestor_id: \u003cuuid\u003e)\" — print, not logger,\n  because the default LOG_LEVEL is WARNING.\n\nNo env set = today's behaviour, byte for byte.\n\nCo-Authored-By: Claude Fable 5 \u003cnoreply@anthropic.com\u003e\n\n* docs(correlation): fix stale command name in module docstring (review)\n\nArturo (di#368): the docstring referenced the old `tracebloc dataset push`;\nrenamed to `tracebloc data ingest` (the current verb). Comment-only.\n\nCo-Authored-By: Claude Opus 4.8 \u003cnoreply@anthropic.com\u003e\n\n---------\n\nCo-authored-by: Claude Fable 5 \u003cnoreply@anthropic.com\u003e",
+  "Tags": [],
+  "Fingerprint": "8f89aece1e0c249a28644eb6cdec47b7572bbec6:tests/test_correlation_id.py:generic-api-key:34"
+ }
+]


### PR DESCRIPTION
Adds a redacted gitleaks history baseline so the full-history dispatch scan runs clean; 1 historical finding triaged, classification relayed privately. Part of tracebloc/backend#1303

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only baseline and workflow input; no application or auth logic changes.
> 
> **Overview**
> Enables **full-repo gitleaks** runs in the shared code-quality workflow without failing on one **already-triaged historical hit**.
> 
> The caller workflow now passes **`gitleaks-baseline: .gitleaks-baseline.json`**. The new baseline records a single **`generic-api-key`** match in **`tests/test_correlation_id.py`** (test fixture `CLI_STYLE_KEY`), with secrets redacted in the committed file. New leaks should still fail the job because **`soft-fail` stays `false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44ec3e3e3649f6a6d79b8fbcfbde7d84975d3ba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->