### PR TITLE
release-train: staging -> main

### DIFF
--- a/.github/workflows/version-bump-gate-caller.yml
+++ b/.github/workflows/version-bump-gate-caller.yml
@@ -1,0 +1,23 @@
+name: Version bump gate
+
+# Caller for tracebloc/.github version-bump-gate.yml. Fails a develop PR that
+# touches this repo's published files while the version those files would ship
+# under is ALREADY released -- caught on the author's diff, not days later at the
+# prod hop (backend#1563; the cli + py-package surprise on 2026-08-10).
+# Override a false positive with the 'skip-version-gate' label (visible in audit).
+on:
+  pull_request:
+    branches: [develop]
+    # labeled/unlabeled so the skip-version-gate override actually re-runs the gate (Bugbot)
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  version-bump-gate:
+    uses: tracebloc/.github/.github/workflows/version-bump-gate.yml@main
+    with:
+      version-file: "tracebloc_ingestor/__init__.py"
+      publish-paths: "tracebloc_ingestor/*"
+      soft-fail: false


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-main` branch (a mirror of `staging`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with read-only permissions; no runtime or publish behavior changes.
> 
> **Overview**
> Adds **`.github/workflows/version-bump-gate-caller.yml`**, which runs on PRs to **`develop`** and delegates to the shared **`tracebloc/.github`** `version-bump-gate` workflow.
> 
> The gate **fails** when a PR changes published paths under **`tracebloc_ingestor/*`** but the version in **`tracebloc_ingestor/__init__.py`** is already released—so authors catch the problem on the PR instead of at prod promotion. It listens for **`labeled` / `unlabeled`** so applying **`skip-version-gate`** re-runs the check; **`soft-fail: false`** makes violations blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5fc9a3c9ddbbad9bc80c7285475e7651aaa1f47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->