### PR TITLE
docs(object_detection): clarify how filename resolves image vs annotation sidecars

### DIFF
--- a/templates/object_detection/README.md
+++ b/templates/object_detection/README.md
@@ -62,12 +62,27 @@ object_detection/
 ### XML Annotations
 - XML files should be placed in the `data/annotations/` directory
 - Each XML file should follow the Pascal VOC format
-- File naming convention: `{image_name}.xml`
+- File naming convention: `{image_name}.xml`, where `{image_name}` is the image's
+  **stem** (its name with no extension). The annotation for `images/image1.jpg` is
+  `annotations/image1.xml`.
 
 ### CSV Labels File
 The CSV file contains the following columns:
 - `object_id`: Unique identifier for each object (format: `{image_name}_obj_{index}`)
-- `filename`: Image filename (with or without extension — the configured extension is appended if missing)
+- `filename`: Image filename. Accepted **with or without an extension** — `image1`
+  and `image1.jpg` are equivalent. The two sidecar files are resolved from it
+  independently:
+  - **Image** — the configured extension is appended when the stem has none
+    (`image1` → `images/image1.jpg`); an extension already present is kept.
+  - **Annotation** — always resolved from the **stem** as `<image_name>.xml`, so
+    both `image1` and `image1.jpg` pair with `annotations/image1.xml`. A
+    `filename` carrying `.jpg` does **not** make the ingestor look for
+    `annotations/image1.jpg`; the image extension is swapped for `.xml`.
+
+  > If a run reports 0 committed rows with "Source file not found:
+  > `annotations/…`", it's almost always a real missing/mis-stemmed annotation —
+  > not the `filename` extension. Object detection is atomic: a record commits
+  > only when **both** the image and its `<stem>.xml` copy successfully.
 - `image_label`: Class label of the object
 - `object_count`: Number of objects in the image (always 1 for individual objects)
 


### PR DESCRIPTION
## What

Clarify, in the object_detection template README, how the CSV `filename` column
resolves the **two** sidecar files — because the ambiguity was surfacing as a
misread "framework bug."

## Why

An old object_detection retry failed with **0 committed rows**. Root cause chase
landed on a labels CSV whose `filename` carried the image extension
(`image1.jpg`); the reporter expected the annotation lookup to then search
`annotations/image1.jpg` and read the empty run as a framework defect.

It isn't one. `file_transfer.annotation_transfer` already resolves the annotation
from the image **stem** via `_find_src(..., force_extension=True)` — it strips a
recognised image extension and appends `.xml`, so `image1` and `image1.jpg` both
map to `annotations/image1.xml`. The README simply never documented the
annotation side of that contract; the old `filename` bullet only described the
image.

## Change (docs only)

- The `filename` bullet now spells out that image and annotation sidecars resolve
  **independently**: image keeps/appends its extension; annotation is always
  `<stem>.xml`. Explicitly states a `.jpg` in `filename` does **not** make the
  ingestor look for `annotations/image1.jpg`.
- The XML-annotations naming-convention line now says `{image_name}` is the
  image's stem, with a concrete `image1.jpg → image1.xml` example.
- Added a troubleshooting note: a 0-row run with "Source file not found:
  `annotations/…`" is a real missing/mis-stemmed annotation (object detection is
  atomic — a record commits only when both files copy), not the `filename`
  extension.

No code changes — the transfer behaviour already matches what's now documented.
The shipped `data/labels_file_sample.csv` uses bare stems, consistent with this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only clarification with no code, config, or data-path behavior changes.
> 
> **Overview**
> **Docs-only** update to the object_detection template README so the CSV `filename` contract matches how ingest actually resolves sidecars.
> 
> The **XML annotations** naming line now defines `{image_name}` as the image **stem** (e.g. `image1.jpg` → `annotations/image1.xml`). The **`filename`** column bullet is expanded: image and annotation paths resolve **independently**—images keep or get the configured extension; annotations are always `<stem>.xml`, so `image1.jpg` does **not** imply `annotations/image1.jpg`. A short **troubleshooting** note explains 0 committed rows with missing `annotations/…` as missing/mis-stemmed XML (atomic image+annotation commit), not a `filename` extension bug.
> 
> No runtime or ingest code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae7e639dc61099e75f3d7a4647a56110f223136b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->