### PR TITLE
sec(#1752): publish the runtime-env contract the spawner must satisfy

### DIFF
--- a/tests/test_runtime_env_contract.py
+++ b/tests/test_runtime_env_contract.py
@@ -1,0 +1,124 @@
+"""Pins the runtime-env contract the spawner has to satisfy (backend#1752).
+
+WHY THIS EXISTS
+---------------
+#468 made DB_USER/DB_PASSWORD required by removing the edgeuser fallback. The
+credentials that replace them are injected by jobs-manager only when
+SERVICE_DB_ACCOUNTS is on, and that flag is off everywhere. Staging edges float
+on the `:stg` ingestor channel, so they picked the change up within hours and
+every ingestion Job began failing at Config() before reading a byte.
+
+NOTHING COULD HAVE CAUGHT IT, and that is the point. This repo's required
+`e2e (real MySQL)` check sets `DB_USER: root` in its own workflow env — it
+supplies the credentials whose absence is the bug, so it is structurally
+incapable of noticing that no one else supplies them. client-runtime's tests
+assert the injection is correctly *gated*. Both halves are individually right;
+the pair was never tested.
+
+WHAT THIS FILE BUYS
+-------------------
+It makes the requirement a PUBLISHED FACT rather than an implementation detail
+buried in a property getter, so the spawner can assert against it in its own CI
+— the same shape as layout.v1.json, which the CLI reads instead of restating
+the layout rules.
+
+On its own this file cannot fail the spawner's build; that is client-runtime's
+half (backend#1753). What it does guarantee is that the contract can never
+drift from the code, so when the spawner does read it, it is reading the truth.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = _ROOT / "tracebloc_ingestor" / "schema" / "runtime_env.v1.json"
+CONFIG_PY = _ROOT / "tracebloc_ingestor" / "config.py"
+
+SUPPORTED_VERSIONS = {"1"}
+
+
+def _contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def _required_from_contract() -> set:
+    return {entry["name"] for entry in _contract()["required"]}
+
+
+def _required_from_code() -> set:
+    """Every env var `config.py` passes to `_require_env`, read from the AST.
+
+    Parsed rather than imported: importing the package pulls in sqlalchemy and
+    the rest of the runtime, and a contract test should depend on the source it
+    is pinning, not on the environment it happens to run in.
+    """
+    tree = ast.parse(CONFIG_PY.read_text(encoding="utf-8"))
+    found = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = getattr(fn, "attr", None) or getattr(fn, "id", None)
+        if name != "_require_env" or not node.args:
+            continue
+        arg = node.args[0]
+        assert isinstance(arg, ast.Constant) and isinstance(arg.value, str), (
+            "_require_env must be called with a literal env-var name so this "
+            "contract can be checked statically; got a computed value"
+        )
+        found.add(arg.value)
+    return found
+
+
+def test_the_contract_is_a_version_we_understand():
+    assert _contract()["version"] in SUPPORTED_VERSIONS
+
+
+def test_every_required_var_in_the_code_is_declared():
+    """The direction that matters.
+
+    Adding a `_require_env` call without declaring it is exactly what happened
+    in #468: a new hard requirement on the spawner, invisible to the spawner.
+    """
+    undeclared = _required_from_code() - _required_from_contract()
+    assert not undeclared, (
+        f"config.py requires {sorted(undeclared)} but runtime_env.v1.json does "
+        "not declare them. Whatever spawns this container has no way to know it "
+        "must provide them — which is how backend#1752 broke staging ingestion. "
+        "Declare them, and check the spawner actually injects them before "
+        "merging."
+    )
+
+
+def test_the_contract_does_not_claim_requirements_the_code_dropped():
+    """The other direction, so the contract cannot rot into over-claiming.
+
+    A stale entry would make a spawner inject something pointless forever, and
+    would make this file untrustworthy in the direction that matters.
+    """
+    stale = _required_from_contract() - _required_from_code()
+    assert not stale, (
+        f"runtime_env.v1.json declares {sorted(stale)} as required but nothing "
+        "in config.py requires them any more."
+    )
+
+
+def test_each_entry_says_who_is_supposed_to_provide_it():
+    """An entry that does not name its provider is not actionable.
+
+    `provided_by` is what turns this from a list of names into something a
+    reviewer can check: it is the sentence that would have made the #468
+    ordering hazard obvious at review time.
+    """
+    for entry in _contract()["required"]:
+        for field in ("name", "provided_by", "reason"):
+            assert entry.get(field), f"{entry.get('name', entry)} lacks {field!r}"
+
+
+def test_it_currently_pins_the_two_credentials_1528_made_required():
+    # A concrete anchor: if these ever stop being required, that is a
+    # deliberate decision and this line should be the thing that notices.
+    assert _required_from_contract() == {"DB_USER", "DB_PASSWORD"}

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.5"
+__version__ = "0.8.6"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/schema/runtime_env.v1.json
+++ b/tracebloc_ingestor/schema/runtime_env.v1.json
@@ -1,0 +1,20 @@
+{
+  "version": "1",
+  "description": "Environment variables the ingestor requires from whatever spawns it (jobs-manager's ingestion Job, or an operator running the container directly). A spawner that omits a required variable produces a container that fails at Config() before reading any data. Published so the spawner can assert it satisfies this contract in CI, rather than the two sides discovering a disagreement in a live environment (backend#1752).",
+  "required": [
+    {
+      "name": "DB_USER",
+      "since": "0.8.0",
+      "provided_by": "jobs-manager, gated on SERVICE_DB_ACCOUNTS",
+      "was_defaulted_to": "edgeuser",
+      "reason": "backend#1528 D10 retired the root-equivalent edgeuser identity; the ingestor now authenticates as the per-Job tb_ingest account the spawner injects."
+    },
+    {
+      "name": "DB_PASSWORD",
+      "since": "0.8.0",
+      "provided_by": "jobs-manager, gated on SERVICE_DB_ACCOUNTS",
+      "was_defaulted_to": "<the legacy edgeuser password>",
+      "reason": "Same as DB_USER. Injected as a secretKeyRef so the value never lands in the Job spec."
+    }
+  ]
+}


### PR DESCRIPTION
Half of the durable fix for [backend#1752](https://github.com/tracebloc/backend/issues/1752) — staging ingestion is currently broken and **no check anywhere could have caught it**.

## What happened

#468 removed the `edgeuser` fallback, making `DB_USER`/`DB_PASSWORD` required. jobs-manager injects them **only when `SERVICE_DB_ACCOUNTS` is on** — and the flag is off on develop, staging and main. Staging edges float on the `:stg` channel, so they picked 0.8.5 up at 16:00 the same day. Verified by running the published image:

```
$ docker run --rm --entrypoint python ghcr.io/tracebloc/ingestor:stg -c "…"
  __version__ = 0.8.5
  DB_USER -> ValueError: DB_USER is not set. …
```

Prod is unaffected — it is digest-pinned to 0.7.7, which still has the fallback.

## Why nothing caught it

This repo's required **`e2e (real MySQL)`** check sets its own credentials:

```yaml
# .github/workflows/e2e.yml
DB_USER: root
DB_PASSWORD: root
```

It supplies the credentials whose absence *is* the bug. It proves the ingestor works **given** creds; the bug is that nothing gives it creds. It is structurally incapable of failing for this reason.

client-runtime's tests assert the injection is correctly **gated**. Both halves are individually correct. **The pair was never tested, and no cross-repo contract existed.**

## What this adds

The requirement stops being an implementation detail inside a property getter and becomes a **published fact** — the same shape as `layout.v1.json`, which the CLI reads rather than restating the layout rules.

`schema/runtime_env.v1.json` declares what the ingestor requires from its spawner, **who is supposed to provide it**, and why. That `provided_by` field is the sentence that would have made the #468 ordering hazard obvious at review time.

The test pins contract to code in **both directions**, parsed from `config.py`'s AST rather than by importing (a contract test should depend on the source it pins, not on whether sqlalchemy happens to be installed):

- a `_require_env` call that isn't declared → **fail** (this is exactly #468)
- a declaration nothing requires any more → **fail** (so it can't rot into over-claiming)

**Mutation-checked against the real scenario.** Adding an undeclared `_require_env("DB_TLS_CERT")` is refused:

> `config.py requires ['DB_TLS_CERT'] but runtime_env.v1.json does not declare them. Whatever spawns this container has no way to know it must provide them — which is how backend#1752 broke staging ingestion.`

## Scope

This half **cannot** fail the spawner's build — that's the client-runtime counterpart, filed as backend#1753: a test asserting the spawned-Job spec satisfies this contract **in both flag states**. That's the one that would have gone red the moment the two disagreed.

What this half guarantees is that when the spawner reads this file, it is reading the truth.

Does **not** unbreak staging — that needs the flag turned on, or the `:stg` channel repinned. Options are laid out in #1752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds schema and tests only; no runtime behavior or credential handling changes in this diff.
> 
> **Overview**
> Publishes **`tracebloc_ingestor/schema/runtime_env.v1.json`** so required container env vars (today **`DB_USER`** / **`DB_PASSWORD`**) are documented with **`provided_by`** and rationale, not only enforced inside **`config.py`**.
> 
> Adds **`tests/test_runtime_env_contract.py`**, which AST-scans **`_require_env`** literals and fails if the JSON and code disagree in either direction, and validates contract metadata fields. Bumps package version **0.8.5 → 0.8.6**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 396c099308d0b616a5fe4230db85a92d47aba612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->