### PR TITLE
sec(ci): pin actions/* refs to commit SHAs (backend#1491, D10)

### DIFF
--- a/.github/workflows/add-to-kanban.yml
+++ b/.github/workflows/add-to-kanban.yml
@@ -10,7 +10,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/tracebloc/projects/2
           github-token: ${{ secrets.PROJECTS_KANBAN_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,9 @@ jobs:
           --health-timeout=3s
           --health-retries=20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: pip

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -20,10 +20,10 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -133,7 +133,7 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
@@ -198,7 +198,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: digests-${{ matrix.platform.arch }}
           path: ${{ runner.temp }}/digests/*
@@ -211,7 +211,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -30,10 +30,10 @@ jobs:
     # repo secrets -- is best closed by PyPI Trusted Publishing (OIDC), which removes
     # the token entirely with no blocking step; flagged for follow-up, not a settings pass.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -178,7 +178,7 @@ jobs:
           done
           echo "Dispatcher $ACTOR (triggering: $TRIGGERING_ACTOR) is on the allowlist."
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ inputs.ref || github.ref }}
           # cosign + buildkit reproducibility benefit from full history.

--- a/.github/workflows/stale-backlog.yml
+++ b/.github/workflows/stale-backlog.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-issue-stale: 42  # 6 weeks of no activity → warning
           days-before-issue-close: 14  # +2 weeks of silence → close

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,9 @@ jobs:
         python: ['3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python }}
           cache: pip
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload coverage HTML
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-html-py${{ matrix.python }}
           path: htmlcov/

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -17,7 +17,7 @@ jobs:
     name: package change ⇒ __version__ bump
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - name: Require a __version__ bump when the package changes


### PR DESCRIPTION
Pin every `actions/*` ref in this repo's workflows to the full 40-char commit SHA it currently resolves to, with a trailing exact-version comment — same form and rules as the third-party run under backend#1490 (D10, RFC-BACKEND-1405). Behaviour-preserving: no version changes, only removal of silent tag mutation. `tracebloc/*` refs stay on `@main` by design; third-party refs were already pinned under backend#1490.

| Action | Old ref | New pin | Sites |
|---|---|---|---|
| `actions/add-to-project` | `@v1.0.2` | `244f685bbc3b7adfa8466e08b698b5577571133e` `# v1.0.2` | 1 |
| `actions/checkout` | `@v4` | `11d5960a326750d5838078e36cf38b85af677262` `# v4.4.0` | 7 |
| `actions/download-artifact` | `@v4` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` `# v4.3.0` | 1 |
| `actions/setup-python` | `@v5` | `a26af69be951a213d495a4c3e4e4022e16d87065` `# v5.6.0` | 4 |
| `actions/stale` | `@v9` | `5bef64f19d7facfb25b37b414482c7164d639639` `# v9.1.0` | 1 |
| `actions/upload-artifact` | `@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` `# v4.6.2` | 2 |

**16 call sites** pinned across **9 workflow files**. Verified: actionlint clean (no new findings vs the base branch), YAML parses, no mutable `actions/*` refs remain in `.github/workflows/`.

Part of tracebloc/backend#1491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only supply-chain hardening; same action versions as before, no application or runtime changes.
> 
> **Overview**
> **Pins every `actions/*` step in `.github/workflows/` to a full 40-character commit SHA**, with a trailing `# vX.Y.Z` comment, instead of mutable `@v4` / `@v5` style refs. This matches the repo’s existing third-party pinning pattern (backend#1490) and closes the gap where GitHub-owned action tags could move without a workflow edit.
> 
> **Six action types, 16 call sites across nine workflows:** `checkout`, `setup-python`, `upload-artifact`, `download-artifact`, `add-to-project`, and `stale`. **No version bumps**—each SHA is the commit those tags already pointed at. **`tracebloc/*` and already-pinned third-party actions are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29299fd369645f1bf629e853d2c3a844a387a32a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->