### PR TITLE
docs(job): set the now-required DB_USER/DB_PASSWORD in the custom-Job path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -129,6 +129,7 @@ The Job needs these environment variables (set in [`ingestor-job.yaml`](ingestor
 | `CLIENT_ID`, `CLIENT_PASSWORD` | Tracebloc client credentials |
 | `CLIENT_PVC` | PVC name shared with the client (must match `values.yaml`) |
 | `MYSQL_HOST` | Hostname of the client's MySQL service |
+| `DB_USER`, `DB_PASSWORD` | **Required.** Credentials for the dataset database. There is no built-in fallback account — the Job fails at startup without these. On installs with `serviceDbAccounts: true`, use the generated `tb_ingest` account (password in the `<release-name>-secrets` Secret, key `TB_INGEST_PASSWORD`). |
 | `SRC_PATH` | Where your raw data is mounted in the ingestor pod |
 | `LABEL_FILE` | Path to labels (e.g. `Xy_train.csv`) |
 | `TABLE_NAME` | Destination table name in the client database |

--- a/ingestor-job.yaml
+++ b/ingestor-job.yaml
@@ -32,6 +32,21 @@ spec:
           value: "client-pvc"
         - name: MYSQL_HOST
           value: "mysql-client"
+        # Dataset-DB credentials. REQUIRED: the ingestor no longer falls back to
+        # a built-in account, so `Database()` init fails without these.
+        - name: DB_USER
+          value: "<replace_with_db_user>"
+        - name: DB_PASSWORD
+          value: "<replace_with_db_password>"
+        # On installs with `serviceDbAccounts: true` in the client's values.yaml,
+        # use the generated tb_ingest account instead of a literal password:
+        # - name: DB_USER
+        #   value: "tb_ingest"
+        # - name: DB_PASSWORD
+        #   valueFrom:
+        #     secretKeyRef:
+        #       name: <release-name>-secrets
+        #       key: TB_INGEST_PASSWORD
         - name: SRC_PATH
           value: "/data" # Source folder path whithin the data ingestor
         - name: LABEL_FILE


### PR DESCRIPTION
## Why

Dropping the built-in account fallback made `DB_USER`/`DB_PASSWORD` **required**, but the documented custom-processor flow never set them — `ingestor-job.yaml` and the README env table both omitted the pair, so following that canonical path now fails at `Database()` init. (Flagged by Bugbot on the develop→staging mirror #479, which is currently held out of the staging hop.)

The security change itself is right; only the docs/manifest lagged it.

## What

- **`ingestor-job.yaml`** — adds `DB_USER` / `DB_PASSWORD` beside `MYSQL_HOST`, using the file's existing `<replace_with_...>` placeholder convention, with a note that there is no fallback.
- **README env table** — adds the pair, marked required.
- For installs running `serviceDbAccounts: true`, a commented `secretKeyRef` shows the generated `tb_ingest` account (key `TB_INGEST_PASSWORD` in the `<release-name>-secrets` Secret) instead of a literal password.

Deliberately placeholders rather than a hardcoded `secretKeyRef`: `serviceDbAccounts` defaults to **false**, so `tb_ingest` does not exist on a default install — pointing every user at that Secret would document something most clusters don't have.

## Test plan

- `ingestor-job.yaml` parses; env list is `CLIENT_ID, CLIENT_PASSWORD, CLIENT_PVC, MYSQL_HOST, DB_USER, DB_PASSWORD, SRC_PATH, LABEL_FILE, TABLE_NAME, TITLE, LOG_LEVEL`.
- No literal credential committed (placeholders only).
- README table renders intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example manifest placeholders only; no runtime or credential changes in code.
> 
> **Overview**
> Documents that **`DB_USER` and `DB_PASSWORD` are mandatory** for the legacy custom-processor Kubernetes Job path, matching the ingestor behavior where **`Database()` init fails** if they are missing (no built-in account fallback).
> 
> **`ingestor-job.yaml`** adds placeholder env vars next to `MYSQL_HOST`, plus commented **`secretKeyRef`** guidance for installs with **`serviceDbAccounts: true`** (`tb_ingest` / `TB_INGEST_PASSWORD`). The **README** env table gets the same pair, marked required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52cc6753964a4c8055e1bcfa4ab208b9db96398f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->