### PR TITLE
release-train: develop -> staging

### DIFF
--- a/tests/test_file_transfer_reclaim.py
+++ b/tests/test_file_transfer_reclaim.py
@@ -351,3 +351,63 @@ def test_user_dir_skip_stays_quiet(tmp_path, monkeypatch):
     cfg = _cfg(userdir, storage, table="cats_dogs_train")
     assert file_transfer.reclaim_source(cfg) is False
     assert calls["info"] == 1 and calls["warning"] == 0  # deliberate, quiet
+
+
+# ---------------------------------------------------------------------------
+# reclaim_dest_tree — a FAILED per-ingestion run's dest tree (#437 / #439)
+# ---------------------------------------------------------------------------
+# Flag-on file trees key on a UNIQUE ds_<hex> handle, so a failed run's assets
+# are never overwritten by a retry (fresh handle) and nothing else reclaims
+# them. reclaim_dest_tree removes them on the failure path — but ONLY when it
+# can prove the dir is a ds_<hex> handle directly under STORAGE_PATH.
+
+_HANDLE = "ds_" + "a" * 32
+
+
+def _dest_cfg(storage, dest_table):
+    """Config whose DEST_PATH = storage/<dest_table> (set_dest_table override)."""
+    cfg = Config(TABLE_NAME="my_label")
+    cfg.STORAGE_PATH = str(storage)
+    cfg.set_dest_table(dest_table)
+    return cfg
+
+
+def test_reclaim_dest_removes_per_ingestion_handle_tree(tmp_path):
+    storage = tmp_path / "shared"
+    dest = storage / _HANDLE
+    dest.mkdir(parents=True)
+    (dest / "img.jpg").write_bytes(b"x")
+    assert file_transfer.reclaim_dest_tree(_dest_cfg(storage, _HANDLE)) is True
+    assert not dest.exists()
+
+
+def test_reclaim_dest_leaves_flag_off_label_tree(tmp_path):
+    # flag off: DEST_PATH = storage/<label>; the basename is not a ds_<hex>
+    # handle, so it must be LEFT (a same-label re-run overwrites it instead).
+    storage = tmp_path / "shared"
+    dest = storage / "my_label"
+    dest.mkdir(parents=True)
+    (dest / "img.jpg").write_bytes(b"x")
+    cfg = Config(TABLE_NAME="my_label")
+    cfg.STORAGE_PATH = str(storage)  # DEST_TABLE defaults to the label
+    assert file_transfer.reclaim_dest_tree(cfg) is False
+    assert dest.exists()
+
+
+def test_reclaim_dest_refuses_handle_not_direct_child_of_storage(tmp_path):
+    # a ds_<hex>-named dir nested deeper than a direct child is left alone
+    # (defense-in-depth: DEST_PATH must resolve to STORAGE_PATH/<handle>).
+    storage = tmp_path / "shared"
+    nested = storage / "sub" / _HANDLE
+    nested.mkdir(parents=True)
+    assert (
+        file_transfer.reclaim_dest_tree(_dest_cfg(storage, f"sub/{_HANDLE}")) is False
+    )
+    assert nested.exists()
+
+
+def test_reclaim_dest_noop_when_dest_missing(tmp_path):
+    # best-effort: a nonexistent DEST_PATH is a quiet no-op, never an error
+    storage = tmp_path / "shared"
+    storage.mkdir()
+    assert file_transfer.reclaim_dest_tree(_dest_cfg(storage, _HANDLE)) is False

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -195,9 +195,12 @@ def test_process_record_generates_content_hash_data_id_by_default():
     assert len(data_id) == 64 and all(c in "0123456789abcdef" for c in data_id)
     # deterministic: a fresh ingestor with the same salt reproduces the id
     again = make_ingestor(category=None, label_column="a")
-    assert again.process_record(
-        {"a": "cat", "filename": "x", "extension": ".jpg"}
-    )["data_id"] == data_id
+    assert (
+        again.process_record({"a": "cat", "filename": "x", "extension": ".jpg"})[
+            "data_id"
+        ]
+        == data_id
+    )
 
 
 def test_process_record_uses_unique_id_column():
@@ -230,11 +233,18 @@ def test_process_record_reads_label_by_configured_key():
     a mismatched key it reads None — this is why the ingestor must resolve the
     label column to the real header before processing (see the
     _resolve_label_column + end-to-end tests below)."""
-    ing = make_ingestor(label_column="label", schema={"a": "INT", "label": "VARCHAR(10)"}, category=None)
+    ing = make_ingestor(
+        label_column="label", schema={"a": "INT", "label": "VARCHAR(10)"}, category=None
+    )
     # exact key -> label present
-    assert ing.process_record({"a": "1", "label": "cat", "filename": "f"})["label"] == "cat"
+    assert (
+        ing.process_record({"a": "1", "label": "cat", "filename": "f"})["label"]
+        == "cat"
+    )
     # mismatched-case key with the SAME configured name -> None (the bug)
-    assert ing.process_record({"a": "1", "Label": "cat", "filename": "f"})["label"] is None
+    assert (
+        ing.process_record({"a": "1", "Label": "cat", "filename": "f"})["label"] is None
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -245,14 +255,16 @@ def test_process_record_reads_label_by_configured_key():
 @pytest.mark.parametrize(
     "columns,expected",
     [
-        (["a", "Label"], "Label"),      # case mismatch -> real header
+        (["a", "Label"], "Label"),  # case mismatch -> real header
         (["a", " label "], " label "),  # whitespace mismatch -> raw header
-        (["a", "label"], "label"),       # exact -> unchanged
-        (["a", "b"], "label"),           # absent -> configured name untouched
+        (["a", "label"], "label"),  # exact -> unchanged
+        (["a", "b"], "label"),  # absent -> configured name untouched
     ],
 )
 def test_resolve_label_column(columns, expected):
-    ing = make_ingestor(label_column="label", schema={"a": "INT", "label": "VARCHAR(10)"})
+    ing = make_ingestor(
+        label_column="label", schema={"a": "INT", "label": "VARCHAR(10)"}
+    )
     ing._resolve_label_column(columns)
     assert ing.label_column == expected
 
@@ -285,9 +297,10 @@ def test_ingest_label_case_mismatch_survives_to_db():
         ing.ingest("src", batch_size=10)
     ing.database.insert_batch.assert_called()
     _table, batch = ing.database.insert_batch.call_args.args
-    assert [r.get("label") for r in batch] == ["cat", "dog"], (
-        f"labels nulled by case mismatch: {[r.get('label') for r in batch]}"
-    )
+    assert [r.get("label") for r in batch] == [
+        "cat",
+        "dog",
+    ], f"labels nulled by case mismatch: {[r.get('label') for r in batch]}"
 
 
 def test_ingest_label_resolves_on_later_record_for_sparse_json():
@@ -296,8 +309,8 @@ def test_ingest_label_resolves_on_later_record_for_sparse_json():
     or a mis-cased label on every subsequent row would still null. The first
     (label-less) record legitimately gets None; the second resolves 'Label'."""
     records = [
-        {"a": "1", "filename": "f1"},                   # no label key at all
-        {"a": "2", "Label": "dog", "filename": "f2"},   # mis-cased label
+        {"a": "1", "filename": "f1"},  # no label key at all
+        {"a": "2", "Label": "dog", "filename": "f2"},  # mis-cased label
     ]
     ing = make_ingestor(
         records=records,
@@ -311,9 +324,10 @@ def test_ingest_label_resolves_on_later_record_for_sparse_json():
         Sess.return_value.__enter__.return_value = MagicMock()
         ing.ingest("src", batch_size=10)
     _table, batch = ing.database.insert_batch.call_args.args
-    assert [r.get("label") for r in batch] == [None, "dog"], (
-        f"expected [None, 'dog']; got {[r.get('label') for r in batch]}"
-    )
+    assert [r.get("label") for r in batch] == [
+        None,
+        "dog",
+    ], f"expected [None, 'dog']; got {[r.get('label') for r in batch]}"
 
 
 def test_process_record_strips_whitespace_from_string_label():
@@ -512,9 +526,7 @@ def test_process_record_omits_mask_id_for_non_semseg_categories():
 def test_process_batch_success():
     ing = make_ingestor()
     session = MagicMock()
-    ids, db_failures = ing._batch_writer._process(
-        [{"data_id": "a"}], session
-    )
+    ids, db_failures = ing._batch_writer._process([{"data_id": "a"}], session)
     assert ids == [1, 2]
     assert db_failures == []
 
@@ -523,9 +535,7 @@ def test_process_batch_no_ids_skips_api():
     ing = make_ingestor()
     ing.database.insert_batch.return_value = ([], [{"err": "x"}])
     session = MagicMock()
-    ids, db_failures = ing._batch_writer._process(
-        [{"data_id": "a"}], session
-    )
+    ids, db_failures = ing._batch_writer._process([{"data_id": "a"}], session)
     assert ids == []
     assert db_failures == [{"err": "x"}]
 
@@ -1599,6 +1609,57 @@ def test_late_failure_after_registration_never_deletes():
     ing.database.delete_by_ingestor_id.assert_not_called()
 
 
+def test_failed_per_ingestion_file_ingest_reclaims_dest_tree():
+    """A per-ingestion file-bearing run that fails BEFORE registration reclaims
+    its ds_<hex> file tree (data-ingestors#439): a retry mints a fresh handle,
+    so nothing else would ever overwrite or reclaim it."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    ing = make_ingestor(
+        records=[{"a": "1", "filename": "f1"}],
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    ing.per_ingestion_tables = True
+    ing.physical_table_name = "ds_" + "a" * 32
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
+    with patch.object(base_mod, "reclaim_dest_tree") as reclaim:
+        _ingest_expecting(ing, RuntimeError)
+    reclaim.assert_called_once_with(ing.database.config)
+
+
+def test_late_failure_after_registration_never_reclaims_dest_tree():
+    """The dataset_registered guard for FILES: a failure AFTER a successful
+    send_ingest_summary must NOT reclaim the now-registered dataset's ds_<hex>
+    tree — the backend points at it, so deleting would be permanent asset loss
+    (Bugbot). Mutation check: dropping `and not dataset_registered` fails this."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    ing = make_ingestor(
+        records=[{"a": "1", "filename": "f1"}],
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    ing.per_ingestion_tables = True
+    ing.physical_table_name = "ds_" + "a" * 32
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        ing, "_log_summary", side_effect=RuntimeError("render blew up")
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ), patch.object(
+        base_mod, "reclaim_dest_tree"
+    ) as reclaim:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError):
+            ing.ingest("src", batch_size=10)
+    ing.api_client.send_ingest_summary.assert_called_once()
+    reclaim.assert_not_called()
+
+
 # ── backend#1028 item 2: orphan-row reconciliation on start ──────────────────
 # The #227 compensating delete only runs on a CAUGHT failure. A hard kill
 # (OOMKilled / SIGKILL mid-ingest) bypasses it, leaving the dead run's rows in
@@ -1633,9 +1694,7 @@ def test_reconcile_and_start_journal_run_before_first_insert():
     )
     names = [name for name, _, _ in ing.database.mock_calls]
     assert names.index("create_table") < names.index("reclaim_dead_run_rows")
-    assert names.index("reclaim_dead_run_rows") < names.index(
-        "record_ingest_started"
-    )
+    assert names.index("reclaim_dead_run_rows") < names.index("record_ingest_started")
     assert names.index("record_ingest_started") < names.index("insert_batch")
 
 
@@ -1655,9 +1714,7 @@ def test_successful_registration_marks_journal_registered_before_send():
         ing.table_name, ing.ingestor_id
     )
     seq = [c[0] for c in parent.mock_calls]
-    assert seq.index("db.mark_ingest_registered") < seq.index(
-        "api.send_ingest_summary"
-    )
+    assert seq.index("db.mark_ingest_registered") < seq.index("api.send_ingest_summary")
 
 
 def test_failed_registration_undoes_optimistic_flip_and_deletes(caplog):
@@ -1667,9 +1724,7 @@ def test_failed_registration_undoes_optimistic_flip_and_deletes(caplog):
     registered entry no reconcile pass would clean. The #227 delete still
     fires (rows are not registered)."""
     ing = make_ingestor(records=[{"a": "1"}], label_column="a")
-    ing.api_client.send_ingest_summary.side_effect = RuntimeError(
-        "backend rejected"
-    )
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
     with patch.object(base_mod, "Session") as Sess, patch.object(
         ing, "validate_data", return_value=True
     ):
@@ -1718,9 +1773,7 @@ def test_journal_reset_failure_never_masks_original_error(caplog):
     import logging
 
     ing = make_ingestor(records=[{"a": "1"}], label_column="a")
-    ing.api_client.send_ingest_summary.side_effect = RuntimeError(
-        "backend rejected"
-    )
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
     ing.database.mark_ingest_unregistered.side_effect = Exception("journal down")
     with caplog.at_level(logging.CRITICAL):
         with patch.object(base_mod, "Session") as Sess, patch.object(
@@ -1733,8 +1786,7 @@ def test_journal_reset_failure_never_masks_original_error(caplog):
         ing.table_name, ing.ingestor_id
     )
     assert any(
-        "reset the run journal to unregistered" in r.message
-        for r in caplog.records
+        "reset the run journal to unregistered" in r.message for r in caplog.records
     )
 
 
@@ -1751,9 +1803,7 @@ def test_reclaim_failure_never_blocks_the_ingest(caplog):
         _run_happy_ingest(ing)  # must NOT raise
     ing.database.insert_batch.assert_called()
     ing.database.record_ingest_started.assert_called_once()
-    assert any(
-        "Orphan-row reconciliation failed" in r.message for r in caplog.records
-    )
+    assert any("Orphan-row reconciliation failed" in r.message for r in caplog.records)
 
 
 def test_zero_record_run_journals_start_but_not_registered():
@@ -1784,7 +1834,5 @@ def test_objdet_content_hash_constructor_warns(caplog):
 
     caplog.clear()
     with caplog.at_level(logging.WARNING):
-        make_ingestor(
-            category=TaskCategory.OBJECT_DETECTION, data_id_strategy="uuid"
-        )
+        make_ingestor(category=TaskCategory.OBJECT_DETECTION, data_id_strategy="uuid")
     assert not any("collapse" in r.getMessage() for r in caplog.records)

--- a/tests/test_per_ingestion_tables.py
+++ b/tests/test_per_ingestion_tables.py
@@ -10,6 +10,7 @@ ingest summary carries the physical handle so the backend can persist it
 """
 
 import json
+import os
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -23,7 +24,6 @@ from tracebloc_ingestor.ingestors import base as base_mod
 from tracebloc_ingestor.ingestors.base import BaseIngestor
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
 
-
 # ── Config flag ──────────────────────────────────────────────────────────────
 
 
@@ -34,8 +34,16 @@ def test_flag_defaults_off(monkeypatch):
 
 @pytest.mark.parametrize(
     "raw,expected",
-    [("1", True), ("true", True), ("YES", True), ("on", True),
-     ("0", False), ("", False), ("no", False), ("off", False)],
+    [
+        ("1", True),
+        ("true", True),
+        ("YES", True),
+        ("on", True),
+        ("0", False),
+        ("", False),
+        ("no", False),
+        ("off", False),
+    ],
 )
 def test_flag_env_parsing(monkeypatch, raw, expected):
     monkeypatch.setenv("PER_INGESTION_TABLES", raw)
@@ -44,9 +52,14 @@ def test_flag_env_parsing(monkeypatch, raw, expected):
 
 def test_flag_override_beats_env(monkeypatch):
     monkeypatch.setenv("PER_INGESTION_TABLES", "1")
-    assert Config(EDGE_ENV="local", PER_INGESTION_TABLES=False).PER_INGESTION_TABLES is False
+    assert (
+        Config(EDGE_ENV="local", PER_INGESTION_TABLES=False).PER_INGESTION_TABLES
+        is False
+    )
     monkeypatch.delenv("PER_INGESTION_TABLES", raising=False)
-    assert Config(EDGE_ENV="local", PER_INGESTION_TABLES=True).PER_INGESTION_TABLES is True
+    assert (
+        Config(EDGE_ENV="local", PER_INGESTION_TABLES=True).PER_INGESTION_TABLES is True
+    )
 
 
 # ── Ingestor naming ─────────────────────────────────────────────────────────
@@ -87,25 +100,40 @@ def test_flag_on_physical_name_is_hex_of_ingestor_id():
     assert ing.table_name == "my_dataset"
 
 
-def test_flag_on_rejects_file_bearing_categories():
-    """v1 boundary (Bugbot): the flag isolates the row store only — assets of
-    file-bearing categories still land under the shared label tree, where a
-    later same-label ingest would overwrite an earlier dataset's files. Fail
-    at construction, before any validation or DDL; per-dataset file isolation
-    ships with tracebloc/client-runtime#203 phase 2."""
+def test_flag_on_file_bearing_injects_the_handle():
+    """#203 phase 2: file-bearing categories are no longer refused under the
+    flag. The file tree now keys on the physical ``ds_<hex>`` handle instead of
+    the shared label tree — so a same-label re-ingest writes to its OWN handle
+    and can't overwrite an earlier dataset's files — which the ingestor sets by
+    pointing DEST_PATH at the handle via ``set_dest_table``."""
     from tracebloc_ingestor.utils.constants import TaskCategory
 
     database = MagicMock(name="Database")
     database.config.PER_INGESTION_TABLES = True
-    with pytest.raises(ValueError, match="file-bearing"):
-        CSVIngestor(
-            database=database,
-            api_client=MagicMock(),
-            table_name="imgs",
-            schema={"filename": "VARCHAR(255)", "label": "VARCHAR(50)"},
-            label_column="label",
-            category=TaskCategory.IMAGE_CLASSIFICATION,
-        )
+    ing = CSVIngestor(  # no longer raises
+        database=database,
+        api_client=MagicMock(),
+        table_name="imgs",
+        schema={"filename": "VARCHAR(255)", "label": "VARCHAR(50)"},
+        label_column="label",
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+    )
+    # the file tree is pointed at the same ds_<hex> handle as the row store
+    assert ing.physical_table_name.startswith("ds_")
+    database.config.set_dest_table.assert_called_once_with(ing.physical_table_name)
+
+
+def test_dest_path_keys_on_injected_handle():
+    """DEST_PATH defaults to STORAGE_PATH/<label>; ``set_dest_table`` repoints it
+    at an explicit physical handle (the #203-phase-2 file-isolation unit)
+    without touching TABLE_NAME (the user-facing label)."""
+    cfg = Config(EDGE_ENV="local", TABLE_NAME="my_label")
+    assert cfg.DEST_PATH == os.path.join(cfg.STORAGE_PATH, "my_label")
+    handle = "ds_" + "a" * 32
+    cfg.set_dest_table(handle)
+    assert cfg.DEST_TABLE == handle
+    assert cfg.DEST_PATH == os.path.join(cfg.STORAGE_PATH, handle)
+    assert cfg.TABLE_NAME == "my_label"  # label untouched
 
 
 def test_flag_on_accepts_row_only_categories():
@@ -203,13 +231,21 @@ def _client():
 def _send_and_capture(client, **extra):
     """POST a summary against a mocked transport; return the JSON payload."""
     with patch.object(
-        client.session, "post",
+        client.session,
+        "post",
         return_value=_resp(201, {"dataset_id": 1, "dataset_key": "k"}),
     ) as post:
         client.send_ingest_summary(
-            table_name="my_dataset", ingestor_id="ing-1", labels={"cat": 2},
-            dataset_title="T", data_format="tabular", data_intent="train",
-            category="tabular_classification", schema={}, samples=[], **extra,
+            table_name="my_dataset",
+            ingestor_id="ing-1",
+            labels={"cat": 2},
+            dataset_title="T",
+            data_format="tabular",
+            data_intent="train",
+            category="tabular_classification",
+            schema={},
+            samples=[],
+            **extra,
         )
         _, kwargs = post.call_args
     return json.loads(kwargs["data"])

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -16,7 +16,6 @@ import os
 
 from .utils.constants import LogLevel
 
-
 # Sentinel signalling \"caller did not pass this field as an override\".
 # Distinguishes the absent case from an explicit ``Field=None``, which
 # tests use to *suppress* a value (e.g. ``BACKEND_TOKEN=None``).
@@ -35,17 +34,28 @@ class Config:
 
     # Whitelist of valid override keys. A typo at the call site raises
     # immediately rather than silently no-op'ing.
-    _ENV_FIELDS = frozenset({
-        "DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
-        "BATCH_SIZE",
-        "EDGE_ENV",
-        "BACKEND_TOKEN", "CLIENT_USERNAME", "CLIENT_PASSWORD",
-        "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
-        "LOG_LEVEL",
-        "CATEGORICAL_MIN_COUNT",
-        "EMIT_ENRICHED_SCHEMA",
-        "PER_INGESTION_TABLES",
-    })
+    _ENV_FIELDS = frozenset(
+        {
+            "DB_HOST",
+            "DB_PORT",
+            "DB_USER",
+            "DB_PASSWORD",
+            "DB_NAME",
+            "BATCH_SIZE",
+            "EDGE_ENV",
+            "BACKEND_TOKEN",
+            "CLIENT_USERNAME",
+            "CLIENT_PASSWORD",
+            "SRC_PATH",
+            "LABEL_FILE",
+            "TABLE_NAME",
+            "TITLE",
+            "LOG_LEVEL",
+            "CATEGORICAL_MIN_COUNT",
+            "EMIT_ENRICHED_SCHEMA",
+            "PER_INGESTION_TABLES",
+        }
+    )
 
     # Env values (case-insensitive) that read as boolean true; anything else
     # (including unset) is false.
@@ -125,7 +135,11 @@ class Config:
     @property
     def DB_NAME(self) -> str:
         ov = self._override("DB_NAME")
-        return ov if ov is not _MISSING else os.environ.get("DB_NAME", "training_test_datasets")
+        return (
+            ov
+            if ov is not _MISSING
+            else os.environ.get("DB_NAME", "training_test_datasets")
+        )
 
     @property
     def BATCH_SIZE(self) -> int:
@@ -200,8 +214,29 @@ class Config:
         return ov if ov is not _MISSING else os.environ.get("TABLE_NAME", "")
 
     @property
+    def DEST_TABLE(self) -> str:
+        """The directory the file tree lands in under STORAGE_PATH. Defaults to
+        the dataset label (``TABLE_NAME``); when PER_INGESTION_TABLES is on the
+        ingestor injects the physical ``ds_<hex>`` handle via ``set_dest_table``
+        so file-bearing assets key on the SAME isolation unit as the row store,
+        the SQL grant, and the scoped mount (RFC-0003 D9 phase 2 / D16 —
+        client-runtime#203, tracebloc-engine#569). Not a user env field: the
+        only writer is ``set_dest_table``."""
+        ov = self._override("DEST_TABLE")
+        return ov if ov is not _MISSING else self.TABLE_NAME
+
+    @property
     def DEST_PATH(self) -> str:
-        return os.path.join(self.STORAGE_PATH, self.TABLE_NAME)
+        return os.path.join(self.STORAGE_PATH, self.DEST_TABLE)
+
+    def set_dest_table(self, physical_table_name: str) -> None:
+        """Point the file tree (``DEST_PATH``) at an explicit physical-table
+        directory. The ingestor calls this once, after it derives the
+        per-ingestion ``ds_<hex>`` handle, so file-bearing assets land under the
+        same handle as the row store instead of the shared label tree (#203
+        phase 2). Flag-off ingests never call it, so ``DEST_TABLE`` stays the
+        label and behavior is byte-for-byte today's."""
+        self._overrides["DEST_TABLE"] = physical_table_name
 
     @property
     def TITLE(self) -> Optional[str]:
@@ -232,7 +267,11 @@ class Config:
         """
         ov = self._override("PER_INGESTION_TABLES")
         if ov is not _MISSING:
-            return ov if isinstance(ov, bool) else str(ov).strip().lower() in self._TRUE_STRINGS
+            return (
+                ov
+                if isinstance(ov, bool)
+                else str(ov).strip().lower() in self._TRUE_STRINGS
+            )
         env = os.environ.get("PER_INGESTION_TABLES")
         if env is None:
             return False
@@ -254,7 +293,11 @@ class Config:
         """
         ov = self._override("EMIT_ENRICHED_SCHEMA")
         if ov is not _MISSING:
-            return ov if isinstance(ov, bool) else str(ov).strip().lower() in self._TRUE_STRINGS
+            return (
+                ov
+                if isinstance(ov, bool)
+                else str(ov).strip().lower() in self._TRUE_STRINGS
+            )
         env = os.environ.get("EMIT_ENRICHED_SCHEMA")
         if env is not None and env.strip() != "":
             return env.strip().lower() in self._TRUE_STRINGS

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -7,6 +7,7 @@ supporting both binary data and file-based image processing.
 
 import logging
 import os
+import re
 import shutil
 from typing import Any, Dict, Optional
 
@@ -665,5 +666,81 @@ def _reclaim_source(cfg: Config) -> bool:
     logger.info(
         f"{GREEN}Reclaimed staged source {src_real} after a verified, clean "
         f"load — no duplicate copy left on the PVC (#346).{RESET}"
+    )
+    return True
+
+
+# A per-ingestion physical handle: ``ds_`` + uuid4 hex (35 chars). Same grammar
+# the ingestor derives (BaseIngestor.physical_table_name) and the client-runtime
+# husk sweep matches — used here to PROVE a dest dir is a throwaway per-ingestion
+# handle before removing it, never a user label dir.
+_DS_HANDLE_RE = re.compile(r"^ds_[0-9a-f]{32}$")
+
+
+def reclaim_dest_tree(cfg: Optional[Config] = None) -> bool:
+    """Best-effort removal of THIS run's per-ingestion DEST_PATH tree after a
+    FAILED file-bearing ingest (#437 follow-up — data-ingestors#439).
+
+    Under PER_INGESTION_TABLES the file tree is keyed on the run's unique
+    ``ds_<hex>`` handle (``config.set_dest_table``), so — unlike the flag-off
+    label tree, which a same-label re-run overwrites — a failed run's assets are
+    NEVER overwritten (the retry mints a fresh handle) and nothing else reclaims
+    them: a lasting PVC leak for image-sized payloads. The graceful-failure path
+    (``BaseIngestor._ingest_with_lock``'s compensating-delete branch) calls this
+    to remove them. Hard kills (OOMKilled/SIGKILL) bypass that branch; those
+    orphans are the edge-side husk sweep's job, exactly like the DB husk tables.
+
+    SAFETY — opt-in, provable: delete DEST_PATH only when its basename is a
+    ``ds_<hex>`` handle (``_DS_HANDLE_RE`` — the per-ingestion pattern, never a
+    user label) AND it resolves to a DIRECT child of STORAGE_PATH. A flag-off
+    label dir, a user's mounted dataset dir, or the storage root is always left
+    untouched. Paths are ``realpath``-resolved before the check and the delete,
+    so a symlinked PVC mount cannot slip a non-handle target past the gate.
+
+    Best-effort: ANY error is logged + swallowed (returns False) so a cleanup
+    failure can never mask the ingest's original error.
+
+    Returns ``True`` iff a per-ingestion dest tree was removed.
+    """
+    cfg = cfg or config
+    try:
+        return _reclaim_dest_tree(cfg)
+    except Exception as e:
+        try:
+            logger.warning(
+                f"{YELLOW}Could not reclaim the failed run's dest tree "
+                f"(DEST_PATH={cfg.DEST_PATH!r}): {e}. Left in place — a manual "
+                f"cleanup or the husk sweep can remove it.{RESET}"
+            )
+        except Exception:
+            pass  # a broken logger must not fail the failure path either
+        return False
+
+
+def _reclaim_dest_tree(cfg: Config) -> bool:
+    """The guarded dest-tree reclaim decision + delete (contract: see
+    ``reclaim_dest_tree``). Split out so the wrapper can best-effort the WHOLE
+    thing — a raise anywhere here must never propagate to the ingest."""
+    dest = cfg.DEST_PATH
+    storage = cfg.STORAGE_PATH
+    if not dest or not storage or not os.path.isdir(dest):
+        return False
+    dest_real = os.path.realpath(dest)
+    storage_real = os.path.realpath(storage)
+    # Must be a DIRECT ds_<hex> child of STORAGE_PATH — never a flag-off label
+    # dir, a user dataset dir, the storage root, or anything outside it.
+    if os.path.dirname(dest_real) != storage_real:
+        logger.info(
+            f"{YELLOW}Not reclaiming dest {dest_real}: not a direct child of "
+            f"STORAGE_PATH {storage_real} — left in place.{RESET}"
+        )
+        return False
+    if not _DS_HANDLE_RE.match(os.path.basename(dest_real)):
+        # flag-off label tree (overwritten on re-run) or any non-handle dir
+        return False
+    shutil.rmtree(dest_real)
+    logger.info(
+        f"{GREEN}Reclaimed the failed per-ingestion run's file tree {dest_real} "
+        f"— no orphaned payload left on the PVC (#437 follow-up).{RESET}"
     )
     return True

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -25,7 +25,7 @@ from ..utils import redaction
 from ..utils.columns import resolve_column
 from ..utils.correlation import resolve_correlation_id
 from ..utils.validators_mapping import map_validators
-from ..file_transfer import map_file_transfer, reclaim_source
+from ..file_transfer import map_file_transfer, reclaim_dest_tree, reclaim_source
 from ..text_profile import compute_text_profile
 from ..schema_inference import canonical_dtype
 from ..reporting import ConsoleRenderer
@@ -1349,6 +1349,29 @@ class BaseIngestor(ABC):
                             f"{stats.get('inserted_records', 0)} unregistered "
                             "row(s) remain orphaned (#227)."
                         )
+                # Per-ingestion file trees are keyed on this run's UNIQUE
+                # ds_<hex> handle, so — unlike the flag-off label tree that a
+                # same-label re-run overwrites — a failed run's file-bearing
+                # assets are never overwritten (a retry mints a fresh handle)
+                # and nothing else reclaims them: a lasting PVC leak
+                # (data-ingestors#439). Remove them — but ONLY when the dataset
+                # did NOT register, mirroring the row compensating-delete's
+                # `not dataset_registered` guard above. A LATE failure after a
+                # successful send_ingest_summary leaves the backend pointing at
+                # this ds_<hex>, so deleting its files would be permanent asset
+                # loss for a LIVE dataset (Bugbot). NOT gated on
+                # inserted_records — files can land before any row does. Flag
+                # off is a safe no-op (reclaim_dest_tree only matches a ds_<hex>
+                # basename, never a label dir). Best-effort inside the helper,
+                # so it can't mask the original error. Hard kills (OOMKilled/
+                # SIGKILL) bypass this branch; those orphans are the edge-side
+                # husk sweep's job, exactly like the DB husk tables.
+                if (
+                    self.per_ingestion_tables
+                    and self.category in _FILE_BEARING_CATEGORIES
+                    and not dataset_registered
+                ):
+                    reclaim_dest_tree(self.database.config)
                 raise e
 
         # Reclaim the staged source tree now that the load is fully verified

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -316,33 +316,26 @@ class BaseIngestor(ABC):
         # The ``is True`` comparison is deliberate: test doubles use bare
         # MagicMocks for config, and a truthy Mock must not silently flip
         # the storage model.
-        self.per_ingestion_tables = (
-            database.config.PER_INGESTION_TABLES is True
-        )
+        self.per_ingestion_tables = database.config.PER_INGESTION_TABLES is True
         self.physical_table_name = (
             f"ds_{uuid.UUID(self.ingestor_id).hex}"
             if self.per_ingestion_tables
             else table_name
         )
-        # v1 boundary (Bugbot on the PR): the flag isolates the ROW STORE
-        # only. File-bearing categories also persist assets under the shared
-        # label tree (STORAGE_PATH/<label>), where a later same-label ingest
-        # would overwrite an earlier dataset's files while both ds_ tables
-        # keep referencing them — silent cross-dataset corruption. The file
-        # tree's isolation unit moves to the same handle with the
-        # per-dataset-mount work (tracebloc/client-runtime#203 phase 2);
-        # until then, refuse loudly instead of corrupting quietly. Row-only
-        # categories (tabular / time-series families) are the RFC-0003 v1
-        # rollout target and are unaffected.
-        if self.per_ingestion_tables and category in _FILE_BEARING_CATEGORIES:
-            raise ValueError(
-                f"PER_INGESTION_TABLES does not support file-bearing "
-                f"category {category!r} yet: assets would land in the shared "
-                f"label tree and be overwritten by a later ingest under the "
-                f"same label (per-dataset file isolation ships with "
-                f"tracebloc/client-runtime#203 phase 2). Run this ingest "
-                f"with the flag off."
-            )
+        # Under PER_INGESTION_TABLES the file tree keys on the SAME physical
+        # ds_<hex> handle as the row store, not the shared label tree: point
+        # DEST_PATH — which every file-copy primitive, the text profiler, the
+        # duplicate validator, and the source-reclaim path all read off this
+        # run's config — at the handle, so file-bearing assets land in
+        # STORAGE_PATH/ds_<hex>/. That matches the per-dataset scoped mount
+        # (client-runtime#203) and the engine's get_dataset_path resolution
+        # (tracebloc-engine#569), closing the #203-phase-2 file half. It lifts
+        # the earlier refusal: a same-label re-ingest now writes to its OWN
+        # handle instead of overwriting an earlier dataset's files. Flag off =>
+        # set_dest_table is never called and DEST_PATH stays
+        # STORAGE_PATH/<label>, byte-for-byte today's behavior.
+        if self.per_ingestion_tables:
+            self.database.config.set_dest_table(self.physical_table_name)
         self.schema = schema
         self.unique_id_column = unique_id_column
         self.label_column = label_column
@@ -609,9 +602,7 @@ class BaseIngestor(ABC):
 
                 if not result.is_valid:
                     all_valid = False
-                    validation_errors.append(
-                        f"{BOLD}{label} failed: {RESET} \n {RED}"
-                    )
+                    validation_errors.append(f"{BOLD}{label} failed: {RESET} \n {RED}")
                     validation_errors.extend(result.errors)
                     validation_errors.append(f"{RESET}")
 


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where copied files live under per-ingestion mode and add best-effort `rmtree` on failure; guards and the `dataset_registered` check limit mistaken deletes, but mistakes would affect PVC assets for live or failed ingests.
> 
> **Overview**
> **Per-ingestion file isolation (phase 2):** With `PER_INGESTION_TABLES` on, file-bearing ingests no longer fail at construction. The ingestor calls `Config.set_dest_table` so `DEST_PATH` is `STORAGE_PATH/ds_<hex>` (same handle as the row store) instead of the shared label directory; flag-off behavior stays label-based.
> 
> **Config** adds `DEST_TABLE` (defaults to `TABLE_NAME`) and routes `DEST_PATH` through it.
> 
> **Failed-run cleanup:** New `reclaim_dest_tree` removes a failed run’s `ds_<hex>` asset tree only when the basename matches the handle regex and the path is a direct child of `STORAGE_PATH`. `BaseIngestor` invokes it on the compensating-delete path for per-ingestion file-bearing runs that never registered (`not dataset_registered`), parallel to row cleanup.
> 
> Package version **0.8.0 → 0.8.2**. Tests cover dest reclaim guards and registration ordering; remaining diff is mostly formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0133f5038a4bb8104d10c41b479f214a79f981fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->