### PR TITLE
fix(images): emit ::error:: on stdout so the guard failures annotate

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -96,14 +96,14 @@ jobs:
             develop) tag="dev" ;;
             staging) tag="stg" ;;
             *)
-              echo "::error::refusing to publish an internal channel from '$REF_NAME' - this workflow handles develop/staging only; prod images come from release-image.yml on a vX.Y.Z tag." >&2
+              echo "::error::refusing to publish an internal channel from '$REF_NAME' - this workflow handles develop/staging only; prod images come from release-image.yml on a vX.Y.Z tag."
               exit 1
               ;;
           esac
           # Belt and braces: never let this workflow mint a prod-looking tag.
           case "$tag" in
             dev|stg) ;;
-            *) echo "::error::channel '$tag' is not an internal channel (dev|stg)" >&2; exit 1 ;;
+            *) echo "::error::channel '$tag' is not an internal channel (dev|stg)"; exit 1 ;;
           esac
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "Publishing internal channel: $tag"
@@ -180,7 +180,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${DIGEST:-}" ]; then
-            echo "::error::build produced no digest" >&2
+            echo "::error::build produced no digest"
             exit 1
           fi
           mkdir -p "${{ runner.temp }}/digests"
@@ -224,7 +224,7 @@ jobs:
           set -euo pipefail
           count=$(find . -maxdepth 1 -type f | wc -l | tr -d ' ')
           if [ "$count" -lt 2 ]; then
-            echo "::error::expected 2 per-arch digests, found $count - refusing to publish a partial (single-arch) index. An amd64-only channel tag ImagePullBackOffs on arm64 kubelets (client#186)." >&2
+            echo "::error::expected 2 per-arch digests, found $count - refusing to publish a partial (single-arch) index. An amd64-only channel tag ImagePullBackOffs on arm64 kubelets (client#186)."
             exit 1
           fi
           # shellcheck disable=SC2046  # intentional word splitting: one arg per digest file
@@ -241,7 +241,7 @@ jobs:
           echo "$out"
           for arch in amd64 arm64; do
             printf '%s' "$out" | grep -q "linux/${arch}" || {
-              echo "::error::published ${IMAGE}:${TAG} is missing linux/${arch}" >&2
+              echo "::error::published ${IMAGE}:${TAG} is missing linux/${arch}"
               exit 1
             }
           done


### PR DESCRIPTION
Follow-up to #422 (thanks for merging). Bugbot found this class on tracebloc/client#497 and I audited my other workflows from today — `publish-images.yml` had it **five times**.

GitHub Actions parses workflow commands from **stdout only**. Every `::error::` in that file went to `>&2`, so each guard failed the step with **no annotation** — the reader gets a bare red X and has to dig through the log to find out why. That defeats the point of the carefully-worded refusals:

- refusing a non-develop/staging ref
- refusing a non-internal channel tag
- a build that produced no digest
- **refusing to publish a partial single-arch index** (the client#186 ImagePullBackOff guard)
- a published index missing an arch

All five now write to stdout, so they annotate on the PR/run as intended. No logic change; the messages and exit codes are identical.

`actionlint` + `shellcheck` clean at the CI-pinned versions.

Worth knowing for the wider codebase: `.github/workflows/merge-settings-drift.yml` (already merged) has one instance of the same pattern in its zero-repos guard — I'll fix it separately rather than reach across repos in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only stderr→stdout tweak for workflow commands; no build, publish, or application logic changes.
> 
> **Overview**
> **GitHub Actions workflow commands only apply when `::error::` is written to stdout.** In `publish-images.yml`, five guard failures still echoed those lines to stderr (`>&2`), so steps failed without the intended run/PR annotations.
> 
> This change removes `>&2` on those echoes only—**no change to messages, exit codes, or guard logic**. Affected guards: refusing non-develop/staging refs, refusing non-internal channel tags, missing build digest, refusing a partial single-arch manifest merge, and a published index missing `linux/amd64` or `linux/arm64`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38daba8dc0da6c2760991a5c57e615889546daf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->