### PR TITLE
ci(publish): the smoke gate must not lose a race to its own grep (backend#1778)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -183,7 +183,15 @@ jobs:
           # The CLI has no --help: main() expects INGEST_CONFIG and says so.
           output=$(docker run --rm --entrypoint tracebloc-ingest "${IMAGE}@${DIGEST}" 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q "INGEST_CONFIG"
+          # MATCHED FROM A HERE-STRING, NOT THROUGH A PIPE -- same reason as
+          # release-image.yml (backend#1778). `echo "$output" | grep -q` under
+          # `set -euo pipefail` lets `grep -q` close the pipe on its first match;
+          # once $output outgrows the pipe buffer the `echo` subshell takes
+          # SIGPIPE, pipefail reports 141 and errexit fails the step. $output is
+          # unbounded container stdout+stderr, so a verbose traceback is all it
+          # would take -- and a 141 here reads as a broken image, failing the
+          # channel publish for a race rather than a packaging break.
+          grep -q "INGEST_CONFIG" <<<"$output"
 
       - name: Export digest
         env:
@@ -251,7 +259,14 @@ jobs:
           out=$(docker buildx imagetools inspect "${IMAGE}:${TAG}")
           echo "$out"
           for arch in amd64 arm64; do
-            printf '%s' "$out" | grep -q "linux/${arch}" || {
+            # Here-string, not a pipe: the third instance of the same shape
+            # (backend#1778). `grep -q` closes the pipe on its first match and a
+            # `printf` subshell killed by SIGPIPE makes the pipeline 141, which
+            # `||` reads as "this arch is missing" -- failing a correctly
+            # published multi-arch index. `imagetools inspect` output is small,
+            # so this has never tipped; leaving one instance of the bug in a file
+            # being fixed for it is the part worth avoiding.
+            grep -q "linux/${arch}" <<<"$out" || {
               echo "::error::published ${IMAGE}:${TAG} is missing linux/${arch}"
               exit 1
             }

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -315,7 +315,19 @@ jobs:
             -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
           output=$(docker run --rm --entrypoint tracebloc-ingest "${IMAGE}@${DIGEST}" 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q "INGEST_CONFIG"
+          # MATCHED FROM A HERE-STRING, NOT THROUGH A PIPE. `echo "$output" |
+          # grep -q` under this step's `set -euo pipefail` is a trap: `grep -q`
+          # exits on its first match, and once $output no longer fits the pipe
+          # buffer the `echo` subshell dies of SIGPIPE, pipefail reports 141, and
+          # errexit fails the step (backend#1778). $output is `docker run ...
+          # 2>&1` -- measured at 147 bytes today against a 64 KiB buffer, so this
+          # is latent, not live. But it is unbounded container stdout+stderr and
+          # the match is on the FIRST line, so `grep -q` leaves early: one
+          # verbose traceback is all it would take to tip it. A 141
+          # here aborts the smoke gate before the cosign signing steps below, so
+          # the failure would read as "the image is broken" rather than "grep
+          # won the race". A here-string has no producer to signal.
+          grep -q "INGEST_CONFIG" <<<"$output"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1


### PR DESCRIPTION
## Summary

The image smoke probes gate publishing with:

```bash
set -euo pipefail
output=$(docker run --rm --entrypoint tracebloc-ingest "${IMAGE}@${DIGEST}" 2>&1 || true)
echo "$output"
echo "$output" | grep -q "INGEST_CONFIG"
```

`grep -q` exits on its **first** match — and the match is on the first line — so once `$output` outgrows the 64 KiB pipe buffer the `echo` subshell takes SIGPIPE, `pipefail` turns the pipeline into **141**, and `errexit` fails the step. In `release-image.yml` that aborts the smoke gate **before the cosign signing steps**, so a lost race would present as "the image is broken".

All three sites now match from a here-string, which has no producer to signal. Part of the fleet-wide sweep in backend#1778.

| site | shape |
|---|---|
| `release-image.yml:318` | `echo "$output" \| grep -q "INGEST_CONFIG"` |
| `publish-images.yml:186` | `echo "$output" \| grep -q "INGEST_CONFIG"` |
| `publish-images.yml:254` | `printf '%s' "$out" \| grep -q "linux/${arch}"` (multi-arch verify — same shape, same file) |

### Severity: latent, not live

The CLI's no-config message is **147 bytes** measured — 0.2% of the pipe buffer:

```
$ out=$(tracebloc-ingest 2>&1 || true); printf '%s\n' "$out"; echo "size: ${#out} bytes"
INGEST_CONFIG env var not set. The official image expects the Helm subchart (client#86) to mount the ingest.yaml and set INGEST_CONFIG to its path.
size: 147 bytes (pipe buffer is 65536)
```

This has never fired and there is no evidence it has. It is worth fixing because `$output` is `docker run … 2>&1` — unbounded container stdout+stderr — so a single verbose traceback or import-time dump would tip it, and it would tip on the failure path, when the output is largest and the diagnosis matters most.

## Evidence

### Behaviour is identical, and the 141 reproduces

`echo "$v"` and `<<<"$v"` emit exactly the same bytes (both append one newline), so the truth table is unchanged. Run under `set -euo pipefail`, `GATE-PASS` printed only if the gate passes:

```
empty               0 bytes  old: rc=1
                            new: rc=1
nomatch            23 bytes  old: rc=1
                            new: rc=1
match_small        32 bytes  old:GATE-PASS rc=0
                            new:GATE-PASS rc=0
match_1MB     1000022 bytes  old: rc=141        <- THE BUG: gate never reached
                            new:GATE-PASS rc=0
```

Same status on every case that fits the buffer; the 141 becomes the pass it should always have been.

Note `printf '%s'` does not append a newline where `<<<` does. That cannot change the result for `grep -q "linux/${arch}"` — grep treats an unterminated final line as a line either way — and the match is not anchored.

### YAML parses

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-image.yml'))"
OK  .github/workflows/release-image.yml  jobs: ['verify-published', 'release']
OK  .github/workflows/publish-images.yml  jobs: ['resolve', 'build', 'merge']
```

### Every `run:` body through `bash -n`

All 13 `run:` blocks in both workflows extracted (with `${{ }}` stubbed) and syntax-checked:

```
run: blocks checked = 13, bash -n syntax errors = 0
```

### shellcheck — zero new findings

Same extraction, `shellcheck -f gcc`, `develop` vs this branch (line:col stripped so the added comments don't create phantom diffs):

```
base findings: 1   branch findings: 1
=== diff ===
IDENTICAL — no new shellcheck findings

=== the pre-existing findings ===
.github/workflows/release-image.yml :: release :: Update release notes with digest :: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
```

The one finding is pre-existing and in a step this PR does not touch.

`actionlint` on both files reports the same single pre-existing SC2016 before and after — only its line number shifts (347 → 359) because of the added comments:

```
=== BASE (develop) ===
.github/workflows/release-image.yml:347:9: shellcheck reported issue in this script: SC2016 …
=== BRANCH ===
.github/workflows/release-image.yml:359:9: shellcheck reported issue in this script: SC2016 …
```

### Test suite

```
$ python -m pytest -q
1935 passed, 1 xfailed, 17 warnings in 22.02s
```

No test references the workflows, so the suite is a no-regression check rather than coverage of the change; the `bash -n` / shellcheck / actionlint / truth-table results above are what actually cover it. The gate's **premise** is separately confirmed intact — `tracebloc-ingest` with no config still prints `INGEST_CONFIG`, and the here-string form still matches it.

## Sites checked and found NOT vulnerable

Swept every `.github/workflows/*.yml`, `docker-entrypoint.sh` and `Makefile` for `| head`, `| grep -q`, `-m1`, `| awk`, `| sed …q`:

| site | why it is safe |
|---|---|
| `release-image.yml:116` — `printf '%s' "$version" \| grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+…'` | `$version` is a semver tag — bounded by construction to tens of bytes, never near the buffer. A `printf` builtin writes it in one syscall that always completes. Left alone rather than churn a release-gating validator for a bound that cannot be reached. |
| `publish-images.yml:236` — `find . -maxdepth 1 -type f \| wc -l \| tr -d ' '` | `wc` and `tr` both read to EOF; no consumer exits early. |
| `release-image.yml` / `publish-images.yml` cosign loops — `echo "$TAGS" \| while IFS= read -r tag` | `while read` consumes the whole stream; no early close. |

Confirmed there is **no** `defaults.run.shell` at workflow or job level anywhere in `.github/workflows/` — so steps without an explicit `set -o pipefail` run under the default `bash -e {0}`, which has no pipefail and is not vulnerable. Only steps that opt into `pipefail` themselves were in scope, and all three fixed sites do.

## Deliberately not touched (in flight)

- `.github/workflows/version-guard.yml` — being fixed for this same bug class in #483.
- `.github/workflows/publish-main.yml` — in flight on #466 (PyPI Trusted Publishing).

Branched off `develop` directly, not off #483.

## Test plan

- [x] `yaml.safe_load` on both workflows
- [x] All 13 extracted `run:` bodies through `bash -n` — 0 errors
- [x] shellcheck base-vs-branch on extracted bodies: +0 findings
- [x] `actionlint` — same single pre-existing finding before and after
- [x] `pytest` — 1935 passed, 1 xfailed
- [x] Old-vs-new truth table incl. the >64 KiB case that reproduces the 141
- [x] Gate premise re-confirmed against the real CLI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only shell change with identical gate predicates; no app, auth, or publish-policy logic changes. Risk is limited to workflow smoke-step behavior.
> 
> **Overview**
> Fixes a latent `pipefail` race in image publish smoke checks: under `set -euo pipefail`, `echo`/`printf | grep -q` can exit **141** when `grep -q` closes early and the producer hits SIGPIPE, which can fail a good image (or falsely report a missing arch) before signing/publish.
> 
> Switches all three sites in `release-image.yml` and `publish-images.yml` to here-string matches (`grep -q … <<<…`) so the gate still checks for `INGEST_CONFIG` / `linux/${arch}` without a pipe producer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48329c0bbd81564e9ce1201e6c232330550ac050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->