### PR TITLE
fix(images): require a branch ref before mapping an internal channel

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -96,7 +96,7 @@ jobs:
           # code. Same class as the client-runtime#213 finding, where the
           # equivalent gap could reach :prod. Require a real branch first.
           if [ "$REF_TYPE" != "branch" ]; then
-            echo "::error::refusing to publish an internal channel from a $REF_TYPE ref ('$REF_NAME'): channels are bound to the develop/staging BRANCHES, and a tag of the same name would otherwise map to a channel. Re-run selecting the develop or staging branch." >&2
+            echo "::error::refusing to publish an internal channel from a $REF_TYPE ref ('$REF_NAME'): channels are bound to the develop/staging BRANCHES, and a tag of the same name would otherwise map to a channel. Re-run selecting the develop or staging branch."
             exit 1
           fi
           # The ref is the ONLY source of the channel -- there is no input that

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -86,8 +86,19 @@ jobs:
         env:
           # Via env, never interpolated into the script (R8).
           REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
           set -euo pipefail
+          # A git tag's ref_name is indistinguishable from a branch's:
+          # refs/tags/develop and refs/heads/develop both yield "develop". Since
+          # workflow_dispatch can run from a tag, without this a tag named
+          # develop/staging would publish an internal channel from unreviewed
+          # code. Same class as the client-runtime#213 finding, where the
+          # equivalent gap could reach :prod. Require a real branch first.
+          if [ "$REF_TYPE" != "branch" ]; then
+            echo "::error::refusing to publish an internal channel from a $REF_TYPE ref ('$REF_NAME'): channels are bound to the develop/staging BRANCHES, and a tag of the same name would otherwise map to a channel. Re-run selecting the develop or staging branch." >&2
+            exit 1
+          fi
           # The ref is the ONLY source of the channel -- there is no input that
           # could disagree with it, so the code built and the tag published
           # always match. Any ref other than develop/staging is refused, on


### PR DESCRIPTION
Carry-over of the **High**-severity Bugbot finding on tracebloc/client-runtime#213 — the same gap exists in the channel workflow I added in #422.

## The gap

`publish-images.yml` maps the channel from `github.ref_name`, and a git tag's `ref_name` is **indistinguishable from a branch's**: `refs/tags/develop` and `refs/heads/develop` both yield `develop`. Since `workflow_dispatch` can be run from a tag, a tag named `develop` or `staging` would publish an internal channel from whatever commit that tag points at — bypassing the branch allowlist entirely.

Branch protection guards the *branch*; nothing guards a tag of the same name.

**Severity here is lower than in client-runtime**, where the equivalent gap could publish `:prod` and reach customer clusters via image-refresh. `:dev`/`:stg` are internal, unsigned channels only ever consumed by our own dev/staging edges. But it is the same class, so it gets closed the same way rather than left as "probably fine".

## The fix

Fail closed on any non-branch ref, **before** the name-based mapping runs:

```yaml
REF_TYPE: ${{ github.ref_type }}
...
if [ "$REF_TYPE" != "branch" ]; then
  echo "::error::refusing to publish an internal channel from a $REF_TYPE ref …" >&2
  exit 1
fi
```

Verified:

| ref | outcome |
|---|---|
| branch `develop` / `staging` | allowed, maps to `:dev` / `:stg` |
| tag `develop` | **refused** |
| tag `master` | **refused** |
| tag `v0.8.0` | **refused** |

`actionlint` + `shellcheck` clean at the CI-pinned versions (1.7.12 / 0.11.0).

Note this stacks defence rather than replacing it: the existing allowlist (only `develop`/`staging` names map, everything else is refused) stays, and the channel is still derived solely from the ref with no input able to override it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow hardening only; no runtime or customer-facing release path changes, and internal :dev/:stg channels remain unsigned.
> 
> **Overview**
> Closes a **workflow_dispatch** bypass in `publish-images.yml`: channel resolution used only `github.ref_name`, so a tag named `develop` or `staging` looked like the protected branch and could publish `:dev`/`:stg` from arbitrary commits.
> 
> The **Resolve channel** step now sets `REF_TYPE` from `github.ref_type` and **fails closed** when the ref is not a branch, before the existing `develop`/`staging` name allowlist runs. Push on real branches is unchanged; tag-triggered dispatches are refused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36bf3a2a53a9e16a1d1972b12c8f1ef18918a5e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->