### PR TITLE
release-train: staging -> main

### DIFF
--- a/.github/workflows/add-to-kanban.yml
+++ b/.github/workflows/add-to-kanban.yml
@@ -10,7 +10,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/tracebloc/projects/2
           github-token: ${{ secrets.PROJECTS_KANBAN_TOKEN }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -183,7 +183,15 @@ jobs:
           # The CLI has no --help: main() expects INGEST_CONFIG and says so.
           output=$(docker run --rm --entrypoint tracebloc-ingest "${IMAGE}@${DIGEST}" 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q "INGEST_CONFIG"
+          # MATCHED FROM A HERE-STRING, NOT THROUGH A PIPE -- same reason as
+          # release-image.yml (backend#1778). `echo "$output" | grep -q` under
+          # `set -euo pipefail` lets `grep -q` close the pipe on its first match;
+          # once $output outgrows the pipe buffer the `echo` subshell takes
+          # SIGPIPE, pipefail reports 141 and errexit fails the step. $output is
+          # unbounded container stdout+stderr, so a verbose traceback is all it
+          # would take -- and a 141 here reads as a broken image, failing the
+          # channel publish for a race rather than a packaging break.
+          grep -q "INGEST_CONFIG" <<<"$output"
 
       - name: Export digest
         env:
@@ -251,7 +259,14 @@ jobs:
           out=$(docker buildx imagetools inspect "${IMAGE}:${TAG}")
           echo "$out"
           for arch in amd64 arm64; do
-            printf '%s' "$out" | grep -q "linux/${arch}" || {
+            # Here-string, not a pipe: the third instance of the same shape
+            # (backend#1778). `grep -q` closes the pipe on its first match and a
+            # `printf` subshell killed by SIGPIPE makes the pipeline 141, which
+            # `||` reads as "this arch is missing" -- failing a correctly
+            # published multi-arch index. `imagetools inspect` output is small,
+            # so this has never tipped; leaving one instance of the bug in a file
+            # being fixed for it is the part worth avoiding.
+            grep -q "linux/${arch}" <<<"$out" || {
               echo "::error::published ${IMAGE}:${TAG} is missing linux/${arch}"
               exit 1
             }

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -315,7 +315,19 @@ jobs:
             -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
           output=$(docker run --rm --entrypoint tracebloc-ingest "${IMAGE}@${DIGEST}" 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q "INGEST_CONFIG"
+          # MATCHED FROM A HERE-STRING, NOT THROUGH A PIPE. `echo "$output" |
+          # grep -q` under this step's `set -euo pipefail` is a trap: `grep -q`
+          # exits on its first match, and once $output no longer fits the pipe
+          # buffer the `echo` subshell dies of SIGPIPE, pipefail reports 141, and
+          # errexit fails the step (backend#1778). $output is `docker run ...
+          # 2>&1` -- measured at 147 bytes today against a 64 KiB buffer, so this
+          # is latent, not live. But it is unbounded container stdout+stderr and
+          # the match is on the FIRST line, so `grep -q` leaves early: one
+          # verbose traceback is all it would take to tip it. A 141
+          # here aborts the smoke gate before the cosign signing steps below, so
+          # the failure would read as "the image is broken" rather than "grep
+          # won the race". A here-string has no producer to signal.
+          grep -q "INGEST_CONFIG" <<<"$output"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -26,11 +26,18 @@ jobs:
         run: |
           set -euo pipefail
           changed="$(git diff --name-only "${BASE_SHA}...HEAD")"
-          if ! printf '%s\n' "$changed" | grep -qE '^tracebloc_ingestor/'; then
+          # Here-string, not a pipe: `grep -q` closes the pipe at its first
+          # match, and under `pipefail` a producer killed by SIGPIPE makes the
+          # pipeline status 141. `if !` reads that as "no match" and exits 0
+          # "guard N/A" -- the guard would silently PASS a PR that did change
+          # the package. This repo's path list is ~14 KB today, well under the
+          # 64 KB pipe buffer, so it is latent rather than live (backend#1778).
+          if ! grep -qE '^tracebloc_ingestor/' <<<"$changed"; then
             echo "No tracebloc_ingestor/ change in this PR — guard N/A."
             exit 0
           fi
-          if git diff "${BASE_SHA}...HEAD" -- tracebloc_ingestor/__init__.py | grep -qE '^\+__version__'; then
+          version_diff="$(git diff "${BASE_SHA}...HEAD" -- tracebloc_ingestor/__init__.py)"
+          if grep -qE '^\+__version__' <<<"$version_diff"; then
             echo "Package changed and __version__ was bumped. ✓"
             exit 0
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Python 3.11+, `sqlalchemy`, `mysql-connector-python`, `pandas`, `Pillow`, `reque
 ### Engineer kanban
 
 - Every ticket on the board carries a `Status` — no card sits at "No Status". New tickets start in `Backlog`. **Bugs are the exception:** label them `work-type:bug` (the Bug template does it) and put them straight into `Ready` — defects don't wait for refinement.
-- Picking up work: the team coordinates. `Ready` is the refined queue and the first choice when it's stocked; pulling from `Backlog` is normal when refinement hasn't caught up — say what you're taking.
+- Picking up work: the team coordinates. `Ready` is the refined queue — bugs excepted, per the line above — and the first choice when it's stocked; pulling from `Backlog` is normal when refinement hasn't caught up — say what you're taking.
 - Merging to `develop` moves the card to `On dev` automatically; there is no dev-side review.
 - Functional review happens once, on staging: when it passes, comment `/fr-pass` on the PR or drag the card to `Ready for prod`. Self-signoff is allowed.
 - `fr-gate` is a required check on promotions. If it blocks, the board or the work isn't ready — fix that. `skip-fr-gate` is audited, for emergencies only.

--- a/Readme.md
+++ b/Readme.md
@@ -129,6 +129,7 @@ The Job needs these environment variables (set in [`ingestor-job.yaml`](ingestor
 | `CLIENT_ID`, `CLIENT_PASSWORD` | Tracebloc client credentials |
 | `CLIENT_PVC` | PVC name shared with the client (must match `values.yaml`) |
 | `MYSQL_HOST` | Hostname of the client's MySQL service |
+| `DB_USER`, `DB_PASSWORD` | **Required.** Credentials for the dataset database. There is no built-in fallback account — the Job fails at startup without these. On installs with `serviceDbAccounts: true`, use the generated `tb_ingest` account (password in the `<release-name>-secrets` Secret, key `TB_INGEST_PASSWORD`). |
 | `SRC_PATH` | Where your raw data is mounted in the ingestor pod |
 | `LABEL_FILE` | Path to labels (e.g. `Xy_train.csv`) |
 | `TABLE_NAME` | Destination table name in the client database |

--- a/e2e/test_database_e2e.py
+++ b/e2e/test_database_e2e.py
@@ -9,6 +9,7 @@ for real, closing the gap between "every line executed" and "the DB behaves".
 Skipped unless a MySQL is reachable (see ``conftest.py``); CI runs it with a
 MySQL service in ``.github/workflows/e2e.yml``.
 """
+
 import os
 import uuid
 
@@ -21,8 +22,10 @@ from tracebloc_ingestor.database import Database
 
 def _query(sql):
     conn = mysql.connector.connect(
-        host=os.environ["MYSQL_HOST"], port=int(os.environ["MYSQL_PORT"]),
-        user=os.environ["DB_USER"], password=os.environ["DB_PASSWORD"],
+        host=os.environ["MYSQL_HOST"],
+        port=int(os.environ["MYSQL_PORT"]),
+        user=os.environ["DB_USER"],
+        password=os.environ["DB_PASSWORD"],
         database=os.environ["DB_NAME"],
     )
     cur = conn.cursor()
@@ -53,7 +56,9 @@ def _rec(data_id, **cols):
 def test_create_table_and_insert_roundtrip(db, table):
     """CREATE TABLE + INSERT actually run, and values come back intact."""
     db.create_table(table, {"feature": "FLOAT"})
-    ids, failures = db.insert_batch(table, [_rec("a", feature=1.5), _rec("b", feature=2.5)])
+    ids, failures = db.insert_batch(
+        table, [_rec("a", feature=1.5), _rec("b", feature=2.5)]
+    )
     assert failures == []
     assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2
     vals = sorted(r[0] for r in _query(f"SELECT feature FROM `{table}`"))
@@ -77,14 +82,16 @@ def test_partial_batch_falls_back_without_duplicating_good_rows(db, table):
     batch = [_rec("ok1", feature=1), _rec(None, feature=2), _rec("ok2", feature=3)]
     ids, failures = db.insert_batch(table, batch)
     assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2  # ok1 + ok2, once each
-    assert len(failures) == 1                                    # the NULL-data_id row
+    assert len(failures) == 1  # the NULL-data_id row
 
 
 def test_non_ascii_data_roundtrip(db, table):
     """Non-ASCII values (German umlauts) survive the real INSERT/SELECT."""
     db.create_table(table, {"name": "VARCHAR(64)"})
     db.insert_batch(table, [_rec("u", name="Größe-Meßwert")])
-    assert _query(f"SELECT name FROM `{table}` WHERE data_id='u'")[0][0] == "Größe-Meßwert"
+    assert (
+        _query(f"SELECT name FROM `{table}` WHERE data_id='u'")[0][0] == "Größe-Meßwert"
+    )
 
 
 def test_get_table_schema_reports_real_mysql_types(db, table):
@@ -97,14 +104,17 @@ def test_get_table_schema_reports_real_mysql_types(db, table):
     catch that — it fed generic types into a fake inspector. This is the
     test shape that does: declared type in, real CREATE TABLE, real
     reflection out."""
-    db.create_table(table, {
-        "f_int": "INT",
-        "f_float": "FLOAT",
-        "f_dec": "DECIMAL(10,2)",
-        "f_bool": "BOOLEAN",
-        "f_dt": "DATETIME",
-        "f_name": "VARCHAR(64)",
-    })
+    db.create_table(
+        table,
+        {
+            "f_int": "INT",
+            "f_float": "FLOAT",
+            "f_dec": "DECIMAL(10,2)",
+            "f_bool": "BOOLEAN",
+            "f_dt": "DATETIME",
+            "f_name": "VARCHAR(64)",
+        },
+    )
     schema = db.get_table_schema(table)
     assert schema["f_int"] == "INT"
     assert schema["f_float"] == "FLOAT"
@@ -124,7 +134,6 @@ def test_content_hash_retry_reclaims_rows_instead_of_duplicating(db, table):
     the data_id UNIQUE upsert — row count stays constant and ownership moves
     to the retry's ingestor_id (whose scoped label counts then match)."""
     from tracebloc_ingestor.ingestors.record_processor import RecordProcessor
-    from tracebloc_ingestor.utils import label_policy as label_policy_module
 
     db.create_table(table, {"feature": "FLOAT"})
     salt = db.get_or_create_table_salt(table)
@@ -137,7 +146,6 @@ def test_content_hash_retry_reclaims_rows_instead_of_duplicating(db, table):
             label_column="target",
             annotation_column=None,
             unique_id_column=None,
-            label_policy=label_policy_module.PASSTHROUGH,
             ingestor_id=ingestor_id,
             data_id_strategy="content_hash",
             table_salt=salt,
@@ -149,10 +157,10 @@ def test_content_hash_retry_reclaims_rows_instead_of_duplicating(db, table):
             records.append(rec)
         db.insert_batch(table, records)
 
-    run("attempt-1")               # first attempt: rows land
+    run("attempt-1")  # first attempt: rows land
     assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2
 
-    run("attempt-2-retry")         # k8s Job retry: SAME content, new run id
+    run("attempt-2-retry")  # k8s Job retry: SAME content, new run id
     assert _query(f"SELECT COUNT(*) FROM `{table}`")[0][0] == 2  # no duplication
     owners = {r[0] for r in _query(f"SELECT ingestor_id FROM `{table}`")}
     assert owners == {"attempt-2-retry"}  # re-claimed by the retry

--- a/ingestor-job.yaml
+++ b/ingestor-job.yaml
@@ -32,6 +32,21 @@ spec:
           value: "client-pvc"
         - name: MYSQL_HOST
           value: "mysql-client"
+        # Dataset-DB credentials. REQUIRED: the ingestor no longer falls back to
+        # a built-in account, so `Database()` init fails without these.
+        - name: DB_USER
+          value: "<replace_with_db_user>"
+        - name: DB_PASSWORD
+          value: "<replace_with_db_password>"
+        # On installs with `serviceDbAccounts: true` in the client's values.yaml,
+        # use the generated tb_ingest account instead of a literal password:
+        # - name: DB_USER
+        #   value: "tb_ingest"
+        # - name: DB_PASSWORD
+        #   valueFrom:
+        #     secretKeyRef:
+        #       name: <release-name>-secrets
+        #       key: TB_INGEST_PASSWORD
         - name: SRC_PATH
           value: "/data" # Source folder path whithin the data ingestor
         - name: LABEL_FILE

--- a/templates/tabular_regression/README.md
+++ b/templates/tabular_regression/README.md
@@ -38,7 +38,7 @@ helm install my-regression-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Regression-class tasks require an explicit `label.policy` (typically `bucket`) so the central backend never sees raw target values — the schema enforces this. Canonical example: [`examples/yaml/tabular_regression.yaml`](../../examples/yaml/tabular_regression.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
+Regression-class tasks require an explicit `label.policy` (typically `bucket`) so the central backend never sees raw target values — the schema enforces this. Bucketing applies to the metadata payload only: the row stored in your cluster's MySQL keeps the raw target, which is what training reads (#486). Canonical example: [`examples/yaml/tabular_regression.yaml`](../../examples/yaml/tabular_regression.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/time_series_forecasting/README.md
+++ b/templates/time_series_forecasting/README.md
@@ -43,7 +43,7 @@ helm install my-forecast-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-Forecasting is a regression-class task — `label.policy: bucket` is required so the central backend never sees raw target values. Canonical example: [`examples/yaml/time_series_forecasting.yaml`](../../examples/yaml/time_series_forecasting.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
+Forecasting is a regression-class task — `label.policy: bucket` is required so the central backend never sees raw target values. Bucketing applies to the metadata payload only: the row stored in your cluster's MySQL keeps the raw target, which is what training reads (#486). Canonical example: [`examples/yaml/time_series_forecasting.yaml`](../../examples/yaml/time_series_forecasting.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/templates/time_to_event_prediction/README.md
+++ b/templates/time_to_event_prediction/README.md
@@ -39,7 +39,7 @@ helm install my-survival-dataset tracebloc/ingestor \
   --set-file ingestConfig=./ingest.yaml
 ```
 
-`time_column:` names the column that holds the time-to-event value. `label.policy: bucket` is required so the central backend never sees raw target values. Canonical example: [`examples/yaml/time_to_event_prediction.yaml`](../../examples/yaml/time_to_event_prediction.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
+`time_column:` names the column that holds the time-to-event value. `label.policy: bucket` is required so the central backend never sees raw target values. Bucketing applies to the metadata payload only: the row stored in your cluster's MySQL keeps the raw target, which is what training reads (#486). Canonical example: [`examples/yaml/time_to_event_prediction.yaml`](../../examples/yaml/time_to_event_prediction.yaml). Full chart docs: [`tracebloc/client/ingestor/README.md`](https://github.com/tracebloc/client/blob/develop/ingestor/README.md).
 
 ## Directory Structure
 

--- a/tests/test_api_client_auth.py
+++ b/tests/test_api_client_auth.py
@@ -11,9 +11,10 @@ Covers all three boot paths required by the #43 acceptance criteria:
 A fourth path — ``CLIENT_ENV=local`` — is also exercised because it bypasses
 both validation and the network entirely.
 
-Database credentials are intentionally **not** in the validation surface:
-they're connection conventions for the bundled MySQL container, not
-customer-facing secrets. See `Config.validate()` for the rationale.
+Database credentials (``DB_USER`` / ``DB_PASSWORD``) are required for a real
+run as of backend#1528 (the ``edgeuser`` fallback was removed — jobs-manager
+injects ``tb_ingest`` per-Job), but they are NOT part of this auth-scoped
+``validate()``; they fail fast at ``Database()`` init instead.
 """
 
 from __future__ import annotations
@@ -32,8 +33,8 @@ def _make_config(**overrides) -> Config:
 
     Default: a valid prod-like config with BACKEND_TOKEN set so ``validate()``
     passes; tests override only the auth fields they care about. DB creds are
-    not part of the validation surface (they're bundled-MySQL conventions),
-    so they're left to their env/property defaults here.
+    not part of ``validate()`` (it's auth-scoped) — they fail fast at
+    ``Database()`` init instead — so they're left unset here.
     """
     defaults = dict(
         BACKEND_TOKEN="test-token-abc",
@@ -181,8 +182,9 @@ class TestLocalModeBypassesValidation:
             CLIENT_PASSWORD=None,
         )
 
-        with patch.object(APIClient, "authenticate") as mock_auth, \
-             patch("requests.Session.post") as mock_post:
+        with patch.object(APIClient, "authenticate") as mock_auth, patch(
+            "requests.Session.post"
+        ) as mock_post:
             client = APIClient(config)
 
         mock_auth.assert_not_called()

--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -60,16 +60,23 @@ def test_authenticate_http_error_raises():
 
 def _summary_call(client):
     return client.send_ingest_summary(
-        table_name="tbl", ingestor_id="ing", labels={"cat": 1},
-        dataset_title="T", data_format="image", data_intent="train",
-        category="image_classification", schema={}, samples=[],
+        table_name="tbl",
+        ingestor_id="ing",
+        labels={"cat": 1},
+        dataset_title="T",
+        data_format="image",
+        data_intent="train",
+        category="image_classification",
+        schema={},
+        samples=[],
     )
 
 
 def test_send_ingest_summary_success():
     client = _client()
     with patch.object(
-        client.session, "post",
+        client.session,
+        "post",
         return_value=_resp(200, {"dataset_id": 1, "dataset_key": "key"}),
     ):
         result = _summary_call(client)
@@ -90,7 +97,8 @@ def test_send_ingest_summary_409_returns_existing_dataset():
     the client must return the existing dataset, not raise (issue #332)."""
     client = _client()
     with patch.object(
-        client.session, "post",
+        client.session,
+        "post",
         return_value=_resp(409, {"dataset_id": 7, "dataset_key": "existing"}),
     ):
         result = _summary_call(client)
@@ -110,7 +118,8 @@ def test_send_ingest_summary_payload_shape():
 
     client = _client()
     with patch.object(
-        client.session, "post",
+        client.session,
+        "post",
         return_value=_resp(200, {"dataset_id": 42, "dataset_key": "k"}),
     ) as post:
         client.send_ingest_summary(
@@ -127,8 +136,17 @@ def test_send_ingest_summary_payload_shape():
         )
 
     sent = _json.loads(post.call_args.kwargs["data"])
-    for key in ("ingestor_id", "labels", "dataset_title", "data_format",
-                "data_intent", "category", "schema", "samples", "meta_data"):
+    for key in (
+        "ingestor_id",
+        "labels",
+        "dataset_title",
+        "data_format",
+        "data_intent",
+        "category",
+        "schema",
+        "samples",
+        "meta_data",
+    ):
         assert key in sent, f"missing key: {key}"
     assert sent["meta_data"] == {"source": "test"}
 
@@ -196,7 +214,8 @@ def test_authed_request_passes_through_non_401_unchanged():
     failure — the per-call error handling already covers those."""
     client = _client()
     with patch.object(
-        client.session, "post",
+        client.session,
+        "post",
         return_value=_resp(200, {"dataset_id": 1, "dataset_key": "k"}),
     ) as post:
         _summary_call(client)
@@ -337,7 +356,9 @@ def test_send_metadata_backfill_payload_shape():
     def _capture(url, **kwargs):
         captured["url"] = url
         captured["data"] = kwargs.get("data")
-        return _resp(201, {"table_name": "tb", "created": False, "competitions_refolded": 0})
+        return _resp(
+            201, {"table_name": "tb", "created": False, "competitions_refolded": 0}
+        )
 
     with patch.object(client.session, "post", side_effect=_capture):
         client.send_metadata_backfill("tb", {"x": {"dtype": "int"}}, {"attributes": {}})
@@ -345,3 +366,132 @@ def test_send_metadata_backfill_payload_shape():
     assert captured["url"].endswith("/global_meta/metadata_backfill/tb/")
     sent = _json.loads(captured["data"])
     assert sent == {"schema": {"x": {"dtype": "int"}}, "meta_data": {"attributes": {}}}
+
+
+# ---------------------------------------------------------------------------
+# send_ingest_summary: the label-policy boundary (#486)
+# ---------------------------------------------------------------------------
+#
+# The policy is applied HERE and nowhere earlier — the row stored in the
+# cluster's MySQL keeps the raw target, which is what the training client reads.
+# These pin that both label-bearing payload fields go through it.
+
+
+def _captured_summary_payload(client, **overrides):
+    """POST the summary with a mocked session and return the decoded body."""
+    import json as _json
+
+    kwargs = dict(
+        table_name="tbl",
+        ingestor_id="ing",
+        labels={"1": 19, "0": 11},
+        dataset_title="T",
+        data_format="tabular",
+        data_intent="train",
+        category="time_to_event_prediction",
+        schema={},
+        samples=[{"data_id": "d1", "label": "1"}, {"data_id": "d2", "label": "0"}],
+    )
+    kwargs.update(overrides)
+    captured = {}
+
+    def _capture(url, **request_kwargs):
+        captured["data"] = request_kwargs.get("data")
+        return _resp(200, {"dataset_id": 1, "dataset_key": "key"})
+
+    with patch.object(client.session, "post", side_effect=_capture):
+        client.send_ingest_summary(**kwargs)
+    return _json.loads(captured["data"])
+
+
+def test_summary_default_policy_sends_raw_labels():
+    """Default is passthrough — classification payloads are unchanged."""
+    sent = _captured_summary_payload(_client())
+    assert sent["labels"] == {"1": 19, "0": 11}
+    assert [s["label"] for s in sent["samples"]] == ["1", "0"]
+
+
+def test_summary_bucket_policy_buckets_labels_and_samples():
+    from tracebloc_ingestor.utils.label_policy import BUCKET, apply
+
+    sent = _captured_summary_payload(_client(), label_policy=BUCKET)
+    # JSON object keys are strings, so compare against stringified bucket ids.
+    assert sent["labels"] == {str(apply("1", BUCKET)): 19, str(apply("0", BUCKET)): 11}
+    # Strings, not JSON numbers: data_samples[].label has always been a string
+    # (pre-#486 the bucket was read back out of the VARCHAR label column).
+    assert [s["label"] for s in sent["samples"]] == [
+        str(apply("1", BUCKET)),
+        str(apply("0", BUCKET)),
+    ]
+    assert all(isinstance(s["label"], str) for s in sent["samples"])
+    # ...and no raw target value survives anywhere in the body.
+    assert sent["labels"].keys() != {"1", "0"}
+
+
+def test_summary_bucket_policy_preserves_total_row_count():
+    from tracebloc_ingestor.utils.label_policy import BUCKET
+
+    sent = _captured_summary_payload(
+        _client(), labels={str(i): 1 for i in range(200)}, label_policy=BUCKET
+    )
+    assert sum(sent["labels"].values()) == 200
+
+
+def test_summary_does_not_mutate_the_callers_labels_or_samples():
+    """base.py reuses these for its own logging/stats after the call."""
+    from tracebloc_ingestor.utils.label_policy import BUCKET
+
+    labels = {"1": 19, "0": 11}
+    samples = [{"data_id": "d1", "label": "1"}]
+    _captured_summary_payload(
+        _client(), labels=labels, samples=samples, label_policy=BUCKET
+    )
+    assert labels == {"1": 19, "0": 11}
+    assert samples == [{"data_id": "d1", "label": "1"}]
+
+
+def test_summary_unknown_policy_raises_before_sending():
+    client = _client()
+    with patch.object(client.session, "post") as post:
+        with pytest.raises(ValueError, match="Unknown label policy"):
+            client.send_ingest_summary(
+                table_name="tbl",
+                ingestor_id="ing",
+                labels={"1": 1},
+                dataset_title="T",
+                data_format="tabular",
+                data_intent="train",
+                category="tabular_regression",
+                schema={},
+                samples=[],
+                label_policy="ohno",
+            )
+    post.assert_not_called()
+
+
+def test_summary_local_mode_still_applies_policy_to_its_log(caplog):
+    """The mock branch reports what WOULD ship: bucket collisions merge keys,
+    so the label count it logs is the post-policy one."""
+    import logging as _logging
+
+    from tracebloc_ingestor.utils.label_policy import BUCKET, apply
+
+    client = _client(EDGE_ENV="local")
+    labels = {str(i): 1 for i in range(200)}
+    expected_labels = len({apply(k, BUCKET) for k in labels})
+    with caplog.at_level(_logging.INFO, logger="tracebloc_ingestor.api.client"):
+        with patch.object(client.session, "post") as post:
+            client.send_ingest_summary(
+                table_name="tbl",
+                ingestor_id="ing",
+                labels=labels,
+                dataset_title="T",
+                data_format="tabular",
+                data_intent="train",
+                category="tabular_regression",
+                schema={},
+                samples=[],
+                label_policy=BUCKET,
+            )
+    post.assert_not_called()
+    assert f"200 rows across {expected_labels} label(s)" in caplog.text

--- a/tests/test_config_lazy.py
+++ b/tests/test_config_lazy.py
@@ -28,10 +28,21 @@ from tracebloc_ingestor.config import Config
 def clean_env(monkeypatch):
     """Strip the env vars these tests read/write."""
     for var in (
-        "SRC_PATH", "LABEL_FILE", "TABLE_NAME", "TITLE",
-        "BACKEND_TOKEN", "CLIENT_ID", "CLIENT_PASSWORD",
-        "CLIENT_ENV", "LOG_LEVEL", "BATCH_SIZE",
-        "MYSQL_HOST", "MYSQL_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
+        "SRC_PATH",
+        "LABEL_FILE",
+        "TABLE_NAME",
+        "TITLE",
+        "BACKEND_TOKEN",
+        "CLIENT_ID",
+        "CLIENT_PASSWORD",
+        "CLIENT_ENV",
+        "LOG_LEVEL",
+        "BATCH_SIZE",
+        "MYSQL_HOST",
+        "MYSQL_PORT",
+        "DB_USER",
+        "DB_PASSWORD",
+        "DB_NAME",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -169,7 +180,9 @@ def test_api_endpoint_follows_edge_env(clean_env, monkeypatch):
     assert config.API_ENDPOINT == "http://localhost:8000"
 
 
-@pytest.mark.parametrize("env,attr", [("MYSQL_PORT", "DB_PORT"), ("BATCH_SIZE", "BATCH_SIZE")])
+@pytest.mark.parametrize(
+    "env,attr", [("MYSQL_PORT", "DB_PORT"), ("BATCH_SIZE", "BATCH_SIZE")]
+)
 def test_non_numeric_int_field_raises_clear_error(clean_env, monkeypatch, env, attr):
     # A non-numeric MYSQL_PORT / BATCH_SIZE must surface a clear config error
     # naming the field, not a raw "invalid literal for int()" (#238).
@@ -184,3 +197,27 @@ def test_numeric_int_field_still_coerces(clean_env, monkeypatch):
     config = Config()
     assert config.DB_PORT == 3307
     assert config.BATCH_SIZE == 500
+
+
+@pytest.mark.parametrize("attr", ["DB_USER", "DB_PASSWORD"])
+def test_db_credentials_required_no_edgeuser_fallback(clean_env, attr):
+    """backend#1528: the root-equivalent 'edgeuser' fallback is gone. With the
+    env var unset, accessing DB_USER/DB_PASSWORD must fail fast with a message
+    naming the variable — never silently return the legacy edgeuser default."""
+    with pytest.raises(ValueError, match=f"{attr} is not set"):
+        getattr(Config(), attr)
+
+
+@pytest.mark.parametrize(
+    "attr,env,value",
+    [("DB_USER", "DB_USER", "tb_ingest"), ("DB_PASSWORD", "DB_PASSWORD", "s3cret")],
+)
+def test_db_credentials_flow_from_env(clean_env, monkeypatch, attr, env, value):
+    monkeypatch.setenv(env, value)
+    assert getattr(Config(), attr) == value
+
+
+def test_db_credentials_override_wins(clean_env):
+    config = Config(DB_USER="tb_ingest", DB_PASSWORD="s3cret")
+    assert config.DB_USER == "tb_ingest"
+    assert config.DB_PASSWORD == "s3cret"

--- a/tests/test_content_hash_data_id.py
+++ b/tests/test_content_hash_data_id.py
@@ -7,13 +7,10 @@ duplicating them. The per-table salt keeps ids unlinkable across tables and
 never leaves the cluster.
 """
 
-
 import pytest
 
 from tracebloc_ingestor.cli.conventions import resolve
 from tracebloc_ingestor.ingestors.record_processor import RecordProcessor
-from tracebloc_ingestor.utils import label_policy as label_policy_module
-
 
 SALT_A = "a" * 64
 SALT_B = "b" * 64
@@ -26,7 +23,6 @@ def make_processor(salt=SALT_A, strategy="content_hash", unique_id_column=None):
         label_column="target",
         annotation_column=None,
         unique_id_column=unique_id_column,
-        label_policy=label_policy_module.PASSTHROUGH,
         ingestor_id="run-1",
         data_id_strategy=strategy,
         table_salt=salt,
@@ -52,7 +48,6 @@ def test_same_record_same_salt_same_id_across_instances():
         label_column="target",
         annotation_column=None,
         unique_id_column=None,
-        label_policy=label_policy_module.PASSTHROUGH,
         ingestor_id="run-2-after-retry",  # different run
         data_id_strategy="content_hash",
         table_salt=SALT_A,
@@ -199,7 +194,9 @@ def _build(config):
 
     db = MagicMock()
     db.get_or_create_table_salt.return_value = SALT_A
-    return _build_ingestor(database=db, api_client=MagicMock(), resolved=resolve(config))
+    return _build_ingestor(
+        database=db, api_client=MagicMock(), resolved=resolve(config)
+    )
 
 
 @pytest.mark.parametrize("source_key", ["csv", "json"])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -42,12 +42,15 @@ def mock_engine_factory():
 
 @pytest.fixture
 def db(mock_engine_factory):
-    return Database(Config(EDGE_ENV="local"))
+    # DB_USER/DB_PASSWORD are required (backend#1528 removed the edgeuser
+    # fallback); the engine is mocked so the values are arbitrary.
+    return Database(Config(EDGE_ENV="local", DB_USER="tb_ingest", DB_PASSWORD="pw"))
 
 
 # ---------------------------------------------------------------------------
 # __init__ / _create_engine
 # ---------------------------------------------------------------------------
+
 
 def test_init_builds_engine(db, mock_engine_factory):
     ce, engine, conn = mock_engine_factory
@@ -63,18 +66,22 @@ def test_init_builds_engine(db, mock_engine_factory):
 # _get_sqlalchemy_type (pure)
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("mysql_type,expected_cls", [
-    ("INT", Integer),
-    ("INTEGER", Integer),
-    ("BIGINT", BigInteger),
-    ("TEXT", db_mod.Text),
-    ("FLOAT", db_mod.Float),
-    ("BOOLEAN", db_mod.Boolean),
-    ("DATE", db_mod.Date),
-    ("DATETIME", db_mod.DateTime),
-    ("TIMESTAMP", db_mod.DateTime),
-    ("TIME", db_mod.Time),
-])
+
+@pytest.mark.parametrize(
+    "mysql_type,expected_cls",
+    [
+        ("INT", Integer),
+        ("INTEGER", Integer),
+        ("BIGINT", BigInteger),
+        ("TEXT", db_mod.Text),
+        ("FLOAT", db_mod.Float),
+        ("BOOLEAN", db_mod.Boolean),
+        ("DATE", db_mod.Date),
+        ("DATETIME", db_mod.DateTime),
+        ("TIMESTAMP", db_mod.DateTime),
+        ("TIME", db_mod.Time),
+    ],
+)
 def test_get_sqlalchemy_type_mapping(db, mysql_type, expected_cls):
     result = db._get_sqlalchemy_type(mysql_type)
     # result may be a class or an instance depending on length handling.
@@ -134,12 +141,15 @@ def test_get_sqlalchemy_type_typo_no_suggestion_for_distant_input(db):
     assert "Did you mean" not in str(excinfo.value)
 
 
-@pytest.mark.parametrize("typo,suggestion", [
-    ("INTGER", "INTEGER"),
-    ("NUMRIC", "NUMERIC"),
-    ("BOLEAN", "BOOLEAN"),
-    ("VARCAHR", "VARCHAR"),
-])
+@pytest.mark.parametrize(
+    "typo,suggestion",
+    [
+        ("INTGER", "INTEGER"),
+        ("NUMRIC", "NUMERIC"),
+        ("BOLEAN", "BOOLEAN"),
+        ("VARCAHR", "VARCHAR"),
+    ],
+)
 def test_get_sqlalchemy_type_typo_suggestions_cover_common_mistakes(
     db, typo, suggestion
 ):
@@ -201,6 +211,7 @@ def test_get_sqlalchemy_type_char_bare(db):
 # create_table
 # ---------------------------------------------------------------------------
 
+
 def test_create_table_new(db):
     db.metadata.create_all = MagicMock()
     inspector = MagicMock()
@@ -244,7 +255,8 @@ def test_create_table_existing_matching_schema_reflects_ok(db):
 
     def fake_reflect(engine, only=None):
         Table(
-            "panel", db.metadata,
+            "panel",
+            db.metadata,
             Column("id", BigInteger, primary_key=True),
             Column("data_id", String(255)),
             Column("P01033_TIMP1", String(255)),
@@ -275,7 +287,8 @@ def test_create_table_existing_schema_mismatch_fails_fast(db):
 
     def fake_reflect(engine, only=None):
         Table(
-            "IBD_Biomarker", db.metadata,
+            "IBD_Biomarker",
+            db.metadata,
             Column("id", BigInteger, primary_key=True),
             Column("data_id", String(255)),
             Column("P02452|COL1A1", String(255)),  # original header (stale table)
@@ -290,6 +303,7 @@ def test_create_table_existing_schema_mismatch_fails_fast(db):
 # ---------------------------------------------------------------------------
 # insert_batch
 # ---------------------------------------------------------------------------
+
 
 def _seed_table(db):
     db.metadata.create_all = MagicMock()
@@ -382,12 +396,14 @@ def test_insert_batch_connection_error(db, mock_engine_factory):
 # Transient DB retry via tenacity — backend/#772 P2
 # ---------------------------------------------------------------------------
 
+
 def test_insert_batch_retries_on_transient_operational_error(db, mock_engine_factory):
     """A transient MySQL hiccup (server-gone-away, lost connection,
     deadlock) used to fail every in-flight batch permanently. tenacity
     now retries up to 3 attempts with exponential backoff; the second
     attempt succeeds in this test."""
     from sqlalchemy.exc import OperationalError
+
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
 
@@ -423,6 +439,7 @@ def test_insert_batch_does_not_retry_permanent_error_falls_to_per_row(
     straight through to the existing per-row fallback path so the
     offending record can be identified."""
     from sqlalchemy.exc import IntegrityError
+
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
 
@@ -453,12 +470,11 @@ def test_insert_batch_gives_up_after_max_retries(db, mock_engine_factory):
     to the per-row path (which will see the same error and record the
     failure)."""
     from sqlalchemy.exc import OperationalError
+
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
 
-    err = OperationalError(
-        "INSERT …", {}, Exception("MySQL server has gone away")
-    )
+    err = OperationalError("INSERT …", {}, Exception("MySQL server has gone away"))
 
     def execute_side_effect(stmt, *a, **k):
         raise err
@@ -482,6 +498,7 @@ def test_insert_batch_rolls_back_between_transient_retries(db, mock_engine_facto
     is reset before the retry runs.
     """
     from sqlalchemy.exc import OperationalError
+
     ce, engine, conn = mock_engine_factory
     _seed_table(db)
 
@@ -513,14 +530,15 @@ def test_insert_batch_rolls_back_between_transient_retries(db, mock_engine_facto
     # before re-raising for the next retry. Two failures -> at least two
     # rollback calls (plus the outer commit-or-rollback path's own).
     rollback_count = sum(1 for e in events if e == "rollback")
-    assert rollback_count >= 2, (
-        f"expected at least 2 rollbacks between retries; events={events}"
-    )
+    assert (
+        rollback_count >= 2
+    ), f"expected at least 2 rollbacks between retries; events={events}"
 
 
 # ---------------------------------------------------------------------------
 # get_table_schema
 # ---------------------------------------------------------------------------
+
 
 def test_get_table_schema_reflected_dialect_types(db):
     """Regression: ``inspector.get_columns()`` against a real MySQL returns
@@ -571,6 +589,7 @@ def test_get_table_schema_generic_types(db):
     """Generic (in-process) SQLAlchemy types map to the same MySQL vocabulary
     as their reflected dialect counterparts."""
     inspector = MagicMock()
+
     class Weird:  # unknown SQLAlchemy type, no 'length' attribute
         pass
 
@@ -630,6 +649,7 @@ def test_create_table_rejects_overlong_column_name():
 # ---------------------------------------------------------------------------
 # upsert quoting (regression): special-character column names
 # ---------------------------------------------------------------------------
+
 
 def test_upsert_backtick_quotes_special_char_columns_in_values_clause():
     """ON DUPLICATE KEY UPDATE must backtick-quote the column name inside
@@ -725,9 +745,9 @@ def test_upsert_doubles_embedded_backticks_in_column_name():
         for column in table.columns
         if column.name not in ["id", "created_at", "data_id"]
     }
-    stmt = insert_stmt.values(
-        [{"data_id": "x", weird: 1.0}]
-    ).on_duplicate_key_update(**update_dict)
+    stmt = insert_stmt.values([{"data_id": "x", weird: 1.0}]).on_duplicate_key_update(
+        **update_dict
+    )
     sql = str(stmt.compile(dialect=mysql.dialect()))
 
     # Escaped form ` -> `` is present.
@@ -747,7 +767,7 @@ def test_get_samples_null_label_normalised_to_empty_string(db, mock_engine_facto
     convention the old per-row API always sent when no label was present)."""
     _, _, conn = mock_engine_factory
     conn.execute.return_value.fetchall.return_value = [
-        ("id-1", None),   # self-supervised / no label column → SQL NULL
+        ("id-1", None),  # self-supervised / no label column → SQL NULL
         ("id-2", "cat"),
     ]
     result = db.get_samples("tbl", "ing-uuid")
@@ -757,12 +777,14 @@ def test_get_samples_null_label_normalised_to_empty_string(db, mock_engine_facto
     ]
 
 
-def test_get_label_counts_null_label_normalised_to_empty_string(db, mock_engine_factory):
+def test_get_label_counts_null_label_normalised_to_empty_string(
+    db, mock_engine_factory
+):
     """SQL NULL and '' both map to '' so they merge into a single count."""
     _, _, conn = mock_engine_factory
     conn.execute.return_value.fetchall.return_value = [
         (None, 3),
-        ("",   2),
+        ("", 2),
         ("cat", 5),
     ]
     result = db.get_label_counts("tbl", "ing-uuid")
@@ -994,9 +1016,7 @@ def test_reclaim_dead_run_rows_noop_when_nothing_dead(db, mock_engine_factory):
     delete.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "reserved", ["tracebloc_ingest_meta", "tracebloc_ingest_runs"]
-)
+@pytest.mark.parametrize("reserved", ["tracebloc_ingest_meta", "tracebloc_ingest_runs"])
 def test_create_table_rejects_reserved_bookkeeping_tables(reserved):
     """The salt store (#225) and the run journal (backend#1028) share the
     cluster MySQL with dataset tables — a dataset must not be able to claim
@@ -1061,7 +1081,9 @@ def test_list_dataset_ingestor_ids_scans_tables_excluding_framework(
 
     executed = _executed_sql(conn)
     # Discovery query hit information_schema for the ingestor_id column.
-    assert any("information_schema.columns" in s and "ingestor_id" in s for s in executed)
+    assert any(
+        "information_schema.columns" in s and "ingestor_id" in s for s in executed
+    )
     # The framework run-journal table was skipped — never SELECTed as a dataset.
     assert not any("`tracebloc_ingest_runs`" in s for s in executed)
     # Per-dataset-table id scans excluded null/empty ids.

--- a/tests/test_error_redaction.py
+++ b/tests/test_error_redaction.py
@@ -22,7 +22,9 @@ SECRET = "patient-4711-Müller"
 
 def test_row_refs_formats_and_caps():
     assert redaction.row_refs([2, 17, 108], total=3) == "rows [2, 17, 108]"
-    assert redaction.row_refs([0, 1, 2, 3, 4], total=9) == "rows [0, 1, 2, 3, 4] (+4 more)"
+    assert (
+        redaction.row_refs([0, 1, 2, 3, 4], total=9) == "rows [0, 1, 2, 3, 4] (+4 more)"
+    )
 
 
 def test_mask_shape_keeps_structure_never_content():
@@ -90,7 +92,6 @@ def test_int64_overflow_error_redacts():
 
 def _rp(unique_id_column=None):
     from tracebloc_ingestor.ingestors.record_processor import RecordProcessor
-    from tracebloc_ingestor.utils import label_policy as label_policy_module
 
     return RecordProcessor(
         schema={"x": "FLOAT"},
@@ -98,7 +99,6 @@ def _rp(unique_id_column=None):
         label_column="y",
         annotation_column=None,
         unique_id_column=unique_id_column,
-        label_policy=label_policy_module.PASSTHROUGH,
         ingestor_id="run-1",
         # #350: content_hash is now the default strategy and needs a salt.
         table_salt="0" * 64,
@@ -164,9 +164,11 @@ def test_json_dtype_error_masks_the_value():
 def test_json_non_dict_record_reports_position_not_content():
     from tracebloc_ingestor.ingestors.json_ingestor import JSONIngestor
 
-    gen = JSONIngestor._iter_validated_records.__wrapped__ if hasattr(
-        JSONIngestor._iter_validated_records, "__wrapped__"
-    ) else JSONIngestor._iter_validated_records
+    gen = (
+        JSONIngestor._iter_validated_records.__wrapped__
+        if hasattr(JSONIngestor._iter_validated_records, "__wrapped__")
+        else JSONIngestor._iter_validated_records
+    )
     ing = object.__new__(JSONIngestor)
     ing.schema = {}
     with pytest.raises(ValueError) as exc:

--- a/tests/test_file_transfer_failure_modes.py
+++ b/tests/test_file_transfer_failure_modes.py
@@ -170,3 +170,62 @@ def test_segmentation_missing_mask_leaves_no_orphan(dirs):
     )
     assert rec is None
     assert not dest.exists() or not any(dest.iterdir())
+
+
+# --- client#653: the teardown runs as a DIFFERENT uid, so group-write is not enough
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root's created dirs ignore umask/perms nuances",
+)
+def test_ensure_dest_dir_is_world_writable_not_just_group_writable(tmp_path):
+    """Removing a file needs write on its PARENT DIR, and the pods that create
+    and delete these trees never share an identity: the ingestion Job runs as
+    65534 (or HOST_UID), the CLI teardown pod as 65532/fsGroup 65532, and the
+    chart chowns the shared mount to 1000:1000 with setgid -- so a dir created
+    underneath inherits group 1000, never 65532.
+
+    Group-write therefore could not work, and fsGroup cannot rescue it because
+    kubelet ignores fsGroup on hostPath volumes (kubernetes#138411) -- the layout
+    every installer-provisioned cluster uses. The observed failure was
+    "rm: can't remove '/data/shared/<table>/<file>': Permission denied" with the
+    table already dropped, leaving a half-deleted dataset.
+    """
+    dest = tmp_path / "storage" / "tbl"
+    file_transfer._ensure_dest_dir(str(dest))
+    mode = os.stat(dest).st_mode
+    assert mode & 0o002, "other-write must be set: the teardown uid shares no group"
+    assert mode & 0o001, "other-execute must be set, or the dir cannot be traversed"
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root's created dirs ignore umask/perms nuances",
+)
+def test_duplicate_validator_creates_dest_reclaimable_too(tmp_path):
+    """The duplicate validator creates the SAME DEST_PATH and runs BEFORE the
+    transfer, so it decides the mode -- and _ensure_dest_dir deliberately does not
+    re-chmod a dir that already exists. While this used a bare mkdir, the mode fix
+    in file_transfer was dead code on every run that validated first: the tree was
+    left at the umask default and the teardown could not remove it (client#653).
+    """
+    from tracebloc_ingestor.validators.duplicate_validator import DuplicateValidator
+
+    dest = tmp_path / "storage" / "tbl"
+    validator = DuplicateValidator(dest_path=str(dest))
+    assert validator._create_directory_if_needed() is True
+    mode = os.stat(dest).st_mode
+    assert mode & 0o002, "the validator-created dir must be reclaimable as well"
+    assert mode & 0o2000, "setgid, so entries keep inheriting the mount's group"
+
+
+def test_both_creation_sites_share_one_mode_definition():
+    """Two independent copies of this mode would drift, and the drift is invisible
+    until a delete fails in the field. Both sites must resolve to the same object.
+    """
+    from tracebloc_ingestor.utils import fs
+    from tracebloc_ingestor.validators import duplicate_validator
+
+    assert file_transfer.DEST_DIR_MODE is fs.DEST_DIR_MODE
+    assert duplicate_validator.ensure_reclaimable_dir is fs.ensure_reclaimable_dir

--- a/tests/test_ingestor_base.py
+++ b/tests/test_ingestor_base.py
@@ -219,13 +219,15 @@ def test_process_record_missing_unique_id_returns_none():
     assert ing.process_record({"a": "1", "uid": "   "}) is None
 
 
-def test_process_record_applies_bucket_label_policy():
+def test_process_record_stores_raw_label_under_bucket_policy():
+    """#486, inverting what this test used to assert. The stored row is what
+    the training client reads, so the bucket policy must NOT touch it — the
+    bucketing happens at the send boundary (APIClient.send_ingest_summary)."""
     from tracebloc_ingestor.utils.label_policy import BUCKET
 
     ing = make_ingestor(label_column="a", label_policy=BUCKET, category=None)
     rec = ing.process_record({"a": "12345", "filename": "f"})
-    # bucket policy hashes the raw value -> not equal to the raw value
-    assert rec["label"] != "12345"
+    assert rec["label"] == "12345"
 
 
 def test_process_record_reads_label_by_configured_key():

--- a/tests/test_label_policy.py
+++ b/tests/test_label_policy.py
@@ -6,9 +6,10 @@ The pure-function tests pin the bucketing contract:
   - missing values produce MISSING_LABEL_BUCKET
   - unknown policies raise
 
-The integration test pins that the policy fires inside ``BaseIngestor``
-just before the API payload is built, so the central backend never sees
-raw regression target values.
+The boundary tests pin WHERE the policy fires (#486): inside
+``APIClient.send_ingest_summary``, on both label-bearing payload fields, and
+NOT on the record written to the cluster's MySQL — the row training reads keeps
+the raw target.
 """
 
 from __future__ import annotations
@@ -89,19 +90,102 @@ def test_unknown_policy_raises():
 
 
 # ---------------------------------------------------------------------------
-# Integration: BaseIngestor wiring
+# Payload helpers: apply_to_label_counts / apply_to_samples
+# ---------------------------------------------------------------------------
+
+
+class TestApplyToLabelCounts:
+    def test_passthrough_returns_equal_mapping(self):
+        counts = {"cat": 3, "dog": 2}
+        assert label_policy.apply_to_label_counts(counts, PASSTHROUGH) == counts
+
+    def test_passthrough_does_not_alias_the_input(self):
+        counts = {"cat": 3}
+        out = label_policy.apply_to_label_counts(counts, PASSTHROUGH)
+        out["cat"] = 99
+        assert counts["cat"] == 3
+
+    def test_bucket_rekeys_to_bucket_ids(self):
+        out = label_policy.apply_to_label_counts({"0": 11, "1": 19}, BUCKET)
+        # Keys are stringified bucket ids — the wire shape the backend has
+        # always received (review on #487).
+        assert out == {
+            str(label_policy.apply("0", BUCKET)): 11,
+            str(label_policy.apply("1", BUCKET)): 19,
+        }
+        assert all(isinstance(k, str) and 0 <= int(k) < NUM_BUCKETS for k in out)
+
+    def test_bucket_sums_colliding_raw_values(self):
+        """64 buckets means collisions are routine. Dropping one of two
+        colliding entries would under-report the dataset's row count to the
+        backend, so counts are summed."""
+        colliding = [
+            v
+            for v in (str(i) for i in range(500))
+            if label_policy.apply(v, BUCKET) == 0
+        ]
+        assert len(colliding) >= 2, "fixture needs two values in the same bucket"
+        a, b = colliding[0], colliding[1]
+        out = label_policy.apply_to_label_counts({a: 4, b: 6}, BUCKET)
+        assert out == {"0": 10}
+
+    def test_bucket_preserves_total_row_count(self):
+        counts = {str(i): i for i in range(1, 40)}
+        out = label_policy.apply_to_label_counts(counts, BUCKET)
+        assert sum(out.values()) == sum(counts.values())
+
+    def test_bucket_missing_label_key_uses_sentinel(self):
+        # get_label_counts maps a SQL NULL label to the "" key.
+        out = label_policy.apply_to_label_counts({"": 7}, BUCKET)
+        assert out == {str(MISSING_LABEL_BUCKET): 7}
+
+    def test_unknown_policy_raises(self):
+        with pytest.raises(ValueError, match="Unknown label policy"):
+            label_policy.apply_to_label_counts({"a": 1}, "ohno")
+
+
+class TestApplyToSamples:
+    def test_passthrough_keeps_labels(self):
+        samples = [{"data_id": "d1", "label": "cat"}]
+        assert label_policy.apply_to_samples(samples, PASSTHROUGH) == samples
+
+    def test_bucket_replaces_each_label(self):
+        out = label_policy.apply_to_samples(
+            [{"data_id": "d1", "label": "1"}, {"data_id": "d2", "label": "0"}],
+            BUCKET,
+        )
+        # Stringified: data_samples[].label has always been a JSON string.
+        assert [s["label"] for s in out] == [
+            str(label_policy.apply("1", BUCKET)),
+            str(label_policy.apply("0", BUCKET)),
+        ]
+        assert [s["data_id"] for s in out] == ["d1", "d2"]
+
+    def test_does_not_mutate_the_input_samples(self):
+        samples = [{"data_id": "d1", "label": "1"}]
+        label_policy.apply_to_samples(samples, BUCKET)
+        assert samples == [{"data_id": "d1", "label": "1"}]
+
+    def test_sample_without_label_key_is_left_alone(self):
+        out = label_policy.apply_to_samples([{"data_id": "d1"}], BUCKET)
+        assert out == [{"data_id": "d1"}]
+
+    def test_unknown_policy_raises(self):
+        with pytest.raises(ValueError, match="Unknown label policy"):
+            label_policy.apply_to_samples([{"data_id": "d", "label": "1"}], "ohno")
+
+
+# ---------------------------------------------------------------------------
+# The boundary: the stored row keeps the raw target (#486)
 # ---------------------------------------------------------------------------
 #
 # We can't construct CSVIngestor / JSONIngestor without a working DB, but we
-# can construct BaseIngestor subclass-shape directly and exercise
-# _map_unique_id which is where the label-policy hook lives.
+# can exercise RecordProcessor directly — it owns the DB-bound record.
 
 
-def _TestIngestor(label_column, label_policy_value, intent="train"):
-    """A RecordProcessor configured for the label-policy hook, which lives in
-    ``_map_unique_id``. P5c moved that method off BaseIngestor into
-    RecordProcessor, so the tests exercise it there directly (no DB / no
-    BaseIngestor.__init__ needed)."""
+def _TestRecordProcessor(label_column, intent="train"):
+    """The transform that builds the row handed to the batch writer for INSERT.
+    It takes no label policy since #486: bucketing is a boundary control."""
     from tracebloc_ingestor.ingestors.record_processor import RecordProcessor
 
     return RecordProcessor(
@@ -110,45 +194,60 @@ def _TestIngestor(label_column, label_policy_value, intent="train"):
         label_column=label_column,
         annotation_column=None,
         unique_id_column=None,  # → content_hash generation (#350 default)
-        label_policy=label_policy_value,
         ingestor_id="test",
         # #350: content_hash is the default strategy and needs a salt.
         table_salt="0" * 64,
     )
 
 
-def test_base_ingestor_passthrough_does_not_mutate_label():
-    ing = _TestIngestor(label_column="label", label_policy_value=PASSTHROUGH)
-    cleaned = ing._map_unique_id(
+def test_stored_row_keeps_string_label():
+    rp = _TestRecordProcessor(label_column="label")
+    cleaned = rp._map_unique_id(
         record={"label": "cancer_positive"},
         cleaned_record={},
     )
     assert cleaned["label"] == "cancer_positive"
 
 
-def test_base_ingestor_bucket_replaces_label_with_int():
-    ing = _TestIngestor(label_column="label", label_policy_value=BUCKET)
-    cleaned = ing._map_unique_id(
-        record={"label": 1234.56},
-        cleaned_record={},
-    )
-    assert isinstance(cleaned["label"], int)
-    assert 0 <= cleaned["label"] < NUM_BUCKETS
+def test_stored_row_keeps_raw_numeric_target():
+    """A regression target reaches MySQL as itself, not as a bucket id — this
+    is the row the training client trains on."""
+    rp = _TestRecordProcessor(label_column="label")
+    cleaned = rp._map_unique_id({"label": 1234.56}, {})
+    assert cleaned["label"] == 1234.56
 
 
-def test_base_ingestor_bucket_stable_across_calls():
-    """Two records with the same label must land in the same bucket so the
-    central backend can group identical labels without seeing them."""
-    ing = _TestIngestor(label_column="label", label_policy_value=BUCKET)
-    a = ing._map_unique_id({"label": 99.5}, {})
-    b = ing._map_unique_id({"label": 99.5}, {})
-    assert a["label"] == b["label"]
+def test_stored_row_keeps_binary_event_indicator():
+    """The #486 reproduction: a time_to_event event indicator of 0/1 used to be
+    stored as sha256("1")%64 = 33 / sha256("0")%64 = 56, and the engine rejects
+    anything but 0/1 for that column."""
+    rp = _TestRecordProcessor(label_column="DEATH_EVENT")
+    assert rp._map_unique_id({"DEATH_EVENT": "1"}, {})["label"] == "1"
+    assert rp._map_unique_id({"DEATH_EVENT": "0"}, {})["label"] == "0"
 
 
-def test_base_ingestor_bucket_missing_label_uses_sentinel():
-    ing = _TestIngestor(label_column="label", label_policy_value=BUCKET)
-    cleaned = ing._map_unique_id({"label": None}, {})
-    assert cleaned["label"] == MISSING_LABEL_BUCKET
+def test_record_processor_takes_no_label_policy():
+    """Pins the collaborator boundary: a policy passed here would be silently
+    ignored, so the constructor must refuse it outright."""
+    from tracebloc_ingestor.ingestors.record_processor import RecordProcessor
+
+    with pytest.raises(TypeError):
+        RecordProcessor(
+            schema={},
+            intent="train",
+            label_column="label",
+            annotation_column=None,
+            unique_id_column=None,
+            label_policy=BUCKET,
+            ingestor_id="test",
+            table_salt="0" * 64,
+        )
+
+
+def test_stored_row_keeps_missing_label_as_none():
+    rp = _TestRecordProcessor(label_column="label")
+    cleaned = rp._map_unique_id({"label": None}, {})
+    assert cleaned["label"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -220,3 +319,135 @@ def test_entrypoint_passes_passthrough_policy_for_classification(tmp_path, monke
 
     _, kwargs = mock_csv_cls.call_args
     assert kwargs["label_policy"] == PASSTHROUGH
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a TTE ingest under `bucket` stores 0/1 and sends buckets (#486)
+# ---------------------------------------------------------------------------
+
+
+def test_tte_ingest_stores_raw_event_indicator_and_sends_buckets(make_csv):
+    """The prod reproduction, end to end through CSVIngestor.
+
+    A time_to_event_prediction CSV whose event column is 0/1, ingested with the
+    policy the CLI defaults to for regression-class tasks. What lands in MySQL
+    must stay 0/1 (the engine rejects anything else, and it is the training
+    target); what goes to the backend must be bucketed.
+    """
+    from unittest.mock import patch
+
+    import pandas as pd
+
+    from tracebloc_ingestor.config import Config
+    from tracebloc_ingestor.ingestors import base as base_mod
+    from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
+    from tracebloc_ingestor.utils.constants import DataFormat, TaskCategory
+
+    schema = {"age": "INT", "time": "INT"}
+    frame = pd.DataFrame(
+        {
+            "age": [45, 60, 75, 80],
+            "time": [4, 12, 20, 30],
+            "DEATH_EVENT": [1, 1, 0, 1],
+        }
+    )
+    csv_path = make_csv(frame, name="tte.csv")
+
+    db = MagicMock(name="Database")
+    db.config = Config(TABLE_NAME="tte_toy")
+    db.get_or_create_table_salt.return_value = "0" * 64
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.side_effect = lambda table, batch: (list(range(len(batch))), [])
+    db.get_table_schema.return_value = dict(schema, label="INT")
+    # Read back from the DB, i.e. RAW labels — that is what the boundary gets.
+    db.get_label_counts.return_value = {"1": 3, "0": 1}
+    db.get_samples.return_value = [
+        {"data_id": "d1", "label": "1"},
+        {"data_id": "d2", "label": "0"},
+    ]
+    api = MagicMock(name="APIClient")
+    api.config.TITLE = "toy tte"
+    api.send_ingest_summary.return_value = {"dataset_id": 1}
+
+    ing = CSVIngestor(
+        database=db,
+        api_client=api,
+        table_name="tte_toy",
+        schema=dict(schema),
+        label_column="DEATH_EVENT",
+        intent="train",
+        category=TaskCategory.TIME_TO_EVENT_PREDICTION,
+        data_format=DataFormat.TABULAR,
+        label_policy=BUCKET,
+        file_options={"time_column": "time", "schema": dict(schema)},
+    )
+    with patch.object(base_mod, "Session") as Sess:
+        Sess.return_value.__enter__.return_value = MagicMock()
+        failed = ing.ingest(str(csv_path), batch_size=50)
+
+    assert failed == []
+    stored_labels = {
+        row["label"] for call in db.insert_batch.call_args_list for row in call.args[1]
+    }
+    # An INT label column arrives as a native int (numpy scalars are coerced so
+    # mysql-connector can bind them); what matters is the VALUE, not its type.
+    assert {str(v) for v in stored_labels} == {
+        "1",
+        "0",
+    }, "the DB row must keep the event indicator"
+
+    # The policy travels to the boundary rather than being pre-applied.
+    assert api.send_ingest_summary.call_args.kwargs["label_policy"] == BUCKET
+    assert api.send_ingest_summary.call_args.kwargs["labels"] == {"1": 3, "0": 1}
+
+
+# ---------------------------------------------------------------------------
+# Missing targets: NULL in, sentinel out (Bugbot on #487)
+# ---------------------------------------------------------------------------
+#
+# The write-path bucketing this PR removed used to absorb NaN into
+# MISSING_LABEL_BUCKET. The stored row now normalizes a missing target to SQL
+# NULL instead — the label column is VARCHAR(255) NULL — and the outbound
+# sentinel is reconstructed at the boundary from the DB's own NULL reporting.
+
+
+def test_stored_row_normalizes_nan_label_to_null():
+    """A float nan would otherwise reach the binder and land as "nan"."""
+    rp = _TestRecordProcessor(label_column="label")
+    assert rp._map_unique_id({"label": float("nan")}, {})["label"] is None
+
+
+def test_stored_row_normalizes_pandas_na_label_to_null():
+    import pandas as pd
+
+    rp = _TestRecordProcessor(label_column="label")
+    assert rp._map_unique_id({"label": pd.NA}, {})["label"] is None
+    assert rp._map_unique_id({"label": pd.NaT}, {})["label"] is None
+
+
+def test_stored_row_keeps_empty_string_label():
+    """ "" stores fine and already buckets to the sentinel — left untouched so
+    classification behavior is unchanged."""
+    rp = _TestRecordProcessor(label_column="label")
+    assert rp._map_unique_id({"label": ""}, {})["label"] == ""
+
+
+def test_stored_row_keeps_zero_and_false_labels():
+    """Guard against a truthiness-based null check: 0 and False are real
+    label values, not missing ones."""
+    rp = _TestRecordProcessor(label_column="label")
+    assert rp._map_unique_id({"label": 0}, {})["label"] == 0
+    assert rp._map_unique_id({"label": False}, {})["label"] is False
+
+
+def test_null_label_round_trips_to_the_missing_sentinel():
+    """The chain the NULL relies on: Database.get_label_counts keys a NULL
+    label as "" and get_samples reports "", and the boundary buckets both to
+    MISSING_LABEL_BUCKET — so a missing target still reaches the backend as the
+    sentinel, without a sentinel ever being stored locally."""
+    assert label_policy.apply_to_label_counts({"": 3}, BUCKET) == {
+        str(MISSING_LABEL_BUCKET): 3
+    }
+    assert label_policy.apply_to_samples([{"data_id": "d", "label": ""}], BUCKET) == [
+        {"data_id": "d", "label": str(MISSING_LABEL_BUCKET)}
+    ]

--- a/tests/test_no_hardcoded_secrets.py
+++ b/tests/test_no_hardcoded_secrets.py
@@ -12,29 +12,30 @@ from pathlib import Path
 
 import pytest
 
-
 # Strings that previously shipped as hardcoded defaults for the **backend**
 # (tracebloc API) credentials in `tracebloc_ingestor/config.py`. These are
 # real per-customer credentials — shipping a default value made every install
 # ship the same secret. If this reappears anywhere in the package source, the
 # test fails, even in a comment.
 #
-# NOTE: `DB_PASSWORD` ("Edg9@Tr@ce") and `DB_USER` ("edgeuser") are
-# intentionally **not** in these lists. They're connection conventions for
-# the cluster-internal MySQL container, which bakes the same values into its
-# own image. They never vary per customer and don't leave the cluster, so
-# shipping them as defaults in `config.py` is correct, not a leak. See the
-# database-section comment in `config.py` and `Config.validate()` for the
-# rationale.
+# `Edg9@Tr@ce` is the legacy root-equivalent `edgeuser` password that DB_USER/
+# DB_PASSWORD used to fall back to. That fallback was removed in backend#1528
+# (D10 close-out): jobs-manager now injects per-Job tb_ingest credentials, so
+# the ingestor no longer connects as edgeuser and this password must never be
+# baked into source again. (`edgeuser` the username is guarded below.)
 KNOWN_LEAKED_SECRETS = (
     "&6edg*D9e16",
+    "Edg9@Tr@ce",
 )
 
-# Username default for the backend (tracebloc API) credential. Not secret on
-# its own, but paired with the leaked password above it formed a working
-# credential in legacy local dev — shouldn't be baked into source either.
+# Usernames that must not be baked into source. `testedge` was a legacy
+# backend (tracebloc API) default that — paired with the leaked password
+# above — formed a working credential in local dev. `edgeuser` is the
+# root-equivalent MySQL identity retired in backend#1528; DB_USER now comes
+# from the injected per-Job env, never a hardcoded default.
 LEGACY_USERNAME_DEFAULTS = (
     "testedge",
+    "edgeuser",
 )
 
 

--- a/tests/test_per_ingestion_tables.py
+++ b/tests/test_per_ingestion_tables.py
@@ -185,7 +185,9 @@ def mock_engine_factory():
 
 @pytest.fixture
 def db(mock_engine_factory):
-    return Database(Config(EDGE_ENV="local"))
+    # DB_USER/DB_PASSWORD are required (backend#1528 removed the edgeuser
+    # fallback); the engine is mocked so the values are arbitrary.
+    return Database(Config(EDGE_ENV="local", DB_USER="tb_ingest", DB_PASSWORD="pw"))
 
 
 def test_create_table_must_not_exist_rejects_cached_table(db):

--- a/tests/test_runtime_env_contract.py
+++ b/tests/test_runtime_env_contract.py
@@ -1,0 +1,124 @@
+"""Pins the runtime-env contract the spawner has to satisfy (backend#1752).
+
+WHY THIS EXISTS
+---------------
+#468 made DB_USER/DB_PASSWORD required by removing the edgeuser fallback. The
+credentials that replace them are injected by jobs-manager only when
+SERVICE_DB_ACCOUNTS is on, and that flag is off everywhere. Staging edges float
+on the `:stg` ingestor channel, so they picked the change up within hours and
+every ingestion Job began failing at Config() before reading a byte.
+
+NOTHING COULD HAVE CAUGHT IT, and that is the point. This repo's required
+`e2e (real MySQL)` check sets `DB_USER: root` in its own workflow env — it
+supplies the credentials whose absence is the bug, so it is structurally
+incapable of noticing that no one else supplies them. client-runtime's tests
+assert the injection is correctly *gated*. Both halves are individually right;
+the pair was never tested.
+
+WHAT THIS FILE BUYS
+-------------------
+It makes the requirement a PUBLISHED FACT rather than an implementation detail
+buried in a property getter, so the spawner can assert against it in its own CI
+— the same shape as layout.v1.json, which the CLI reads instead of restating
+the layout rules.
+
+On its own this file cannot fail the spawner's build; that is client-runtime's
+half (backend#1753). What it does guarantee is that the contract can never
+drift from the code, so when the spawner does read it, it is reading the truth.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = _ROOT / "tracebloc_ingestor" / "schema" / "runtime_env.v1.json"
+CONFIG_PY = _ROOT / "tracebloc_ingestor" / "config.py"
+
+SUPPORTED_VERSIONS = {"1"}
+
+
+def _contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def _required_from_contract() -> set:
+    return {entry["name"] for entry in _contract()["required"]}
+
+
+def _required_from_code() -> set:
+    """Every env var `config.py` passes to `_require_env`, read from the AST.
+
+    Parsed rather than imported: importing the package pulls in sqlalchemy and
+    the rest of the runtime, and a contract test should depend on the source it
+    is pinning, not on the environment it happens to run in.
+    """
+    tree = ast.parse(CONFIG_PY.read_text(encoding="utf-8"))
+    found = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = getattr(fn, "attr", None) or getattr(fn, "id", None)
+        if name != "_require_env" or not node.args:
+            continue
+        arg = node.args[0]
+        assert isinstance(arg, ast.Constant) and isinstance(arg.value, str), (
+            "_require_env must be called with a literal env-var name so this "
+            "contract can be checked statically; got a computed value"
+        )
+        found.add(arg.value)
+    return found
+
+
+def test_the_contract_is_a_version_we_understand():
+    assert _contract()["version"] in SUPPORTED_VERSIONS
+
+
+def test_every_required_var_in_the_code_is_declared():
+    """The direction that matters.
+
+    Adding a `_require_env` call without declaring it is exactly what happened
+    in #468: a new hard requirement on the spawner, invisible to the spawner.
+    """
+    undeclared = _required_from_code() - _required_from_contract()
+    assert not undeclared, (
+        f"config.py requires {sorted(undeclared)} but runtime_env.v1.json does "
+        "not declare them. Whatever spawns this container has no way to know it "
+        "must provide them — which is how backend#1752 broke staging ingestion. "
+        "Declare them, and check the spawner actually injects them before "
+        "merging."
+    )
+
+
+def test_the_contract_does_not_claim_requirements_the_code_dropped():
+    """The other direction, so the contract cannot rot into over-claiming.
+
+    A stale entry would make a spawner inject something pointless forever, and
+    would make this file untrustworthy in the direction that matters.
+    """
+    stale = _required_from_contract() - _required_from_code()
+    assert not stale, (
+        f"runtime_env.v1.json declares {sorted(stale)} as required but nothing "
+        "in config.py requires them any more."
+    )
+
+
+def test_each_entry_says_who_is_supposed_to_provide_it():
+    """An entry that does not name its provider is not actionable.
+
+    `provided_by` is what turns this from a list of names into something a
+    reviewer can check: it is the sentence that would have made the #468
+    ordering hazard obvious at review time.
+    """
+    for entry in _contract()["required"]:
+        for field in ("name", "provided_by", "reason"):
+            assert entry.get(field), f"{entry.get('name', entry)} lacks {field!r}"
+
+
+def test_it_currently_pins_the_two_credentials_1528_made_required():
+    # A concrete anchor: if these ever stop being required, that is a
+    # deliberate decision and this line should be the thing that notices.
+    assert _required_from_contract() == {"DB_USER", "DB_PASSWORD"}

--- a/tests/test_scalar_attributes.py
+++ b/tests/test_scalar_attributes.py
@@ -5,6 +5,7 @@ time-series ``timezone`` / ``sampling_frequency`` from the CSV timestamp pass.
 
 from __future__ import annotations
 
+from datetime import date, datetime
 from unittest.mock import MagicMock
 
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
@@ -319,3 +320,38 @@ def test_positive_definition_not_emitted_for_text():
     )
     attrs = ing._collect_run_metadata()["attributes"]
     assert "positive_definition" not in attrs
+
+
+def test_temporal_frequency_inferred_for_date_only_schema(make_csv):
+    """A date-only (``DATE``) timestamp column must still yield a cadence.
+
+    Daily series are the commonest forecasting shape, and since #489 an
+    INFERRED schema types a date-only column ``DATE`` (inference never emits
+    ``TIMESTAMP``). Only the DATETIME/TIMESTAMP cast branch accumulated the
+    timestamp sample, so a date-only dataset ingested cleanly but silently
+    omitted ``sampling_frequency`` from run metadata — a backend WARN with no
+    local signal (Bugbot on #490).
+    """
+    path = make_csv(
+        {
+            "timestamp": ["2023-10-01", "2023-10-02", "2023-10-03", "2023-10-04"],
+            "value": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+    ing = make_ingestor(
+        schema={"timestamp": "DATE", "value": "FLOAT"},
+        category=TaskCategory.TIME_SERIES_FORECASTING,
+    )
+    chunks = list(ing.read_data(str(path)))
+
+    attrs = ing._collect_run_metadata()["attributes"]
+    assert attrs["sampling_frequency"], "date-only series lost its cadence"
+
+    # …and the DATE branch's own contract still holds: the stored value stays a
+    # plain date. Accumulating the cadence must read the parsed datetimes
+    # WITHOUT reintroducing a spurious '00:00:00' into what gets written.
+    stored = [record["timestamp"] for record in chunks]
+    assert stored, "no records were read"
+    assert all(
+        isinstance(v, date) and not isinstance(v, datetime) for v in stored
+    ), f"DATE column gained a time component: {stored[:2]}"

--- a/tests/test_semseg_mask_id_contract.py
+++ b/tests/test_semseg_mask_id_contract.py
@@ -407,7 +407,6 @@ def test_declared_mask_id_is_stored_populated_on_the_row():
         label_column=None,
         annotation_column=None,
         unique_id_column=None,
-        label_policy=None,
         ingestor_id="t",
         # #350: content_hash is now the default strategy and needs a salt.
         table_salt="0" * 64,

--- a/tests/test_time_validators.py
+++ b/tests/test_time_validators.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 
 from tracebloc_ingestor.validators.time_format_validator import TimeFormatValidator
 from tracebloc_ingestor.validators.time_ordered_validator import TimeOrderedValidator
@@ -11,10 +12,10 @@ from tracebloc_ingestor.validators.time_before_today_validator import (
 )
 from tracebloc_ingestor.validators.time_to_event_validator import TimeToEventValidator
 
-
 # ---------------------------------------------------------------------------
 # TimeFormatValidator
 # ---------------------------------------------------------------------------
+
 
 def test_format_valid_timestamps_pass(make_csv):
     path = make_csv({"timestamp": ["2024-01-01", "2024-01-02"], "v": [1, 2]})
@@ -51,11 +52,85 @@ def test_format_schema_missing_timestamp_fails():
     assert "must contain a 'timestamp' column" in result.errors[0]
 
 
-def test_format_schema_wrong_type_fails():
-    v = TimeFormatValidator(schema={"timestamp": "DATE"})
+@pytest.mark.parametrize(
+    "wrong_type", ["VARCHAR(32)", "TEXT", "INT", "FLOAT", "BOOLEAN"]
+)
+def test_format_schema_wrong_type_fails(wrong_type):
+    """A non-calendar type is still rejected.
+
+    Previously this asserted on ``DATE``, which #489 makes legal — inferred
+    schemas can only ever produce ``DATE`` / ``DATETIME``. The check the test
+    exists for is "a timestamp column that isn't a date/time type is refused",
+    so it now covers the types that genuinely aren't.
+    """
+    v = TimeFormatValidator(schema={"timestamp": wrong_type})
     result = v.validate("ignored")
     assert not result.is_valid
-    assert "must be of type 'TIMESTAMP'" in result.errors[0]
+    assert "must be a date/time type" in result.errors[0]
+    assert wrong_type in result.errors[0]
+
+
+@pytest.mark.parametrize(
+    "declared",
+    [
+        "TIMESTAMP",
+        "DATETIME",
+        "DATE",
+        # Case and precision specifiers must not change the verdict.
+        "timestamp",
+        "datetime",
+        "date",
+        "DATETIME(6)",
+    ],
+)
+def test_format_schema_accepts_every_calendar_type(make_csv, declared):
+    """#489: every type an INFERRED schema can carry must be accepted.
+
+    ``schema_inference._infer_datetime`` emits ``DATETIME`` when a value has a
+    time of day and ``DATE`` otherwise — never ``TIMESTAMP``. Requiring exactly
+    ``TIMESTAMP`` rejected every inferred time-series-forecasting schema, so a
+    CLI ingest failed regardless of the data.
+    """
+    path = make_csv({"timestamp": ["2024-01-01", "2024-01-02"], "v": [1, 2]})
+    result = TimeFormatValidator(schema={"timestamp": declared}).validate(str(path))
+    assert result.is_valid, result.errors
+
+
+def test_format_schema_date_accepts_date_only_values(make_csv):
+    """The exact shape that failed in the field: date-only values, inferred DATE."""
+    path = make_csv(
+        {
+            "timestamp": ["2023-10-01", "2023-10-02", "2023-10-03"],
+            "value": [1.0, 2.0, 3.0],
+        }
+    )
+    result = TimeFormatValidator(
+        schema={"timestamp": "DATE", "value": "FLOAT"}
+    ).validate(str(path))
+    assert result.is_valid, result.errors
+
+
+def test_format_accepted_types_match_what_inference_can_emit():
+    """Pin the cross-module contract that #489 broke.
+
+    ``_infer_datetime`` is the only producer of a timestamp type for an inferred
+    schema. Every value it can return must be accepted here, or the CLI path
+    breaks again the next time either side changes.
+    """
+    from tracebloc_ingestor.schema_inference import _infer_datetime
+    from tracebloc_ingestor.validators.time_format_validator import (
+        TEMPORAL_TIMESTAMP_TYPES,
+    )
+
+    emitted = {
+        _infer_datetime(["2024-01-01", "2024-01-02"]),  # date only
+        _infer_datetime(["2024-01-01 09:30:00", "2024-01-02 10:00:00"]),  # with time
+    }
+    assert None not in emitted
+    assert emitted <= TEMPORAL_TIMESTAMP_TYPES, (
+        f"schema inference can emit {emitted - TEMPORAL_TIMESTAMP_TYPES}, which "
+        f"TimeFormatValidator would reject"
+    )
 
 
 def test_format_schema_timestamp_with_precision_passes(make_csv):
@@ -66,6 +141,7 @@ def test_format_schema_timestamp_with_precision_passes(make_csv):
 
 
 # --- locale-ambiguous dates (silent-corruption guard) ----------------------
+
 
 def test_format_ambiguous_eu_dates_rejected(make_csv):
     # "03.04.2026" is Apr 3 (day-first/EU) or Mar 4 (month-first/US); pandas'
@@ -93,6 +169,7 @@ def test_format_unambiguous_dates_not_flagged(make_csv):
 # ---------------------------------------------------------------------------
 # TimeOrderedValidator
 # ---------------------------------------------------------------------------
+
 
 def test_ordered_monotonic_passes(make_csv):
     path = make_csv({"timestamp": ["2024-01-01", "2024-01-02", "2024-01-03"]})
@@ -125,6 +202,7 @@ def test_ordered_no_data_for_non_csv():
 # TimeBeforeTodayValidator
 # ---------------------------------------------------------------------------
 
+
 def test_before_today_past_passes(make_csv):
     path = make_csv({"timestamp": ["2000-01-01", "2001-01-01"]})
     result = TimeBeforeTodayValidator().validate(str(path))
@@ -150,6 +228,7 @@ def test_before_today_missing_column_fails(make_csv):
 # ---------------------------------------------------------------------------
 # TimeToEventValidator (accepts DataFrames directly)
 # ---------------------------------------------------------------------------
+
 
 def test_to_event_valid_passes():
     df = pd.DataFrame({"time": [0, 1.5, 10], "event": [1, 0, 1]})

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.5"
+__version__ = "0.8.6"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.6"
+__version__ = "0.8.7"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.7"
+__version__ = "0.8.8"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -14,6 +14,7 @@ from ..utils.constants import (
     RED,
     YELLOW,
 )
+from ..utils import label_policy as label_policy_module
 
 # Logger for this module. Level is set by `setup_logging()` on the root
 # logger when the user script calls it; child loggers inherit that level.
@@ -154,9 +155,7 @@ class APIClient:
             new = self.config.BACKEND_TOKEN or os.environ.get("BACKEND_TOKEN")
             if new and new != old:
                 self.token = new
-                logger.info(
-                    f"{GREEN}Re-read rotated BACKEND_TOKEN after 401.{RESET}"
-                )
+                logger.info(f"{GREEN}Re-read rotated BACKEND_TOKEN after 401.{RESET}")
                 return True
             return False
         # CLIENT_ID/PASSWORD path: mint a new token.
@@ -164,9 +163,7 @@ class APIClient:
             self.token = self.authenticate()
             return self.token != old
         except Exception as exc:
-            logger.error(
-                f"{RED}Failed to re-authenticate after 401: {exc}{RESET}"
-            )
+            logger.error(f"{RED}Failed to re-authenticate after 401: {exc}{RESET}")
             return False
 
     def _authed_request(
@@ -225,6 +222,7 @@ class APIClient:
         samples: List[Dict[str, Any]],
         meta_data: Optional[Dict[str, Any]] = None,
         physical_table: Optional[str] = None,
+        label_policy: str = label_policy_module.PASSTHROUGH,
     ) -> Dict[str, Any]:
         """
         Send a single ingest summary to the backend, creating the UserDataSet in one
@@ -234,13 +232,22 @@ class APIClient:
         Args:
             table_name: Dataset table name (used as the URL path segment)
             ingestor_id: UUID identifying this ingest run
-            labels: ``{label: row_count}`` — computed locally after DB insert
+            labels: ``{label: row_count}`` — computed locally after DB insert,
+                keyed by the RAW label as stored
             dataset_title: Human-readable name for the new dataset
             data_format: One of "image", "tabular", "text", "audio", "video"
             data_intent: "train" or "test"
             category: TaskCategory value, e.g. "image_classification"
             schema: Column schema written to GlobalMetaData
             samples: Small list of representative records shown in the UI
+            label_policy: ``"passthrough"`` (classification — raw label values
+                ride the payload) or ``"bucket"`` (regression-class — every
+                outbound label becomes a stable hash-bucket id so the central
+                backend never sees the raw target). This is the ONLY place the
+                policy is applied: it is a boundary control, and the row in the
+                cluster's own MySQL keeps the raw target the training client
+                needs (#486). Both label-bearing payload fields — ``labels``
+                and ``samples`` — go through it.
             physical_table: RFC-0003 D16 (tracebloc/backend#1205) — the
                 per-ingestion physical table (``ds_<uuid4().hex>``, derived
                 from ingestor_id) this run wrote into, reported so the
@@ -254,7 +261,14 @@ class APIClient:
 
         Raises:
             requests.exceptions.RequestException: If the API call fails after retries
+            ValueError: If ``label_policy`` is not a known policy name.
         """
+        # The boundary. Applied before the local-mock branch too, so a dry run
+        # reports the label count that would actually ship (bucket collisions
+        # merge keys, so it can be lower than the raw count).
+        labels = label_policy_module.apply_to_label_counts(labels, label_policy)
+        samples = label_policy_module.apply_to_samples(samples, label_policy)
+
         if self.config.EDGE_ENV == "local":
             logger.info(
                 f"Mock: Would send ingest summary for {table_name} "
@@ -329,7 +343,9 @@ class APIClient:
                     f"HTTP {e.response.status_code}: {body}{RESET}"
                 )
             else:
-                logger.error(f"{RED}Error sending ingest summary: {str(e)[:500]}{RESET}")
+                logger.error(
+                    f"{RED}Error sending ingest summary: {str(e)[:500]}{RESET}"
+                )
             raise
 
     def get_dataset_metadata(self, ingestor_id: str) -> Optional[Dict[str, Any]]:

--- a/tracebloc_ingestor/cli/__init__.py
+++ b/tracebloc_ingestor/cli/__init__.py
@@ -10,8 +10,9 @@ as its entrypoint. The flow:
     3. Resolve convention defaults from ``category`` (validators, sidecar
        patterns, default columns, default file extensions) — see ``conventions``.
     4. Dispatch to ``CSVIngestor`` or ``JSONIngestor`` based on the source type.
-    5. Apply ``label.policy`` bucketing in ``APIClient.send_batch`` for
-       regression-class tasks.
+    5. Apply ``label.policy`` bucketing in ``APIClient.send_ingest_summary``
+       for regression-class tasks — on the outbound payload only; the row
+       stored in the cluster's MySQL keeps the raw target (#486).
 
 Customers no longer write Python or build Docker images for the dominant case.
 """

--- a/tracebloc_ingestor/config.py
+++ b/tracebloc_ingestor/config.py
@@ -107,10 +107,38 @@ class Config:
                 f"{env_name} environment variable to a valid integer."
             )
 
+    @staticmethod
+    def _require_env(env_name: str) -> str:
+        """Read a required DB-credential env var, failing fast if unset
+        (backend#1528).
+
+        DB_USER / DB_PASSWORD used to fall back to the root-equivalent
+        edgeuser identity. That fallback is gone: jobs-manager now injects
+        the per-Job tb_ingest credentials into the ingestion Job's env, so an
+        unset value means a misconfigured Job, not a cue to use edgeuser. Raise
+        a message that names the variable rather than letting SQLAlchemy
+        surface an opaque access-denied (or, worse, silently connecting as the
+        legacy identity).
+        """
+        val = os.environ.get(env_name)
+        if not val:
+            raise ValueError(
+                f"{env_name} is not set. The ingestor authenticates to MySQL "
+                f"as the identity jobs-manager injects per-Job (backend#1528: "
+                f"tb_ingest); set the {env_name} environment variable. The "
+                f"legacy edgeuser fallback was removed once per-Job "
+                f"credentials shipped."
+            )
+        return val
+
     # ===== Database =====
-    # Cluster-internal MySQL ships with these credentials baked into its
-    # image; they're connection conventions, not secrets. Override via env
-    # only if you've replaced the bundled MySQL.
+    # DB_HOST/DB_PORT/DB_NAME are connection conventions for the
+    # cluster-internal MySQL and keep their defaults. DB_USER/DB_PASSWORD do
+    # NOT: the ingestor authenticates as the identity jobs-manager injects
+    # per-Job (backend#1528 — tb_ingest, scoped to training_test_datasets).
+    # The legacy root-equivalent edgeuser fallback was removed here once
+    # those per-Job credentials shipped; both are now required from env and
+    # fail fast if unset rather than silently connecting as the old identity.
     @property
     def DB_HOST(self) -> str:
         ov = self._override("DB_HOST")
@@ -125,12 +153,12 @@ class Config:
     @property
     def DB_USER(self) -> str:
         ov = self._override("DB_USER")
-        return ov if ov is not _MISSING else os.environ.get("DB_USER", "edgeuser")
+        return ov if ov is not _MISSING else self._require_env("DB_USER")
 
     @property
     def DB_PASSWORD(self) -> str:
         ov = self._override("DB_PASSWORD")
-        return ov if ov is not _MISSING else os.environ.get("DB_PASSWORD", "Edg9@Tr@ce")
+        return ov if ov is not _MISSING else self._require_env("DB_PASSWORD")
 
     @property
     def DB_NAME(self) -> str:
@@ -311,15 +339,18 @@ class Config:
         module-level ``Config()`` instantiations elsewhere in the package
         don't blow up at import time.
 
-        In any non-local environment, the pod must boot with either:
-          - ``BACKEND_TOKEN`` (preferred), or
-          - ``CLIENT_ID`` + ``CLIENT_PASSWORD`` (deprecated fallback).
+        In any non-local environment, the pod must boot with:
+          - ``BACKEND_TOKEN`` (preferred) or ``CLIENT_ID`` +
+            ``CLIENT_PASSWORD`` (deprecated fallback) for backend auth, and
+          - ``DB_USER`` + ``DB_PASSWORD`` for MySQL.
 
-        Database credentials are intentionally **not** validated here: the
-        bundled MySQL container ships with fixed credentials that the
-        ingestor defaults match. They're a connection convention, not a
-        secret, and forcing customers to set them in env vars adds friction
-        with no security benefit.
+        Database credentials are required as of backend#1528 (D10): the
+        root-equivalent ``edgeuser`` fallback was removed, so the ingestor
+        authenticates as the identity jobs-manager injects per-Job
+        (``tb_ingest``). They are NOT re-checked here — this method is
+        auth-scoped — but ``Config.DB_USER`` / ``DB_PASSWORD`` fail fast on
+        first access (``Database()`` init) via ``_require_env`` with a message
+        naming the unset variable, so a misconfigured Job still surfaces early.
 
         Set ``CLIENT_ENV=local`` to bypass for development against a mock
         backend.

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -20,6 +20,8 @@ from tenacity import (
 )
 
 from tracebloc_ingestor import Config
+from tracebloc_ingestor.utils.fs import DEST_DIR_MODE as _DEST_DIR_MODE
+from tracebloc_ingestor.utils.fs import ensure_reclaimable_dir
 from tracebloc_ingestor.utils.constants import (
     GREEN,
     RED,
@@ -42,34 +44,20 @@ logger.setLevel(config.LOG_LEVEL)
 # (uid/gid 65532, client-runtime#172). On a hostPath dataset the kubelet ignores
 # that pod's fsGroup, so the ingest side must leave the destination tree
 # group-owned by, and group-writable for, that group — otherwise the teardown
-# can't remove the files and they leak (remainder of client#259). Create the
-# destination dir setgid + group-writable so new entries inherit the group and
-# the group can delete them, regardless of the writing uid. 0o2775 = rwxrwsr-x.
-DEST_DIR_MODE = 0o2775
+# can't remove the files and they leak (remainder of client#259). The rule now
+# lives in utils/fs.py so the duplicate validator -- which creates the SAME
+# destination directory, and gets there first -- applies it too. Re-exported here
+# because callers and tests already reference these names.
+DEST_DIR_MODE = _DEST_DIR_MODE
 
 
 def _ensure_dest_dir(path: str) -> None:
-    """Create ``path`` if absent, setgid + group-writable, so the ``data
-    delete`` teardown group can reclaim the tree (#172).
+    """Create ``path`` reclaimable by the `data delete` teardown (#172).
 
-    Only a directory we *create* is chmod'd — a pre-existing one is left as-is,
-    so we neither override an operator's deliberate mode nor mask a genuine
-    permission problem (an unwritable dest still surfaces downstream). The chmod
-    is best-effort: a failure is logged, not fatal, so ingestion still proceeds.
+    Thin delegation to :func:`ensure_reclaimable_dir`; see utils/fs.py for why
+    the mode is world-writable rather than group-writable.
     """
-    existed = os.path.isdir(path)
-    os.makedirs(path, exist_ok=True)
-    if existed:
-        return
-    try:
-        os.chmod(path, DEST_DIR_MODE)
-    except OSError as error:
-        logger.warning(
-            "Could not set group-writable/setgid mode on %s (%s); the `data "
-            "delete` teardown may not be able to reclaim it",
-            path,
-            error,
-        )
+    ensure_reclaimable_dir(path)
 
 
 # Define retry decorator for file operations

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -265,8 +265,9 @@ class BaseIngestor(ABC):
             label_policy: ``"passthrough"`` (default; classification — the
                 label value crosses the cluster boundary unchanged) or
                 ``"bucket"`` (regression-class — each label is replaced
-                with a stable hash-bucket ID before the API payload is
-                built, so raw target values never leak). Schema-validated
+                with a stable hash-bucket ID in the API payload, so raw
+                target values never leak; the stored row keeps the raw
+                target, which is what training reads — #486). Schema-validated
                 upstream by the YAML entrypoint; templates pass the
                 appropriate constant from :mod:`tracebloc_ingestor.utils.label_policy`.
         Raises:
@@ -461,7 +462,6 @@ class BaseIngestor(ABC):
             label_column=self.label_column,
             annotation_column=self.annotation_column,
             unique_id_column=self.unique_id_column,
-            label_policy=self.label_policy,
             ingestor_id=self.ingestor_id,
             data_id_strategy=self.data_id_strategy,
             table_salt=self._table_salt,
@@ -1207,6 +1207,30 @@ class BaseIngestor(ABC):
                         label_counts.values()
                     )
                 else:
+                    # CEILING (review on #487, tracked in #488): this GROUP BYs
+                    # the RAW label, so a regression-class dataset with a
+                    # continuous target yields up to one entry per distinct
+                    # value — ~N rows — which the send boundary then collapses to
+                    # <= 64 buckets. Before #486 the column held the buckets
+                    # themselves, so the same query grouped over <= 64 keys.
+                    # Fine at the sizes we ingest today: a 100k-row float target
+                    # is a ~100k-entry dict, single-digit MB.
+                    #
+                    # It cannot be fixed by iterating: our DBAPI is
+                    # mysql+mysqlconnector, whose SQLAlchemy dialect reports
+                    # supports_server_side_cursors = False, so stream_results /
+                    # yield_per are no-ops and the driver buffers the whole
+                    # GROUP BY result on execute. Chunking the delivery
+                    # (Result.partitions) would bound the dict we build while
+                    # leaving the driver's buffer just as large — a memory bound
+                    # in the docstring only. Cursor Bugbot caught exactly that on
+                    # an earlier attempt in this PR.
+                    #
+                    # The two shapes that would actually bound it — bucketing in
+                    # SQL (SHA2 + CAST(CONV(...) AS UNSIGNED) % 64, which has to
+                    # agree with _bucket for every value) or moving to a DBAPI
+                    # with server-side cursors — are both bigger than this fix.
+                    # #488 carries them.
                     label_counts = self.database.get_label_counts(
                         self.physical_table_name, self.ingestor_id
                     )
@@ -1291,6 +1315,12 @@ class BaseIngestor(ABC):
                         schema=self._schema_payload(schema_dict),
                         samples=samples,
                         meta_data=self._meta_data_payload(),
+                        # label_counts / samples come straight from the cluster
+                        # DB, i.e. RAW targets. The policy is applied inside
+                        # send_ingest_summary — the boundary — and nowhere
+                        # earlier, so the stored rows keep the values training
+                        # needs (#486).
+                        label_policy=self.label_policy,
                     )
                     dataset_registered = True
                     stats["api_sent_records"] = stats["inserted_records"]

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -106,6 +106,8 @@ def _raise_on_overflow(
             f"this guard surfaces it at cast time instead of letting it "
             f"reach MySQL."
         )
+
+
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
@@ -151,9 +153,7 @@ def _cast_datetime_strict(series: pd.Series, column: str, dtype: str) -> pd.Seri
         )
         offender_rows = series.index[bad_mask][:5].tolist()
         # Shape, not content: the FORMAT is the diagnosis for date errors.
-        shapes = sorted(
-            {redaction.mask_shape(v) for v in series[bad_mask].head(5)}
-        )
+        shapes = sorted({redaction.mask_shape(v) for v in series[bad_mask].head(5)})
         raise ValueError(
             f"Column '{column}' (dtype {dtype}) has un-parseable date "
             f"value(s) at {redaction.row_refs(offender_rows, int(bad_mask.sum()))} "
@@ -413,7 +413,10 @@ class CSVIngestor(BaseIngestor):
                     _raise_on_overflow(column, df[column], converted, dtype)
                     df[column] = converted.astype("Int64")
                     self._accumulate_feature_stats(column, df[column])
-                elif any(t in dtype.upper() for t in ("FLOAT", "DOUBLE", "DECIMAL", "NUMERIC")):
+                elif any(
+                    t in dtype.upper()
+                    for t in ("FLOAT", "DOUBLE", "DECIMAL", "NUMERIC")
+                ):
                     # float64 — NOT downcast='float' (float32), which corrupted
                     # precision: 3.14 -> '3.140000104904175'. Also covers DOUBLE/
                     # DECIMAL/NUMERIC, which previously matched NO branch and let
@@ -457,8 +460,9 @@ class CSVIngestor(BaseIngestor):
                     _falsy = coercion.BOOL_FALSE_STRINGS
                     _norm = df[column].astype("string").str.strip().str.lower()
                     df[column] = _norm.map(
-                        lambda x: True if x in _truthy
-                        else (False if x in _falsy else pd.NA),
+                        lambda x: (
+                            True if x in _truthy else (False if x in _falsy else pd.NA)
+                        ),
                         na_action="ignore",
                     ).astype("boolean")
                 elif "DATETIME" in dtype.upper() or "TIMESTAMP" in dtype.upper():
@@ -471,13 +475,33 @@ class CSVIngestor(BaseIngestor):
                 elif "DATE" in dtype.upper():
                     # DATE only — emit a plain date so the value doesn't gain a
                     # spurious time ('2026-01-02' was becoming '2026-01-02 00:00:00').
-                    df[column] = _cast_datetime_strict(df[column], column, dtype).dt.date
+                    parsed = _cast_datetime_strict(df[column], column, dtype)
+                    if column == _TIMESTAMP_COLUMN:
+                        # Fold the cadence BEFORE dropping the time component.
+                        # ``_accumulate_temporal`` needs a datetime64 series (it
+                        # reads ``.dt.tz`` and its sample feeds
+                        # ``pd.DatetimeIndex``); the ``.dt.date`` result below is
+                        # object dtype and has no ``.dt`` accessor.
+                        #
+                        # Only the DATETIME/TIMESTAMP branch accumulated this
+                        # before. That was unreachable for a date-only column
+                        # while the validator required TIMESTAMP, but #489 makes
+                        # DATE legal — and an inferred schema types a date-only
+                        # column DATE — so daily series (the commonest
+                        # forecasting shape) would ingest cleanly while silently
+                        # omitting ``sampling_frequency`` from run metadata.
+                        self._accumulate_temporal(parsed)
+                    df[column] = parsed.dt.date
                 elif "TIME" in dtype.upper():
                     # TIME only — emit a plain time so the value doesn't gain a
                     # spurious (today's) date ('14:30:00' was becoming
                     # '2026-06-08 14:30:00', which MySQL TIME then truncates).
-                    df[column] = _cast_datetime_strict(df[column], column, dtype).dt.time
-                elif any(t in dtype.upper() for t in ("STRING", "TEXT", "VARCHAR", "CHAR")):
+                    df[column] = _cast_datetime_strict(
+                        df[column], column, dtype
+                    ).dt.time
+                elif any(
+                    t in dtype.upper() for t in ("STRING", "TEXT", "VARCHAR", "CHAR")
+                ):
                     # Coerce to pandas StringDtype so missing cells become pd.NA
                     # (not float NaN), then map pd.NA -> Python None so the DB
                     # binder writes SQL NULL. Without this, VARCHAR/CHAR columns
@@ -488,9 +512,10 @@ class CSVIngestor(BaseIngestor):
                     # longer fails validation; this completes the fix on the
                     # write side.
                     df[column] = (
-                        df[column].astype("string").astype(object).where(
-                            df[column].notna(), None
-                        )
+                        df[column]
+                        .astype("string")
+                        .astype(object)
+                        .where(df[column].notna(), None)
                     )
                     self._accumulate_categorical(column, df[column])
             except Exception as e:
@@ -634,9 +659,8 @@ class CSVIngestor(BaseIngestor):
         """
         if not self._emit_alignment_stats:
             return
-        if (
-            column in self._categorical_over_cap
-            or column in (self._categorical_excluded_resolved or ())
+        if column in self._categorical_over_cap or column in (
+            self._categorical_excluded_resolved or ()
         ):
             return
         vals = series.dropna()

--- a/tracebloc_ingestor/ingestors/record_processor.py
+++ b/tracebloc_ingestor/ingestors/record_processor.py
@@ -31,7 +31,6 @@ from typing import Any, Dict, Optional
 
 import pandas as pd
 
-from ..utils import label_policy as label_policy_module
 from ..utils.constants import Intent
 
 logger = logging.getLogger(__name__)
@@ -49,7 +48,6 @@ class RecordProcessor:
         label_column: Optional[str],
         annotation_column: Optional[str],
         unique_id_column: Optional[str],
-        label_policy: Any,
         ingestor_id: str,
         data_id_strategy: str = "content_hash",
         table_salt: Optional[str] = None,
@@ -61,13 +59,14 @@ class RecordProcessor:
         self.unique_id_column = unique_id_column
         # #225: content-hash strategy needs the per-table salt; failing at
         # construction beats minting unsalted (correlatable) ids at row time.
-        if data_id_strategy == "content_hash" and not unique_id_column and not table_salt:
-            raise ValueError(
-                "data_id_strategy='content_hash' requires a table_salt"
-            )
+        if (
+            data_id_strategy == "content_hash"
+            and not unique_id_column
+            and not table_salt
+        ):
+            raise ValueError("data_id_strategy='content_hash' requires a table_salt")
         self.data_id_strategy = data_id_strategy
         self.table_salt = table_salt
-        self.label_policy = label_policy
         self.ingestor_id = ingestor_id
 
     def _map_unique_id(
@@ -111,31 +110,36 @@ class RecordProcessor:
             )
 
         if self.label_column:
-            # Apply the configured label policy at the latest possible moment
-            # before the API client builds its payload. For classification-class
-            # categories ``label_policy="passthrough"`` is a no-op; for
-            # regression-class categories ``"bucket"`` replaces the raw target
-            # with a stable hash-bucket ID so the value never leaks to the
-            # central backend (#44 / parent client#85).
+            # The RAW label is what gets stored. The ``label.policy`` bucketing
+            # of #44 / client#85 is a BOUNDARY control and runs in
+            # ``APIClient.send_ingest_summary``, on the outbound payload only.
             #
-            # Coerce numpy / pandas scalar types to native Python before the
-            # policy runs. After the INT-cast switch to nullable ``Int64``,
+            # It used to run here, on the record handed to the batch writer for
+            # INSERT (#486). Since ``process()`` also drops the source
+            # ``label_column`` from the schema-filtered columns, the raw target
+            # was then persisted nowhere: every regression-class dataset
+            # (tabular_regression, time_series_forecasting,
+            # time_to_event_prediction) stored a hash bucket in ``[0, 64)``
+            # where its training target belonged. The training client reads
+            # THIS row, so a metadata control silently destroyed the data.
+            #
+            # Coerce numpy / pandas scalar types to native Python. After the
+            # INT-cast switch to nullable ``Int64``,
             # itertuples yields ``numpy.int64`` (the old ``downcast='integer'``
             # incidentally produced plain ``int``) — and mysql-connector-python
             # refuses to bind numpy scalars, failing the passthrough path with
             # "Python type numpy.int64 cannot be converted" on every row of any
             # INT label column (tabular_classification on the e2e job). The
-            # other policies (e.g. ``bucket``) stringify their output so they
-            # never hit this; the fix lives here so passthrough also yields a
-            # binder-friendly value.
+            # bucketing stringifies its output so it never hit this; the fix
+            # lives here so the stored value is binder-friendly.
             label_val = record.get(self.label_column)
             if hasattr(label_val, "item") and not isinstance(label_val, str):
                 try:
                     label_val = label_val.item()
                 except (ValueError, AttributeError):
                     pass
-            # Strip surrounding whitespace from string label values before
-            # the policy runs — protects against silent label-set
+            # Strip surrounding whitespace from string label values —
+            # protects against silent label-set
             # corruption (issue #261) where ``"  A  "`` and ``"A"`` would
             # otherwise land as distinct classes in MySQL. A user
             # copy-pasting from Excel / another tool routinely has
@@ -150,9 +154,23 @@ class RecordProcessor:
             # space-separated tags, etc.) pass through unchanged.
             if isinstance(label_val, str):
                 label_val = label_val.strip()
-            cleaned_record["label"] = label_policy_module.apply(
-                label_val, self.label_policy
-            )
+            # A missing target becomes SQL NULL, the same missing-data
+            # normalization ``process()`` gives every schema column — the
+            # ``label`` column is VARCHAR(255) NULL (``Database.create_table``).
+            # Without this, pandas' float ``nan`` / ``pd.NA`` for an empty cell
+            # reaches the binder and lands as the literal string "nan" (Bugbot
+            # on #487: the write-path bucketing this PR removed used to absorb
+            # NaN into MISSING_LABEL_BUCKET, so dropping it left the hole).
+            # NULL keeps the outbound sentinel intact: ``get_label_counts``
+            # reports a NULL label under the ``""`` key and ``get_samples``
+            # as ``""``, both of which bucket to MISSING_LABEL_BUCKET at the
+            # boundary. An empty-string label is left alone — it stores fine
+            # and already buckets to the same sentinel.
+            if label_val is None or (
+                pd.api.types.is_scalar(label_val) and pd.isna(label_val)
+            ):
+                label_val = None
+            cleaned_record["label"] = label_val
 
         if self.intent:
             cleaned_record["data_intent"] = self.intent
@@ -197,9 +215,13 @@ class RecordProcessor:
         SHA-256 over the per-table salt + a canonical JSON serialization of
         every cleaned field (sorted keys, ASCII, compact separators,
         ``default=str`` so dates/decimals serialize stably post-cast). The
-        record is hashed AFTER schema cleaning and label policy, so the
-        digest reflects exactly what will be stored — identical source
-        records produce identical ids across process restarts.
+        record is hashed AFTER schema cleaning, so the digest reflects exactly
+        what will be stored — identical source records produce identical ids
+        across process restarts. Since #486 that includes the RAW label (the
+        bucketing it used to hash moved to the send boundary), so a
+        regression-class source re-ingested across that change mints different
+        ids for the same rows — a one-off, and those datasets need a re-ingest
+        anyway because their stored targets were buckets.
 
         Privacy: the salt (random per table, cluster-MySQL-only) makes the
         digest unlinkable across tables/clusters and defeats dictionary
@@ -213,9 +235,7 @@ class RecordProcessor:
             separators=(",", ":"),
             default=str,
         )
-        return hashlib.sha256(
-            (self.table_salt + canonical).encode("utf-8")
-        ).hexdigest()
+        return hashlib.sha256((self.table_salt + canonical).encode("utf-8")).hexdigest()
 
     def process(self, record: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Process a single record"""
@@ -269,7 +289,6 @@ class RecordProcessor:
             }
             # Map unique ID if specified
             cleaned_record = self._map_unique_id(record, cleaned_record)
-
 
             if cleaned_record is None:
                 return None

--- a/tracebloc_ingestor/schema/runtime_env.v1.json
+++ b/tracebloc_ingestor/schema/runtime_env.v1.json
@@ -1,0 +1,20 @@
+{
+  "version": "1",
+  "description": "Environment variables the ingestor requires from whatever spawns it (jobs-manager's ingestion Job, or an operator running the container directly). A spawner that omits a required variable produces a container that fails at Config() before reading any data. Published so the spawner can assert it satisfies this contract in CI, rather than the two sides discovering a disagreement in a live environment (backend#1752).",
+  "required": [
+    {
+      "name": "DB_USER",
+      "since": "0.8.0",
+      "provided_by": "jobs-manager, gated on SERVICE_DB_ACCOUNTS",
+      "was_defaulted_to": "edgeuser",
+      "reason": "backend#1528 D10 retired the root-equivalent edgeuser identity; the ingestor now authenticates as the per-Job tb_ingest account the spawner injects."
+    },
+    {
+      "name": "DB_PASSWORD",
+      "since": "0.8.0",
+      "provided_by": "jobs-manager, gated on SERVICE_DB_ACCOUNTS",
+      "was_defaulted_to": "<the legacy edgeuser password>",
+      "reason": "Same as DB_USER. Injected as a secretKeyRef so the value never lands in the Job spec."
+    }
+  ]
+}

--- a/tracebloc_ingestor/utils/fs.py
+++ b/tracebloc_ingestor/utils/fs.py
@@ -1,0 +1,65 @@
+"""Filesystem helpers shared by the validators and the transfer path.
+
+Home of the one rule about destination directories that both sides must follow:
+a directory the ingestor creates has to stay reclaimable by the `data delete`
+teardown, which runs as a DIFFERENT uid in a different pod.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Mode for a destination directory the ingestor creates.
+#
+# 0o2777 = rwxrwsrwx: setgid, plus write for group AND other.
+#
+# Why world-write and not the tighter group-write (0o2775) this used to be:
+# removing a file requires write+execute on its PARENT DIRECTORY, and the
+# processes that create and delete these trees are different pods running as
+# different, non-overlapping identities:
+#
+#   * the ingestion Job runs as uid 65534 (`nobody`) by default, or HOST_UID on
+#     a network export (client-runtime submit_ingestion_run.py);
+#   * the CLI's staging/teardown pod runs as uid 65532 with fsGroup 65532
+#     (cli internal/push/pod.go);
+#   * the chart chowns the shared mount itself to 1000:1000 and sets setgid, so
+#     a directory created underneath INHERITS group 1000 -- not 65532.
+#
+# So group-write could never help: the group the teardown pod carries (65532) is
+# not the group the directory inherits (1000). And the usual fix for that --
+# fsGroup, which makes kubelet recursively chgrp the volume -- does nothing here,
+# because kubelet IGNORES fsGroup on hostPath volumes
+# (kubernetes/kubernetes#138411), the layout every installer-provisioned cluster
+# uses. Nothing at ingest time can know or align those identities, and the parent
+# mount is already world-writable by chart design, so world-write on the
+# directory is both the only mode that works for every caller and no wider a
+# grant than the tree it sits in.
+DEST_DIR_MODE = 0o2777
+
+
+def ensure_reclaimable_dir(path: str) -> None:
+    """Create ``path`` if absent, with a mode the teardown can reclaim.
+
+    Only a directory we *create* is chmod'd. A pre-existing one is left alone so
+    we neither override an operator's deliberate mode nor mask a genuine
+    permission problem -- an unwritable destination still surfaces downstream.
+    (A directory left behind by an older ingestor keeps its old mode; repairing
+    those is the installer's job, not a silent chmod of data we did not create.)
+
+    The chmod is best-effort: a failure is logged, never fatal, so ingestion
+    still proceeds on a filesystem that cannot represent the mode at all.
+    """
+    existed = os.path.isdir(path)
+    os.makedirs(path, exist_ok=True)
+    if existed:
+        return
+    try:
+        os.chmod(path, DEST_DIR_MODE)
+    except OSError as error:
+        logger.warning(
+            "Could not set the reclaimable mode on %s (%s); the `data delete` "
+            "teardown may not be able to remove it",
+            path,
+            error,
+        )

--- a/tracebloc_ingestor/utils/label_policy.py
+++ b/tracebloc_ingestor/utils/label_policy.py
@@ -6,8 +6,17 @@ prediction — the raw value must NOT leak to the central backend. The
 on-prem-data principle is that only metadata crosses the cluster boundary;
 shipping the literal target value defeats it.
 
-This module is the single point where raw labels become bucket IDs before
-``APIClient.send_batch`` builds its payload.
+This module is the single point where raw labels become bucket IDs, and it runs
+at the CLUSTER BOUNDARY — inside ``APIClient.send_ingest_summary``, on the
+payload only. The row written to the on-prem MySQL table keeps the RAW target.
+
+That distinction is the whole bug of #486: the policy used to run in
+``RecordProcessor.clean_record``, i.e. on the record handed to the batch writer
+for INSERT. The stored target became a bucket id, the raw value was persisted
+nowhere, and the training client read hash buckets as labels — a hard failure
+for ``time_to_event_prediction`` (the engine requires the event column ∈ {0,1})
+and a silent one for ``tabular_regression`` / ``time_series_forecasting``. The
+local data is what training consumes; only metadata is in scope for bucketing.
 
 v1 strategy: stable hash-bucket. ``sha256(str(value))`` truncated to 8 bytes,
 modulo ``NUM_BUCKETS``. Properties:
@@ -29,8 +38,7 @@ from __future__ import annotations
 
 import hashlib
 import math
-from typing import Any
-
+from typing import Any, Dict, Iterable, List, Mapping
 
 # Number of buckets. 64 is enough granularity for the central backend to
 # reason about distribution without offering reconstruction power. Trade-off
@@ -71,8 +79,7 @@ def apply(value: Any, policy: str) -> Any:
     if policy == BUCKET:
         return _bucket(value)
     raise ValueError(
-        f"Unknown label policy: {policy!r}. "
-        f"Valid: {PASSTHROUGH!r}, {BUCKET!r}."
+        f"Unknown label policy: {policy!r}. " f"Valid: {PASSTHROUGH!r}, {BUCKET!r}."
     )
 
 
@@ -96,8 +103,83 @@ def _bucket(value: Any) -> int:
     return int.from_bytes(digest[:8], "big") % NUM_BUCKETS
 
 
+def apply_to_label_counts(counts: Mapping[Any, int], policy: str) -> Dict[Any, int]:
+    """Bucket the keys of a ``{label: row_count}`` map for the outbound payload.
+
+    Args:
+        counts: ``{label: row_count}`` as read back from the cluster DB
+            (``Database.get_label_counts``), keyed by the RAW label.
+        policy: ``"passthrough"`` (returned unchanged) or ``"bucket"``.
+
+    Returns:
+        Under ``bucket``, ``{"<bucket_id>": row_count}``. Counts of raw values
+        that share a bucket are SUMMED — with 64 buckets, collisions are
+        expected (a 300-label dataset averages ~5 raw values per bucket), and
+        dropping one of the colliding entries would under-report the dataset's
+        size to the backend.
+
+        Keys are STRINGS, matching what the backend has always received: the
+        bucket id used to be written to the VARCHAR ``label`` column and read
+        back as a string, and JSON object keys are strings regardless. Same
+        reason ``apply_to_samples`` stringifies.
+
+    Raises:
+        ValueError: if ``policy`` is unknown (via :func:`apply`).
+    """
+    if policy == PASSTHROUGH:
+        return dict(counts)
+    bucketed: Dict[Any, int] = {}
+    for label, count in counts.items():
+        key = str(apply(label, policy))
+        bucketed[key] = bucketed.get(key, 0) + count
+    return bucketed
+
+
+def apply_to_samples(
+    samples: Iterable[Mapping[str, Any]], policy: str
+) -> List[Dict[str, Any]]:
+    """Bucket the ``label`` of each outbound ``{data_id, label}`` sample.
+
+    Args:
+        samples: The preview records from ``Database.get_samples``, carrying
+            the RAW label.
+        policy: ``"passthrough"`` (labels returned unchanged) or ``"bucket"``.
+
+    Returns:
+        New sample dicts — the input mappings are never mutated. A sample
+        without a ``label`` key is passed through untouched rather than gaining
+        a bucketed ``None``: the absence is the backend's signal, and inventing
+        ``MISSING_LABEL_BUCKET`` for a shape that never had a label would
+        misreport it as a label the ingest saw.
+
+        The bucketed label is a STRING, not the raw ``int``. Pre-#486 the
+        bucket was stored in the VARCHAR ``label`` column and read back out by
+        ``Database.get_samples``, so ``data_samples[].label`` has always been a
+        JSON string — as it is for classification class names. The backend's
+        summary serializer takes ``samples`` as an untyped ``ListField`` and
+        would accept a number, but every consumer downstream of
+        ``UserDataSet.data_samples`` has only ever seen strings, so this keeps
+        the wire shape identical rather than betting on their tolerance
+        (review on #487).
+
+    Raises:
+        ValueError: if ``policy`` is unknown (via :func:`apply`).
+    """
+    if policy == PASSTHROUGH:
+        return [dict(sample) for sample in samples]
+    out: List[Dict[str, Any]] = []
+    for sample in samples:
+        record = dict(sample)
+        if "label" in record:
+            record["label"] = str(apply(record["label"], policy))
+        out.append(record)
+    return out
+
+
 __all__ = [
     "apply",
+    "apply_to_label_counts",
+    "apply_to_samples",
     "PASSTHROUGH",
     "BUCKET",
     "NUM_BUCKETS",

--- a/tracebloc_ingestor/validators/duplicate_validator.py
+++ b/tracebloc_ingestor/validators/duplicate_validator.py
@@ -10,6 +10,7 @@ import logging
 
 from .base import BaseValidator, ValidationResult
 from ..config import Config
+from ..utils.fs import ensure_reclaimable_dir
 
 config = Config()
 logger = logging.getLogger(__name__)
@@ -203,7 +204,15 @@ class DuplicateValidator(BaseValidator):
         try:
             dest_path = Path(self.dest_path)
             if not dest_path.exists():
-                dest_path.mkdir(parents=True, exist_ok=True)
+                # Shared helper, not a bare mkdir: validation runs BEFORE the
+                # transfer, so whoever creates this directory first decides its
+                # mode -- and file_transfer deliberately does not re-chmod a
+                # directory that already exists. A bare mkdir here therefore left
+                # the tree at the umask default (0755, owned by the ingest uid),
+                # which the `data delete` teardown pod -- a different uid -- cannot
+                # remove: "rm: can't remove ...: Permission denied", with the
+                # table already dropped. See utils/fs.py.
+                ensure_reclaimable_dir(str(dest_path))
                 logger.info(f"Created destination directory: {self.dest_path}")
             return True
         except Exception as e:

--- a/tracebloc_ingestor/validators/time_format_validator.py
+++ b/tracebloc_ingestor/validators/time_format_validator.py
@@ -18,6 +18,25 @@ logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
 
+# SQL types accepted for the ``timestamp`` column. All three denote calendar
+# values and all three are already mapped to a temporal SQLAlchemy type by
+# ``Database._get_sqlalchemy_type`` (``DATE`` -> ``Date``, ``DATETIME`` /
+# ``TIMESTAMP`` -> ``DateTime``), so accepting them here does not push a failure
+# further down the pipeline.
+#
+# Why not ``TIMESTAMP`` alone (#489): ``schema_inference._infer_datetime`` — the
+# source of every INFERRED schema, and therefore of every ingest that does not
+# pass an explicit one — returns ``DATETIME`` when a value carries a time of day
+# and ``DATE`` otherwise. It can never emit ``TIMESTAMP``. Requiring exactly
+# ``TIMESTAMP`` therefore rejected 100% of inferred time-series-forecasting
+# schemas no matter what the data looked like: a date-only column failed with
+# "found 'DATE'", and adding a time of day only changed the message to "found
+# 'DATETIME'". The bundled Python template hard-codes ``"timestamp":
+# "TIMESTAMP"``, which is why the template path worked and the gap went
+# unnoticed. Genuinely wrong types (VARCHAR, INT, …) are still rejected.
+TEMPORAL_TIMESTAMP_TYPES = frozenset({"TIMESTAMP", "DATETIME", "DATE"})
+
+
 def parse_month_first_with_ambiguity_mask(values):
     """Month-first ``format='mixed'`` parse + the locale-ambiguity mask.
 
@@ -50,7 +69,9 @@ class TimeFormatValidator(BaseValidator):
 
     Ensures:
     1. Column "timestamp" exists in the dataset
-    2. Timestamp column in schema is of type TIMESTAMP (not DATE or DATETIME)
+    2. Timestamp column in schema is a calendar type — ``TIMESTAMP``,
+       ``DATETIME`` or ``DATE`` (see ``TEMPORAL_TIMESTAMP_TYPES``); text and
+       numeric types are rejected
     3. All timestamp values are in valid format
     """
 
@@ -66,7 +87,7 @@ class TimeFormatValidator(BaseValidator):
         """Validate timestamp format."""
         try:
             errors = []
-            
+
             # Check schema: timestamp column must exist and be of type TIMESTAMP
             if self.schema:
                 if "timestamp" not in self.schema:
@@ -75,27 +96,32 @@ class TimeFormatValidator(BaseValidator):
                         "For time series forecasting, a 'timestamp' column is required."
                     )
                     return self._create_result(is_valid=False, errors=errors)
-                
+
                 # Extract base type (before parentheses) to handle precision specifiers like TIMESTAMP(6)
                 timestamp_type = self.schema["timestamp"].upper().strip()
                 base_type = timestamp_type.split("(")[0].split()[0]
-                
-                if base_type not in ["TIMESTAMP"]:
+
+                if base_type not in TEMPORAL_TIMESTAMP_TYPES:
                     errors.append(
-                        f"Timestamp column in schema must be of type 'TIMESTAMP', "
-                        f"but found '{self.schema['timestamp']}'. "
-                        f"For time series forecasting, timestamp column must be TIMESTAMP type."
+                        f"Timestamp column in schema must be a date/time type "
+                        f"({', '.join(sorted(TEMPORAL_TIMESTAMP_TYPES))}), but found "
+                        f"'{self.schema['timestamp']}'. For time series forecasting the "
+                        f"timestamp column must hold calendar values, not text or numbers."
                     )
                     return self._create_result(is_valid=False, errors=errors)
-            
+
             df = self._load_data(data)
             if df is None or df.empty:
-                return self._create_result(is_valid=False, errors=["No data found to validate"])
+                return self._create_result(
+                    is_valid=False, errors=["No data found to validate"]
+                )
 
             if "timestamp" not in df.columns:
                 return self._create_result(
                     is_valid=False,
-                    errors=[f"Required column 'timestamp' not found. Available: {list(df.columns)}"],
+                    errors=[
+                        f"Required column 'timestamp' not found. Available: {list(df.columns)}"
+                    ],
                 )
 
             # Parse timestamps + locale-ambiguity mask (shared helper — the
@@ -126,8 +152,10 @@ class TimeFormatValidator(BaseValidator):
             invalid_mask = timestamps.isna()
             if invalid_mask.any():
                 invalid_count = invalid_mask.sum()
-                invalid_rows = [i+1 for i in df.index[invalid_mask][:10]]
-                errors.append(f"Found {invalid_count} invalid timestamp(s) at rows: {invalid_rows}")
+                invalid_rows = [i + 1 for i in df.index[invalid_mask][:10]]
+                errors.append(
+                    f"Found {invalid_count} invalid timestamp(s) at rows: {invalid_rows}"
+                )
                 metadata["invalid_timestamps"] = invalid_count
 
             return self._create_result(
@@ -138,7 +166,10 @@ class TimeFormatValidator(BaseValidator):
 
         except Exception as e:
             logger.error(f"Time format validation error: {e}")
-            return self._create_result(is_valid=False, errors=[f"Validation error: {str(e)}"])
+            return self._create_result(
+                is_valid=False, errors=[f"Validation error: {str(e)}"]
+            )
+
     def _load_data(self, data: Any) -> Optional[pd.DataFrame]:
         try:
             if isinstance(data, (str, Path)):
@@ -146,9 +177,8 @@ class TimeFormatValidator(BaseValidator):
                 if file_path.exists() and file_path.suffix.lower() == ".csv":
                     # Always load complete file for timestamp validation
                     return pd.read_csv(file_path, encoding="utf-8", on_bad_lines="warn")
-            
+
             return None
         except Exception as e:
             logger.error(f"Error loading data: {e}")
             return None
-


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-main` branch (a mirror of `staging`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how regression targets are stored vs sent to the backend, makes DB credentials mandatory (spawner must match `runtime_env.v1.json`), and promotes a broad package release via the train to `main`.
> 
> **Overview**
> **Release train promotion** (`staging` → `main`) shipping ingestor **`0.8.8`** and the behaviors below.
> 
> **Regression / time-series labels (#486)** — `label.policy: bucket` no longer runs in `RecordProcessor` on INSERT. Rows in cluster MySQL keep the **raw target** (what training reads); bucketing applies only in **`APIClient.send_ingest_summary`** on `labels` and `samples`. `RecordProcessor` drops the `label_policy` parameter; helpers `apply_to_label_counts` / `apply_to_samples` own the outbound transform.
> 
> **Database auth (backend#1528)** — `DB_USER` and `DB_PASSWORD` are **required** via `_require_env`; the legacy `edgeuser` defaults are removed. **`runtime_env.v1.json`** plus **`test_runtime_env_contract.py`** document what jobs-manager must inject. **`ingestor-job.yaml`**, **Readme**, and secret-guard tests align with `tb_ingest` / no baked-in passwords.
> 
> **Shared storage teardown (client#653)** — New **`utils/fs.py`** (`DEST_DIR_MODE` `0o2777`, `ensure_reclaimable_dir`) is used from file transfer and **`DuplicateValidator`** so dirs created before copy are removable by the `data delete` pod under mismatched UIDs.
> 
> **Time-series / forecasting (#489)** — **`TimeFormatValidator`** accepts `DATE` / `DATETIME` / `TIMESTAMP` (not `TIMESTAMP` only). **`CSVIngestor`** accumulates temporal cadence for date-only `timestamp` columns so run metadata gets `sampling_frequency`.
> 
> **CI** — Image smoke tests and **`version-guard`** use here-strings instead of `echo | grep -q` under `pipefail` (**backend#1778**). Kanban workflow bumps **`actions/add-to-project`** to v2.0.0.
> 
> Docs and tests are updated throughout (label boundary, DB creds, fs modes, validators); version guard expects a bump when `tracebloc_ingestor/` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b4e94038126c486ec1281d6eb1a4a7405dfaa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->