### PR TITLE
docs(ci): sweep stale publish-master comment refs to publish-main (#445)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Smoke-test the built image
         # Every other publisher runs this probe (release-image.yml,
-        # publish-master.yml, publish-dev.yml) and it exists for a real
+        # publish-main.yml, publish-dev.yml) and it exists for a real
         # regression: v0.3.0-rc1 shipped without tracebloc_ingestor/schema/
         # because the directory had no __init__.py and find_packages() silently
         # dropped it. Without the probe, that class of packaging break would

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -54,10 +54,10 @@ concurrency:
 jobs:
   # Only cut an image for a version that actually published. The old chain got
   # this implicitly: auto-release-on-master.yml ran on a *successful*
-  # publish-master (sdist install + schema probe) and only then tagged and
+  # publish-main (sdist install + schema probe) and only then tagged and
   # dispatched. The release tag now comes from the release train
   # (tracebloc/backend#1345), which pushes it right after the promotion merge
-  # while publish-master is still running — so the guarantee has to be stated
+  # while publish-main is still running — so the guarantee has to be stated
   # explicitly here instead of inherited from the trigger.
   verify-published:
     timeout-minutes: 15


### PR DESCRIPTION
Bugbot flagged this on the develop→staging mirror (data-ingestors#445, Medium): the master→main rename (which removed `publish-master.yml`) left sibling-workflow **comments** still naming the deleted file — `publish-images.yml:164` lists it among current publishers, and `release-image.yml:57,60` describe the train race as `publish-master` still running. Operators following those notes look for a workflow that no longer exists.

Comment-only sweep to `publish-main`. Unblocks data-ingestors for the next staging hop (it was deferred today on this finding).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only updates in GitHub Actions workflows; no runtime, permissions, or build behavior changes.
> 
> **Overview**
> After the **master→main** rename removed `publish-master.yml`, inline workflow comments still pointed operators at that deleted file.
> 
> **`publish-images.yml`** now lists `publish-main.yml` among the publishers that run the schema smoke probe. **`release-image.yml`** comments describe the release train racing **`publish-main`** (not `publish-master`) when explaining why the PyPI verify gate is explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6251fec8f07bc737ab607e39317d508707869d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->