### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/workflows/version-bump-gate-caller.yml
+++ b/.github/workflows/version-bump-gate-caller.yml
@@ -1,0 +1,23 @@
+name: Version bump gate
+
+# Caller for tracebloc/.github version-bump-gate.yml. Fails a develop PR that
+# touches this repo's published files while the version those files would ship
+# under is ALREADY released -- caught on the author's diff, not days later at the
+# prod hop (backend#1563; the cli + py-package surprise on 2026-08-10).
+# Override a false positive with the 'skip-version-gate' label (visible in audit).
+on:
+  pull_request:
+    branches: [develop]
+    # labeled/unlabeled so the skip-version-gate override actually re-runs the gate (Bugbot)
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  version-bump-gate:
+    uses: tracebloc/.github/.github/workflows/version-bump-gate.yml@main
+    with:
+      version-file: "tracebloc_ingestor/__init__.py"
+      publish-paths: "tracebloc_ingestor/*"
+      soft-fail: false


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with read-only repo permissions; no runtime or publish behavior changes.
> 
> **Overview**
> Adds a **develop** pull request check that blocks changes under `tracebloc_ingestor/*` when the version in `tracebloc_ingestor/__init__.py` is already released, so authors fix version bumps on the PR instead of at a later release hop.
> 
> The new workflow `.github/workflows/version-bump-gate-caller.yml` delegates to the shared `tracebloc/.github` `version-bump-gate.yml`, with `soft-fail: false`. It re-runs on `labeled` / `unlabeled` so applying or removing **`skip-version-gate`** re-evaluates the gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72f7dad3897e9058d440c36abf53510c459080bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->