### PR TITLE
sec(#1425): publish to PyPI via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -11,10 +11,12 @@ concurrency:
   # cancel; a publish in flight must not be cancelled anyway. State it plainly.
   cancel-in-progress: false
 
-# Least privilege: this job publishes to PyPI with PYPI_API_TOKEN, not with the
-# workflow token, so it needs nothing beyond reading the checked-out source.
+# Least privilege. Publishing uses PyPI Trusted Publishing (OIDC), so the job
+# needs id-token to mint the short-lived OIDC credential plus read access to the
+# checked-out source -- no long-lived PyPI token in repo secrets (backend#1425).
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -58,17 +60,17 @@ jobs:
           python -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
 
       - name: Publish to production PyPI
-        # This step was named "Publish to GitHub Packages", but `twine upload`
-        # with no --repository-url targets upload.pypi.org -- so every push to
-        # the prod branch published to PRODUCTION PyPI while claiming otherwise
-        # (backend#1427). The target is now explicit and the step is named for
-        # what it does. --skip-existing makes the step idempotent: a re-run
-        # after a partial upload (wheel landed, sdist hit a transient error), or a
-        # push that did not bump the version, becomes a green no-op instead of a
-        # permanent HTTP 400 "File already exists" with no clean re-run path.
-        run: |
-          python -m pip install twine
-          twine upload --skip-existing --repository-url https://upload.pypi.org/legacy/ dist/*
-        env:
-          TWINE_USERNAME: '__token__'
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        # PyPI Trusted Publishing (OIDC): the runner mints a short-lived OIDC
+        # token that PyPI exchanges for an upload scope, so there is no long-lived
+        # PYPI_API_TOKEN in repo secrets (backend#1425). The default repository
+        # target is upload.pypi.org (production PyPI). skip-existing keeps the step
+        # idempotent -- a re-run after a partial upload (wheel landed, sdist hit a
+        # transient error), or a push that did not bump the version, is a green
+        # no-op instead of a permanent HTTP 400 "File already exists".
+        #
+        # PRECONDITION: a trusted publisher must be registered on PyPI for project
+        # `tracebloc_ingestor` (owner tracebloc, repo data-ingestors, workflow
+        # publish-main.yml, no environment) before this step can succeed.
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          skip-existing: true


### PR DESCRIPTION
## What

Replace the long-lived `PYPI_API_TOKEN` repo secret with **PyPI Trusted Publishing (OIDC)** in `publish-main.yml`. The runner mints a short-lived OIDC token (`id-token: write`) that PyPI exchanges for an upload scope — no static token in this **public** repo's secrets. Swaps the `twine upload` step for the SHA-pinned `pypa/gh-action-pypi-publish@dc37677` (v1.14.2); `skip-existing: true` keeps the idempotency the old `--skip-existing` gave us.

Closes the `data-ingestors` half of **backend#1425**.

## ⛔ Blocked — do not merge yet (draft on purpose)

A **trusted publisher must be registered on PyPI first**, or the next push to `main` fails to publish:
- Project: `tracebloc_ingestor`
- Owner: `tracebloc` · Repo: `data-ingestors` · Workflow: `publish-main.yml` · Environment: *(none)*

@LukasWodka owns that registration per backend#1425. Once it's live, mark ready → then `PYPI_API_TOKEN` can be deleted + revoked.

## Verification

- [ ] Trusted publisher registered on PyPI (precondition above)
- [ ] Repo CI green on this PR (local YAML lint not run — pyyaml/actionlint unavailable in my env; relying on CI + the diff)
- [ ] After merge + a real release: confirm OIDC publish succeeds, then delete `PYPI_API_TOKEN` and `GH_PACKAGES_TOKEN` repo secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)