### PR TITLE
docs: BUGBOT.md rule — a secretless code-quality caller is correct (backend#1526)

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -126,6 +126,11 @@ PyPI first. `RELEASING.md` documents how they stay aligned.
   fixture rows (`e2e/test_characterization.py:107,215`).
 - `debug_csv_processing.py` at the repo root is a tracked debugging scratch script — only
   `tracebloc_ingestor/` ships in the package.
+- A `code-quality-caller.yml` that passes **no `secrets:` line** is correct, not an omission.
+  The shared `code-quality.yml` reusable references no secrets by contract
+  (RFC-BACKEND-1405 Q5, backend#1526): secretless callees get no secrets line, and if the
+  reusable ever gains one, callers switch to explicit per-secret passing — never
+  `secrets: inherit`. Flag the *addition* of `secrets: inherit` on this caller instead.
 
 ## Tone
 


### PR DESCRIPTION
## Summary

Fleet half of the RFC-BACKEND-1405 Q5 unwind (tracebloc/backend#1526). Q5 was answered 2026-08-04 via tracebloc/rfcs#11: the shared `code-quality.yml` reusable references **no** secrets by contract, so secretless callees carry **no** `secrets:` line at all — and if the reusable ever gains a secret, callers switch to explicit per-secret passing, never `secrets: inherit`.

- **`.cursor/BUGBOT.md`** — appended one bullet as the last item of the "Known non-issues — do not flag" section: a `code-quality-caller.yml` that passes no `secrets:` line is correct, not an omission; Bugbot should instead flag the *addition* of `secrets: inherit` on this caller. No other lines touched.

This repo's `code-quality-caller.yml` is already secretless on `develop`, so no workflow change is needed here.

Part of tracebloc/backend#1526

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Bugbot guidance; no runtime, CI, or security behavior changes.
> 
> **Overview**
> Adds a **Known non-issues** bullet to `.cursor/BUGBOT.md` so Bugbot stops treating a missing `secrets:` block on `code-quality-caller.yml` as a gap.
> 
> The rule states that the org `code-quality.yml` reusable needs no secrets (RFC-BACKEND-1405 Q5 / backend#1526), so callers should omit `secrets:` entirely—not add `secrets: inherit`. Reviews should flag **adding** `secrets: inherit` on this caller instead.
> 
> No workflow files change in this PR; the repo’s caller is already secretless on `develop`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524c1c9cf7951e72862b63f199e69c6770578e6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->