### PR TITLE
chore: retire master branch references from CI (backend#1428 Change 2)

### DIFF
--- a/.github/workflows/advance-deploy-env.yml
+++ b/.github/workflows/advance-deploy-env.yml
@@ -1,12 +1,12 @@
 name: Advance deploy env
 
 # Calls the reusable workflow in tracebloc/.github.
-# When this branch (develop/staging/master/main) receives a merge,
+# When this branch (develop/staging/main) receives a merge,
 # updates each contained PR's Deploy environment field on the engineer kanban.
 
 on:
   push:
-    branches: [develop, staging, master, main]
+    branches: [develop, staging, main]
 
 jobs:
   advance:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,9 +6,9 @@ name: E2E ingestion
 
 on:
   pull_request:
-    branches: [develop, master, main]
+    branches: [develop, main]
   push:
-    branches: [develop, master, main]
+    branches: [develop, main]
 
 permissions:
   contents: read

--- a/.github/workflows/fr-gate-caller.yml
+++ b/.github/workflows/fr-gate-caller.yml
@@ -1,12 +1,12 @@
 name: FR gate
 
-# Per-repo caller. Blocks merges to staging/main/master unless every contained
+# Per-repo caller. Blocks merges to staging/main unless every contained
 # kanban item is in "Ready for staging" or "Ready for prod" respectively.
 # All logic lives in tracebloc/.github/.github/workflows/fr-gate.yml.
 
 on:
   pull_request:
-    branches: [staging, main, master]
+    branches: [staging, main]
     types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
 
 jobs:

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -1,12 +1,12 @@
-name: Publish Master Package to GitHub Packages
+name: Publish Package to PyPI (prod)
 
 on:
   push:
     branches:
-      - master
+      - main
 
 concurrency:
-  group: publish-master-${{ github.ref }}
+  group: publish-main-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-# Runs the pytest suite on every PR + push to develop/master/main.
+# Runs the pytest suite on every PR + push to develop/main.
 # Matrix: Python 3.11 + 3.12 (matches setup.py: python_requires=">=3.11").
 # Coverage is gated at --cov-fail-under=95 (the suite currently sits at ~99%);
 # CI fails if total coverage regresses below 95%.
@@ -11,9 +11,9 @@ name: Tests
 
 on:
   pull_request:
-    branches: [develop, master, main]
+    branches: [develop, main]
   push:
-    branches: [develop, master, main]
+    branches: [develop, main]
 
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Part of **backend#1428 Change 2** (retire `master`; parent epic #1405). The `data-ingestors` prod branch was renamed **`master` → `main`**. GitHub's rename redirect does **not** rewrite workflow YAML, branch protection, or rulesets, so those are handled explicitly.

This PR carries the **in-repo config** changes. The branch rename + protection re-verify + ruleset update were done out-of-band via the API (see checklist below).

### Changes
- **`publish-master.yml` → `publish-main.yml`**: now triggers on push to `main` (was `master`-only). ⚠️ **This is the one that mattered** — it publishes `tracebloc_ingestor` to PyPI on the prod push and had *no* `main` trigger, so the branch rename alone would have **silently stopped prod publishing** (the exact fail-open class this epic exists to remove). Also updated the workflow `name:` and `concurrency` group.
- **`tests.yml`, `e2e.yml`, `fr-gate-caller.yml`, `advance-deploy-env.yml`**: dropped the now-dead `master` entry from branch filters. These already listed `main`, so required checks kept firing — this is cleanup, not a fix.

### Coordination
The ticket flagged `publish-master.yml` for coordination with **#1427 def3** and **#1422** (publish-half lockdown). Neither has an open PR against this repo yet, so there's no live conflict — this PR takes the branch-name slice; those tickets rebase on top.

## Type
- [x] Chore / CI

## Test plan
- Config-only; no runtime code touched. Workflow YAML validated by grep sweep (no `master` refs remain in triggers / name / concurrency).
- CI on this PR exercises `tests` + `e2e` on the new `[develop, main]` filters.

## Done out-of-band (API, admin)
- [x] Recorded `master` protection snapshot (8 required contexts, 1 approval, release-train bypass, enforce_admins, conv-resolution)
- [x] `master` → `main` rename
- [x] Re-verified protection on `main` — **byte-for-byte identical**; `master` 404s on both ref and protection
- [x] `promotion-branches-merge-commit-only` ruleset: `refs/heads/master` → `refs/heads/main` (merge-commit-only rule preserved)
- [x] `v*` tag ruleset: no change needed (targets `refs/tags/v*`, no branch ref)
- [ ] `release-train/repos.yml` `prod_branch: master → main` (separate PR to release-train)
- [ ] Root workspace CLAUDE.md historical-default table
- [ ] Promotion dry-run before next real hop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only CI trigger and naming updates with no application runtime changes; the publish-on-main fix reduces operational risk from a silent prod publish gap.
> 
> **Overview**
> Aligns GitHub Actions with the prod branch rename **`master` → `main`** so CI and publishing keep running on the new default branch.
> 
> **`publish-main.yml`** (formerly `publish-master.yml`) is the functional fix: it now runs on push to **`main`** instead of **`master` only**, with an updated workflow title and concurrency group. Without that change, prod PyPI publishing would stop after the rename because the old workflow had no `main` trigger.
> 
> **`tests.yml`**, **`e2e.yml`**, **`fr-gate-caller.yml`**, and **`advance-deploy-env.yml`** drop **`master`** from branch filters and related comments; they already included **`main`**, so this is cleanup rather than behavior change for those jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1a40c9bf670d44897fdd9cc5fc51f8dbcf9fe2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->