### PR TITLE
fix(release): emit release-image ::error:: on stdout so they annotate

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -83,11 +83,11 @@ jobs:
           # let `-f ref=0.7.9` clear the gate and then die in checkout instead.
           case "$REF" in
             v*) ;;
-            *) echo "::error::ref '$REF' must be a tag of the form vX.Y.Z (leading v required)" >&2; exit 1 ;;
+            *) echo "::error::ref '$REF' must be a tag of the form vX.Y.Z (leading v required)"; exit 1 ;;
           esac
           version="${REF#v}"
           if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$'; then
-            echo "::error::ref '$REF' is not a vX.Y.Z tag" >&2
+            echo "::error::ref '$REF' is not a vX.Y.Z tag"
             exit 1
           fi
 
@@ -114,7 +114,7 @@ jobs:
               sleep 20
             fi
           done
-          echo "::error::tracebloc-ingestor ${version} never appeared on PyPI (10 min). Refusing to publish an image for a version that did not publish - check the 'Publish Master Package' run for this commit, then re-drive this workflow with: gh workflow run release-image.yml -f ref=${REF}" >&2
+          echo "::error::tracebloc-ingestor ${version} never appeared on PyPI (10 min). Refusing to publish an image for a version that did not publish - check the 'Publish Master Package' run for this commit, then re-drive this workflow with: gh workflow run release-image.yml -f ref=${REF}"
           exit 1
 
   release:
@@ -193,7 +193,7 @@ jobs:
           REF: ${{ inputs.ref || github.ref_name }}
         run: |
           if [ -z "${TAGS//[[:space:]]/}" ]; then
-            echo "::error::docker/metadata-action produced no tags for ref '${REF}'. Aborting before the build silently pushes nothing." >&2
+            echo "::error::docker/metadata-action produced no tags for ref '${REF}'. Aborting before the build silently pushes nothing."
             exit 1
           fi
           echo "Tags to publish:"


### PR DESCRIPTION
Third and last file in this class (after #424 for `publish-images.yml` and tracebloc/client#497). Bugbot flagged it on the `develop -> staging` promotion (#425).

All four `::error::` annotations in `release-image.yml` wrote to stderr, and Actions parses workflow commands from **stdout only**, so each failed the job with **no annotation**:

- the invalid-ref guard (`must be a tag of the form vX.Y.Z`)
- the non-semver ref guard
- **the PyPI gate timeout — including its `gh workflow run release-image.yml -f ref=…` re-drive hint**
- the no-tags-produced abort (`before the build silently pushes nothing`)

The third one is the most costly: that message exists precisely so whoever finds a stuck release knows the one command to run. Sending it to stderr means they get a bare red X instead — which is exactly what happened during today's `v0.8.0` recovery.

Three of the four are the `verify-published` gate I added yesterday, so this is my own mistake repeated in a third file. Fixed by dropping the redirects; messages and exit codes unchanged.

`actionlint`/`shellcheck`: baseline **1** finding, **1** after — the remaining one is a pre-existing markdown-backtick `sed` I did not touch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only echo routing change; exit codes and message text are unchanged.
> 
> **Overview**
> **Fixes missing GitHub Actions failure annotations** in `release-image.yml` by stopping redirects of `::error::` workflow commands to stderr. Actions only parses those commands from **stdout**, so the four failure paths (invalid `v` ref, non-semver ref, PyPI wait timeout with re-drive hint, and empty docker metadata tags) still fail the job the same way but now surface inline annotations in the UI.
> 
> This matches the same class of fix already applied in `publish-images.yml` and the client repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90fc40ccc34efbf78366a95eca7b6a7f32d8d58a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->