### PR TITLE
ci: adopt the black format gate (diff-scoped, pinned 26.3.1)

### DIFF
--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -32,3 +32,9 @@ jobs:
       soft-fail: false
       all-files: ${{ inputs.all-files || false }}
       gitleaks-baseline: .gitleaks-baseline.json
+      # black --check on the .py files a PR touches (diff-scoped -- adopting
+      # the gate needs no repo-wide reformat; the tree converges as files are
+      # touched). Pinned in step with this repo's pre-commit hook so local and
+      # CI never disagree. backend#1382.
+      format: true
+      black-version: "26.3.1"


### PR DESCRIPTION
## What

Enables the shared **`format`** job (`black --check`) from `code-quality.yml`, pinned to **26.3.1**.

## Diff-scoped — adopting costs no churn

Only the `.py` files a PR **touches** must be black-clean; the tree converges as files are touched. No repo-wide reformat, so nothing collides with in-flight branches or damages `git blame`. A PR touching a not-yet-formatted file must reformat that file — that is the intended ratchet.

For reference, this repo currently has **78** files that black 26.3.1 would reformat — none of which block anything until a PR touches them.

## Why this pin

black's stable style changes between releases, so the CI pin must match the pre-commit hook or local and CI disagree. 26.3.1 is what backend (the only repo already gating black) is clean under. Note 23.1.0 cannot run on Python 3.12+ at all (`ast.Str` was removed), so it is not a viable pin.

## If it gets in the way

`format-soft-fail: true` makes this job advisory without un-arming ruff/gitleaks. Locally: `pip install black==26.3.1 && black <file>` (or `pre-commit run black`).

Part of tracebloc/backend#1382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds a formatting check; no runtime, auth, or data-path behavior changes.
> 
> **Overview**
> Turns on the shared **`format`** job in `code-quality-caller.yml` so PR CI runs **`black --check`** on Python files touched by the diff, with **`black-version: "26.3.1"`** aligned to this repo’s pre-commit hook.
> 
> Adoption is **diff-scoped**: no repo-wide reformat is required up front; only `.py` files changed in a PR must be black-clean, so formatting ratchets as files are edited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ed670d97f74cccc0ce8f7e9b76b701722739eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->