### PR TITLE
sec(ci): actor-gate the publish dispatch (backend#1422)

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -70,6 +70,23 @@ jobs:
     # dropping the scopes free.
     permissions: {}
     steps:
+      # No un-gated workflow_dispatch may publish (backend#1422, decided
+      # 2026-08-05). Push/tag-triggered runs are train-owned and skip this
+      # step. A failing STEP is red and auditable; a skipped job would report
+      # green and hide denials (the promote.yml lesson, backend#1424).
+      - name: Authorize dispatcher (backend#1422)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          case "$ACTOR" in
+            LukasWodka|saadqbal) echo "Dispatcher $ACTOR is on the allowlist." ;;
+            *)
+              echo "::error::$ACTOR is not permitted to dispatch this publish workflow (backend#1422)."
+              exit 1
+              ;;
+          esac
       - name: Wait for this version on PyPI
         id: check
         env:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -150,6 +150,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # No un-gated workflow_dispatch may publish (backend#1422, decided
+      # 2026-08-05). Push/tag-triggered runs are train-owned and skip this
+      # step. A failing STEP is red and auditable; a skipped job would report
+      # green and hide denials (the promote.yml lesson, backend#1424).
+      #
+      # BOTH identities must pass: github.actor stays the ORIGINAL dispatcher
+      # on a re-run, while triggering_actor is whoever clicked re-run —
+      # checking only one lets a non-allowlisted user replay an allowlisted
+      # dispatch (Bugbot, backend#1536; the actor-vs-triggering_actor gap
+      # dependabot-auto-merge.yml already documents).
+      - name: Authorize dispatcher (backend#1422)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          set -euo pipefail
+          for who in "$ACTOR" "$TRIGGERING_ACTOR"; do
+            case "$who" in
+              LukasWodka|saadqbal) ;;
+              *)
+                echo "::error::$who is not permitted to (re-)dispatch this publish workflow (backend#1422)."
+                exit 1
+                ;;
+            esac
+          done
+          echo "Dispatcher $ACTOR (triggering: $TRIGGERING_ACTOR) is on the allowlist."
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -74,19 +74,29 @@ jobs:
       # 2026-08-05). Push/tag-triggered runs are train-owned and skip this
       # step. A failing STEP is red and auditable; a skipped job would report
       # green and hide denials (the promote.yml lesson, backend#1424).
+      #
+      # BOTH identities must pass: github.actor stays the ORIGINAL dispatcher
+      # on a re-run, while triggering_actor is whoever clicked re-run —
+      # checking only one lets a non-allowlisted user replay an allowlisted
+      # dispatch (Bugbot, backend#1536; the actor-vs-triggering_actor gap
+      # dependabot-auto-merge.yml already documents).
       - name: Authorize dispatcher (backend#1422)
         if: github.event_name == 'workflow_dispatch'
         env:
           ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
           set -euo pipefail
-          case "$ACTOR" in
-            LukasWodka|saadqbal) echo "Dispatcher $ACTOR is on the allowlist." ;;
-            *)
-              echo "::error::$ACTOR is not permitted to dispatch this publish workflow (backend#1422)."
-              exit 1
-              ;;
-          esac
+          for who in "$ACTOR" "$TRIGGERING_ACTOR"; do
+            case "$who" in
+              LukasWodka|saadqbal) ;;
+              *)
+                echo "::error::$who is not permitted to (re-)dispatch this publish workflow (backend#1422)."
+                exit 1
+                ;;
+            esac
+          done
+          echo "Dispatcher $ACTOR (triggering: $TRIGGERING_ACTOR) is on the allowlist."
       - name: Wait for this version on PyPI
         id: check
         env:


### PR DESCRIPTION
Implements the [ratified #1422 rule](https://github.com/tracebloc/backend/issues/1422#issuecomment-5188218287): **no un-gated `workflow_dispatch` may publish**. Push/tag-triggered runs are train-owned and skip the gate entirely (the step is `if: github.event_name == 'workflow_dispatch'`). A failing STEP is red and auditable — a skipped job would report green and hide denials (the promote.yml lesson, backend#1424). Allowlist matches the train dispatcher list.

Part of tracebloc/backend#1422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens who can manually publish signed GHCR images; misconfiguration or stale allowlist could block legitimate operator re-drives, but tag-train publishes are unaffected.
> 
> **Overview**
> Implements **backend#1422**: manual `workflow_dispatch` runs of `release-image.yml` can no longer publish without an explicit allowlist check. Tag/push-triggered releases are unchanged and skip the gate.
> 
> The new **Authorize dispatcher** step runs at the start of both `verify-published` and `release` (only when `github.event_name == 'workflow_dispatch'`). It requires **both** `github.actor` and `github.triggering_actor` to be `LukasWodka` or `saadqbal`, blocking unauthorized manual dispatches and non-allowlisted re-runs. Denials fail the step (red/auditable) rather than skipping a job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e287d934008e48161e461e292257b7ba82260e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->