### PR TITLE
ci: guard — package change requires a __version__ bump

### DIFF
--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,0 +1,38 @@
+# The ingestor image builds ONLY on a vX.Y.Z tag (release-image.yml), and the
+# tag is cut from __version__. So a package change merged without bumping
+# __version__ never reaches a released image — which is exactly how the D16
+# ds_<hex> write path (#408) sat unreleased: it merged to develop, everyone
+# assumed it shipped, but no version bump meant no tag and no image. This gate
+# makes the bump non-optional for package-source changes.
+name: Version guard
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  require-version-bump:
+    name: package change ⇒ __version__ bump
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Require a __version__ bump when the package changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          changed="$(git diff --name-only "${BASE_SHA}...HEAD")"
+          if ! printf '%s\n' "$changed" | grep -qE '^tracebloc_ingestor/'; then
+            echo "No tracebloc_ingestor/ change in this PR — guard N/A."
+            exit 0
+          fi
+          if git diff "${BASE_SHA}...HEAD" -- tracebloc_ingestor/__init__.py | grep -qE '^\+__version__'; then
+            echo "Package changed and __version__ was bumped. ✓"
+            exit 0
+          fi
+          echo "::error::tracebloc_ingestor/ changed but __version__ (tracebloc_ingestor/__init__.py) was NOT bumped. The ingestor image builds only on a vX.Y.Z tag, so an unbumped change never reaches a released image (this is how the D16 ds_<hex> write path #408 sat unreleased). Bump __version__ in this PR."
+          exit 1


### PR DESCRIPTION
Sibling to tracebloc/client#491, preventing the gap Divya's staging test surfaced on the ingestor side: the D16 `ds_<hex>` write path (#408) **merged without a `__version__` bump**, so no `vX.Y.Z` tag was cut, no image was built, and the deployed `:0.7` ingestor still wrote legacy tables even with the flag on.

This blocking gate: any PR touching `tracebloc_ingestor/**` must also bump `__version__` in `tracebloc_ingestor/__init__.py`, else it fails. Non-package PRs (tests/, docs, CI) are unaffected.

After merge, add it to the required status checks (admin) so it actually blocks. If it proves too strict for genuinely non-shippable package edits, we can carve an opt-out label — but the point is that the image-builds-only-on-a-tag rule stops being silently forgettable.

Epic: tracebloc/backend#1151 · the release it would have caught: #408 / #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only policy enforcement with read-only permissions; no runtime or package behavior changes.
> 
> **Overview**
> Adds a **Version guard** GitHub Actions workflow on every pull request so ingestor package changes cannot merge without a release version bump.
> 
> If the diff touches anything under `tracebloc_ingestor/`, the job requires a `+__version__` line in `tracebloc_ingestor/__init__.py`; otherwise it fails with an error that explains the tag-driven image release path. PRs that only change tests, docs, or other non-package paths skip the check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18bde7b59c6883ea21958a83b90fd63dc6b34e8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->