### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -25,6 +25,12 @@ jobs:
   quality:
     uses: tracebloc/.github/.github/workflows/code-quality.yml@main
     with:
+      # Armed 2026-08-06 (backend#1492). Measured zero pin violations on every
+      # develop branch first, so this makes a green check stay green rather than
+      # importing a backlog. Soft-fail let #1449 add a second unpinned call site
+      # of an action while #1446 was open to pin it.
+      action-pins: true
+      action-pins-soft-fail: false
       python: true          # repos with Python
       shell: true           # repos with shell scripts
       # The gate is armed: findings fail the job. Backlog cleared to zero


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow input change; no application runtime or auth/data paths affected.
> 
> **Overview**
> **Arms the GitHub Action pin gate** on `code-quality-caller.yml` by passing `action-pins: true` and `action-pins-soft-fail: false` into the reusable `tracebloc/.github` code-quality workflow.
> 
> Unpinned `uses:` references in workflow files will now **fail the quality job** instead of only warning, after develop was verified at zero violations (backend#1492). Other gates (`soft-fail`, `format`, `black-version`) are unchanged aside from a trailing newline on the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e97cd7136d7ca4ca58b2867d1580bf7d5749b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->