### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -126,6 +126,11 @@ PyPI first. `RELEASING.md` documents how they stay aligned.
   fixture rows (`e2e/test_characterization.py:107,215`).
 - `debug_csv_processing.py` at the repo root is a tracked debugging scratch script — only
   `tracebloc_ingestor/` ships in the package.
+- A `code-quality-caller.yml` that passes **no `secrets:` line** is correct, not an omission.
+  The shared `code-quality.yml` reusable references no secrets by contract
+  (RFC-BACKEND-1405 Q5, backend#1526): secretless callees get no secrets line, and if the
+  reusable ever gains one, callers switch to explicit per-secret passing — never
+  `secrets: inherit`. Flag the *addition* of `secrets: inherit` on this caller instead.
 
 ## Tone
 

--- a/.github/workflows/advance-deploy-env.yml
+++ b/.github/workflows/advance-deploy-env.yml
@@ -1,12 +1,12 @@
 name: Advance deploy env
 
 # Calls the reusable workflow in tracebloc/.github.
-# When this branch (develop/staging/master/main) receives a merge,
+# When this branch (develop/staging/main) receives a merge,
 # updates each contained PR's Deploy environment field on the engineer kanban.
 
 on:
   push:
-    branches: [develop, staging, master, main]
+    branches: [develop, staging, main]
 
 jobs:
   advance:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,9 +6,9 @@ name: E2E ingestion
 
 on:
   pull_request:
-    branches: [develop, master, main]
+    branches: [develop, main]
   push:
-    branches: [develop, master, main]
+    branches: [develop, main]
 
 permissions:
   contents: read

--- a/.github/workflows/fr-gate-caller.yml
+++ b/.github/workflows/fr-gate-caller.yml
@@ -1,12 +1,12 @@
 name: FR gate
 
-# Per-repo caller. Blocks merges to staging/main/master unless every contained
+# Per-repo caller. Blocks merges to staging/main unless every contained
 # kanban item is in "Ready for staging" or "Ready for prod" respectively.
 # All logic lives in tracebloc/.github/.github/workflows/fr-gate.yml.
 
 on:
   pull_request:
-    branches: [staging, main, master]
+    branches: [staging, main]
     types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
 
 jobs:

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -8,17 +8,22 @@ on:
 
 concurrency:
   group: publish-dev-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
+
+# Parity with publish-main.yml: this workflow builds + smoke-tests only (it does
+# not upload), but least privilege still applies on a public repo.
+permissions:
+  contents: read
 
 jobs:
   publish:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Smoke-test the built image
         # Every other publisher runs this probe (release-image.yml,
-        # publish-master.yml, publish-dev.yml) and it exists for a real
+        # publish-main.yml, publish-dev.yml) and it exists for a real
         # regression: v0.3.0-rc1 shipped without tracebloc_ingestor/schema/
         # because the directory had no __init__.py and find_packages() silently
         # dropped it. Without the probe, that class of packaging break would

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -135,10 +135,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -146,7 +146,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: Dockerfile
@@ -217,10 +217,10 @@ jobs:
           pattern: digests-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -1,12 +1,12 @@
-name: Publish Master Package to GitHub Packages
+name: Publish Package to PyPI (prod)
 
 on:
   push:
     branches:
-      - master
+      - main
 
 concurrency:
-  group: publish-master-${{ github.ref }}
+  group: publish-main-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -7,17 +7,33 @@ on:
 
 concurrency:
   group: publish-main-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # push to the prod branch is the only trigger, so there is never a PR run to
+  # cancel; a publish in flight must not be cancelled anyway. State it plainly.
+  cancel-in-progress: false
+
+# Least privilege: this job publishes to PyPI with PYPI_API_TOKEN, not with the
+# workflow token, so it needs nothing beyond reading the checked-out source.
+permissions:
+  contents: read
 
 jobs:
   publish:
     timeout-minutes: 20
     runs-on: ubuntu-latest
+    # NOT gated behind a required-reviewer environment, deliberately. release-image.yml
+    # (tag-triggered) has a verify-published job that polls PyPI for this version for
+    # ~10 minutes and FAILS CLOSED, and its image build `needs` it -- so a manual
+    # approval that held this upload past 10 minutes would break the image build on
+    # every release (Bugbot, backend#1427). The push to the prod branch is already a
+    # train-gated, reviewed promotion, so a second human approval here is redundant as
+    # well as harmful. The remaining risk -- a long-lived PyPI token in a public repo's
+    # repo secrets -- is best closed by PyPI Trusted Publishing (OIDC), which removes
+    # the token entirely with no blocking step; flagged for follow-up, not a settings pass.
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -41,10 +57,18 @@ jobs:
         run: |
           python -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
 
-      - name: Publish to GitHub Packages
+      - name: Publish to production PyPI
+        # This step was named "Publish to GitHub Packages", but `twine upload`
+        # with no --repository-url targets upload.pypi.org -- so every push to
+        # the prod branch published to PRODUCTION PyPI while claiming otherwise
+        # (backend#1427). The target is now explicit and the step is named for
+        # what it does. --skip-existing makes the step idempotent: a re-run
+        # after a partial upload (wheel landed, sdist hit a transient error), or a
+        # push that did not bump the version, becomes a green no-op instead of a
+        # permanent HTTP 400 "File already exists" with no clean re-run path.
         run: |
           python -m pip install twine
-          twine upload dist/*
+          twine upload --skip-existing --repository-url https://upload.pypi.org/legacy/ dist/*
         env:
           TWINE_USERNAME: '__token__'
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -91,7 +91,7 @@ jobs:
             exit 1
           fi
 
-          # publish-master.yml uploads to PyPI on the master push; the tag can
+          # publish-main.yml uploads to PyPI on the prod-branch push; the tag can
           # land first, and PyPI's CDN lags a little behind an upload. Poll
           # rather than race, and FAIL CLOSED: no published sdist means no
           # image, which is the whole point of this gate.
@@ -114,7 +114,7 @@ jobs:
               sleep 20
             fi
           done
-          echo "::error::tracebloc-ingestor ${version} never appeared on PyPI (10 min). Refusing to publish an image for a version that did not publish - check the 'Publish Master Package' run for this commit, then re-drive this workflow with: gh workflow run release-image.yml -f ref=${REF}"
+          echo "::error::tracebloc-ingestor ${version} never appeared on PyPI (10 min). Refusing to publish an image for a version that did not publish - check the 'Publish Package to PyPI (prod)' run for this commit, then re-drive this workflow with: gh workflow run release-image.yml -f ref=${REF}"
           exit 1
 
   release:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -134,13 +134,13 @@ jobs:
         # Registers binfmt handlers so the arm64 layers can be built
         # under emulation on the amd64 runner. Without this, the
         # multi-arch build below silently degrades to amd64-only.
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -148,7 +148,7 @@ jobs:
 
       - name: Extract image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # Tag strategy: semver only. No :latest — downstream must pick a
@@ -201,7 +201,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           # Multi-arch (#24). Without `platforms`, build-push-action
@@ -264,7 +264,7 @@ jobs:
           echo "$output" | grep -q "INGEST_CONFIG"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
         with:
           cosign-release: 'v2.4.0'
 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -54,10 +54,10 @@ concurrency:
 jobs:
   # Only cut an image for a version that actually published. The old chain got
   # this implicitly: auto-release-on-master.yml ran on a *successful*
-  # publish-master (sdist install + schema probe) and only then tagged and
+  # publish-main (sdist install + schema probe) and only then tagged and
   # dispatched. The release tag now comes from the release train
   # (tracebloc/backend#1345), which pushes it right after the promotion merge
-  # while publish-master is still running — so the guarantee has to be stated
+  # while publish-main is still running — so the guarantee has to be stated
   # explicitly here instead of inherited from the trigger.
   verify-published:
     timeout-minutes: 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-# Runs the pytest suite on every PR + push to develop/master/main.
+# Runs the pytest suite on every PR + push to develop/main.
 # Matrix: Python 3.11 + 3.12 (matches setup.py: python_requires=">=3.11").
 # Coverage is gated at --cov-fail-under=95 (the suite currently sits at ~99%);
 # CI fails if total coverage regresses below 95%.
@@ -11,9 +11,9 @@ name: Tests
 
 on:
   pull_request:
-    branches: [develop, master, main]
+    branches: [develop, main]
   push:
-    branches: [develop, master, main]
+    branches: [develop, main]
 
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the prod PyPI publish workflow and release-image PyPI gate messaging; changes are mostly explicitness, idempotency, and branch renames rather than ingest/runtime logic.
> 
> **Overview**
> Aligns GitHub Actions with the release train using **`main`** as the prod branch: PR/push triggers and comments drop **`master`** in `tests`, `e2e`, `fr-gate-caller`, and `advance-deploy-env`.
> 
> **Prod packaging** moves from deleted `publish-master.yml` to new **`publish-main.yml`** on pushes to `main`. The upload step is renamed and documented as **production PyPI** (explicit `upload.pypi.org` URL), adds **`twine upload --skip-existing`** for safer re-runs, bumps checkout/setup-python, sets **`permissions: contents: read`**, and keeps publish runs from being cancelled mid-flight.
> 
> **`publish-dev.yml`** gets the same action upgrades, **`contents: read`**, and **`cancel-in-progress: false`** (build/smoke only, no upload).
> 
> **`release-image.yml`** and **`publish-images.yml`** pin Docker-related actions to commit SHAs and update references from `publish-master` to **`publish-main`** (PyPI gate messaging included).
> 
> **`.cursor/BUGBOT.md`** adds guidance that secretless `code-quality-caller` workflows should not use `secrets: inherit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c954b9822f6d05e06ec32557698e51e6974adee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->