### PR TITLE
docs(ci): /fr-pass advances staging → prod only (backend#1405 D6)

### DIFF
--- a/.github/workflows/fr-pass-comment-caller.yml
+++ b/.github/workflows/fr-pass-comment-caller.yml
@@ -1,7 +1,14 @@
 name: FR pass comment
 
 # Per-repo caller. Listens for /fr-pass comments and advances kanban items
-# from "FR on dev" → "Ready for staging" or "FR on staging" → "Ready for prod".
+# from "FR on staging" → "Ready for prod" — the single functional-review gate.
+#
+# RFC-BACKEND-1405 D6 retired the dev-side review: "On dev" is set automatically
+# when the release train merges to develop, so there is no "FR on dev" column and
+# nothing for /fr-pass to advance before staging. The reusable has only ever
+# implemented the staging hop; this comment described a transition that does not
+# exist.
+#
 # All logic lives in tracebloc/.github/.github/workflows/fr-pass-comment.yml.
 
 on:


### PR DESCRIPTION
The header comment on this repo's `/fr-pass` caller describes a transition that does not exist:

```
# from "FR on dev" → "Ready for staging" or "FR on staging" → "Ready for prod".
```

**RFC-BACKEND-1405 D6 retired the dev-side review.** `On dev` is now set automatically when the release train merges to `develop`, so there is no `FR on dev` column and nothing for `/fr-pass` to advance before staging. `/fr-pass` has exactly one gate: **`FR on staging` → `Ready for prod`**.

The reusable workflow this calls (`tracebloc/.github`, `.github/workflows/fr-pass-comment.yml`) has only ever implemented the staging hop, and documents it correctly at the top of the file:

```
#   FR on staging  →  Ready for prod
# (D6: the dev-side review is gone — "On dev" is automatic — so /fr-pass only
#  applies at staging, the single functional-review gate.)
```

Verified against the reusable's implementation: the only transition in its column table is `"FR on staging") NEXT="Ready for prod"`, and its refusal message states that `/fr-pass` *"only advances **FR on staging → Ready for prod** (the one functional-review gate)"*. So this was the comment drifting away from the code.

**Comment-only. No logic, no triggers, no inputs changed.**

### Scope note

This stale comment is **byte-identical across 14 repos**, plus a differently-worded copy in the `tracebloc/.github` template it was copied from. A pull request cannot span repositories, so this is one of 15 PRs — the template in `tracebloc/.github` included, because leaving that one stale would reintroduce the drift on the next copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change to a GitHub Actions caller; no runtime or CI behavior is affected.
> 
> **Overview**
> Updates the header comments in `fr-pass-comment-caller.yml` so they match how `/fr-pass` actually works: **only** `FR on staging` → `Ready for prod`, not a dev-side hop.
> 
> The old text implied both `FR on dev` → `Ready for staging` and the staging → prod move. Per **RFC-BACKEND-1405 D6**, dev review was removed—`On dev` is automatic after the release train hits `develop`—so the reusable workflow was always staging-only; this is comment drift, not behavior change.
> 
> **No workflow triggers, jobs, or reusable inputs were modified.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f20b5a5ba222c51c7d2cf53edf5637e3f39bdfd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->