### PR TITLE
feat(#203-A3): ingestor writes file-bearing assets under ds_<hex>

### DIFF
--- a/tests/test_per_ingestion_tables.py
+++ b/tests/test_per_ingestion_tables.py
@@ -10,6 +10,7 @@ ingest summary carries the physical handle so the backend can persist it
 """
 
 import json
+import os
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -23,7 +24,6 @@ from tracebloc_ingestor.ingestors import base as base_mod
 from tracebloc_ingestor.ingestors.base import BaseIngestor
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
 
-
 # ── Config flag ──────────────────────────────────────────────────────────────
 
 
@@ -34,8 +34,16 @@ def test_flag_defaults_off(monkeypatch):
 
 @pytest.mark.parametrize(
     "raw,expected",
-    [("1", True), ("true", True), ("YES", True), ("on", True),
-     ("0", False), ("", False), ("no", False), ("off", False)],
+    [
+        ("1", True),
+        ("true", True),
+        ("YES", True),
+        ("on", True),
+        ("0", False),
+        ("", False),
+        ("no", False),
+        ("off", False),
+    ],
 )
 def test_flag_env_parsing(monkeypatch, raw, expected):
     monkeypatch.setenv("PER_INGESTION_TABLES", raw)
@@ -44,9 +52,14 @@ def test_flag_env_parsing(monkeypatch, raw, expected):
 
 def test_flag_override_beats_env(monkeypatch):
     monkeypatch.setenv("PER_INGESTION_TABLES", "1")
-    assert Config(EDGE_ENV="local", PER_INGESTION_TABLES=False).PER_INGESTION_TABLES is False
+    assert (
+        Config(EDGE_ENV="local", PER_INGESTION_TABLES=False).PER_INGESTION_TABLES
+        is False
+    )
     monkeypatch.delenv("PER_INGESTION_TABLES", raising=False)
-    assert Config(EDGE_ENV="local", PER_INGESTION_TABLES=True).PER_INGESTION_TABLES is True
+    assert (
+        Config(EDGE_ENV="local", PER_INGESTION_TABLES=True).PER_INGESTION_TABLES is True
+    )
 
 
 # ── Ingestor naming ─────────────────────────────────────────────────────────
@@ -87,25 +100,40 @@ def test_flag_on_physical_name_is_hex_of_ingestor_id():
     assert ing.table_name == "my_dataset"
 
 
-def test_flag_on_rejects_file_bearing_categories():
-    """v1 boundary (Bugbot): the flag isolates the row store only — assets of
-    file-bearing categories still land under the shared label tree, where a
-    later same-label ingest would overwrite an earlier dataset's files. Fail
-    at construction, before any validation or DDL; per-dataset file isolation
-    ships with tracebloc/client-runtime#203 phase 2."""
+def test_flag_on_file_bearing_injects_the_handle():
+    """#203 phase 2: file-bearing categories are no longer refused under the
+    flag. The file tree now keys on the physical ``ds_<hex>`` handle instead of
+    the shared label tree — so a same-label re-ingest writes to its OWN handle
+    and can't overwrite an earlier dataset's files — which the ingestor sets by
+    pointing DEST_PATH at the handle via ``set_dest_table``."""
     from tracebloc_ingestor.utils.constants import TaskCategory
 
     database = MagicMock(name="Database")
     database.config.PER_INGESTION_TABLES = True
-    with pytest.raises(ValueError, match="file-bearing"):
-        CSVIngestor(
-            database=database,
-            api_client=MagicMock(),
-            table_name="imgs",
-            schema={"filename": "VARCHAR(255)", "label": "VARCHAR(50)"},
-            label_column="label",
-            category=TaskCategory.IMAGE_CLASSIFICATION,
-        )
+    ing = CSVIngestor(  # no longer raises
+        database=database,
+        api_client=MagicMock(),
+        table_name="imgs",
+        schema={"filename": "VARCHAR(255)", "label": "VARCHAR(50)"},
+        label_column="label",
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+    )
+    # the file tree is pointed at the same ds_<hex> handle as the row store
+    assert ing.physical_table_name.startswith("ds_")
+    database.config.set_dest_table.assert_called_once_with(ing.physical_table_name)
+
+
+def test_dest_path_keys_on_injected_handle():
+    """DEST_PATH defaults to STORAGE_PATH/<label>; ``set_dest_table`` repoints it
+    at an explicit physical handle (the #203-phase-2 file-isolation unit)
+    without touching TABLE_NAME (the user-facing label)."""
+    cfg = Config(EDGE_ENV="local", TABLE_NAME="my_label")
+    assert cfg.DEST_PATH == os.path.join(cfg.STORAGE_PATH, "my_label")
+    handle = "ds_" + "a" * 32
+    cfg.set_dest_table(handle)
+    assert cfg.DEST_TABLE == handle
+    assert cfg.DEST_PATH == os.path.join(cfg.STORAGE_PATH, handle)
+    assert cfg.TABLE_NAME == "my_label"  # label untouched
 
 
 def test_flag_on_accepts_row_only_categories():
@@ -203,13 +231,21 @@ def _client():
 def _send_and_capture(client, **extra):
     """POST a summary against a mocked transport; return the JSON payload."""
     with patch.object(
-        client.session, "post",
+        client.session,
+        "post",
         return_value=_resp(201, {"dataset_id": 1, "dataset_key": "k"}),
     ) as post:
         client.send_ingest_summary(
-            table_name="my_dataset", ingestor_id="ing-1", labels={"cat": 2},
-            dataset_title="T", data_format="tabular", data_intent="train",
-            category="tabular_classification", schema={}, samples=[], **extra,
+            table_name="my_dataset",
+            ingestor_id="ing-1",
+            labels={"cat": 2},
+            dataset_title="T",
+            data_format="tabular",
+            data_intent="train",
+            category="tabular_classification",
+            schema={},
+            samples=[],
+            **extra,
         )
         _, kwargs = post.call_args
     return json.loads(kwargs["data"])

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -16,7 +16,6 @@ import os
 
 from .utils.constants import LogLevel
 
-
 # Sentinel signalling \"caller did not pass this field as an override\".
 # Distinguishes the absent case from an explicit ``Field=None``, which
 # tests use to *suppress* a value (e.g. ``BACKEND_TOKEN=None``).
@@ -35,17 +34,28 @@ class Config:
 
     # Whitelist of valid override keys. A typo at the call site raises
     # immediately rather than silently no-op'ing.
-    _ENV_FIELDS = frozenset({
-        "DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
-        "BATCH_SIZE",
-        "EDGE_ENV",
-        "BACKEND_TOKEN", "CLIENT_USERNAME", "CLIENT_PASSWORD",
-        "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
-        "LOG_LEVEL",
-        "CATEGORICAL_MIN_COUNT",
-        "EMIT_ENRICHED_SCHEMA",
-        "PER_INGESTION_TABLES",
-    })
+    _ENV_FIELDS = frozenset(
+        {
+            "DB_HOST",
+            "DB_PORT",
+            "DB_USER",
+            "DB_PASSWORD",
+            "DB_NAME",
+            "BATCH_SIZE",
+            "EDGE_ENV",
+            "BACKEND_TOKEN",
+            "CLIENT_USERNAME",
+            "CLIENT_PASSWORD",
+            "SRC_PATH",
+            "LABEL_FILE",
+            "TABLE_NAME",
+            "TITLE",
+            "LOG_LEVEL",
+            "CATEGORICAL_MIN_COUNT",
+            "EMIT_ENRICHED_SCHEMA",
+            "PER_INGESTION_TABLES",
+        }
+    )
 
     # Env values (case-insensitive) that read as boolean true; anything else
     # (including unset) is false.
@@ -125,7 +135,11 @@ class Config:
     @property
     def DB_NAME(self) -> str:
         ov = self._override("DB_NAME")
-        return ov if ov is not _MISSING else os.environ.get("DB_NAME", "training_test_datasets")
+        return (
+            ov
+            if ov is not _MISSING
+            else os.environ.get("DB_NAME", "training_test_datasets")
+        )
 
     @property
     def BATCH_SIZE(self) -> int:
@@ -200,8 +214,29 @@ class Config:
         return ov if ov is not _MISSING else os.environ.get("TABLE_NAME", "")
 
     @property
+    def DEST_TABLE(self) -> str:
+        """The directory the file tree lands in under STORAGE_PATH. Defaults to
+        the dataset label (``TABLE_NAME``); when PER_INGESTION_TABLES is on the
+        ingestor injects the physical ``ds_<hex>`` handle via ``set_dest_table``
+        so file-bearing assets key on the SAME isolation unit as the row store,
+        the SQL grant, and the scoped mount (RFC-0003 D9 phase 2 / D16 —
+        client-runtime#203, tracebloc-engine#569). Not a user env field: the
+        only writer is ``set_dest_table``."""
+        ov = self._override("DEST_TABLE")
+        return ov if ov is not _MISSING else self.TABLE_NAME
+
+    @property
     def DEST_PATH(self) -> str:
-        return os.path.join(self.STORAGE_PATH, self.TABLE_NAME)
+        return os.path.join(self.STORAGE_PATH, self.DEST_TABLE)
+
+    def set_dest_table(self, physical_table_name: str) -> None:
+        """Point the file tree (``DEST_PATH``) at an explicit physical-table
+        directory. The ingestor calls this once, after it derives the
+        per-ingestion ``ds_<hex>`` handle, so file-bearing assets land under the
+        same handle as the row store instead of the shared label tree (#203
+        phase 2). Flag-off ingests never call it, so ``DEST_TABLE`` stays the
+        label and behavior is byte-for-byte today's."""
+        self._overrides["DEST_TABLE"] = physical_table_name
 
     @property
     def TITLE(self) -> Optional[str]:
@@ -232,7 +267,11 @@ class Config:
         """
         ov = self._override("PER_INGESTION_TABLES")
         if ov is not _MISSING:
-            return ov if isinstance(ov, bool) else str(ov).strip().lower() in self._TRUE_STRINGS
+            return (
+                ov
+                if isinstance(ov, bool)
+                else str(ov).strip().lower() in self._TRUE_STRINGS
+            )
         env = os.environ.get("PER_INGESTION_TABLES")
         if env is None:
             return False
@@ -254,7 +293,11 @@ class Config:
         """
         ov = self._override("EMIT_ENRICHED_SCHEMA")
         if ov is not _MISSING:
-            return ov if isinstance(ov, bool) else str(ov).strip().lower() in self._TRUE_STRINGS
+            return (
+                ov
+                if isinstance(ov, bool)
+                else str(ov).strip().lower() in self._TRUE_STRINGS
+            )
         env = os.environ.get("EMIT_ENRICHED_SCHEMA")
         if env is not None and env.strip() != "":
             return env.strip().lower() in self._TRUE_STRINGS

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -316,33 +316,26 @@ class BaseIngestor(ABC):
         # The ``is True`` comparison is deliberate: test doubles use bare
         # MagicMocks for config, and a truthy Mock must not silently flip
         # the storage model.
-        self.per_ingestion_tables = (
-            database.config.PER_INGESTION_TABLES is True
-        )
+        self.per_ingestion_tables = database.config.PER_INGESTION_TABLES is True
         self.physical_table_name = (
             f"ds_{uuid.UUID(self.ingestor_id).hex}"
             if self.per_ingestion_tables
             else table_name
         )
-        # v1 boundary (Bugbot on the PR): the flag isolates the ROW STORE
-        # only. File-bearing categories also persist assets under the shared
-        # label tree (STORAGE_PATH/<label>), where a later same-label ingest
-        # would overwrite an earlier dataset's files while both ds_ tables
-        # keep referencing them — silent cross-dataset corruption. The file
-        # tree's isolation unit moves to the same handle with the
-        # per-dataset-mount work (tracebloc/client-runtime#203 phase 2);
-        # until then, refuse loudly instead of corrupting quietly. Row-only
-        # categories (tabular / time-series families) are the RFC-0003 v1
-        # rollout target and are unaffected.
-        if self.per_ingestion_tables and category in _FILE_BEARING_CATEGORIES:
-            raise ValueError(
-                f"PER_INGESTION_TABLES does not support file-bearing "
-                f"category {category!r} yet: assets would land in the shared "
-                f"label tree and be overwritten by a later ingest under the "
-                f"same label (per-dataset file isolation ships with "
-                f"tracebloc/client-runtime#203 phase 2). Run this ingest "
-                f"with the flag off."
-            )
+        # Under PER_INGESTION_TABLES the file tree keys on the SAME physical
+        # ds_<hex> handle as the row store, not the shared label tree: point
+        # DEST_PATH — which every file-copy primitive, the text profiler, the
+        # duplicate validator, and the source-reclaim path all read off this
+        # run's config — at the handle, so file-bearing assets land in
+        # STORAGE_PATH/ds_<hex>/. That matches the per-dataset scoped mount
+        # (client-runtime#203) and the engine's get_dataset_path resolution
+        # (tracebloc-engine#569), closing the #203-phase-2 file half. It lifts
+        # the earlier refusal: a same-label re-ingest now writes to its OWN
+        # handle instead of overwriting an earlier dataset's files. Flag off =>
+        # set_dest_table is never called and DEST_PATH stays
+        # STORAGE_PATH/<label>, byte-for-byte today's behavior.
+        if self.per_ingestion_tables:
+            self.database.config.set_dest_table(self.physical_table_name)
         self.schema = schema
         self.unique_id_column = unique_id_column
         self.label_column = label_column
@@ -609,9 +602,7 @@ class BaseIngestor(ABC):
 
                 if not result.is_valid:
                     all_valid = False
-                    validation_errors.append(
-                        f"{BOLD}{label} failed: {RESET} \n {RED}"
-                    )
+                    validation_errors.append(f"{BOLD}{label} failed: {RESET} \n {RED}")
                     validation_errors.extend(result.errors)
                     validation_errors.append(f"{RESET}")
 


### PR DESCRIPTION
## #203 Track A3 — RFC-0003 D9 phase 2 / D16

Today's [#255](https://github.com/tracebloc/client-runtime/pull/255) (scoped mount) and [#569](https://github.com/tracebloc/tracebloc-engine/pull/569) (engine path) both re-keyed dataset access onto the physical `ds_<hex>` handle. But the ingestor still **hard-refused** file-bearing categories under `PER_INGESTION_TABLES`, because their assets landed in the shared **label** tree (`STORAGE_PATH/<label>`) where a same-label re-ingest would overwrite an earlier dataset's files. This PR moves the file tree onto the same handle and lifts the refusal.

### Change
- **`config.py`** — `DEST_PATH` now keys on a new `DEST_TABLE` (defaults to the `TABLE_NAME` label, injectable via `set_dest_table`). This is the *one knob*: every file-copy primitive, the text profiler, the duplicate validator, and the source-reclaim path already read `DEST_PATH` off the run config, so they all follow automatically.
- **`ingestors/base.py`** — when `per_ingestion_tables`, inject the `ds_<hex>` handle: `config.set_dest_table(physical_table_name)`. File-bearing assets now land in `STORAGE_PATH/ds_<hex>/`, matching the scoped mount (#255) and `get_dataset_path` (#569). The file-bearing refusal is removed.
- **tests** — flipped the "refuses file-bearing" test to assert the handle injection; added a real-`Config` `DEST_PATH` test. **Flag off is byte-for-byte unchanged** (`DEST_TABLE` = label, `set_dest_table` never called).

### Why it matters
Unlocks image / object-detection / semantic-segmentation / keypoint datasets (the bulk of tracebloc's use-cases) under per-ingestion isolation, and completes the D9-phase-2 file half that #255 + #569 were built to enable. It's the ingestor change the on-HOLD [client#490](https://github.com/tracebloc/client/pull/490) v0.8.0 image is waiting on.

### Scope note
The file **table lock** intentionally stays keyed on the label — that's pre-existing #408 behavior (the row store already moved to `ds_<hex>` while the lock stayed on the label); it's a concurrency guard, not a data-isolation unit, so it's out of scope here.

### Verified
Full ingestor suite **1903 passed, 1 xfailed**; `black` clean.

Targets `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk layout for file-bearing datasets when PER_INGESTION_TABLES is on; misalignment with scoped mounts or backend path resolution could strand or mis-associate assets, though flag-off behavior is unchanged.
> 
> **Overview**
> With **PER_INGESTION_TABLES** enabled, file-bearing ingests no longer error at construction; instead the run repoints the on-disk file tree from the shared label directory to the same **`ds_<hex>`** handle used for the MySQL row store.
> 
> **Config** introduces **`DEST_TABLE`** (defaults to the user label) and **`set_dest_table`**, so **`DEST_PATH`** becomes `STORAGE_PATH/<DEST_TABLE>`. **BaseIngestor** calls **`set_dest_table(physical_table_name)`** when the flag is on, which pulls file copy, text profiling, duplicate checks, and source reclaim along without separate changes. **`TABLE_NAME`** and flag-off behavior stay as today.
> 
> Tests now assert handle injection for image-classification under the flag and **`DEST_PATH`** repointing; package version **0.8.0 → 0.8.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110d3d8f67bdf94fc5bb529778a4d129af79d1ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->