### PR TITLE
fix(transfer): make the dest dir removable by the teardown pod (different uid, no shared group)

### DIFF
--- a/tests/test_file_transfer_failure_modes.py
+++ b/tests/test_file_transfer_failure_modes.py
@@ -170,3 +170,62 @@ def test_segmentation_missing_mask_leaves_no_orphan(dirs):
     )
     assert rec is None
     assert not dest.exists() or not any(dest.iterdir())
+
+
+# --- client#653: the teardown runs as a DIFFERENT uid, so group-write is not enough
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root's created dirs ignore umask/perms nuances",
+)
+def test_ensure_dest_dir_is_world_writable_not_just_group_writable(tmp_path):
+    """Removing a file needs write on its PARENT DIR, and the pods that create
+    and delete these trees never share an identity: the ingestion Job runs as
+    65534 (or HOST_UID), the CLI teardown pod as 65532/fsGroup 65532, and the
+    chart chowns the shared mount to 1000:1000 with setgid -- so a dir created
+    underneath inherits group 1000, never 65532.
+
+    Group-write therefore could not work, and fsGroup cannot rescue it because
+    kubelet ignores fsGroup on hostPath volumes (kubernetes#138411) -- the layout
+    every installer-provisioned cluster uses. The observed failure was
+    "rm: can't remove '/data/shared/<table>/<file>': Permission denied" with the
+    table already dropped, leaving a half-deleted dataset.
+    """
+    dest = tmp_path / "storage" / "tbl"
+    file_transfer._ensure_dest_dir(str(dest))
+    mode = os.stat(dest).st_mode
+    assert mode & 0o002, "other-write must be set: the teardown uid shares no group"
+    assert mode & 0o001, "other-execute must be set, or the dir cannot be traversed"
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root's created dirs ignore umask/perms nuances",
+)
+def test_duplicate_validator_creates_dest_reclaimable_too(tmp_path):
+    """The duplicate validator creates the SAME DEST_PATH and runs BEFORE the
+    transfer, so it decides the mode -- and _ensure_dest_dir deliberately does not
+    re-chmod a dir that already exists. While this used a bare mkdir, the mode fix
+    in file_transfer was dead code on every run that validated first: the tree was
+    left at the umask default and the teardown could not remove it (client#653).
+    """
+    from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
+
+    dest = tmp_path / "storage" / "tbl"
+    validator = DuplicateValidator(dest_path=str(dest))
+    assert validator._create_directory_if_needed() is True
+    mode = os.stat(dest).st_mode
+    assert mode & 0o002, "the validator-created dir must be reclaimable as well"
+    assert mode & 0o2000, "setgid, so entries keep inheriting the mount's group"
+
+
+def test_both_creation_sites_share_one_mode_definition():
+    """Two independent copies of this mode would drift, and the drift is invisible
+    until a delete fails in the field. Both sites must resolve to the same object.
+    """
+    from tracebloc_ingestor.utils import fs
+    from tracebloc_ingestor.validators import duplicate_validator
+
+    assert file_transfer.DEST_DIR_MODE is fs.DEST_DIR_MODE
+    assert duplicate_validator.ensure_reclaimable_dir is fs.ensure_reclaimable_dir

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -20,6 +20,8 @@ from tenacity import (
 )
 
 from tracebloc_ingestor import Config
+from tracebloc_ingestor.utils.fs import DEST_DIR_MODE as _DEST_DIR_MODE
+from tracebloc_ingestor.utils.fs import ensure_reclaimable_dir
 from tracebloc_ingestor.utils.constants import (
     GREEN,
     RED,
@@ -42,34 +44,20 @@ logger.setLevel(config.LOG_LEVEL)
 # (uid/gid 65532, client-runtime#172). On a hostPath dataset the kubelet ignores
 # that pod's fsGroup, so the ingest side must leave the destination tree
 # group-owned by, and group-writable for, that group — otherwise the teardown
-# can't remove the files and they leak (remainder of client#259). Create the
-# destination dir setgid + group-writable so new entries inherit the group and
-# the group can delete them, regardless of the writing uid. 0o2775 = rwxrwsr-x.
-DEST_DIR_MODE = 0o2775
+# can't remove the files and they leak (remainder of client#259). The rule now
+# lives in utils/fs.py so the duplicate validator -- which creates the SAME
+# destination directory, and gets there first -- applies it too. Re-exported here
+# because callers and tests already reference these names.
+DEST_DIR_MODE = _DEST_DIR_MODE
 
 
 def _ensure_dest_dir(path: str) -> None:
-    """Create ``path`` if absent, setgid + group-writable, so the ``data
-    delete`` teardown group can reclaim the tree (#172).
+    """Create ``path`` reclaimable by the `data delete` teardown (#172).
 
-    Only a directory we *create* is chmod'd — a pre-existing one is left as-is,
-    so we neither override an operator's deliberate mode nor mask a genuine
-    permission problem (an unwritable dest still surfaces downstream). The chmod
-    is best-effort: a failure is logged, not fatal, so ingestion still proceeds.
+    Thin delegation to :func:`ensure_reclaimable_dir`; see utils/fs.py for why
+    the mode is world-writable rather than group-writable.
     """
-    existed = os.path.isdir(path)
-    os.makedirs(path, exist_ok=True)
-    if existed:
-        return
-    try:
-        os.chmod(path, DEST_DIR_MODE)
-    except OSError as error:
-        logger.warning(
-            "Could not set group-writable/setgid mode on %s (%s); the `data "
-            "delete` teardown may not be able to reclaim it",
-            path,
-            error,
-        )
+    ensure_reclaimable_dir(path)
 
 
 # Define retry decorator for file operations

--- a/tracebloc_ingestor/utils/fs.py
+++ b/tracebloc_ingestor/utils/fs.py
@@ -1,0 +1,65 @@
+"""Filesystem helpers shared by the validators and the transfer path.
+
+Home of the one rule about destination directories that both sides must follow:
+a directory the ingestor creates has to stay reclaimable by the `data delete`
+teardown, which runs as a DIFFERENT uid in a different pod.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Mode for a destination directory the ingestor creates.
+#
+# 0o2777 = rwxrwsrwx: setgid, plus write for group AND other.
+#
+# Why world-write and not the tighter group-write (0o2775) this used to be:
+# removing a file requires write+execute on its PARENT DIRECTORY, and the
+# processes that create and delete these trees are different pods running as
+# different, non-overlapping identities:
+#
+#   * the ingestion Job runs as uid 65534 (`nobody`) by default, or HOST_UID on
+#     a network export (client-runtime submit_ingestion_run.py);
+#   * the CLI's staging/teardown pod runs as uid 65532 with fsGroup 65532
+#     (cli internal/push/pod.go);
+#   * the chart chowns the shared mount itself to 1000:1000 and sets setgid, so
+#     a directory created underneath INHERITS group 1000 -- not 65532.
+#
+# So group-write could never help: the group the teardown pod carries (65532) is
+# not the group the directory inherits (1000). And the usual fix for that --
+# fsGroup, which makes kubelet recursively chgrp the volume -- does nothing here,
+# because kubelet IGNORES fsGroup on hostPath volumes
+# (kubernetes/kubernetes#138411), the layout every installer-provisioned cluster
+# uses. Nothing at ingest time can know or align those identities, and the parent
+# mount is already world-writable by chart design, so world-write on the
+# directory is both the only mode that works for every caller and no wider a
+# grant than the tree it sits in.
+DEST_DIR_MODE = 0o2777
+
+
+def ensure_reclaimable_dir(path: str) -> None:
+    """Create ``path`` if absent, with a mode the teardown can reclaim.
+
+    Only a directory we *create* is chmod'd. A pre-existing one is left alone so
+    we neither override an operator's deliberate mode nor mask a genuine
+    permission problem -- an unwritable destination still surfaces downstream.
+    (A directory left behind by an older ingestor keeps its old mode; repairing
+    those is the installer's job, not a silent chmod of data we did not create.)
+
+    The chmod is best-effort: a failure is logged, never fatal, so ingestion
+    still proceeds on a filesystem that cannot represent the mode at all.
+    """
+    existed = os.path.isdir(path)
+    os.makedirs(path, exist_ok=True)
+    if existed:
+        return
+    try:
+        os.chmod(path, DEST_DIR_MODE)
+    except OSError as error:
+        logger.warning(
+            "Could not set the reclaimable mode on %s (%s); the `data delete` "
+            "teardown may not be able to remove it",
+            path,
+            error,
+        )

--- a/tracebloc_ingestor/validators/duplicate_validator.py
+++ b/tracebloc_ingestor/validators/duplicate_validator.py
@@ -10,6 +10,7 @@ import logging
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
+from ..utils.fs import ensure_reclaimable_dir
 
 config = Config()
 logger = logging.getLogger(__name__)
@@ -203,7 +204,15 @@ class DuplicateValidator(BaseValidator):
         try:
             dest_path = Path(self.dest_path)
             if not dest_path.exists():
-                dest_path.mkdir(parents=True, exist_ok=True)
+                # Shared helper, not a bare mkdir: validation runs BEFORE the
+                # transfer, so whoever creates this directory first decides its
+                # mode -- and file_transfer deliberately does not re-chmod a
+                # directory that already exists. A bare mkdir here therefore left
+                # the tree at the umask default (0755, owned by the ingest uid),
+                # which the `data delete` teardown pod -- a different uid -- cannot
+                # remove: "rm: can't remove ...: Permission denied", with the
+                # table already dropped. See utils/fs.py.
+                ensure_reclaimable_dir(str(dest_path))
                 logger.info(f"Created destination directory: {self.dest_path}")
             return True
         except Exception as e:


### PR DESCRIPTION
Closes #476.

## The bug

`data delete` dropped the table, then failed to remove the files:

```
rm: can't remove '/data/shared/<table>/<file>.jpg': Permission denied
```

The dataset is left half-deleted — gone from the database, still on disk — and the error's
"re-run the delete" advice can't work, because the table it would look for is already gone.

## Root cause

Removing a file needs write+execute on its **parent directory**, not on the file. The pods that
create and delete these trees share no identity:

| Actor | Identity |
|---|---|
| ingestion Job (creates dir + files) | uid 65534 (`nobody`), or `HOST_UID` |
| CLI staging/teardown pod (removes them) | uid 65532, `fsGroup` 65532 |
| the shared mount itself | chowned `1000:1000` + setgid → a dir created underneath inherits group **1000** |

`DEST_DIR_MODE` was `0o2775` — setgid + **group**-writable — and its comment said the teardown
group could reclaim the tree. It couldn't: the inherited group is 1000, the teardown pod carries
65532. `fsGroup` normally fixes precisely this by making kubelet recursively `chgrp` the volume,
but **kubelet ignores `fsGroup` on hostPath volumes**
([kubernetes#138411](https://github.com/kubernetes/kubernetes/issues/138411)) — the layout every
installer-provisioned cluster uses.

Why it shipped green: the existing test asserted the mode **bits** and never that the group
matched the teardown's identity, so a mechanism that cannot work passed its own test.

**Second, independent defect.** The duplicate validator creates the *same* `DEST_PATH` with a bare
`mkdir` and runs **before** the transfer, and `_ensure_dest_dir` deliberately does not re-chmod a
directory that already exists. So on every run where validation created the directory first, the
mode fix was dead code and the tree stayed at the umask default (0755).

Either defect alone leaves the bug reachable, so both are fixed here.

## The change

- **New `tracebloc_ingestor/utils/fs.py`** holds the single rule. `file_transfer` re-exports
  `DEST_DIR_MODE` and keeps `_ensure_dest_dir` as a thin delegation, so existing callers and tests
  are untouched.
- **The validator uses the shared helper**, so the mode applies whichever side creates the dir.
- **Mode widens to `0o2777`.** Nothing at ingest time can know the teardown's uid, and the parent
  mount is already world-writable by chart design — so this is not a wider grant than the tree it
  sits in.

**Deliberately unchanged:** a pre-existing directory is still never re-chmod'd, so an operator's
mode is not overridden and a genuinely unwritable destination still surfaces downstream. Trees
left by an older ingestor keep their old mode — repairing those is a node-side one-off, not a
silent chmod of data the ingestor didn't write.

## Verification

- `pytest` — **1923 passed, 1 xfailed** (3 new tests).
- **Each new test was proved to bite**: reverting the mode to `0o2775` fails
  `test_ensure_dest_dir_is_world_writable_not_just_group_writable`, and restoring the validator's
  bare `mkdir` fails `test_duplicate_validator_creates_dest_reclaimable_too`. A third test pins
  both sites to one mode definition so the two copies can't drift apart again.
- `black` + `ruff` clean.

Found while debugging a Windows install where the first ingest and then the first delete both
failed on hostPath permissions. The ingest half is fixed in the client installer; this is the
delete half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared PVC directory permissions and delete teardown behavior; scope is narrow and well-tested, but mistakes could leave undeletable data or widen per-dir writability on the mount.
> 
> **Overview**
> Fixes **`data delete`** leaving datasets half-removed on disk when the teardown pod (different uid, no shared group with the ingest job on hostPath) cannot delete files under the table directory.
> 
> **Centralizes destination-dir creation** in new `tracebloc_ingestor/utils/fs.py`: `ensure_reclaimable_dir` and `DEST_DIR_MODE` (**`0o2777`**, setgid + world write/execute) replace the previous **`0o2775`** group-writable assumption. `file_transfer._ensure_dest_dir` now delegates there and still re-exports the constants for existing callers/tests.
> 
> **`DuplicateValidator`** no longer uses a bare `mkdir` when it creates `DEST_PATH` first (validation runs before transfer, and existing dirs are not re-chmodded), so the reclaimable mode applies whichever path creates the directory.
> 
> Adds regression tests for world-writable mode, validator-created dirs, and a single shared mode definition. Package version **0.8.5**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cd556965eb73e10b0e3641796251c3095cd8f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->