### PR TITLE
fix(gitleaks): uppercase allowlist condition AND (Bugbot)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,7 +6,7 @@ useDefault = true
 [[allowlists]]
 description = "synthetic 32-hex correlation-id fixture (1 baseline entry)"
 targetRules = ["generic-api-key"]
-condition = "and"
+condition = "AND"
 paths = ['''(^|/)tests/''']
 regexTarget = "line"
 regexes = ['''CLI_STYLE_KEY\s*=\s*"[0-9a-f]{32}"''']


### PR DESCRIPTION
## Finding

Bugbot (from backend#1404, Medium severity): the gitleaks allowlist `condition` field in `.gitleaks.toml` (line 9) was set to lowercase `"and"`.

Gitleaks parses this field case-sensitively and only recognizes uppercase `AND` / `OR`. A lowercase value is not matched, so gitleaks silently falls back to the default `OR` condition. That means the allowlist matched on `targetRules` **OR** `paths` **OR** `regexes` instead of requiring **all** criteria to match together — the intended `AND` was dropped, causing the allowlist to over-match.

## Fix

Change `condition = "and"` to `condition = "AND"` so the allowlist requires all criteria (targetRules AND paths AND regexes) as intended.

## Confirmation that uppercase is correct

Verified against the gitleaks config documentation (gitleaks README): the `condition` field values are uppercase — `"OR"` (default) and `"AND"`. Quote: the default condition is `"OR"`, and `"AND"` "can be used to make sure all criteria match." Lowercase values are not recognized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config-token fix with no runtime or auth impact; it tightens secret-scan allowlist behavior to match the intended scope.
> 
> **Overview**
> Corrects the synthetic test-fixture allowlist in `.gitleaks.toml` so gitleaks actually applies **AND** logic across `targetRules`, `paths`, and `regexes`.
> 
> The `condition` value is changed from lowercase `"and"` to `"AND"`. Gitleaks treats that field case-sensitively; the lowercase value was ignored and the default **OR** applied, so the allowlist could match more broadly than intended (e.g. outside `tests/` or without all regex/path constraints).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8810162e81b5044cfaad38c3e1b9c2f3d5a9789a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->