### PR TITLE
release-train: develop -> staging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Python 3.11+, `sqlalchemy`, `mysql-connector-python`, `pandas`, `Pillow`, `reque
 ### Engineer kanban
 
 - Every ticket on the board carries a `Status` — no card sits at "No Status". New tickets start in `Backlog`. **Bugs are the exception:** label them `work-type:bug` (the Bug template does it) and put them straight into `Ready` — defects don't wait for refinement.
-- Picking up work: the team coordinates. `Ready` is the refined queue and the first choice when it's stocked; pulling from `Backlog` is normal when refinement hasn't caught up — say what you're taking.
+- Picking up work: the team coordinates. `Ready` is the refined queue — bugs excepted, per the line above — and the first choice when it's stocked; pulling from `Backlog` is normal when refinement hasn't caught up — say what you're taking.
 - Merging to `develop` moves the card to `On dev` automatically; there is no dev-side review.
 - Functional review happens once, on staging: when it passes, comment `/fr-pass` on the PR or drag the card to `Ready for prod`. Self-signoff is allowed.
 - `fr-gate` is a required check on promotions. If it blocks, the board or the work isn't ready — fix that. `skip-fr-gate` is audited, for emergencies only.

--- a/Readme.md
+++ b/Readme.md
@@ -129,6 +129,7 @@ The Job needs these environment variables (set in [`ingestor-job.yaml`](ingestor
 | `CLIENT_ID`, `CLIENT_PASSWORD` | Tracebloc client credentials |
 | `CLIENT_PVC` | PVC name shared with the client (must match `values.yaml`) |
 | `MYSQL_HOST` | Hostname of the client's MySQL service |
+| `DB_USER`, `DB_PASSWORD` | **Required.** Credentials for the dataset database. There is no built-in fallback account — the Job fails at startup without these. On installs with `serviceDbAccounts: true`, use the generated `tb_ingest` account (password in the `<release-name>-secrets` Secret, key `TB_INGEST_PASSWORD`). |
 | `SRC_PATH` | Where your raw data is mounted in the ingestor pod |
 | `LABEL_FILE` | Path to labels (e.g. `Xy_train.csv`) |
 | `TABLE_NAME` | Destination table name in the client database |

--- a/ingestor-job.yaml
+++ b/ingestor-job.yaml
@@ -32,6 +32,21 @@ spec:
           value: "client-pvc"
         - name: MYSQL_HOST
           value: "mysql-client"
+        # Dataset-DB credentials. REQUIRED: the ingestor no longer falls back to
+        # a built-in account, so `Database()` init fails without these.
+        - name: DB_USER
+          value: "<replace_with_db_user>"
+        - name: DB_PASSWORD
+          value: "<replace_with_db_password>"
+        # On installs with `serviceDbAccounts: true` in the client's values.yaml,
+        # use the generated tb_ingest account instead of a literal password:
+        # - name: DB_USER
+        #   value: "tb_ingest"
+        # - name: DB_PASSWORD
+        #   valueFrom:
+        #     secretKeyRef:
+        #       name: <release-name>-secrets
+        #       key: TB_INGEST_PASSWORD
         - name: SRC_PATH
           value: "/data" # Source folder path whithin the data ingestor
         - name: LABEL_FILE

--- a/tests/test_api_client_auth.py
+++ b/tests/test_api_client_auth.py
@@ -11,9 +11,10 @@ Covers all three boot paths required by the #43 acceptance criteria:
 A fourth path — ``CLIENT_ENV=local`` — is also exercised because it bypasses
 both validation and the network entirely.
 
-Database credentials are intentionally **not** in the validation surface:
-they're connection conventions for the bundled MySQL container, not
-customer-facing secrets. See `Config.validate()` for the rationale.
+Database credentials (``DB_USER`` / ``DB_PASSWORD``) are required for a real
+run as of backend#1528 (the ``edgeuser`` fallback was removed — jobs-manager
+injects ``tb_ingest`` per-Job), but they are NOT part of this auth-scoped
+``validate()``; they fail fast at ``Database()`` init instead.
 """
 
 from __future__ import annotations
@@ -32,8 +33,8 @@ def _make_config(**overrides) -> Config:
 
     Default: a valid prod-like config with BACKEND_TOKEN set so ``validate()``
     passes; tests override only the auth fields they care about. DB creds are
-    not part of the validation surface (they're bundled-MySQL conventions),
-    so they're left to their env/property defaults here.
+    not part of ``validate()`` (it's auth-scoped) — they fail fast at
+    ``Database()`` init instead — so they're left unset here.
     """
     defaults = dict(
         BACKEND_TOKEN="test-token-abc",
@@ -181,8 +182,9 @@ class TestLocalModeBypassesValidation:
             CLIENT_PASSWORD=None,
         )
 
-        with patch.object(APIClient, "authenticate") as mock_auth, \
-             patch("requests.Session.post") as mock_post:
+        with patch.object(APIClient, "authenticate") as mock_auth, patch(
+            "requests.Session.post"
+        ) as mock_post:
             client = APIClient(config)
 
         mock_auth.assert_not_called()

--- a/tests/test_config_lazy.py
+++ b/tests/test_config_lazy.py
@@ -28,10 +28,21 @@ from tracebloc_ingestor.config import Config
 def clean_env(monkeypatch):
     """Strip the env vars these tests read/write."""
     for var in (
-        "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
-        "BACKEND_TOKEN", "CLIENT_ID", "CLIENT_PASSWORD",
-        "CLIENT_ENV", "LOG_LEVEL", "BATCH_SIZE",
-        "MYSQL_HOST", "MYSQL_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
+        "SRC_PATH",
+        "LABEL_FILE",
+        "TABLE_NAME",
+        "TITLE",
+        "BACKEND_TOKEN",
+        "CLIENT_ID",
+        "CLIENT_PASSWORD",
+        "CLIENT_ENV",
+        "LOG_LEVEL",
+        "BATCH_SIZE",
+        "MYSQL_HOST",
+        "MYSQL_PORT",
+        "DB_USER",
+        "DB_PASSWORD",
+        "DB_NAME",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -169,7 +180,9 @@ def test_api_endpoint_follows_edge_env(clean_env, monkeypatch):
     assert config.API_ENDPOINT == "http://localhost:8000"
 
 
-@pytest.mark.parametrize("env,attr", [("MYSQL_PORT", "DB_PORT"), ("BATCH_SIZE", "BATCH_SIZE")])
+@pytest.mark.parametrize(
+    "env,attr", [("MYSQL_PORT", "DB_PORT"), ("BATCH_SIZE", "BATCH_SIZE")]
+)
 def test_non_numeric_int_field_raises_clear_error(clean_env, monkeypatch, env, attr):
     # A non-numeric MYSQL_PORT / BATCH_SIZE must surface a clear config error
     # naming the field, not a raw "invalid literal for int()" (#238).
@@ -184,3 +197,27 @@ def test_numeric_int_field_still_coerces(clean_env, monkeypatch):
     config = Config()
     assert config.DB_PORT == 3307
     assert config.BATCH_SIZE == 500
+
+
+@pytest.mark.parametrize("attr", ["DB_USER", "DB_PASSWORD"])
+def test_db_credentials_required_no_edgeuser_fallback(clean_env, attr):
+    """backend#1528: the root-equivalent 'edgeuser' fallback is gone. With the
+    env var unset, accessing DB_USER/DB_PASSWORD must fail fast with a message
+    naming the variable — never silently return the legacy edgeuser default."""
+    with pytest.raises(ValueError, match=f"{attr} is not set"):
+        getattr(Config(), attr)
+
+
+@pytest.mark.parametrize(
+    "attr,env,value",
+    [("DB_USER", "DB_USER", "tb_ingest"), ("DB_PASSWORD", "DB_PASSWORD", "s3cret")],
+)
+def test_db_credentials_flow_from_env(clean_env, monkeypatch, attr, env, value):
+    monkeypatch.setenv(env, value)
+    assert getattr(Config(), attr) == value
+
+
+def test_db_credentials_override_wins(clean_env):
+    config = Config(DB_USER="tb_ingest", DB_PASSWORD="s3cret")
+    assert config.DB_USER == "tb_ingest"
+    assert config.DB_PASSWORD == "s3cret"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -42,12 +42,15 @@ def mock_engine_factory():
 
 @pytest.fixture
 def db(mock_engine_factory):
-    return Database(Config(EDGE_ENV="local"))
+    # DB_USER/DB_PASSWORD are required (backend#1528 removed the edgeuser
+    # fallback); the engine is mocked so the values are arbitrary.
+    return Database(Config(EDGE_ENV="local", DB_USER="tb_ingest", DB_PASSWORD="pw"))
 
 
 # ---------------------------------------------------------------------------
 # __init__ / _create_engine
 # ---------------------------------------------------------------------------
+
 
 def test_init_builds_engine(db, mock_engine_factory):
     ce, engine, conn = mock_engine_factory
@@ -63,18 +66,22 @@ def test_init_builds_engine(db, mock_engine_factory):
 # _get_sqlalchemy_type (pure)
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("mysql_type,expected_cls", [
-    ("INT", Integer),
-    ("INTEGER", Integer),
-    ("BIGINT", BigInteger),
-    ("TEXT", db_mod.Text),
-    ("FLOAT", db_mod.Float),
-    ("BOOLEAN", db_mod.Boolean),
-    ("DATE", db_mod.Date),
-    ("DATETIME", db_mod.DateTime),
-    ("TIMESTAMP", db_mod.DateTime),
-    ("TIME", db_mod.Time),
-])
+
+@pytest.mark.parametrize(
+    "mysql_type,expected_cls",
+    [
+        ("INT", Integer),
+        ("INTEGER", Integer),
+        ("BIGINT", BigInteger),
+        ("TEXT", db_mod.Text),
+        ("FLOAT", db_mod.Float),
+        ("BOOLEAN", db_mod.Boolean),
+        ("DATE", db_mod.Date),
+        ("DATETIME", db_mod.DateTime),
+        ("TIMESTAMP", db_mod.DateTime),
+        ("TIME", db_mod.Time),
+    ],
+)
 def test_get_sqlalchemy_type_mapping(db, mysql_type, expected_cls):
     result = db._get_sqlalchemy_type(mysql_type)
     # result may be a class or an instance depending on length handling.
@@ -134,12 +141,15 @@ def test_get_sqlalchemy_type_typo_no_suggestion_for_distant_input(db):
     assert "Did you mean" not in str(excinfo.value)
 
 
-@pytest.mark.parametrize("typo,suggestion", [
-    ("INTGER", "INTEGER"),
-    ("NUMRIC", "NUMERIC"),
-    ("BOLEAN", "BOOLEAN"),
-    ("VARCAHR", "VARCHAR"),
-])
+@pytest.mark.parametrize(
+    "typo,suggestion",
+    [
+        ("INTGER", "INTEGER"),
+        ("NUMRIC", "NUMERIC"),
+        ("BOLEAN", "BOOLEAN"),
+        ("VARCAHR", "VARCHAR"),
+    ],
+)
 def test_get_sqlalchemy_type_typo_suggestions_cover_common_mistakes(
     db, typo, suggestion
 ):
@@ -201,6 +211,7 @@ def test_get_sqlalchemy_type_char_bare(db):
 # create_table
 # ---------------------------------------------------------------------------
 
+
 def test_create_table_new(db):
     db.metadata.create_all = MagicMock()
     inspector = MagicMock()
@@ -244,7 +255,8 @@ def test_create_table_existing_matching_schema_reflects_ok(db):
 
     def fake_reflect(engine, only=None):
         Table(
-            "panel", db.metadata,
+            "panel",
+            db.metadata,
             Column("id", BigInteger, primary_key=True),
             Column("data_id", String(255)),
             Column("P01033_TIMP1", String(255)),
@@ -275,7 +287,8 @@ def test_create_table_existing_schema_mismatch_fails_fast(db):
 
     def fake_reflect(engine, only=None):
         Table(
-            "IBD_Biomarker", db.metadata,
+            "IBD_Biomarker",
+            db.metadata,
             Column("id", BigInteger, primary_key=True),
             Column("data_id", String(255)),
             Column("P02452|COL1A1", String(255)),  # original header (stale table)
@@ -290,6 +303,7 @@ def test_create_table_existing_schema_mismatch_fails_fast(db):
 # ---------------------------------------------------------------------------
 # insert_batch
 # ---------------------------------------------------------------------------
+
 
 def _seed_table(db):
     db.metadata.create_all = MagicMock()
@@ -382,12 +396,14 @@ def test_insert_batch_connection_error(db, mock_engine_factory):
 # Transient DB retry via tenacity — backend/#772 P2
 # ---------------------------------------------------------------------------
 
+
 def test_insert_batch_retries_on_transient_operational_error(db, mock_engine_factory):
     """A transient MySQL hiccup (server-gone-away, lost connection,
     deadlock) used to fail every in-flight batch permanently. tenacity
     now retries up to 3 attempts with exponential backoff; the second
     attempt succeeds in this test."""
     from sqlalchemy.exc import OperationalError
+
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
 
@@ -423,6 +439,7 @@ def test_insert_batch_does_not_retry_permanent_error_falls_to_per_row(
     straight through to the existing per-row fallback path so the
     offending record can be identified."""
     from sqlalchemy.exc import IntegrityError
+
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
 
@@ -453,12 +470,11 @@ def test_insert_batch_gives_up_after_max_retries(db, mock_engine_factory):
     to the per-row path (which will see the same error and record the
     failure)."""
     from sqlalchemy.exc import OperationalError
+
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
 
-    err = OperationalError(
-        "INSERT …", {}, Exception("MySQL server has gone away")
-    )
+    err = OperationalError("INSERT …", {}, Exception("MySQL server has gone away"))
 
     def execute_side_effect(stmt, *a, **k):
         raise err
@@ -482,6 +498,7 @@ def test_insert_batch_rolls_back_between_transient_retries(db, mock_engine_facto
     is reset before the retry runs.
     """
     from sqlalchemy.exc import OperationalError
+
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
 
@@ -513,14 +530,15 @@ def test_insert_batch_rolls_back_between_transient_retries(db, mock_engine_facto
     # before re-raising for the next retry. Two failures -> at least two
     # rollback calls (plus the outer commit-or-rollback path's own).
     rollback_count = sum(1 for e in events if e == "rollback")
-    assert rollback_count >= 2, (
-        f"expected at least 2 rollbacks between retries; events={events}"
-    )
+    assert (
+        rollback_count >= 2
+    ), f"expected at least 2 rollbacks between retries; events={events}"
 
 
 # ---------------------------------------------------------------------------
 # get_table_schema
 # ---------------------------------------------------------------------------
+
 
 def test_get_table_schema_reflected_dialect_types(db):
     """Regression: ``inspector.get_columns()`` against a real MySQL returns
@@ -571,6 +589,7 @@ def test_get_table_schema_generic_types(db):
     """Generic (in-process) SQLAlchemy types map to the same MySQL vocabulary
     as their reflected dialect counterparts."""
     inspector = MagicMock()
+
     class Weird:  # unknown SQLAlchemy type, no 'length' attribute
         pass
 
@@ -630,6 +649,7 @@ def test_create_table_rejects_overlong_column_name():
 # ---------------------------------------------------------------------------
 # upsert quoting (regression): special-character column names
 # ---------------------------------------------------------------------------
+
 
 def test_upsert_backtick_quotes_special_char_columns_in_values_clause():
     """ON DUPLICATE KEY UPDATE must backtick-quote the column name inside
@@ -725,9 +745,9 @@ def test_upsert_doubles_embedded_backticks_in_column_name():
         for column in table.columns
         if column.name not in ["id", "created_at", "data_id"]
     }
-    stmt = insert_stmt.values(
-        [{"data_id": "x", weird: 1.0}]
-    ).on_duplicate_key_update(**update_dict)
+    stmt = insert_stmt.values([{"data_id": "x", weird: 1.0}]).on_duplicate_key_update(
+        **update_dict
+    )
     sql = str(stmt.compile(dialect=mysql.dialect()))
 
     # Escaped form ` -> `` is present.
@@ -747,7 +767,7 @@ def test_get_samples_null_label_normalised_to_empty_string(db, mock_engine_facto
     convention the old per-row API always sent when no label was present)."""
     _, _, conn = mock_engine_factory
     conn.execute.return_value.fetchall.return_value = [
-        ("id-1", None),   # self-supervised / no label column → SQL NULL
+        ("id-1", None),  # self-supervised / no label column → SQL NULL
         ("id-2", "cat"),
     ]
     result = db.get_samples("tbl", "ing-uuid")
@@ -757,12 +777,14 @@ def test_get_samples_null_label_normalised_to_empty_string(db, mock_engine_facto
     ]
 
 
-def test_get_label_counts_null_label_normalised_to_empty_string(db, mock_engine_factory):
+def test_get_label_counts_null_label_normalised_to_empty_string(
+    db, mock_engine_factory
+):
     """SQL NULL and '' both map to '' so they merge into a single count."""
     _, _, conn = mock_engine_factory
     conn.execute.return_value.fetchall.return_value = [
         (None, 3),
-        ("",   2),
+        ("", 2),
         ("cat", 5),
     ]
     result = db.get_label_counts("tbl", "ing-uuid")
@@ -994,9 +1016,7 @@ def test_reclaim_dead_run_rows_noop_when_nothing_dead(db, mock_engine_factory):
     delete.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "reserved", ["tracebloc_ingest_meta", "tracebloc_ingest_runs"]
-)
+@pytest.mark.parametrize("reserved", ["tracebloc_ingest_meta", "tracebloc_ingest_runs"])
 def test_create_table_rejects_reserved_bookkeeping_tables(reserved):
     """The salt store (#225) and the run journal (backend#1028) share the
     cluster MySQL with dataset tables — a dataset must not be able to claim
@@ -1061,7 +1081,9 @@ def test_list_dataset_ingestor_ids_scans_tables_excluding_framework(
 
     executed = _executed_sql(conn)
     # Discovery query hit information_schema for the ingestor_id column.
-    assert any("information_schema.columns" in s and "ingestor_id" in s for s in executed)
+    assert any(
+        "information_schema.columns" in s and "ingestor_id" in s for s in executed
+    )
     # The framework run-journal table was skipped — never SELECTed as a dataset.
     assert not any("`tracebloc_ingest_runs`" in s for s in executed)
     # Per-dataset-table id scans excluded null/empty ids.

--- a/tests/test_file_transfer_failure_modes.py
+++ b/tests/test_file_transfer_failure_modes.py
@@ -170,3 +170,62 @@ def test_segmentation_missing_mask_leaves_no_orphan(dirs):
     )
     assert rec is None
     assert not dest.exists() or not any(dest.iterdir())
+
+
+# --- client#653: the teardown runs as a DIFFERENT uid, so group-write is not enough
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root's created dirs ignore umask/perms nuances",
+)
+def test_ensure_dest_dir_is_world_writable_not_just_group_writable(tmp_path):
+    """Removing a file needs write on its PARENT DIR, and the pods that create
+    and delete these trees never share an identity: the ingestion Job runs as
+    65534 (or HOST_UID), the CLI teardown pod as 65532/fsGroup 65532, and the
+    chart chowns the shared mount to 1000:1000 with setgid -- so a dir created
+    underneath inherits group 1000, never 65532.
+
+    Group-write therefore could not work, and fsGroup cannot rescue it because
+    kubelet ignores fsGroup on hostPath volumes (kubernetes#138411) -- the layout
+    every installer-provisioned cluster uses. The observed failure was
+    "rm: can't remove '/data/shared/<table>/<file>': Permission denied" with the
+    table already dropped, leaving a half-deleted dataset.
+    """
+    dest = tmp_path / "storage" / "tbl"
+    file_transfer._ensure_dest_dir(str(dest))
+    mode = os.stat(dest).st_mode
+    assert mode & 0o002, "other-write must be set: the teardown uid shares no group"
+    assert mode & 0o001, "other-execute must be set, or the dir cannot be traversed"
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root's created dirs ignore umask/perms nuances",
+)
+def test_duplicate_validator_creates_dest_reclaimable_too(tmp_path):
+    """The duplicate validator creates the SAME DEST_PATH and runs BEFORE the
+    transfer, so it decides the mode -- and _ensure_dest_dir deliberately does not
+    re-chmod a dir that already exists. While this used a bare mkdir, the mode fix
+    in file_transfer was dead code on every run that validated first: the tree was
+    left at the umask default and the teardown could not remove it (client#653).
+    """
+    from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
+
+    dest = tmp_path / "storage" / "tbl"
+    validator = DuplicateValidator(dest_path=str(dest))
+    assert validator._create_directory_if_needed() is True
+    mode = os.stat(dest).st_mode
+    assert mode & 0o002, "the validator-created dir must be reclaimable as well"
+    assert mode & 0o2000, "setgid, so entries keep inheriting the mount's group"
+
+
+def test_both_creation_sites_share_one_mode_definition():
+    """Two independent copies of this mode would drift, and the drift is invisible
+    until a delete fails in the field. Both sites must resolve to the same object.
+    """
+    from tracebloc_ingestor.utils import fs
+    from tracebloc_ingestor.validators import duplicate_validator
+
+    assert file_transfer.DEST_DIR_MODE is fs.DEST_DIR_MODE
+    assert duplicate_validator.ensure_reclaimable_dir is fs.ensure_reclaimable_dir

--- a/tests/test_no_hardcoded_secrets.py
+++ b/tests/test_no_hardcoded_secrets.py
@@ -12,29 +12,30 @@ from pathlib import Path
 
 import pytest
 
-
 # Strings that previously shipped as hardcoded defaults for the **backend**
 # (tracebloc API) credentials in `tracebloc_ingestor/config.py`. These are
 # real per-customer credentials — shipping a default value made every install
 # ship the same secret. If this reappears anywhere in the package source, the
 # test fails, even in a comment.
 #
-# NOTE: `DB_PASSWORD` ("Edg9@Tr@ce") and `DB_USER` ("edgeuser") are
-# intentionally **not** in these lists. They're connection conventions for
-# the cluster-internal MySQL container, which bakes the same values into its
-# own image. They never vary per customer and don't leave the cluster, so
-# shipping them as defaults in `config.py` is correct, not a leak. See the
-# database-section comment in `config.py` and `Config.validate()` for the
-# rationale.
+# `Edg9@Tr@ce` is the legacy root-equivalent `edgeuser` password that DB_USER/
+# DB_PASSWORD used to fall back to. That fallback was removed in backend#1528
+# (D10 close-out): jobs-manager now injects per-Job tb_ingest credentials, so
+# the ingestor no longer connects as edgeuser and this password must never be
+# baked into source again. (`edgeuser` the username is guarded below.)
 KNOWN_LEAKED_SECRETS = (
     "&6edg*D9e16",
+    "Edg9@Tr@ce",
 )
 
-# Username default for the backend (tracebloc API) credential. Not secret on
-# its own, but paired with the leaked password above it formed a working
-# credential in legacy local dev — shouldn't be baked into source either.
+# Usernames that must not be baked into source. `testedge` was a legacy
+# backend (tracebloc API) default that — paired with the leaked password
+# above — formed a working credential in local dev. `edgeuser` is the
+# root-equivalent MySQL identity retired in backend#1528; DB_USER now comes
+# from the injected per-Job env, never a hardcoded default.
 LEGACY_USERNAME_DEFAULTS = (
     "testedge",
+    "edgeuser",
 )
 
 

--- a/tests/test_per_ingestion_tables.py
+++ b/tests/test_per_ingestion_tables.py
@@ -185,7 +185,9 @@ def mock_engine_factory():
 
 @pytest.fixture
 def db(mock_engine_factory):
-    return Database(Config(EDGE_ENV="local"))
+    # DB_USER/DB_PASSWORD are required (backend#1528 removed the edgeuser
+    # fallback); the engine is mocked so the values are arbitrary.
+    return Database(Config(EDGE_ENV="local", DB_USER="tb_ingest", DB_PASSWORD="pw"))
 
 
 def test_create_table_must_not_exist_rejects_cached_table(db):

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -107,10 +107,38 @@ class Config:
                 f"{env_name} environment variable to a valid integer."
             )
 
+    @staticmethod
+    def _require_env(env_name: str) -> str:
+        """Read a required DB-credential env var, failing fast if unset
+        (backend#1528).
+
+        DB_USER / DB_PASSWORD used to fall back to the root-equivalent
+        edgeuser identity. That fallback is gone: jobs-manager now injects
+        the per-Job tb_ingest credentials into the ingestion Job's env, so an
+        unset value means a misconfigured Job, not a cue to use edgeuser. Raise
+        a message that names the variable rather than letting SQLAlchemy
+        surface an opaque access-denied (or, worse, silently connecting as the
+        legacy identity).
+        """
+        val = os.environ.get(env_name)
+        if not val:
+            raise ValueError(
+                f"{env_name} is not set. The ingestor authenticates to MySQL "
+                f"as the identity jobs-manager injects per-Job (backend#1528: "
+                f"tb_ingest); set the {env_name} environment variable. The "
+                f"legacy edgeuser fallback was removed once per-Job "
+                f"credentials shipped."
+            )
+        return val
+
     # ===== Database =====
-    # Cluster-internal MySQL ships with these credentials baked into its
-    # image; they're connection conventions, not secrets. Override via env
-    # only if you've replaced the bundled MySQL.
+    # DB_HOST/DB_PORT/DB_NAME are connection conventions for the
+    # cluster-internal MySQL and keep their defaults. DB_USER/DB_PASSWORD do
+    # NOT: the ingestor authenticates as the identity jobs-manager injects
+    # per-Job (backend#1528 — tb_ingest, scoped to training_test_datasets).
+    # The legacy root-equivalent edgeuser fallback was removed here once
+    # those per-Job credentials shipped; both are now required from env and
+    # fail fast if unset rather than silently connecting as the old identity.
     @property
     def DB_HOST(self) -> str:
         ov = self._override("DB_HOST")
@@ -125,12 +153,12 @@ class Config:
     @property
     def DB_USER(self) -> str:
         ov = self._override("DB_USER")
-        return ov if ov is not _MISSING else os.environ.get("DB_USER", "edgeuser")
+        return ov if ov is not _MISSING else self._require_env("DB_USER")
 
     @property
     def DB_PASSWORD(self) -> str:
         ov = self._override("DB_PASSWORD")
-        return ov if ov is not _MISSING else os.environ.get("DB_PASSWORD", "Edg9@Tr@ce")
+        return ov if ov is not _MISSING else self._require_env("DB_PASSWORD")
 
     @property
     def DB_NAME(self) -> str:
@@ -311,15 +339,18 @@ class Config:
         module-level ``Config()`` instantiations elsewhere in the package
         don't blow up at import time.
 
-        In any non-local environment, the pod must boot with either:
-          - ``BACKEND_TOKEN`` (preferred), or
-          - ``CLIENT_ID`` + ``CLIENT_PASSWORD`` (deprecated fallback).
+        In any non-local environment, the pod must boot with:
+          - ``BACKEND_TOKEN`` (preferred) or ``CLIENT_ID`` +
+            ``CLIENT_PASSWORD`` (deprecated fallback) for backend auth, and
+          - ``DB_USER`` + ``DB_PASSWORD`` for MySQL.
 
-        Database credentials are intentionally **not** validated here: the
-        bundled MySQL container ships with fixed credentials that the
-        ingestor defaults match. They're a connection convention, not a
-        secret, and forcing customers to set them in env vars adds friction
-        with no security benefit.
+        Database credentials are required as of backend#1528 (D10): the
+        root-equivalent ``edgeuser`` fallback was removed, so the ingestor
+        authenticates as the identity jobs-manager injects per-Job
+        (``tb_ingest``). They are NOT re-checked here — this method is
+        auth-scoped — but ``Config.DB_USER`` / ``DB_PASSWORD`` fail fast on
+        first access (``Database()`` init) via ``_require_env`` with a message
+        naming the unset variable, so a misconfigured Job still surfaces early.
 
         Set ``CLIENT_ENV=local`` to bypass for development against a mock
         backend.

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -20,6 +20,8 @@ from tenacity import (
 )
 
 from tracebloc_ingestor import Config
+from tracebloc_ingestor.utils.fs import DEST_DIR_MODE as _DEST_DIR_MODE
+from tracebloc_ingestor.utils.fs import ensure_reclaimable_dir
 from tracebloc_ingestor.utils.constants import (
     GREEN,
     RED,
@@ -42,34 +44,20 @@ logger.setLevel(config.LOG_LEVEL)
 # (uid/gid 65532, client-runtime#172). On a hostPath dataset the kubelet ignores
 # that pod's fsGroup, so the ingest side must leave the destination tree
 # group-owned by, and group-writable for, that group — otherwise the teardown
-# can't remove the files and they leak (remainder of client#259). Create the
-# destination dir setgid + group-writable so new entries inherit the group and
-# the group can delete them, regardless of the writing uid. 0o2775 = rwxrwsr-x.
-DEST_DIR_MODE = 0o2775
+# can't remove the files and they leak (remainder of client#259). The rule now
+# lives in utils/fs.py so the duplicate validator -- which creates the SAME
+# destination directory, and gets there first -- applies it too. Re-exported here
+# because callers and tests already reference these names.
+DEST_DIR_MODE = _DEST_DIR_MODE
 
 
 def _ensure_dest_dir(path: str) -> None:
-    """Create ``path`` if absent, setgid + group-writable, so the ``data
-    delete`` teardown group can reclaim the tree (#172).
+    """Create ``path`` reclaimable by the `data delete` teardown (#172).
 
-    Only a directory we *create* is chmod'd — a pre-existing one is left as-is,
-    so we neither override an operator's deliberate mode nor mask a genuine
-    permission problem (an unwritable dest still surfaces downstream). The chmod
-    is best-effort: a failure is logged, not fatal, so ingestion still proceeds.
+    Thin delegation to :func:`ensure_reclaimable_dir`; see utils/fs.py for why
+    the mode is world-writable rather than group-writable.
     """
-    existed = os.path.isdir(path)
-    os.makedirs(path, exist_ok=True)
-    if existed:
-        return
-    try:
-        os.chmod(path, DEST_DIR_MODE)
-    except OSError as error:
-        logger.warning(
-            "Could not set group-writable/setgid mode on %s (%s); the `data "
-            "delete` teardown may not be able to reclaim it",
-            path,
-            error,
-        )
+    ensure_reclaimable_dir(path)
 
 
 # Define retry decorator for file operations

--- a/tracebloc_ingestor/utils/fs.py
+++ b/tracebloc_ingestor/utils/fs.py
@@ -1,0 +1,65 @@
+"""Filesystem helpers shared by the validators and the transfer path.
+
+Home of the one rule about destination directories that both sides must follow:
+a directory the ingestor creates has to stay reclaimable by the `data delete`
+teardown, which runs as a DIFFERENT uid in a different pod.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Mode for a destination directory the ingestor creates.
+#
+# 0o2777 = rwxrwsrwx: setgid, plus write for group AND other.
+#
+# Why world-write and not the tighter group-write (0o2775) this used to be:
+# removing a file requires write+execute on its PARENT DIRECTORY, and the
+# processes that create and delete these trees are different pods running as
+# different, non-overlapping identities:
+#
+#   * the ingestion Job runs as uid 65534 (`nobody`) by default, or HOST_UID on
+#     a network export (client-runtime submit_ingestion_run.py);
+#   * the CLI's staging/teardown pod runs as uid 65532 with fsGroup 65532
+#     (cli internal/push/pod.go);
+#   * the chart chowns the shared mount itself to 1000:1000 and sets setgid, so
+#     a directory created underneath INHERITS group 1000 -- not 65532.
+#
+# So group-write could never help: the group the teardown pod carries (65532) is
+# not the group the directory inherits (1000). And the usual fix for that --
+# fsGroup, which makes kubelet recursively chgrp the volume -- does nothing here,
+# because kubelet IGNORES fsGroup on hostPath volumes
+# (kubernetes/kubernetes#138411), the layout every installer-provisioned cluster
+# uses. Nothing at ingest time can know or align those identities, and the parent
+# mount is already world-writable by chart design, so world-write on the
+# directory is both the only mode that works for every caller and no wider a
+# grant than the tree it sits in.
+DEST_DIR_MODE = 0o2777
+
+
+def ensure_reclaimable_dir(path: str) -> None:
+    """Create ``path`` if absent, with a mode the teardown can reclaim.
+
+    Only a directory we *create* is chmod'd. A pre-existing one is left alone so
+    we neither override an operator's deliberate mode nor mask a genuine
+    permission problem -- an unwritable destination still surfaces downstream.
+    (A directory left behind by an older ingestor keeps its old mode; repairing
+    those is the installer's job, not a silent chmod of data we did not create.)
+
+    The chmod is best-effort: a failure is logged, never fatal, so ingestion
+    still proceeds on a filesystem that cannot represent the mode at all.
+    """
+    existed = os.path.isdir(path)
+    os.makedirs(path, exist_ok=True)
+    if existed:
+        return
+    try:
+        os.chmod(path, DEST_DIR_MODE)
+    except OSError as error:
+        logger.warning(
+            "Could not set the reclaimable mode on %s (%s); the `data delete` "
+            "teardown may not be able to remove it",
+            path,
+            error,
+        )

--- a/tracebloc_ingestor/validators/duplicate_validator.py
+++ b/tracebloc_ingestor/validators/duplicate_validator.py
@@ -10,6 +10,7 @@ import logging
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
+from ..utils.fs import ensure_reclaimable_dir
 
 config = Config()
 logger = logging.getLogger(__name__)
@@ -203,7 +204,15 @@ class DuplicateValidator(BaseValidator):
         try:
             dest_path = Path(self.dest_path)
             if not dest_path.exists():
-                dest_path.mkdir(parents=True, exist_ok=True)
+                # Shared helper, not a bare mkdir: validation runs BEFORE the
+                # transfer, so whoever creates this directory first decides its
+                # mode -- and file_transfer deliberately does not re-chmod a
+                # directory that already exists. A bare mkdir here therefore left
+                # the tree at the umask default (0755, owned by the ingest uid),
+                # which the `data delete` teardown pod -- a different uid -- cannot
+                # remove: "rm: can't remove ...: Permission denied", with the
+                # table already dropped. See utils/fs.py.
+                ensure_reclaimable_dir(str(dest_path))
                 logger.info(f"Created destination directory: {self.dest_path}")
             return True
         except Exception as e:


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes implicit DB login (misconfigured Jobs fail at startup) and widens permissions on newly created dataset directories; both are intentional but affect every ingestion and custom Job manifest.
> 
> **Overview**
> **Release train promotion** bundling ingestor **0.8.5** with two operational fixes.
> 
> **MySQL credentials (backend#1528):** `DB_USER` and `DB_PASSWORD` no longer default to the legacy `edgeuser` / built-in password. `Config` uses `_require_env()` so missing vars raise a clear error at first access (typically `Database()` init). Docs and `ingestor-job.yaml` now require explicit creds (e.g. `tb_ingest` from the release secrets). Hardcoded-secret guards treat `edgeuser` and `Edg9@Tr@ce` as banned literals.
> 
> **Dataset delete / teardown (client#653):** Destination dirs created during ingest move from group-writable `0o2775` to **`0o2777` (setgid + world write/execute)** so the CLI `data delete` pod (different UID than the ingestion Job, hostPath without fsGroup) can remove files. Logic is centralized in `tracebloc_ingestor/utils/fs.py`; **`DuplicateValidator`** uses the same helper because it often creates the dest tree before transfer and previously left `0755` dirs that teardown could not delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 718aa61857d7a7ee0bc0cf3d4153f060e7b14c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->