### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/workflows/fr-pass-comment-caller.yml
+++ b/.github/workflows/fr-pass-comment-caller.yml
@@ -1,7 +1,14 @@
 name: FR pass comment
 
 # Per-repo caller. Listens for /fr-pass comments and advances kanban items
-# from "FR on dev" → "Ready for staging" or "FR on staging" → "Ready for prod".
+# from "FR on staging" → "Ready for prod" — the single functional-review gate.
+#
+# RFC-BACKEND-1405 D6 retired the dev-side review: "On dev" is set automatically
+# when the release train merges to develop, so there is no "FR on dev" column and
+# nothing for /fr-pass to advance before staging. The reusable has only ever
+# implemented the staging hop; this comment described a transition that does not
+# exist.
+#
 # All logic lives in tracebloc/.github/.github/workflows/fr-pass-comment.yml.
 
 on:


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in a GitHub Actions caller workflow; no runtime or gate logic is modified.
> 
> **Overview**
> Updates comments in `fr-pass-comment-caller.yml` so they match the current functional-review flow.
> 
> The header no longer mentions advancing from **"FR on dev" → "Ready for staging"**. It now states that `/fr-pass` only moves items **"FR on staging" → "Ready for prod"**, and explains that RFC-BACKEND-1405 D6 removed the dev-side gate because **"On dev"** is set when the release train lands on `develop`.
> 
> **No workflow behavior changes** — the job still delegates to `tracebloc/.github/.github/workflows/fr-pass-comment.yml@main` on `issue_comment` `created` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 840b9b0b85227f2a4caf3e6ecc7fa25a0f0a7c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->