### PR TITLE
ci(version-guard): stop the change detection from failing open under pipefail

### DIFF
--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -26,11 +26,18 @@ jobs:
         run: |
           set -euo pipefail
           changed="$(git diff --name-only "${BASE_SHA}...HEAD")"
-          if ! printf '%s\n' "$changed" | grep -qE '^tracebloc_ingestor/'; then
+          # Here-string, not a pipe: `grep -q` closes the pipe at its first
+          # match, and under `pipefail` a producer killed by SIGPIPE makes the
+          # pipeline status 141. `if !` reads that as "no match" and exits 0
+          # "guard N/A" -- the guard would silently PASS a PR that did change
+          # the package. This repo's path list is ~14 KB today, well under the
+          # 64 KB pipe buffer, so it is latent rather than live (backend#1778).
+          if ! grep -qE '^tracebloc_ingestor/' <<<"$changed"; then
             echo "No tracebloc_ingestor/ change in this PR — guard N/A."
             exit 0
           fi
-          if git diff "${BASE_SHA}...HEAD" -- tracebloc_ingestor/__init__.py | grep -qE '^\+__version__'; then
+          version_diff="$(git diff "${BASE_SHA}...HEAD" -- tracebloc_ingestor/__init__.py)"
+          if grep -qE '^\+__version__' <<<"$version_diff"; then
             echo "Package changed and __version__ was bumped. ✓"
             exit 0
           fi


### PR DESCRIPTION
Found by the fleet-wide audit of the `| head`/`| grep -q` under-`pipefail` hazard (tracebloc/backend#1778). This is the one instance in the fleet that fails **open**.

## The bug

```bash
if ! printf '%s\n' "$changed" | grep -qE '^tracebloc_ingestor/'; then
  echo "No tracebloc_ingestor/ change in this PR — guard N/A."
  exit 0
fi
```

`grep -q` closes the pipe at its first match. Under `pipefail` a producer killed by SIGPIPE makes the pipeline status **141**, and `if !` reads 141 as "no match" — so the step announces "guard N/A" and exits 0 **for a PR that did change the package**. That is precisely the outcome this guard exists to prevent: an unbumped package change that never reaches a released image, which is how the D16 `ds_<hex>` write path (#408) sat unreleased.

## Reproduced

A matching path followed by 120 KB of other paths:

```
── OLD form (pipe) ──
  RESULT: 'guard N/A' -> exit 0   ** FAIL OPEN: package DID change **
  pipeline status was: 141
── NEW form (here-string) ──
  RESULT: match detected -> guard runs (correct)
```

## Severity, honestly

**Latent, and there is a backstop.** Two things keep this from being a live hole:

1. This repo's entire path list is ~14 KB (`git ls-files | wc -c`) against a 64 KB pipe buffer on `ubuntu-latest`, so `git diff --name-only` cannot currently produce enough output to tip it.
2. `version-guard` is **not** in the required-check list on `develop`. The required version check there is the org-level `version-bump-gate / version-check`, which is a different workflow and doesn't share this shape.

So this is "a gate that would lie if it ever grew", not "a gate that is lying". Worth fixing anyway because it fails in the direction where nobody finds out.

## Change

Both pipelines in the step become here-strings — no pipe, so no SIGPIPE, so no 141.

The second one (`git diff ... | grep -qE '^\+__version__'`) fails *closed* — a 141 there sends the run to the error branch — so it was merely wrong rather than dangerous. It's converted too, because leaving one of the two is how the idiom grows back.

## Verification

- `yaml.safe_load` parses the workflow.
- `bash -n` on the extracted step body: syntax OK.
- Repro above shows old → 141/fail-open, new → correct.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI shell idiom fix with no application or release-path logic changes; corrects a latent fail-open in a non-required check.
> 
> **Overview**
> Fixes a **latent fail-open** in the version-guard workflow: under `pipefail`, `grep -q` on a pipe can return 141 (SIGPIPE), and `if !` treated that as "no package change," so the guard could exit 0 for PRs that *did* change `tracebloc_ingestor/`.
> 
> Both checks now use here-strings (`<<<"$changed"` / `<<<"$version_diff"`) instead of pipes, so match detection no longer depends on pipe status. The bug was latent today (~14 KB path list vs 64 KB pipe buffer) but would have silently bypassed the bump requirement if the repo grew.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49282e3bc57278e146ac51df9155f2c575f772ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->