### PR TITLE
sec(ci): pin third-party action refs to commit SHAs (backend#1490, D10)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -135,10 +135,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -146,7 +146,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: Dockerfile
@@ -217,10 +217,10 @@ jobs:
           pattern: digests-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -134,13 +134,13 @@ jobs:
         # Registers binfmt handlers so the arm64 layers can be built
         # under emulation on the amd64 runner. Without this, the
         # multi-arch build below silently degrades to amd64-only.
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -148,7 +148,7 @@ jobs:
 
       - name: Extract image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # Tag strategy: semver only. No :latest — downstream must pick a
@@ -201,7 +201,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           # Multi-arch (#24). Without `platforms`, build-push-action
@@ -264,7 +264,7 @@ jobs:
           echo "$output" | grep -q "INGEST_CONFIG"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
         with:
           cosign-release: 'v2.4.0'
 


### PR DESCRIPTION
Mechanical half of the D10 supply-chain sweep (RFC-BACKEND-1405): every third-party action ref in `.github/workflows` is pinned to the full 40-character commit SHA it already resolves to today, with a trailing exact-version comment. Behaviour-preserving — the same code runs; only silent tag mutation is removed. No upgrades.

| action | old ref | new sha | version comment |
|---|---|---|---|
| `docker/build-push-action` | `@v5` | `ca052bb54ab0790a636c9b5f226502c73d547a25` | `# v5.4.0` |
| `docker/build-push-action` | `@v6` | `10e90e3645eae34f1e60eeb005ba3a3d33f178e8` | `# v6.19.2` |
| `docker/login-action` | `@v3` | `c94ce9fb468520275223c153574b00df6fe4bcc9` | `# v3.7.0` |
| `docker/metadata-action` | `@v5` | `c299e40c65443455700f0fdfc63efafe5b349051` | `# v5.10.0` |
| `docker/setup-buildx-action` | `@v3` | `8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` | `# v3.12.0` |
| `docker/setup-qemu-action` | `@v3` | `c7c53464625b32c7a7e944ae62b3e17d2b600130` | `# v3.7.0` |
| `sigstore/cosign-installer` | `@v3` | `398d4b0eeef1380460a10c8013a76f728fb906ac` | `# v3.9.1` |

- 11 call site(s) pinned across 2 file(s).
- SHAs resolved via the GitHub API (`git/ref/tags`, annotated tags dereferenced through `git/tags` to the commit), cross-checked against the exact release tag named in the comment.
- `actionlint`: no new findings vs base.
- `tracebloc/*` refs (stay `@main` per D10) and `actions/*` refs (split to backend#1491) deliberately untouched.

Part of tracebloc/backend#1490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical ref pinning with no workflow logic or secret-handling changes; runtime behavior of image publish/release jobs stays the same.
> 
> **Overview**
> Part of the D10 supply-chain sweep: **third-party** `docker/*` and `sigstore/cosign-installer` steps in `publish-images.yml` and `release-image.yml` now use **40-character commit SHAs** instead of floating `@v3`/`@v5`/`@v6` tags, each with a trailing version comment (e.g. `# v3.12.0`).
> 
> **11 call sites** across the two workflows—buildx, login, build-push (v5 and v6), metadata, qemu, and cosign-installer. Same binaries as before; only silent tag retargeting is removed. **`actions/*`** and **`tracebloc/*`** refs are intentionally unchanged in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94edd3c57500a46c81edad1bdae20c42c244e658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->