### PR TITLE
chore(release): bump ingestor to 0.8.0 — release the #408 per-ingestion write path

### DIFF
--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.7.9"
+__version__ = "0.8.0"
 
 __all__ = [
     "Config",


### PR DESCRIPTION
Bumps `__version__` 0.7.9 → 0.8.0 so a `v0.8.0` tag can be cut, which `release-image.yml` builds into `ghcr.io/tracebloc/ingestor:0.8.0` (+ :0.8, :0) **carrying the RFC-0003 I2 ds_<hex> write path (#408)**.

**Why:** #408 merged with no version bump, so no tag/image was ever built — the deployed `:0.7` ingestor has the journal+salt scaffolding but not the ds_ write path. Divya's staging functional test surfaced this: flag ON, but ingest still wrote a legacy dataset-named table because the running ingestor predates #408.

**After merge:** cut `v0.8.0` (release authority) → CI publishes the image → the D16 write path becomes testable/deployable. The chart's ingestor pin (currently 0.7) then bumps to 0.8 as part of the chart release.

Feature is flag-gated (PER_INGESTION_TABLES, default off), so the image is backward-compatible.

Epic: tracebloc/backend#1151 · I2: #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version constant change with no behavioral diff in this PR.
> 
> **Overview**
> Bumps the package **`__version__`** in `tracebloc_ingestor/__init__.py` from **0.7.9** to **0.8.0** so release tooling can tag **`v0.8.0`** and publish a container image that includes the per-ingestion **`ds_<hex>`** write path from #408 (RFC-0003 I2).
> 
> No runtime or API code changes in this PR—only the version literal that `setup.py` reads as the single source of truth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7395a892dc57f40eec12726969d51f0514baf495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->