### PR TITLE
fix(#203-A3): reclaim ds_<hex> file tree on failed per-ingestion ingest (data-ingestors#439)

### DIFF
--- a/tests/test_file_transfer_reclaim.py
+++ b/tests/test_file_transfer_reclaim.py
@@ -351,3 +351,63 @@ def test_user_dir_skip_stays_quiet(tmp_path, monkeypatch):
     cfg = _cfg(userdir, storage, table="cats_dogs_train")
     assert file_transfer.reclaim_source(cfg) is False
     assert calls["info"] == 1 and calls["warning"] == 0  # deliberate, quiet
+
+
+# ---------------------------------------------------------------------------
+# reclaim_dest_tree — a FAILED per-ingestion run's dest tree (#437 / #439)
+# ---------------------------------------------------------------------------
+# Flag-on file trees key on a UNIQUE ds_<hex> handle, so a failed run's assets
+# are never overwritten by a retry (fresh handle) and nothing else reclaims
+# them. reclaim_dest_tree removes them on the failure path — but ONLY when it
+# can prove the dir is a ds_<hex> handle directly under STORAGE_PATH.
+
+_HANDLE = "ds_" + "a" * 32
+
+
+def _dest_cfg(storage, dest_table):
+    """Config whose DEST_PATH = storage/<dest_table> (set_dest_table override)."""
+    cfg = Config(TABLE_NAME="my_label")
+    cfg.STORAGE_PATH = str(storage)
+    cfg.set_dest_table(dest_table)
+    return cfg
+
+
+def test_reclaim_dest_removes_per_ingestion_handle_tree(tmp_path):
+    storage = tmp_path / "shared"
+    dest = storage / _HANDLE
+    dest.mkdir(parents=True)
+    (dest / "img.jpg").write_bytes(b"x")
+    assert file_transfer.reclaim_dest_tree(_dest_cfg(storage, _HANDLE)) is True
+    assert not dest.exists()
+
+
+def test_reclaim_dest_leaves_flag_off_label_tree(tmp_path):
+    # flag off: DEST_PATH = storage/<label>; the basename is not a ds_<hex>
+    # handle, so it must be LEFT (a same-label re-run overwrites it instead).
+    storage = tmp_path / "shared"
+    dest = storage / "my_label"
+    dest.mkdir(parents=True)
+    (dest / "img.jpg").write_bytes(b"x")
+    cfg = Config(TABLE_NAME="my_label")
+    cfg.STORAGE_PATH = str(storage)  # DEST_TABLE defaults to the label
+    assert file_transfer.reclaim_dest_tree(cfg) is False
+    assert dest.exists()
+
+
+def test_reclaim_dest_refuses_handle_not_direct_child_of_storage(tmp_path):
+    # a ds_<hex>-named dir nested deeper than a direct child is left alone
+    # (defense-in-depth: DEST_PATH must resolve to STORAGE_PATH/<handle>).
+    storage = tmp_path / "shared"
+    nested = storage / "sub" / _HANDLE
+    nested.mkdir(parents=True)
+    assert (
+        file_transfer.reclaim_dest_tree(_dest_cfg(storage, f"sub/{_HANDLE}")) is False
+    )
+    assert nested.exists()
+
+
+def test_reclaim_dest_noop_when_dest_missing(tmp_path):
+    # best-effort: a nonexistent DEST_PATH is a quiet no-op, never an error
+    storage = tmp_path / "shared"
+    storage.mkdir()
+    assert file_transfer.reclaim_dest_tree(_dest_cfg(storage, _HANDLE)) is False

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -195,9 +195,12 @@ def test_process_record_generates_content_hash_data_id_by_default():
     assert len(data_id) == 64 and all(c in "0123456789abcdef" for c in data_id)
     # deterministic: a fresh ingestor with the same salt reproduces the id
     again = make_ingestor(category=None, label_column="a")
-    assert again.process_record(
-        {"a": "cat", "filename": "x", "extension": ".jpg"}
-    )["data_id"] == data_id
+    assert (
+        again.process_record({"a": "cat", "filename": "x", "extension": ".jpg"})[
+            "data_id"
+        ]
+        == data_id
+    )
 
 
 def test_process_record_uses_unique_id_column():
@@ -230,11 +233,18 @@ def test_process_record_reads_label_by_configured_key():
     a mismatched key it reads None — this is why the ingestor must resolve the
     label column to the real header before processing (see the
     _resolve_label_column + end-to-end tests below)."""
-    ing = make_ingestor(label_column="label", schema={"a": "INT", "label": "VARCHAR(10)"}, category=None)
+    ing = make_ingestor(
+        label_column="label", schema={"a": "INT", "label": "VARCHAR(10)"}, category=None
+    )
     # exact key -> label present
-    assert ing.process_record({"a": "1", "label": "cat", "filename": "f"})["label"] == "cat"
+    assert (
+        ing.process_record({"a": "1", "label": "cat", "filename": "f"})["label"]
+        == "cat"
+    )
     # mismatched-case key with the SAME configured name -> None (the bug)
-    assert ing.process_record({"a": "1", "Label": "cat", "filename": "f"})["label"] is None
+    assert (
+        ing.process_record({"a": "1", "Label": "cat", "filename": "f"})["label"] is None
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -245,14 +255,16 @@ def test_process_record_reads_label_by_configured_key():
 @pytest.mark.parametrize(
     "columns,expected",
     [
-        (["a", "Label"], "Label"),      # case mismatch -> real header
+        (["a", "Label"], "Label"),  # case mismatch -> real header
         (["a", " label "], " label "),  # whitespace mismatch -> raw header
-        (["a", "label"], "label"),       # exact -> unchanged
-        (["a", "b"], "label"),           # absent -> configured name untouched
+        (["a", "label"], "label"),  # exact -> unchanged
+        (["a", "b"], "label"),  # absent -> configured name untouched
     ],
 )
 def test_resolve_label_column(columns, expected):
-    ing = make_ingestor(label_column="label", schema={"a": "INT", "label": "VARCHAR(10)"})
+    ing = make_ingestor(
+        label_column="label", schema={"a": "INT", "label": "VARCHAR(10)"}
+    )
     ing._resolve_label_column(columns)
     assert ing.label_column == expected
 
@@ -285,9 +297,10 @@ def test_ingest_label_case_mismatch_survives_to_db():
         ing.ingest("src", batch_size=10)
     ing.database.insert_batch.assert_called()
     _table, batch = ing.database.insert_batch.call_args.args
-    assert [r.get("label") for r in batch] == ["cat", "dog"], (
-        f"labels nulled by case mismatch: {[r.get('label') for r in batch]}"
-    )
+    assert [r.get("label") for r in batch] == [
+        "cat",
+        "dog",
+    ], f"labels nulled by case mismatch: {[r.get('label') for r in batch]}"
 
 
 def test_ingest_label_resolves_on_later_record_for_sparse_json():
@@ -296,8 +309,8 @@ def test_ingest_label_resolves_on_later_record_for_sparse_json():
     or a mis-cased label on every subsequent row would still null. The first
     (label-less) record legitimately gets None; the second resolves 'Label'."""
     records = [
-        {"a": "1", "filename": "f1"},                   # no label key at all
-        {"a": "2", "Label": "dog", "filename": "f2"},   # mis-cased label
+        {"a": "1", "filename": "f1"},  # no label key at all
+        {"a": "2", "Label": "dog", "filename": "f2"},  # mis-cased label
     ]
     ing = make_ingestor(
         records=records,
@@ -311,9 +324,10 @@ def test_ingest_label_resolves_on_later_record_for_sparse_json():
         Sess.return_value.__enter__.return_value = MagicMock()
         ing.ingest("src", batch_size=10)
     _table, batch = ing.database.insert_batch.call_args.args
-    assert [r.get("label") for r in batch] == [None, "dog"], (
-        f"expected [None, 'dog']; got {[r.get('label') for r in batch]}"
-    )
+    assert [r.get("label") for r in batch] == [
+        None,
+        "dog",
+    ], f"expected [None, 'dog']; got {[r.get('label') for r in batch]}"
 
 
 def test_process_record_strips_whitespace_from_string_label():
@@ -512,9 +526,7 @@ def test_process_record_omits_mask_id_for_non_semseg_categories():
 def test_process_batch_success():
     ing = make_ingestor()
     session = MagicMock()
-    ids, db_failures = ing._batch_writer._process(
-        [{"data_id": "a"}], session
-    )
+    ids, db_failures = ing._batch_writer._process([{"data_id": "a"}], session)
     assert ids == [1, 2]
     assert db_failures == []
 
@@ -523,9 +535,7 @@ def test_process_batch_no_ids_skips_api():
     ing = make_ingestor()
     ing.database.insert_batch.return_value = ([], [{"err": "x"}])
     session = MagicMock()
-    ids, db_failures = ing._batch_writer._process(
-        [{"data_id": "a"}], session
-    )
+    ids, db_failures = ing._batch_writer._process([{"data_id": "a"}], session)
     assert ids == []
     assert db_failures == [{"err": "x"}]
 
@@ -1599,6 +1609,57 @@ def test_late_failure_after_registration_never_deletes():
     ing.database.delete_by_ingestor_id.assert_not_called()
 
 
+def test_failed_per_ingestion_file_ingest_reclaims_dest_tree():
+    """A per-ingestion file-bearing run that fails BEFORE registration reclaims
+    its ds_<hex> file tree (data-ingestors#439): a retry mints a fresh handle,
+    so nothing else would ever overwrite or reclaim it."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    ing = make_ingestor(
+        records=[{"a": "1", "filename": "f1"}],
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    ing.per_ingestion_tables = True
+    ing.physical_table_name = "ds_" + "a" * 32
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
+    with patch.object(base_mod, "reclaim_dest_tree") as reclaim:
+        _ingest_expecting(ing, RuntimeError)
+    reclaim.assert_called_once_with(ing.database.config)
+
+
+def test_late_failure_after_registration_never_reclaims_dest_tree():
+    """The dataset_registered guard for FILES: a failure AFTER a successful
+    send_ingest_summary must NOT reclaim the now-registered dataset's ds_<hex>
+    tree — the backend points at it, so deleting would be permanent asset loss
+    (Bugbot). Mutation check: dropping `and not dataset_registered` fails this."""
+    from tracebloc_ingestor.utils.constants import TaskCategory
+
+    ing = make_ingestor(
+        records=[{"a": "1", "filename": "f1"}],
+        category=TaskCategory.IMAGE_CLASSIFICATION,
+        label_column="a",
+    )
+    ing.per_ingestion_tables = True
+    ing.physical_table_name = "ds_" + "a" * 32
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        ing, "_log_summary", side_effect=RuntimeError("render blew up")
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ), patch.object(
+        base_mod, "reclaim_dest_tree"
+    ) as reclaim:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        with pytest.raises(RuntimeError):
+            ing.ingest("src", batch_size=10)
+    ing.api_client.send_ingest_summary.assert_called_once()
+    reclaim.assert_not_called()
+
+
 # ── backend#1028 item 2: orphan-row reconciliation on start ──────────────────
 # The #227 compensating delete only runs on a CAUGHT failure. A hard kill
 # (OOMKilled / SIGKILL mid-ingest) bypasses it, leaving the dead run's rows in
@@ -1633,9 +1694,7 @@ def test_reconcile_and_start_journal_run_before_first_insert():
     )
     names = [name for name, _, _ in ing.database.mock_calls]
     assert names.index("create_table") < names.index("reclaim_dead_run_rows")
-    assert names.index("reclaim_dead_run_rows") < names.index(
-        "record_ingest_started"
-    )
+    assert names.index("reclaim_dead_run_rows") < names.index("record_ingest_started")
     assert names.index("record_ingest_started") < names.index("insert_batch")
 
 
@@ -1655,9 +1714,7 @@ def test_successful_registration_marks_journal_registered_before_send():
         ing.table_name, ing.ingestor_id
     )
     seq = [c[0] for c in parent.mock_calls]
-    assert seq.index("db.mark_ingest_registered") < seq.index(
-        "api.send_ingest_summary"
-    )
+    assert seq.index("db.mark_ingest_registered") < seq.index("api.send_ingest_summary")
 
 
 def test_failed_registration_undoes_optimistic_flip_and_deletes(caplog):
@@ -1667,9 +1724,7 @@ def test_failed_registration_undoes_optimistic_flip_and_deletes(caplog):
     registered entry no reconcile pass would clean. The #227 delete still
     fires (rows are not registered)."""
     ing = make_ingestor(records=[{"a": "1"}], label_column="a")
-    ing.api_client.send_ingest_summary.side_effect = RuntimeError(
-        "backend rejected"
-    )
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
     with patch.object(base_mod, "Session") as Sess, patch.object(
         ing, "validate_data", return_value=True
     ):
@@ -1718,9 +1773,7 @@ def test_journal_reset_failure_never_masks_original_error(caplog):
     import logging
 
     ing = make_ingestor(records=[{"a": "1"}], label_column="a")
-    ing.api_client.send_ingest_summary.side_effect = RuntimeError(
-        "backend rejected"
-    )
+    ing.api_client.send_ingest_summary.side_effect = RuntimeError("backend rejected")
     ing.database.mark_ingest_unregistered.side_effect = Exception("journal down")
     with caplog.at_level(logging.CRITICAL):
         with patch.object(base_mod, "Session") as Sess, patch.object(
@@ -1733,8 +1786,7 @@ def test_journal_reset_failure_never_masks_original_error(caplog):
         ing.table_name, ing.ingestor_id
     )
     assert any(
-        "reset the run journal to unregistered" in r.message
-        for r in caplog.records
+        "reset the run journal to unregistered" in r.message for r in caplog.records
     )
 
 
@@ -1751,9 +1803,7 @@ def test_reclaim_failure_never_blocks_the_ingest(caplog):
         _run_happy_ingest(ing)  # must NOT raise
     ing.database.insert_batch.assert_called()
     ing.database.record_ingest_started.assert_called_once()
-    assert any(
-        "Orphan-row reconciliation failed" in r.message for r in caplog.records
-    )
+    assert any("Orphan-row reconciliation failed" in r.message for r in caplog.records)
 
 
 def test_zero_record_run_journals_start_but_not_registered():
@@ -1784,7 +1834,5 @@ def test_objdet_content_hash_constructor_warns(caplog):
 
     caplog.clear()
     with caplog.at_level(logging.WARNING):
-        make_ingestor(
-            category=TaskCategory.OBJECT_DETECTION, data_id_strategy="uuid"
-        )
+        make_ingestor(category=TaskCategory.OBJECT_DETECTION, data_id_strategy="uuid")
     assert not any("collapse" in r.getMessage() for r in caplog.records)

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -7,6 +7,7 @@ supporting both binary data and file-based image processing.
 
 import logging
 import os
+import re
 import shutil
 from typing import Any, Dict, Optional
 
@@ -665,5 +666,81 @@ def _reclaim_source(cfg: Config) -> bool:
     logger.info(
         f"{GREEN}Reclaimed staged source {src_real} after a verified, clean "
         f"load — no duplicate copy left on the PVC (#346).{RESET}"
+    )
+    return True
+
+
+# A per-ingestion physical handle: ``ds_`` + uuid4 hex (35 chars). Same grammar
+# the ingestor derives (BaseIngestor.physical_table_name) and the client-runtime
+# husk sweep matches — used here to PROVE a dest dir is a throwaway per-ingestion
+# handle before removing it, never a user label dir.
+_DS_HANDLE_RE = re.compile(r"^ds_[0-9a-f]{32}$")
+
+
+def reclaim_dest_tree(cfg: Optional[Config] = None) -> bool:
+    """Best-effort removal of THIS run's per-ingestion DEST_PATH tree after a
+    FAILED file-bearing ingest (#437 follow-up — data-ingestors#439).
+
+    Under PER_INGESTION_TABLES the file tree is keyed on the run's unique
+    ``ds_<hex>`` handle (``config.set_dest_table``), so — unlike the flag-off
+    label tree, which a same-label re-run overwrites — a failed run's assets are
+    NEVER overwritten (the retry mints a fresh handle) and nothing else reclaims
+    them: a lasting PVC leak for image-sized payloads. The graceful-failure path
+    (``BaseIngestor._ingest_with_lock``'s compensating-delete branch) calls this
+    to remove them. Hard kills (OOMKilled/SIGKILL) bypass that branch; those
+    orphans are the edge-side husk sweep's job, exactly like the DB husk tables.
+
+    SAFETY — opt-in, provable: delete DEST_PATH only when its basename is a
+    ``ds_<hex>`` handle (``_DS_HANDLE_RE`` — the per-ingestion pattern, never a
+    user label) AND it resolves to a DIRECT child of STORAGE_PATH. A flag-off
+    label dir, a user's mounted dataset dir, or the storage root is always left
+    untouched. Paths are ``realpath``-resolved before the check and the delete,
+    so a symlinked PVC mount cannot slip a non-handle target past the gate.
+
+    Best-effort: ANY error is logged + swallowed (returns False) so a cleanup
+    failure can never mask the ingest's original error.
+
+    Returns ``True`` iff a per-ingestion dest tree was removed.
+    """
+    cfg = cfg or config
+    try:
+        return _reclaim_dest_tree(cfg)
+    except Exception as e:
+        try:
+            logger.warning(
+                f"{YELLOW}Could not reclaim the failed run's dest tree "
+                f"(DEST_PATH={cfg.DEST_PATH!r}): {e}. Left in place — a manual "
+                f"cleanup or the husk sweep can remove it.{RESET}"
+            )
+        except Exception:
+            pass  # a broken logger must not fail the failure path either
+        return False
+
+
+def _reclaim_dest_tree(cfg: Config) -> bool:
+    """The guarded dest-tree reclaim decision + delete (contract: see
+    ``reclaim_dest_tree``). Split out so the wrapper can best-effort the WHOLE
+    thing — a raise anywhere here must never propagate to the ingest."""
+    dest = cfg.DEST_PATH
+    storage = cfg.STORAGE_PATH
+    if not dest or not storage or not os.path.isdir(dest):
+        return False
+    dest_real = os.path.realpath(dest)
+    storage_real = os.path.realpath(storage)
+    # Must be a DIRECT ds_<hex> child of STORAGE_PATH — never a flag-off label
+    # dir, a user dataset dir, the storage root, or anything outside it.
+    if os.path.dirname(dest_real) != storage_real:
+        logger.info(
+            f"{YELLOW}Not reclaiming dest {dest_real}: not a direct child of "
+            f"STORAGE_PATH {storage_real} — left in place.{RESET}"
+        )
+        return False
+    if not _DS_HANDLE_RE.match(os.path.basename(dest_real)):
+        # flag-off label tree (overwritten on re-run) or any non-handle dir
+        return False
+    shutil.rmtree(dest_real)
+    logger.info(
+        f"{GREEN}Reclaimed the failed per-ingestion run's file tree {dest_real} "
+        f"— no orphaned payload left on the PVC (#437 follow-up).{RESET}"
     )
     return True

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -25,7 +25,7 @@ from ..utils import redaction
 from ..utils.columns import resolve_column
 from ..utils.correlation import resolve_correlation_id
 from ..utils.validators_mapping import map_validators
-from ..file_transfer import map_file_transfer, reclaim_source
+from ..file_transfer import map_file_transfer, reclaim_dest_tree, reclaim_source
 from ..text_profile import compute_text_profile
 from ..schema_inference import canonical_dtype
 from ..reporting import ConsoleRenderer
@@ -1349,6 +1349,23 @@ class BaseIngestor(ABC):
                             f"{stats.get('inserted_records', 0)} unregistered "
                             "row(s) remain orphaned (#227)."
                         )
+                # Per-ingestion file trees are keyed on this run's UNIQUE
+                # ds_<hex> handle, so — unlike the flag-off label tree that a
+                # same-label re-run overwrites — a failed run's file-bearing
+                # assets are never overwritten (a retry mints a fresh handle)
+                # and nothing else reclaims them: a lasting PVC leak
+                # (data-ingestors#439). Remove them. NOT gated on
+                # inserted_records — files can land before any row does. Flag
+                # off is a safe no-op (reclaim_dest_tree only matches a ds_<hex>
+                # basename, never a label dir). Best-effort inside the helper,
+                # so it can't mask the original error. Hard kills (OOMKilled/
+                # SIGKILL) bypass this branch; those orphans are the edge-side
+                # husk sweep's job, exactly like the DB husk tables.
+                if (
+                    self.per_ingestion_tables
+                    and self.category in _FILE_BEARING_CATEGORIES
+                ):
+                    reclaim_dest_tree(self.database.config)
                 raise e
 
         # Reclaim the staged source tree now that the load is fully verified

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -1354,7 +1354,12 @@ class BaseIngestor(ABC):
                 # same-label re-run overwrites — a failed run's file-bearing
                 # assets are never overwritten (a retry mints a fresh handle)
                 # and nothing else reclaims them: a lasting PVC leak
-                # (data-ingestors#439). Remove them. NOT gated on
+                # (data-ingestors#439). Remove them — but ONLY when the dataset
+                # did NOT register, mirroring the row compensating-delete's
+                # `not dataset_registered` guard above. A LATE failure after a
+                # successful send_ingest_summary leaves the backend pointing at
+                # this ds_<hex>, so deleting its files would be permanent asset
+                # loss for a LIVE dataset (Bugbot). NOT gated on
                 # inserted_records — files can land before any row does. Flag
                 # off is a safe no-op (reclaim_dest_tree only matches a ds_<hex>
                 # basename, never a label dir). Best-effort inside the helper,
@@ -1364,6 +1369,7 @@ class BaseIngestor(ABC):
                 if (
                     self.per_ingestion_tables
                     and self.category in _FILE_BEARING_CATEGORIES
+                    and not dataset_registered
                 ):
                     reclaim_dest_tree(self.database.config)
                 raise e


### PR DESCRIPTION
## Fixes the #439 PVC-leak finding on #437

**Finding (Bugbot Medium):** a failed file-bearing ingest under `PER_INGESTION_TABLES` leaves assets under its unique `ds_<hex>` handle. Unlike the flag-off label tree (a same-label re-run overwrites it), the retry mints a **fresh** handle → the orphaned files are never overwritten and nothing reclaims them → lasting PVC leak for image-sized payloads.

> Verified real. Dormant in prod *only* because `PER_INGESTION_TABLES` defaults off — so this is a **blocker to close before the enablement flip**, not a live prod bug. (Note: #437 *lifted* the refusal, so file-bearing now writes; the earlier "refused cleanly" read was pre-A3.)

## Fix
- **`file_transfer.reclaim_dest_tree()`** — guarded, best-effort `rmtree` of `DEST_PATH`. **Safety (opt-in, provable):** deletes only when the basename is a `ds_<hex>` handle (never a user label) **and** it resolves to a *direct child* of `STORAGE_PATH`; `realpath` before check + delete; every error logged + swallowed so a cleanup failure can never mask the ingest's original error. Mirrors `reclaim_source`'s posture.
- **`base.py` failure handler** calls it for per-ingestion file-bearing runs — **not** gated on `inserted_records` (files can land before any row). Flag-off is a safe no-op (the handle guard only matches `ds_<hex>`).
- **+4 tests**: removes the handle tree; leaves the flag-off label tree; refuses a non-direct-child handle; no-op on missing dest.

## Scope
Closes the **graceful-failure** path (the common case). **Hard kills** (OOMKilled/SIGKILL) bypass the except-branch — those orphaned file trees are the **edge-side husk sweep**'s job (client-runtime, exactly like the DB husk tables it already reaps); flagged for a separate client-runtime change, not done here.

Full suite **1907 passed**; `black` clean. `__version__` 0.8.1 → 0.8.2. Targets `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes files on the shared PVC during ingest failure handling; mitigated by strict `ds_<hex>` and direct-child guards plus the `dataset_registered` check, but a guard bug could cause data loss on registered datasets.
> 
> **Overview**
> Fixes **PVC leaks** when a file-bearing ingest fails under `PER_INGESTION_TABLES`: each run writes assets under a unique `ds_<hex>` tree that retries never overwrite, so orphaned files could accumulate until this change.
> 
> Adds **`reclaim_dest_tree()`** in `file_transfer` — a best-effort, guarded `rmtree` of `DEST_PATH` that only runs when the basename matches `ds_<hex>` and the path is a **direct child** of `STORAGE_PATH` (with `realpath` checks). Flag-off label directories and nested paths are left alone; errors are swallowed so cleanup cannot mask the original failure.
> 
> Wires it into **`BaseIngestor`’s compensating-failure path** for per-ingestion, file-bearing runs that did **not** register (`not dataset_registered`), mirroring the existing row delete guard so a late post-registration failure does not delete live dataset files.
> 
> Adds unit and ingest integration tests for the happy reclaim path, safety no-ops, and the registration guard. Bumps package version **0.8.1 → 0.8.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b51fa136e624817a30f56aeea113d703e8153b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->