### PR TITLE
sec(#1528): require DB_USER/DB_PASSWORD, drop the edgeuser fallback (D10) [blocked on S2]

### DIFF
--- a/tests/test_api_client_auth.py
+++ b/tests/test_api_client_auth.py
@@ -11,10 +11,10 @@ Covers all three boot paths required by the #43 acceptance criteria:
 A fourth path — ``CLIENT_ENV=local`` — is also exercised because it bypasses
 both validation and the network entirely.
 
-Database credentials (``DB_USER`` / ``DB_PASSWORD``) are also part of the
-validation surface as of backend#1528: the root-equivalent ``edgeuser``
-fallback was removed, so a real run requires the ``tb_ingest`` identity
-jobs-manager injects per-Job. See `Config.validate()`.
+Database credentials (``DB_USER`` / ``DB_PASSWORD``) are required for a real
+run as of backend#1528 (the ``edgeuser`` fallback was removed — jobs-manager
+injects ``tb_ingest`` per-Job), but they are NOT part of this auth-scoped
+``validate()``; they fail fast at ``Database()`` init instead.
 """
 
 from __future__ import annotations
@@ -33,16 +33,13 @@ def _make_config(**overrides) -> Config:
 
     Default: a valid prod-like config with BACKEND_TOKEN set so ``validate()``
     passes; tests override only the auth fields they care about. DB creds are
-    now part of the validation surface (backend#1528 removed the edgeuser
-    fallback — jobs-manager injects tb_ingest per-Job), so the defaults include
-    them; a test can drop them via ``DB_USER=None`` / ``DB_PASSWORD=None``.
+    not part of ``validate()`` (it's auth-scoped) — they fail fast at
+    ``Database()`` init instead — so they're left unset here.
     """
     defaults = dict(
         BACKEND_TOKEN="test-token-abc",
         CLIENT_USERNAME=None,
         CLIENT_PASSWORD=None,
-        DB_USER="tb_ingest",
-        DB_PASSWORD="pw",
         EDGE_ENV="prod",
     )
     defaults.update(overrides)
@@ -145,25 +142,6 @@ class TestNoCredsFailsFast:
         assert "CLIENT_PASSWORD" in msg
         # The error message points users at the local-mode escape hatch.
         assert "CLIENT_ENV=local" in msg
-
-    def test_validate_requires_db_credentials(self):
-        """backend#1528: DB creds are required at boot now that the edgeuser
-        fallback is gone — a prod pod with backend auth but no DB_USER/
-        DB_PASSWORD must fail fast at validate(), naming them."""
-        config = _make_config(DB_USER=None, DB_PASSWORD=None)
-
-        with pytest.raises(ValueError) as exc_info:
-            config.validate()
-
-        msg = str(exc_info.value)
-        assert "DB_USER" in msg and "DB_PASSWORD" in msg
-        # Backend auth was present, so it must NOT be in the missing list.
-        assert "BACKEND_TOKEN" not in msg
-
-    def test_local_mode_skips_db_credential_check(self):
-        """Local dev has no jobs-manager to inject creds — validate() must
-        still pass with DB creds unset under CLIENT_ENV=local."""
-        _make_config(EDGE_ENV="local", DB_USER=None, DB_PASSWORD=None).validate()
 
     def test_apiclient_init_raises_before_network(self):
         config = _make_config(

--- a/tests/test_api_client_auth.py
+++ b/tests/test_api_client_auth.py
@@ -11,9 +11,10 @@ Covers all three boot paths required by the #43 acceptance criteria:
 A fourth path — ``CLIENT_ENV=local`` — is also exercised because it bypasses
 both validation and the network entirely.
 
-Database credentials are intentionally **not** in the validation surface:
-they're connection conventions for the bundled MySQL container, not
-customer-facing secrets. See `Config.validate()` for the rationale.
+Database credentials (``DB_USER`` / ``DB_PASSWORD``) are also part of the
+validation surface as of backend#1528: the root-equivalent ``edgeuser``
+fallback was removed, so a real run requires the ``tb_ingest`` identity
+jobs-manager injects per-Job. See `Config.validate()`.
 """
 
 from __future__ import annotations
@@ -32,13 +33,16 @@ def _make_config(**overrides) -> Config:
 
     Default: a valid prod-like config with BACKEND_TOKEN set so ``validate()``
     passes; tests override only the auth fields they care about. DB creds are
-    not part of the validation surface (they're bundled-MySQL conventions),
-    so they're left to their env/property defaults here.
+    now part of the validation surface (backend#1528 removed the edgeuser
+    fallback — jobs-manager injects tb_ingest per-Job), so the defaults include
+    them; a test can drop them via ``DB_USER=None`` / ``DB_PASSWORD=None``.
     """
     defaults = dict(
         BACKEND_TOKEN="test-token-abc",
         CLIENT_USERNAME=None,
         CLIENT_PASSWORD=None,
+        DB_USER="tb_ingest",
+        DB_PASSWORD="pw",
         EDGE_ENV="prod",
     )
     defaults.update(overrides)
@@ -142,6 +146,25 @@ class TestNoCredsFailsFast:
         # The error message points users at the local-mode escape hatch.
         assert "CLIENT_ENV=local" in msg
 
+    def test_validate_requires_db_credentials(self):
+        """backend#1528: DB creds are required at boot now that the edgeuser
+        fallback is gone — a prod pod with backend auth but no DB_USER/
+        DB_PASSWORD must fail fast at validate(), naming them."""
+        config = _make_config(DB_USER=None, DB_PASSWORD=None)
+
+        with pytest.raises(ValueError) as exc_info:
+            config.validate()
+
+        msg = str(exc_info.value)
+        assert "DB_USER" in msg and "DB_PASSWORD" in msg
+        # Backend auth was present, so it must NOT be in the missing list.
+        assert "BACKEND_TOKEN" not in msg
+
+    def test_local_mode_skips_db_credential_check(self):
+        """Local dev has no jobs-manager to inject creds — validate() must
+        still pass with DB creds unset under CLIENT_ENV=local."""
+        _make_config(EDGE_ENV="local", DB_USER=None, DB_PASSWORD=None).validate()
+
     def test_apiclient_init_raises_before_network(self):
         config = _make_config(
             BACKEND_TOKEN=None,
@@ -181,8 +204,9 @@ class TestLocalModeBypassesValidation:
             CLIENT_PASSWORD=None,
         )
 
-        with patch.object(APIClient, "authenticate") as mock_auth, \
-             patch("requests.Session.post") as mock_post:
+        with patch.object(APIClient, "authenticate") as mock_auth, patch(
+            "requests.Session.post"
+        ) as mock_post:
             client = APIClient(config)
 
         mock_auth.assert_not_called()

--- a/tests/test_config_lazy.py
+++ b/tests/test_config_lazy.py
@@ -184,3 +184,27 @@ def test_numeric_int_field_still_coerces(clean_env, monkeypatch):
     config = Config()
     assert config.DB_PORT == 3307
     assert config.BATCH_SIZE == 500
+
+
+@pytest.mark.parametrize("attr", ["DB_USER", "DB_PASSWORD"])
+def test_db_credentials_required_no_edgeuser_fallback(clean_env, attr):
+    """backend#1528: the root-equivalent 'edgeuser' fallback is gone. With the
+    env var unset, accessing DB_USER/DB_PASSWORD must fail fast with a message
+    naming the variable — never silently return the legacy edgeuser default."""
+    with pytest.raises(ValueError, match=f"{attr} is not set"):
+        getattr(Config(), attr)
+
+
+@pytest.mark.parametrize(
+    "attr,env,value",
+    [("DB_USER", "DB_USER", "tb_ingest"), ("DB_PASSWORD", "DB_PASSWORD", "s3cret")],
+)
+def test_db_credentials_flow_from_env(clean_env, monkeypatch, attr, env, value):
+    monkeypatch.setenv(env, value)
+    assert getattr(Config(), attr) == value
+
+
+def test_db_credentials_override_wins(clean_env):
+    config = Config(DB_USER="tb_ingest", DB_PASSWORD="s3cret")
+    assert config.DB_USER == "tb_ingest"
+    assert config.DB_PASSWORD == "s3cret"

--- a/tests/test_config_lazy.py
+++ b/tests/test_config_lazy.py
@@ -28,10 +28,21 @@ from tracebloc_ingestor.config import Config
 def clean_env(monkeypatch):
     """Strip the env vars these tests read/write."""
     for var in (
-        "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
-        "BACKEND_TOKEN", "CLIENT_ID", "CLIENT_PASSWORD",
-        "CLIENT_ENV", "LOG_LEVEL", "BATCH_SIZE",
-        "MYSQL_HOST", "MYSQL_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
+        "SRC_PATH",
+        "LABEL_FILE",
+        "TABLE_NAME",
+        "TITLE",
+        "BACKEND_TOKEN",
+        "CLIENT_ID",
+        "CLIENT_PASSWORD",
+        "CLIENT_ENV",
+        "LOG_LEVEL",
+        "BATCH_SIZE",
+        "MYSQL_HOST",
+        "MYSQL_PORT",
+        "DB_USER",
+        "DB_PASSWORD",
+        "DB_NAME",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -169,7 +180,9 @@ def test_api_endpoint_follows_edge_env(clean_env, monkeypatch):
     assert config.API_ENDPOINT == "http://localhost:8000"
 
 
-@pytest.mark.parametrize("env,attr", [("MYSQL_PORT", "DB_PORT"), ("BATCH_SIZE", "BATCH_SIZE")])
+@pytest.mark.parametrize(
+    "env,attr", [("MYSQL_PORT", "DB_PORT"), ("BATCH_SIZE", "BATCH_SIZE")]
+)
 def test_non_numeric_int_field_raises_clear_error(clean_env, monkeypatch, env, attr):
     # A non-numeric MYSQL_PORT / BATCH_SIZE must surface a clear config error
     # naming the field, not a raw "invalid literal for int()" (#238).

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -42,7 +42,9 @@ def mock_engine_factory():
 
 @pytest.fixture
 def db(mock_engine_factory):
-    return Database(Config(EDGE_ENV="local"))
+    # DB_USER/DB_PASSWORD are required (backend#1528 removed the edgeuser
+    # fallback); the engine is mocked so the values are arbitrary.
+    return Database(Config(EDGE_ENV="local", DB_USER="tb_ingest", DB_PASSWORD="pw"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -51,6 +51,7 @@ def db(mock_engine_factory):
 # __init__ / _create_engine
 # ---------------------------------------------------------------------------
 
+
 def test_init_builds_engine(db, mock_engine_factory):
     ce, engine, conn = mock_engine_factory
     assert db.engine is engine
@@ -65,18 +66,22 @@ def test_init_builds_engine(db, mock_engine_factory):
 # _get_sqlalchemy_type (pure)
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("mysql_type,expected_cls", [
-    ("INT", Integer),
-    ("INTEGER", Integer),
-    ("BIGINT", BigInteger),
-    ("TEXT", db_mod.Text),
-    ("FLOAT", db_mod.Float),
-    ("BOOLEAN", db_mod.Boolean),
-    ("DATE", db_mod.Date),
-    ("DATETIME", db_mod.DateTime),
-    ("TIMESTAMP", db_mod.DateTime),
-    ("TIME", db_mod.Time),
-])
+
+@pytest.mark.parametrize(
+    "mysql_type,expected_cls",
+    [
+        ("INT", Integer),
+        ("INTEGER", Integer),
+        ("BIGINT", BigInteger),
+        ("TEXT", db_mod.Text),
+        ("FLOAT", db_mod.Float),
+        ("BOOLEAN", db_mod.Boolean),
+        ("DATE", db_mod.Date),
+        ("DATETIME", db_mod.DateTime),
+        ("TIMESTAMP", db_mod.DateTime),
+        ("TIME", db_mod.Time),
+    ],
+)
 def test_get_sqlalchemy_type_mapping(db, mysql_type, expected_cls):
     result = db._get_sqlalchemy_type(mysql_type)
     # result may be a class or an instance depending on length handling.
@@ -136,12 +141,15 @@ def test_get_sqlalchemy_type_typo_no_suggestion_for_distant_input(db):
     assert "Did you mean" not in str(excinfo.value)
 
 
-@pytest.mark.parametrize("typo,suggestion", [
-    ("INTGER", "INTEGER"),
-    ("NUMRIC", "NUMERIC"),
-    ("BOLEAN", "BOOLEAN"),
-    ("VARCAHR", "VARCHAR"),
-])
+@pytest.mark.parametrize(
+    "typo,suggestion",
+    [
+        ("INTGER", "INTEGER"),
+        ("NUMRIC", "NUMERIC"),
+        ("BOLEAN", "BOOLEAN"),
+        ("VARCAHR", "VARCHAR"),
+    ],
+)
 def test_get_sqlalchemy_type_typo_suggestions_cover_common_mistakes(
     db, typo, suggestion
 ):
@@ -203,6 +211,7 @@ def test_get_sqlalchemy_type_char_bare(db):
 # create_table
 # ---------------------------------------------------------------------------
 
+
 def test_create_table_new(db):
     db.metadata.create_all = MagicMock()
     inspector = MagicMock()
@@ -246,7 +255,8 @@ def test_create_table_existing_matching_schema_reflects_ok(db):
 
     def fake_reflect(engine, only=None):
         Table(
-            "panel", db.metadata,
+            "panel",
+            db.metadata,
             Column("id", BigInteger, primary_key=True),
             Column("data_id", String(255)),
             Column("P01033_TIMP1", String(255)),
@@ -277,7 +287,8 @@ def test_create_table_existing_schema_mismatch_fails_fast(db):
 
     def fake_reflect(engine, only=None):
         Table(
-            "IBD_Biomarker", db.metadata,
+            "IBD_Biomarker",
+            db.metadata,
             Column("id", BigInteger, primary_key=True),
             Column("data_id", String(255)),
             Column("P02452|COL1A1", String(255)),  # original header (stale table)
@@ -292,6 +303,7 @@ def test_create_table_existing_schema_mismatch_fails_fast(db):
 # ---------------------------------------------------------------------------
 # insert_batch
 # ---------------------------------------------------------------------------
+
 
 def _seed_table(db):
     db.metadata.create_all = MagicMock()
@@ -384,12 +396,14 @@ def test_insert_batch_connection_error(db, mock_engine_factory):
 # Transient DB retry via tenacity — backend/#772 P2
 # ---------------------------------------------------------------------------
 
+
 def test_insert_batch_retries_on_transient_operational_error(db, mock_engine_factory):
     """A transient MySQL hiccup (server-gone-away, lost connection,
     deadlock) used to fail every in-flight batch permanently. tenacity
     now retries up to 3 attempts with exponential backoff; the second
     attempt succeeds in this test."""
     from sqlalchemy.exc import OperationalError
+
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
 
@@ -425,6 +439,7 @@ def test_insert_batch_does_not_retry_permanent_error_falls_to_per_row(
     straight through to the existing per-row fallback path so the
     offending record can be identified."""
     from sqlalchemy.exc import IntegrityError
+
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
 
@@ -455,12 +470,11 @@ def test_insert_batch_gives_up_after_max_retries(db, mock_engine_factory):
     to the per-row path (which will see the same error and record the
     failure)."""
     from sqlalchemy.exc import OperationalError
+
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
 
-    err = OperationalError(
-        "INSERT …", {}, Exception("MySQL server has gone away")
-    )
+    err = OperationalError("INSERT …", {}, Exception("MySQL server has gone away"))
 
     def execute_side_effect(stmt, *a, **k):
         raise err
@@ -484,6 +498,7 @@ def test_insert_batch_rolls_back_between_transient_retries(db, mock_engine_facto
     is reset before the retry runs.
     """
     from sqlalchemy.exc import OperationalError
+
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
 
@@ -515,14 +530,15 @@ def test_insert_batch_rolls_back_between_transient_retries(db, mock_engine_facto
     # before re-raising for the next retry. Two failures -> at least two
     # rollback calls (plus the outer commit-or-rollback path's own).
     rollback_count = sum(1 for e in events if e == "rollback")
-    assert rollback_count >= 2, (
-        f"expected at least 2 rollbacks between retries; events={events}"
-    )
+    assert (
+        rollback_count >= 2
+    ), f"expected at least 2 rollbacks between retries; events={events}"
 
 
 # ---------------------------------------------------------------------------
 # get_table_schema
 # ---------------------------------------------------------------------------
+
 
 def test_get_table_schema_reflected_dialect_types(db):
     """Regression: ``inspector.get_columns()`` against a real MySQL returns
@@ -573,6 +589,7 @@ def test_get_table_schema_generic_types(db):
     """Generic (in-process) SQLAlchemy types map to the same MySQL vocabulary
     as their reflected dialect counterparts."""
     inspector = MagicMock()
+
     class Weird:  # unknown SQLAlchemy type, no 'length' attribute
         pass
 
@@ -632,6 +649,7 @@ def test_create_table_rejects_overlong_column_name():
 # ---------------------------------------------------------------------------
 # upsert quoting (regression): special-character column names
 # ---------------------------------------------------------------------------
+
 
 def test_upsert_backtick_quotes_special_char_columns_in_values_clause():
     """ON DUPLICATE KEY UPDATE must backtick-quote the column name inside
@@ -727,9 +745,9 @@ def test_upsert_doubles_embedded_backticks_in_column_name():
         for column in table.columns
         if column.name not in ["id", "created_at", "data_id"]
     }
-    stmt = insert_stmt.values(
-        [{"data_id": "x", weird: 1.0}]
-    ).on_duplicate_key_update(**update_dict)
+    stmt = insert_stmt.values([{"data_id": "x", weird: 1.0}]).on_duplicate_key_update(
+        **update_dict
+    )
     sql = str(stmt.compile(dialect=mysql.dialect()))
 
     # Escaped form ` -> `` is present.
@@ -749,7 +767,7 @@ def test_get_samples_null_label_normalised_to_empty_string(db, mock_engine_facto
     convention the old per-row API always sent when no label was present)."""
     _, _, conn = mock_engine_factory
     conn.execute.return_value.fetchall.return_value = [
-        ("id-1", None),   # self-supervised / no label column → SQL NULL
+        ("id-1", None),  # self-supervised / no label column → SQL NULL
         ("id-2", "cat"),
     ]
     result = db.get_samples("tbl", "ing-uuid")
@@ -759,12 +777,14 @@ def test_get_samples_null_label_normalised_to_empty_string(db, mock_engine_facto
     ]
 
 
-def test_get_label_counts_null_label_normalised_to_empty_string(db, mock_engine_factory):
+def test_get_label_counts_null_label_normalised_to_empty_string(
+    db, mock_engine_factory
+):
     """SQL NULL and '' both map to '' so they merge into a single count."""
     _, _, conn = mock_engine_factory
     conn.execute.return_value.fetchall.return_value = [
         (None, 3),
-        ("",   2),
+        ("", 2),
         ("cat", 5),
     ]
     result = db.get_label_counts("tbl", "ing-uuid")
@@ -996,9 +1016,7 @@ def test_reclaim_dead_run_rows_noop_when_nothing_dead(db, mock_engine_factory):
     delete.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "reserved", ["tracebloc_ingest_meta", "tracebloc_ingest_runs"]
-)
+@pytest.mark.parametrize("reserved", ["tracebloc_ingest_meta", "tracebloc_ingest_runs"])
 def test_create_table_rejects_reserved_bookkeeping_tables(reserved):
     """The salt store (#225) and the run journal (backend#1028) share the
     cluster MySQL with dataset tables — a dataset must not be able to claim
@@ -1063,7 +1081,9 @@ def test_list_dataset_ingestor_ids_scans_tables_excluding_framework(
 
     executed = _executed_sql(conn)
     # Discovery query hit information_schema for the ingestor_id column.
-    assert any("information_schema.columns" in s and "ingestor_id" in s for s in executed)
+    assert any(
+        "information_schema.columns" in s and "ingestor_id" in s for s in executed
+    )
     # The framework run-journal table was skipped — never SELECTed as a dataset.
     assert not any("`tracebloc_ingest_runs`" in s for s in executed)
     # Per-dataset-table id scans excluded null/empty ids.

--- a/tests/test_no_hardcoded_secrets.py
+++ b/tests/test_no_hardcoded_secrets.py
@@ -19,22 +19,24 @@ import pytest
 # ship the same secret. If this reappears anywhere in the package source, the
 # test fails, even in a comment.
 #
-# NOTE: `DB_PASSWORD` ("Edg9@Tr@ce") and `DB_USER` ("edgeuser") are
-# intentionally **not** in these lists. They're connection conventions for
-# the cluster-internal MySQL container, which bakes the same values into its
-# own image. They never vary per customer and don't leave the cluster, so
-# shipping them as defaults in `config.py` is correct, not a leak. See the
-# database-section comment in `config.py` and `Config.validate()` for the
-# rationale.
+# `Edg9@Tr@ce` is the legacy root-equivalent `edgeuser` password that DB_USER/
+# DB_PASSWORD used to fall back to. That fallback was removed in backend#1528
+# (D10 close-out): jobs-manager now injects per-Job tb_ingest credentials, so
+# the ingestor no longer connects as edgeuser and this password must never be
+# baked into source again. (`edgeuser` the username is guarded below.)
 KNOWN_LEAKED_SECRETS = (
     "&6edg*D9e16",
+    "Edg9@Tr@ce",
 )
 
-# Username default for the backend (tracebloc API) credential. Not secret on
-# its own, but paired with the leaked password above it formed a working
-# credential in legacy local dev — shouldn't be baked into source either.
+# Usernames that must not be baked into source. `testedge` was a legacy
+# backend (tracebloc API) default that — paired with the leaked password
+# above — formed a working credential in local dev. `edgeuser` is the
+# root-equivalent MySQL identity retired in backend#1528; DB_USER now comes
+# from the injected per-Job env, never a hardcoded default.
 LEGACY_USERNAME_DEFAULTS = (
     "testedge",
+    "edgeuser",
 )
 
 

--- a/tests/test_no_hardcoded_secrets.py
+++ b/tests/test_no_hardcoded_secrets.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import pytest
 
-
 # Strings that previously shipped as hardcoded defaults for the **backend**
 # (tracebloc API) credentials in `tracebloc_ingestor/config.py`. These are
 # real per-customer credentials — shipping a default value made every install

--- a/tests/test_per_ingestion_tables.py
+++ b/tests/test_per_ingestion_tables.py
@@ -185,7 +185,9 @@ def mock_engine_factory():
 
 @pytest.fixture
 def db(mock_engine_factory):
-    return Database(Config(EDGE_ENV="local"))
+    # DB_USER/DB_PASSWORD are required (backend#1528 removed the edgeuser
+    # fallback); the engine is mocked so the values are arbitrary.
+    return Database(Config(EDGE_ENV="local", DB_USER="tb_ingest", DB_PASSWORD="pw"))
 
 
 def test_create_table_must_not_exist_rejects_cached_table(db):

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.5"
+__version__ = "0.8.4"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -344,12 +344,13 @@ class Config:
             ``CLIENT_PASSWORD`` (deprecated fallback) for backend auth, and
           - ``DB_USER`` + ``DB_PASSWORD`` for MySQL.
 
-        Database credentials ARE validated here as of backend#1528 (D10): the
+        Database credentials are required as of backend#1528 (D10): the
         root-equivalent ``edgeuser`` fallback was removed, so the ingestor
         authenticates as the identity jobs-manager injects per-Job
-        (``tb_ingest``). They are now required, not a connection convention —
-        checking them at boot surfaces a misconfigured Job here rather than
-        deep in ``_create_engine`` on the first query.
+        (``tb_ingest``). They are NOT re-checked here — this method is
+        auth-scoped — but ``Config.DB_USER`` / ``DB_PASSWORD`` fail fast on
+        first access (``Database()`` init) via ``_require_env`` with a message
+        naming the unset variable, so a misconfigured Job still surfaces early.
 
         Set ``CLIENT_ENV=local`` to bypass for development against a mock
         backend.
@@ -369,22 +370,6 @@ class Config:
             missing.append(
                 "BACKEND_TOKEN (preferred) or CLIENT_ID + CLIENT_PASSWORD "
                 "(deprecated fallback)"
-            )
-
-        # DB creds are required post-backend#1528 (edgeuser fallback removed).
-        # Peek at override/env directly rather than the properties, whose
-        # getters raise individually — this keeps the single aggregated
-        # "missing vars" error below.
-        db_user = self._override("DB_USER")
-        if db_user is _MISSING:
-            db_user = os.environ.get("DB_USER")
-        db_password = self._override("DB_PASSWORD")
-        if db_password is _MISSING:
-            db_password = os.environ.get("DB_PASSWORD")
-        if not db_user or not db_password:
-            missing.append(
-                "DB_USER + DB_PASSWORD (injected per-Job by jobs-manager; "
-                "backend#1528)"
             )
 
         if missing:

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -339,15 +339,17 @@ class Config:
         module-level ``Config()`` instantiations elsewhere in the package
         don't blow up at import time.
 
-        In any non-local environment, the pod must boot with either:
-          - ``BACKEND_TOKEN`` (preferred), or
-          - ``CLIENT_ID`` + ``CLIENT_PASSWORD`` (deprecated fallback).
+        In any non-local environment, the pod must boot with:
+          - ``BACKEND_TOKEN`` (preferred) or ``CLIENT_ID`` +
+            ``CLIENT_PASSWORD`` (deprecated fallback) for backend auth, and
+          - ``DB_USER`` + ``DB_PASSWORD`` for MySQL.
 
-        Database credentials are intentionally **not** validated here: the
-        bundled MySQL container ships with fixed credentials that the
-        ingestor defaults match. They're a connection convention, not a
-        secret, and forcing customers to set them in env vars adds friction
-        with no security benefit.
+        Database credentials ARE validated here as of backend#1528 (D10): the
+        root-equivalent ``edgeuser`` fallback was removed, so the ingestor
+        authenticates as the identity jobs-manager injects per-Job
+        (``tb_ingest``). They are now required, not a connection convention —
+        checking them at boot surfaces a misconfigured Job here rather than
+        deep in ``_create_engine`` on the first query.
 
         Set ``CLIENT_ENV=local`` to bypass for development against a mock
         backend.
@@ -367,6 +369,22 @@ class Config:
             missing.append(
                 "BACKEND_TOKEN (preferred) or CLIENT_ID + CLIENT_PASSWORD "
                 "(deprecated fallback)"
+            )
+
+        # DB creds are required post-backend#1528 (edgeuser fallback removed).
+        # Peek at override/env directly rather than the properties, whose
+        # getters raise individually — this keeps the single aggregated
+        # "missing vars" error below.
+        db_user = self._override("DB_USER")
+        if db_user is _MISSING:
+            db_user = os.environ.get("DB_USER")
+        db_password = self._override("DB_PASSWORD")
+        if db_password is _MISSING:
+            db_password = os.environ.get("DB_PASSWORD")
+        if not db_user or not db_password:
+            missing.append(
+                "DB_USER + DB_PASSWORD (injected per-Job by jobs-manager; "
+                "backend#1528)"
             )
 
         if missing:

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -107,10 +107,38 @@ class Config:
                 f"{env_name} environment variable to a valid integer."
             )
 
+    @staticmethod
+    def _require_env(env_name: str) -> str:
+        """Read a required DB-credential env var, failing fast if unset
+        (backend#1528).
+
+        DB_USER / DB_PASSWORD used to fall back to the root-equivalent
+        edgeuser identity. That fallback is gone: jobs-manager now injects
+        the per-Job tb_ingest credentials into the ingestion Job's env, so an
+        unset value means a misconfigured Job, not a cue to use edgeuser. Raise
+        a message that names the variable rather than letting SQLAlchemy
+        surface an opaque access-denied (or, worse, silently connecting as the
+        legacy identity).
+        """
+        val = os.environ.get(env_name)
+        if not val:
+            raise ValueError(
+                f"{env_name} is not set. The ingestor authenticates to MySQL "
+                f"as the identity jobs-manager injects per-Job (backend#1528: "
+                f"tb_ingest); set the {env_name} environment variable. The "
+                f"legacy edgeuser fallback was removed once per-Job "
+                f"credentials shipped."
+            )
+        return val
+
     # ===== Database =====
-    # Cluster-internal MySQL ships with these credentials baked into its
-    # image; they're connection conventions, not secrets. Override via env
-    # only if you've replaced the bundled MySQL.
+    # DB_HOST/DB_PORT/DB_NAME are connection conventions for the
+    # cluster-internal MySQL and keep their defaults. DB_USER/DB_PASSWORD do
+    # NOT: the ingestor authenticates as the identity jobs-manager injects
+    # per-Job (backend#1528 — tb_ingest, scoped to training_test_datasets).
+    # The legacy root-equivalent edgeuser fallback was removed here once
+    # those per-Job credentials shipped; both are now required from env and
+    # fail fast if unset rather than silently connecting as the old identity.
     @property
     def DB_HOST(self) -> str:
         ov = self._override("DB_HOST")
@@ -125,12 +153,12 @@ class Config:
     @property
     def DB_USER(self) -> str:
         ov = self._override("DB_USER")
-        return ov if ov is not _MISSING else os.environ.get("DB_USER", "edgeuser")
+        return ov if ov is not _MISSING else self._require_env("DB_USER")
 
     @property
     def DB_PASSWORD(self) -> str:
         ov = self._override("DB_PASSWORD")
-        return ov if ov is not _MISSING else os.environ.get("DB_PASSWORD", "Edg9@Tr@ce")
+        return ov if ov is not _MISSING else self._require_env("DB_PASSWORD")
 
     @property
     def DB_NAME(self) -> str:


### PR DESCRIPTION
## What

Remove the hardcoded `edgeuser` / `Edg9@Tr@ce` fallback for `DB_USER` / `DB_PASSWORD` in `config.py`. Both are now **required from env** and fail fast (via a new `_require_env` helper mirroring `_as_int`) with a message that names the variable and points at `tb_ingest` — instead of silently authenticating to MySQL as the root-equivalent `edgeuser`.

This is the **data-ingestors slice** of backend#1528 (RFC-0003 D10 close-out: retire `edgeuser` root-equivalence, mint `tb_ingest` + `tb_meta`).

## Why

The ingestor already reads `DB_USER`/`DB_PASSWORD` from env (`database.py` `_create_engine`); the only thing pinning it to `edgeuser` is the config-level default. backend#1528 mints a dedicated least-privilege `tb_ingest` identity (`CREATE, ALTER, SELECT, INSERT, UPDATE, DELETE` on `training_test_datasets.*`) and has jobs-manager inject it into each spawned ingestion Job. Once that lands, this fallback is dead — and while it lives, a misconfigured Job silently connects as root-equivalent `edgeuser` rather than failing loudly.

## Changes

- **`tracebloc_ingestor/config.py`** — `DB_USER`/`DB_PASSWORD` require env; new `_require_env` fail-fast helper; `===== Database =====` comment rewritten to state the new contract (`DB_HOST`/`DB_PORT`/`DB_NAME` keep their conventional defaults; `DB_USER`/`DB_PASSWORD` do not). Lazy `@property`, so only the DB path triggers the check.
- **`tests/test_no_hardcoded_secrets.py`** — `Edg9@Tr@ce` and `edgeuser` moved from the allowlist into the regression guard; they can no longer reappear in package source, even in a comment.
- **`tests/test_config_lazy.py`** — fail-fast (unset → `ValueError` naming the var), env-flow, and override tests.
- **`tests/test_database.py`, `tests/test_per_ingestion_tables.py`** — the two mocked-engine `Database` fixtures now pass throwaway creds (matches the existing pattern in `test_time_series_classification.py`).

## Verification

- `pytest`: **1927 passed, 1 xfailed** (pre-existing).
- `ruff check`: clean.

## ⚠️ Release constraint — DRAFT until S2

This must **not** reach any fleet until backend#1528 **S2** (client-runtime `submit_ingestion_run` stamping `DB_USER`/`DB_PASSWORD=tb_ingest` onto spawned ingestion Jobs) is deployed there. Sequence:

```
S1 mint  →  S2 inject env  →  (this PR) drop fallback  →  S3 REVOKE edgeuser
```

Pre-S2, jobs-manager sets no DB creds, so an ingestor image built from this branch would hit the new fail-fast at init. S1 is merged but not enabled anywhere; **S2 is not yet built**. Keeping this a draft until S2 has deployed fleet-wide.

Refs: backend#1528 (D10 close-out), client-runtime#290 / client#643 (S1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Misconfigured Jobs without injected DB creds will fail at Database init; fleet rollout must follow backend#1528 S2 (jobs-manager injecting tb_ingest) before shipping this image.
> 
> **Overview**
> **Requires `DB_USER` and `DB_PASSWORD` from the environment** — the hardcoded `edgeuser` / `Edg9@Tr@ce` defaults are removed (backend#1528 D10). A new `_require_env` helper raises a clear `ValueError` naming the missing variable and pointing at per-Job `tb_ingest` injection instead of silently using the legacy MySQL identity.
> 
> `Config.validate()` stays **auth-scoped** (backend token / client creds only); DB credentials are enforced on first property access when `Database()` initializes. Host/port/database name defaults are unchanged.
> 
> Regression guards now forbid `Edg9@Tr@ce` and `edgeuser` string literals in package source. Tests cover fail-fast, env flow, and overrides; mocked `Database` fixtures supply throwaway creds. Version **0.8.5**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 820e9f5410c7780de0de319d59680d4214d986e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->