### PR TITLE
fix(ingest): create dataset dirs group-writable/setgid so teardown can reclaim them (client-runtime#172)

### DIFF
--- a/tests/test_file_transfer_failure_modes.py
+++ b/tests/test_file_transfer_failure_modes.py
@@ -117,6 +117,32 @@ def test_image_transfer_unwritable_dest_raises(dirs, no_retry_wait):
         os.chmod(dest, 0o700)  # restore so pytest can clean up tmp_path
 
 
+# --- #172: dest dir is created group-writable + setgid for teardown ---------
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root's created dirs ignore umask/perms nuances",
+)
+def test_ensure_dest_dir_new_dir_is_setgid_and_group_writable(tmp_path):
+    """#172: a dir the ingestor creates is setgid + group-writable so the
+    `data delete` teardown group (65532) can reclaim the tree on hostPath."""
+    dest = tmp_path / "storage" / "tbl"
+    file_transfer._ensure_dest_dir(str(dest))
+    mode = os.stat(dest).st_mode
+    assert mode & 0o2000, "setgid bit must be set so entries inherit the group"
+    assert mode & 0o020, "group-write bit must be set so the group can delete"
+
+
+def test_ensure_dest_dir_leaves_existing_dir_mode_untouched(tmp_path):
+    """A pre-existing dest is not re-chmod'd — we don't override an operator's
+    mode or mask a permission problem."""
+    dest = tmp_path / "storage" / "tbl"
+    dest.mkdir(parents=True)
+    os.chmod(dest, 0o750)
+    file_transfer._ensure_dest_dir(str(dest))
+    assert (os.stat(dest).st_mode & 0o777) == 0o750
+
+
 # --- atomic skip leaves no orphan (the #99 data-integrity invariant) --------
 
 def test_object_detection_missing_annotation_leaves_no_orphan(dirs):

--- a/tests/test_file_transfer_failure_modes.py
+++ b/tests/test_file_transfer_failure_modes.py
@@ -54,6 +54,7 @@ def _raise_oserror(*_a, **_k):
 
 # --- retry behaviour (tenacity on _copy_file_with_retry) --------------------
 
+
 def test_copy_retries_transient_error_then_succeeds(dirs, no_retry_wait, monkeypatch):
     src, dest = dirs
     s = _seed(src, "images", "a.jpg", b"payload")
@@ -101,6 +102,7 @@ def test_image_transfer_wraps_persistent_copy_error(dirs, no_retry_wait, monkeyp
 
 # --- a real filesystem permission error (not a mock) ------------------------
 
+
 @pytest.mark.skipif(
     hasattr(os, "geteuid") and os.geteuid() == 0,
     reason="root bypasses filesystem permission checks",
@@ -118,6 +120,7 @@ def test_image_transfer_unwritable_dest_raises(dirs, no_retry_wait):
 
 
 # --- #172: dest dir is created group-writable + setgid for teardown ---------
+
 
 @pytest.mark.skipif(
     hasattr(os, "geteuid") and os.geteuid() == 0,
@@ -145,6 +148,7 @@ def test_ensure_dest_dir_leaves_existing_dir_mode_untouched(tmp_path):
 
 # --- atomic skip leaves no orphan (the #99 data-integrity invariant) --------
 
+
 def test_object_detection_missing_annotation_leaves_no_orphan(dirs):
     src, dest = dirs
     _seed(src, "images", "x.jpg")  # image present, annotation absent
@@ -161,7 +165,8 @@ def test_segmentation_missing_mask_leaves_no_orphan(dirs):
     _seed(src, "images", "x.jpg")  # image present, mask file absent
     rec = file_transfer.map_file_transfer(
         TaskCategory.SEMANTIC_SEGMENTATION,
-        {"filename": "x", "mask_id": "m"}, {"extension": ".jpg"},
+        {"filename": "x", "mask_id": "m"},
+        {"extension": ".jpg"},
     )
     assert rec is None
     assert not dest.exists() or not any(dest.iterdir())

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -75,6 +75,14 @@ def main(argv: List[str] | None = None) -> int:  # pragma: no cover - thin shell
     ``sys.exit`` by the console-script wrapper; using a return value (rather
     than raising) keeps the function testable from inside pytest.
     """
+    # Group-writable by default (umask 002) so every directory and file the run
+    # writes under DEST_PATH can be reclaimed by the `data delete` teardown
+    # group (uid/gid 65532), not just the setgid DEST_PATH root itself — the
+    # hostPath half of client-runtime#172 (the teardown pod's fsGroup is ignored
+    # on hostPath). Files themselves need no write bit to be deleted; the
+    # containing directories do, which this guarantees for the whole tree.
+    os.umask(0o002)
+
     config_path = os.environ.get("INGEST_CONFIG")
     if not config_path:
         return _fail(

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -71,6 +71,7 @@ def _ensure_dest_dir(path: str) -> None:
             error,
         )
 
+
 # Define retry decorator for file operations
 retry_decorator = retry(
     stop=stop_after_attempt(RETRY_MAX_ATTEMPTS),

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -38,6 +38,39 @@ config = Config()
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
+# `data delete` reclaims a dataset with an ephemeral stage-identity pod
+# (uid/gid 65532, client-runtime#172). On a hostPath dataset the kubelet ignores
+# that pod's fsGroup, so the ingest side must leave the destination tree
+# group-owned by, and group-writable for, that group — otherwise the teardown
+# can't remove the files and they leak (remainder of client#259). Create the
+# destination dir setgid + group-writable so new entries inherit the group and
+# the group can delete them, regardless of the writing uid. 0o2775 = rwxrwsr-x.
+DEST_DIR_MODE = 0o2775
+
+
+def _ensure_dest_dir(path: str) -> None:
+    """Create ``path`` if absent, setgid + group-writable, so the ``data
+    delete`` teardown group can reclaim the tree (#172).
+
+    Only a directory we *create* is chmod'd — a pre-existing one is left as-is,
+    so we neither override an operator's deliberate mode nor mask a genuine
+    permission problem (an unwritable dest still surfaces downstream). The chmod
+    is best-effort: a failure is logged, not fatal, so ingestion still proceeds.
+    """
+    existed = os.path.isdir(path)
+    os.makedirs(path, exist_ok=True)
+    if existed:
+        return
+    try:
+        os.chmod(path, DEST_DIR_MODE)
+    except OSError as error:
+        logger.warning(
+            "Could not set group-writable/setgid mode on %s (%s); the `data "
+            "delete` teardown may not be able to reclaim it",
+            path,
+            error,
+        )
+
 # Define retry decorator for file operations
 retry_decorator = retry(
     stop=stop_after_attempt(RETRY_MAX_ATTEMPTS),
@@ -212,7 +245,7 @@ def image_transfer(
     """
     cfg = cfg or config
     # Create destination directory if it doesn't exist
-    os.makedirs(cfg.DEST_PATH, exist_ok=True)
+    _ensure_dest_dir(cfg.DEST_PATH)
 
     try:
         # Get the filename from the record
@@ -272,7 +305,7 @@ def annotation_transfer(
     """
     cfg = cfg or config
     # Create destination directory if it doesn't exist
-    os.makedirs(cfg.DEST_PATH, exist_ok=True)
+    _ensure_dest_dir(cfg.DEST_PATH)
 
     try:
         # Get the filename from the record
@@ -327,7 +360,7 @@ def text_transfer(
     """
     cfg = cfg or config
     # Create destination directory if it doesn't exist
-    os.makedirs(cfg.DEST_PATH, exist_ok=True)
+    _ensure_dest_dir(cfg.DEST_PATH)
 
     try:
         # Get the filename from the record
@@ -396,7 +429,7 @@ def mask_transfer(
     call per record.
     """
     cfg = cfg or config
-    os.makedirs(cfg.DEST_PATH, exist_ok=True)
+    _ensure_dest_dir(cfg.DEST_PATH)
 
     try:
         # Write target guarded against escaping DEST via a crafted mask_id (#239)


### PR DESCRIPTION
## What
Make the ingestor write its destination tree **group-writable + setgid** so the `data delete` teardown pod can reclaim datasets on **hostPath** installs. **Companion (part 2 of 2)** to tracebloc/client-runtime#172.

## Why
On a hostPath dataset the kubelet **ignores the teardown pod's `fsGroup`** (it only applies to CSI/ownership-managing volumes), so files the ingest Job writes stay owned by the writing uid/group and `data delete` (uid/gid 65532) can't remove them — they leak (remainder of client#259). Group deletion needs the **containing directories** to be group-owned (65532) and group-writable.

## Change
- **`_ensure_dest_dir`** — centralises the four `os.makedirs(cfg.DEST_PATH)` sites and sets the created dir **setgid + group-writable (`0o2775`)** so new entries inherit the group and the group can delete them. Only a dir **we create** is chmod'd — a pre-existing dir is left untouched, so we don't override an operator's mode or mask a genuine permission error (an unwritable dest still surfaces downstream, as its test asserts).
- **`cli/run.main`: `os.umask(0o002)`** — every directory/file the run writes under DEST_PATH is group-writable, not just the DEST_PATH root (deletion needs write on the *containing* dir, so the whole tree must be group-writable).

## Pairs with
tracebloc/client-runtime#172 runs the ingest Job with **gid 65532** (+ supplemental group), so created files are group-owned by the teardown group. This PR makes the dirs group-*writable* so that group can actually delete. Both are needed.

## Tests
- `_ensure_dest_dir`: new dir is setgid + group-writable; a pre-existing dir's mode is left untouched.
- The pre-existing "unwritable dest raises" test stays green (pre-existing dir not re-chmod'd).
- 66 file-transfer/config tests pass locally.

Refs tracebloc/client-runtime#172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default filesystem permissions for all ingest writes under DEST_PATH; misconfiguration could affect teardown or operator-owned dirs, though existing dirs are left untouched and chmod is best-effort.
> 
> **Overview**
> Fixes **hostPath** datasets where `data delete` (uid/gid 65532) could not reclaim ingest output because kubelet ignores teardown `fsGroup` on hostPath.
> 
> **`file_transfer`** adds **`_ensure_dest_dir`** and uses it everywhere **`DEST_PATH`** was created via plain **`makedirs`**. Newly created destination directories get **setgid + group-writable (`0o2775`)** so the teardown group can delete the tree; **pre-existing** dirs are **not** re-chmod’d, and chmod failures are **logged only**.
> 
> **`cli/run.main`** sets **`os.umask(0o002)`** at startup so files and nested dirs written under **`DEST_PATH`** stay group-writable for the same teardown story.
> 
> Package version bumps to **0.8.4**; tests cover new-dir permissions and unchanged modes on existing dirs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f19f7fe7be36a82337f253484c9fe27d04a29bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->