### PR TITLE
release-train: develop -> staging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,56 @@ the file extension — drives validation and file transfer.
 ## Key Dependencies
 
 Python 3.11+, `sqlalchemy`, `mysql-connector-python`, `pandas`, `Pillow`, `requests`, `tenacity`, `tqdm`.
+
+<!-- org-standards:begin -->
+## tracebloc engineering standards (org-wide)
+
+<!-- Canonical source: tracebloc/.github/org-standards.md.
+     Synced into every repo's CLAUDE.md between org-standards markers — never
+     edit it inside a consuming repo; open a PR against tracebloc/.github.
+     Meta-rule: the moment a rule below becomes mechanically enforced (a lint
+     rule, a house-rules grep, a required check), delete the sentence here and
+     let the check carry it. Prose is only for what tooling can't judge. -->
+
+### Branches & PRs
+
+- Branch model: `develop → staging → main`. Branch off `develop`; every PR targets `develop`. Never open PRs to `staging` or `main` — promotions are the release train's job. (Sole exception: the `docs` repo may target `main`.)
+- Before starting any task: `git fetch` and branch from the current tip of `develop` — never build on a stale checkout. A branch that lives more than a day gets `develop` merged back in before review. We move fast; stale starts mean silent divergence and duplicated work.
+- One self-contained change per PR. A few hundred changed lines reviews well; at 1000+ split it. Refactors ship in separate PRs from behavior changes.
+- Branches are short-lived (aim to merge within a day or two), single-author, and based on `develop` — no stacked PRs on top of other open PRs.
+- Names and commits: `feat/ fix/ docs/ sec/ ci/ chore/` + issue number + short slug (`fix/1234-ingest-timeout`); commit subjects `type(scope): summary`, referencing the ticket (`backend#1234`).
+- When you open a PR: assign yourself and request exactly one reviewer immediately — a PR without a reviewer stalls by construction. You pick the reviewer: whoever knows the code best. There is no per-repo default, and no automation assigns one — branch protection just refuses to merge without a review.
+- When you are the reviewer: first response within one business day.
+
+### Quality bar
+
+- Before every push: run the linter and the tests that cover your change. Never push a branch you believe is red — CI is the backstop, not the first run.
+- Read the full diff before opening the PR. You own every line you ship, whoever — or whatever — wrote it.
+- AI sessions end with evidence, not assertion: run the relevant check (tests, build, lint) and show the output. A change that could not be verified does not ship.
+- After opening or pushing to a PR, stay on it: poll CI and Bugbot on the current head and triage every finding the same day — fix it, or reply on the thread saying why not. No silent dismissals. Unresolved threads block the merge and stall the release train's settle stage; cheap now beats expensive later.
+- A finding that recurs across PRs becomes a rule: add it to `.cursor/BUGBOT.md`, and if it is grep-expressible, to code-quality's house-rules — then stop re-arguing it in comments.
+- Style and naming rules live in tooling (black/ruff, eslint/prettier, house-rules), never in prose. If a rule matters, encode it; do not restate linter rules in CLAUDE.md files.
+- Never commit secrets, tokens, or customer data — not in code, config, tests, issues, or commit messages. gitleaks catches secrets in **code**. Nothing scans PR titles, descriptions or commit messages: the public PII gate that did was retired on 2026-08-06 (backend#1409), so keeping customer names out of PR prose on public repos is on you, not on a check.
+
+### Engineer kanban
+
+- Picking up work: the team coordinates. `Ready` is the refined queue and the first choice when it's stocked; pulling from `Backlog` is normal when refinement hasn't caught up — say what you're taking.
+- Merging to `develop` moves the card to `On dev` automatically; there is no dev-side review.
+- Functional review happens once, on staging: when it passes, comment `/fr-pass` on the PR or drag the card to `Ready for prod`. Self-signoff is allowed.
+- `fr-gate` is a required check on promotions. If it blocks, the board or the work isn't ready — fix that. `skip-fr-gate` is audited, for emergencies only.
+
+### Releases & publishing
+
+- The release train is the only path to `staging`, `main`, and every package registry. Never hand-cut a `v*` tag, hand-bump a version file, or publish an artifact — every legal publish path is inventoried in release-train's `PUBLISH-PATHS.md`.
+- Findings on a promotion PR are fixed on the source branch (`develop`/`staging`), then the train re-prepares. Never push fixes onto a promotion PR — every push re-rolls its review.
+
+### Filing issues
+
+- Internal work — planning, epics, security findings, infrastructure, anything mentioning a customer — is filed in `backend` (the private catch-all), never in a public repo. When in doubt: `backend`.
+- Public repos (`cli`, `client`, `docs`, `data-ingestors`, `model-zoo`, `start-training`, `.github`) only get issues a stranger could act on: about the public artifact itself, with no customer names, internal URLs, or internal paths.
+
+### AI-assisted sessions (Claude Code, etc.)
+
+- An AI session may open PRs and push its own branches. It never: merges a PR, closes another person's PR, deletes another person's branch, or force-pushes — each of those needs an explicit instruction from the human running it.
+- If your change makes a statement in any CLAUDE.md, BUGBOT.md, or runbook false, update that file in the same PR.
+<!-- org-standards:end -->

--- a/tests/test_file_transfer_failure_modes.py
+++ b/tests/test_file_transfer_failure_modes.py
@@ -54,6 +54,7 @@ def _raise_oserror(*_a, **_k):
 
 # --- retry behaviour (tenacity on _copy_file_with_retry) --------------------
 
+
 def test_copy_retries_transient_error_then_succeeds(dirs, no_retry_wait, monkeypatch):
     src, dest = dirs
     s = _seed(src, "images", "a.jpg", b"payload")
@@ -101,6 +102,7 @@ def test_image_transfer_wraps_persistent_copy_error(dirs, no_retry_wait, monkeyp
 
 # --- a real filesystem permission error (not a mock) ------------------------
 
+
 @pytest.mark.skipif(
     hasattr(os, "geteuid") and os.geteuid() == 0,
     reason="root bypasses filesystem permission checks",
@@ -117,7 +119,35 @@ def test_image_transfer_unwritable_dest_raises(dirs, no_retry_wait):
         os.chmod(dest, 0o700)  # restore so pytest can clean up tmp_path
 
 
+# --- #172: dest dir is created group-writable + setgid for teardown ---------
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root's created dirs ignore umask/perms nuances",
+)
+def test_ensure_dest_dir_new_dir_is_setgid_and_group_writable(tmp_path):
+    """#172: a dir the ingestor creates is setgid + group-writable so the
+    `data delete` teardown group (65532) can reclaim the tree on hostPath."""
+    dest = tmp_path / "storage" / "tbl"
+    file_transfer._ensure_dest_dir(str(dest))
+    mode = os.stat(dest).st_mode
+    assert mode & 0o2000, "setgid bit must be set so entries inherit the group"
+    assert mode & 0o020, "group-write bit must be set so the group can delete"
+
+
+def test_ensure_dest_dir_leaves_existing_dir_mode_untouched(tmp_path):
+    """A pre-existing dest is not re-chmod'd — we don't override an operator's
+    mode or mask a permission problem."""
+    dest = tmp_path / "storage" / "tbl"
+    dest.mkdir(parents=True)
+    os.chmod(dest, 0o750)
+    file_transfer._ensure_dest_dir(str(dest))
+    assert (os.stat(dest).st_mode & 0o777) == 0o750
+
+
 # --- atomic skip leaves no orphan (the #99 data-integrity invariant) --------
+
 
 def test_object_detection_missing_annotation_leaves_no_orphan(dirs):
     src, dest = dirs
@@ -135,7 +165,8 @@ def test_segmentation_missing_mask_leaves_no_orphan(dirs):
     _seed(src, "images", "x.jpg")  # image present, mask file absent
     rec = file_transfer.map_file_transfer(
         TaskCategory.SEMANTIC_SEGMENTATION,
-        {"filename": "x", "mask_id": "m"}, {"extension": ".jpg"},
+        {"filename": "x", "mask_id": "m"},
+        {"extension": ".jpg"},
     )
     assert rec is None
     assert not dest.exists() or not any(dest.iterdir())

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -75,6 +75,14 @@ def main(argv: List[str] | None = None) -> int:  # pragma: no cover - thin shell
     ``sys.exit`` by the console-script wrapper; using a return value (rather
     than raising) keeps the function testable from inside pytest.
     """
+    # Group-writable by default (umask 002) so every directory and file the run
+    # writes under DEST_PATH can be reclaimed by the `data delete` teardown
+    # group (uid/gid 65532), not just the setgid DEST_PATH root itself — the
+    # hostPath half of client-runtime#172 (the teardown pod's fsGroup is ignored
+    # on hostPath). Files themselves need no write bit to be deleted; the
+    # containing directories do, which this guarantees for the whole tree.
+    os.umask(0o002)
+
     config_path = os.environ.get("INGEST_CONFIG")
     if not config_path:
         return _fail(

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -38,6 +38,40 @@ config = Config()
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
+# `data delete` reclaims a dataset with an ephemeral stage-identity pod
+# (uid/gid 65532, client-runtime#172). On a hostPath dataset the kubelet ignores
+# that pod's fsGroup, so the ingest side must leave the destination tree
+# group-owned by, and group-writable for, that group — otherwise the teardown
+# can't remove the files and they leak (remainder of client#259). Create the
+# destination dir setgid + group-writable so new entries inherit the group and
+# the group can delete them, regardless of the writing uid. 0o2775 = rwxrwsr-x.
+DEST_DIR_MODE = 0o2775
+
+
+def _ensure_dest_dir(path: str) -> None:
+    """Create ``path`` if absent, setgid + group-writable, so the ``data
+    delete`` teardown group can reclaim the tree (#172).
+
+    Only a directory we *create* is chmod'd — a pre-existing one is left as-is,
+    so we neither override an operator's deliberate mode nor mask a genuine
+    permission problem (an unwritable dest still surfaces downstream). The chmod
+    is best-effort: a failure is logged, not fatal, so ingestion still proceeds.
+    """
+    existed = os.path.isdir(path)
+    os.makedirs(path, exist_ok=True)
+    if existed:
+        return
+    try:
+        os.chmod(path, DEST_DIR_MODE)
+    except OSError as error:
+        logger.warning(
+            "Could not set group-writable/setgid mode on %s (%s); the `data "
+            "delete` teardown may not be able to reclaim it",
+            path,
+            error,
+        )
+
+
 # Define retry decorator for file operations
 retry_decorator = retry(
     stop=stop_after_attempt(RETRY_MAX_ATTEMPTS),
@@ -212,7 +246,7 @@ def image_transfer(
     """
     cfg = cfg or config
     # Create destination directory if it doesn't exist
-    os.makedirs(cfg.DEST_PATH, exist_ok=True)
+    _ensure_dest_dir(cfg.DEST_PATH)
 
     try:
         # Get the filename from the record
@@ -272,7 +306,7 @@ def annotation_transfer(
     """
     cfg = cfg or config
     # Create destination directory if it doesn't exist
-    os.makedirs(cfg.DEST_PATH, exist_ok=True)
+    _ensure_dest_dir(cfg.DEST_PATH)
 
     try:
         # Get the filename from the record
@@ -327,7 +361,7 @@ def text_transfer(
     """
     cfg = cfg or config
     # Create destination directory if it doesn't exist
-    os.makedirs(cfg.DEST_PATH, exist_ok=True)
+    _ensure_dest_dir(cfg.DEST_PATH)
 
     try:
         # Get the filename from the record
@@ -396,7 +430,7 @@ def mask_transfer(
     call per record.
     """
     cfg = cfg or config
-    os.makedirs(cfg.DEST_PATH, exist_ok=True)
+    _ensure_dest_dir(cfg.DEST_PATH)
 
     try:
         # Write target guarded against escaping DEST via a crafted mask_id (#239)


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem permissions on every file-bearing ingest path; behavior is scoped to dirs the ingestor creates and is best-effort on chmod, but wrong assumptions about group ownership on shared storage could still affect teardown or operator layouts.
> 
> **Overview**
> **Release train promotion** (`develop` → `staging`) that ships **0.8.4**, including the **#172 / client-runtime#172** fix so ingested datasets on **hostPath** can be removed by the `data delete` teardown pod (gid **65532**) when Kubernetes does not apply **fsGroup** on hostPath.
> 
> The ingestor now sets **`umask 002`** at `tracebloc-ingest` startup and replaces plain `os.makedirs` on `DEST_PATH` with **`_ensure_dest_dir`**, which chmods **newly created** destination directories to **setgid + group-writable** (`0o2775`); pre-existing dirs are left unchanged, and chmod failures are logged only. Tests cover setgid/group-write on create and no chmod on existing dirs.
> 
> **CLAUDE.md** gains the synced org-wide **tracebloc engineering standards** block between the org-standards markers (no runtime behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 024031bb751647b3f8eaec65b42cb83f21048be3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->