### PR TITLE
chore(devex): Makefile with a uniform 'make check' (backend#1606)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@
 PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
 
+# Lint tools are invoked through $(PYTHON) -m, not as bare commands on
+# PATH. `setup` pip-installs them into $(PYTHON)'s environment at a
+# pinned version; a bare `ruff` would resolve to whatever happens to be
+# first on PATH — a homebrew build, another venv — and the pin the
+# comment promises would silently not be the thing that ran. (Bugbot,
+# tracebloc/data-ingestors#461.)
+
 # Pinned to the version the org code-quality gate runs
 # (tracebloc/.github code-quality.yml, `ruff-version`). ruff's rule set
 # moves between releases, so an unpinned local install and CI can
@@ -75,17 +82,26 @@ setup:
 # running it. Format the files you touch; `pre-commit` already does.
 .PHONY: lint
 lint:
-	ruff check .
+	$(PYTHON) -m ruff check .
 
 # test: tests.yml's suite without the coverage machinery.
+#
+# Scoped to tests/ ON PURPOSE, even though tests.yml invokes bare
+# `pytest`. There is no `testpaths` setting, so a bare invocation also
+# collects e2e/ — which in CI is harmless (no MySQL is listening, so
+# e2e/conftest.py skips collection) and on a developer machine is not: a
+# laptop with a MySQL up, or with DB_NAME/DB_USER exported, would have
+# `make check` quietly run real ingestion that creates and drops tables
+# in that database. A pre-push check must not touch anyone's data.
+# (Bugbot, #461.) `make e2e` runs that suite deliberately.
 .PHONY: test
 test:
-	$(PYTEST) -q
+	$(PYTEST) tests/ -q
 
 # coverage: tests.yml exactly — the 95% floor included.
 .PHONY: coverage
 coverage:
-	$(PYTEST) --cov=tracebloc_ingestor --cov-report=term --cov-report=xml --cov-fail-under=95
+	$(PYTEST) tests/ --cov=tracebloc_ingestor --cov-report=term --cov-report=xml --cov-fail-under=95
 
 # e2e: e2e.yml — real ingestion against a real MySQL with an in-process
 # mock backend. Needs a database, hence the explicit target rather than

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,87 @@
+# Makefile for tracebloc/data-ingestors — uniform entry points (backend#1606).
+#
+# Every active tracebloc repo exposes the SAME three targets, so "run
+# your tests before you push" stops being a rule you can only obey with
+# per-repo tribal knowledge:
+#
+#   make check      lint + fast tests.   Budget: under 60 s.
+#   make check-all  everything CI runs (bar the CI-only heavy suites).
+#   make setup      install what those targets need.
+#
+# This file is a THIN WRAPPER over tests.yml, e2e.yml and
+# code-quality-caller.yml. It introduces no new tool, no new config and
+# no new rule. When a workflow changes, change the matching line here.
+#
+# Uses whatever python/pytest is on PATH, i.e. your active virtualenv.
+
+.DEFAULT_GOAL := help
+
+PYTHON ?= python3
+PYTEST ?= $(PYTHON) -m pytest
+
+.PHONY: help
+help:
+	@echo "tracebloc/data-ingestors — make targets"
+	@echo
+	@echo "  check       lint + the unit suite (~11 s) — run this before every push"
+	@echo "  check-all   everything CI runs, including the 95% coverage gate"
+	@echo "  setup       pip install -r requirements-dev.txt && pip install -e ."
+	@echo
+	@echo "  individual: lint test coverage e2e"
+	@echo
+	@echo "  e2e needs a real MySQL on MYSQL_HOST/MYSQL_PORT — it is not part of"
+	@echo "  check or check-all for that reason. CI provides one as a service."
+
+# ---- check: the pre-push tier ------------------------------------
+#
+# The unit suite mocks the database and the API, so it needs nothing
+# running and finishes in ~11 s (measured, macOS). The coverage gate is
+# the only thing held back, and only because a floor is a merge concern
+# rather than a pre-push one.
+.PHONY: check
+check: lint test
+	@echo "==> check: green (the coverage gate is in 'make check-all')"
+
+.PHONY: check-all
+check-all: lint coverage
+	@echo "==> check-all: green"
+
+# setup: dependencies only. No pre-commit / pre-push hook is installed
+# here — that is a later step of backend#1606.
+.PHONY: setup
+setup:
+	$(PYTHON) -m pip install --upgrade pip
+	$(PYTHON) -m pip install -r requirements-dev.txt
+	$(PYTHON) -m pip install -e .
+	@echo "==> setup: dependencies installed; run 'make check'"
+
+# ---- individual targets ------------------------------------------
+
+# lint: the org code-quality gate's ruff job, using this repo's own
+# ruff.toml (which is what the shared workflow does when one exists).
+#
+# NOT here: black. The caller does set `format: true`, but the shared
+# gate scans the PR DIFF, and the tree as a whole is not black-clean
+# (72 files at the time of writing). A whole-tree `black --check` in
+# `check` would be red on a clean checkout, which is worse than not
+# running it. Format the files you touch; `pre-commit` already does.
+.PHONY: lint
+lint:
+	ruff check .
+
+# test: tests.yml's suite without the coverage machinery.
+.PHONY: test
+test:
+	$(PYTEST) -q
+
+# coverage: tests.yml exactly — the 95% floor included.
+.PHONY: coverage
+coverage:
+	$(PYTEST) --cov=tracebloc_ingestor --cov-report=term --cov-report=xml --cov-fail-under=95
+
+# e2e: e2e.yml — real ingestion against a real MySQL with an in-process
+# mock backend. Needs a database, hence the explicit target rather than
+# a place in check-all.
+.PHONY: e2e
+e2e:
+	$(PYTEST) e2e/ -v

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@
 PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
 
+# Pinned to the version the org code-quality gate runs
+# (tracebloc/.github code-quality.yml, `ruff-version`). ruff's rule set
+# moves between releases, so an unpinned local install and CI can
+# disagree about the same file. Bump this with the workflow, not apart
+# from it.
+RUFF_VERSION ?= 0.15.20
+
 .PHONY: help
 help:
 	@echo "tracebloc/data-ingestors — make targets"
@@ -53,6 +60,7 @@ setup:
 	$(PYTHON) -m pip install --upgrade pip
 	$(PYTHON) -m pip install -r requirements-dev.txt
 	$(PYTHON) -m pip install -e .
+	$(PYTHON) -m pip install "ruff==$(RUFF_VERSION)"
 	@echo "==> setup: dependencies installed; run 'make check'"
 
 # ---- individual targets ------------------------------------------


### PR DESCRIPTION
## Summary

Today every repo in the org has a different incantation for "run your
tests": `python manage.py test` here, `yarn test:coverage` there,
`make ci` in cli, `pytest tests/ -m "not slow"` somewhere else. That
makes "run your tests before you push" a rule you can only obey if you
already know the repo — which means it is not really a rule, it is
tribal knowledge with a rule's wording. The people most likely to break
it are exactly the people least likely to know the incantation.

backend#1606 fixes that by giving every active repo the same three
targets:

  make check      lint + fast tests. Budget: UNDER 60 SECONDS.
  make check-all  everything CI runs, minus the CI-only heavy suites.
  make setup      install what those targets need.

The 60-second budget is not decoration. It is the property that decides
whether anyone runs the thing: a `make check` that takes ten minutes is
a rule people learn to skip, and skipping one rule teaches skipping
others. So the split between `check` and `check-all` is drawn on
measured wall-clock time, not on taste.

The Makefile is a THIN WRAPPER. Every command in it was lifted from the
workflow that already runs it. It adds no tool, no config, and no rule,
and it changes no CI workflow — making CI call `make check` is a
separate, later wave (decision 2 on backend#1606), deliberately kept out
of this PR so that a Makefile bug cannot redden the pipeline. No
pre-commit or pre-push hook is installed here either; that is step 4.

In this repo
------------

`make check` — MEASURED 19 s warm (44 s on the very first cold run,
which is filesystem cache, not work): ruff over the tree using this
repo's own ruff.toml, then the 1918-test unit suite. The suite mocks
both the database and the API, so it needs nothing running.

`make check-all` swaps the plain pytest run for tests.yml's exact
command, 95% coverage floor included.

`make e2e` exists but is in neither target: e2e.yml drives real
ingestion against a real MySQL, which CI provides as a service container
and a laptop does not.

NOT in `check`: black. The code-quality caller does set `format: true`,
but the shared gate scans the PR DIFF, and the tree as a whole is not
black-clean — 72 files would be reformatted at the time of writing. A
whole-tree `black --check` in `check` would be red on a clean checkout,
which is worse than not running it. ruff, measured the same way, IS
clean tree-wide, so it is in.

## Related

Step 1 of tracebloc/backend#1606 — a `Makefile` with a uniform `check` target in every active repo. One PR per repo; this is this repo's.

## Type of change

- [x] Tech-debt / refactor (developer experience)

## Test plan

`make check` run for real in a fresh venv: **green in 19 s warm** (1918 passed,
1 xfailed). The very first cold run was 44 s — filesystem cache, not work.

`ruff check .` clean tree-wide; `black --check .` NOT clean (72 files would be
reformatted), hence excluded.

`make help` and the dry runs of every target parse clean.

**No CI workflow is touched in this PR.** CI parity — making the workflows call `make check` — is decision 2 on backend#1606 and lands as its own wave, deliberately after the Makefiles exist and are proven locally. No pre-commit or pre-push hook is installed here either; that is step 4.

## Checklist

- [x] Works from a clean checkout — `.PHONY` on every target, `help` is the default goal
- [x] No CI workflow modified
- [x] No pre-commit / pre-push hook installed
- [x] No secrets / credentials in the diff
- [x] Every command is copied from the workflow that already runs it — no new tool, no new config, no new rule
- [x] Portable to GNU Make 3.81 (the macOS system make)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-experience only; no runtime, CI, or application code changes.
> 
> **Overview**
> Adds a **root `Makefile`** so developers can run the same entry points as other tracebloc repos: **`make check`** (ruff + fast unit tests), **`make check-all`** (ruff + pytest with the **95% coverage** gate), and **`make setup`** (pip deps + editable install + pinned ruff).
> 
> Commands mirror existing CI workflows only—**no workflow or hook changes**. **`make test`** deliberately runs **`pytest tests/`** (not a bare `pytest`) so local pre-push checks do not accidentally collect **`e2e/`** against a real MySQL. **`make e2e`** is a separate opt-in target. **Black** is omitted from `check` because a whole-tree format check would fail on a clean checkout; **ruff** is invoked via **`python -m`** at a version pinned to the org gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3d663d4223b44875f318ad1f02a7c57924753d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->