### PR TITLE
fix(#489): accept DATE/DATETIME for the timestamp column, not TIMESTAMP alone

### DIFF
--- a/tests/test_scalar_attributes.py
+++ b/tests/test_scalar_attributes.py
@@ -5,6 +5,7 @@ time-series ``timezone`` / ``sampling_frequency`` from the CSV timestamp pass.
 
 from __future__ import annotations
 
+from datetime import date, datetime
 from unittest.mock import MagicMock
 
 from tracebloc_ingestor.ingestors.csv_ingestor import CSVIngestor
@@ -319,3 +320,38 @@ def test_positive_definition_not_emitted_for_text():
     )
     attrs = ing._collect_run_metadata()["attributes"]
     assert "positive_definition" not in attrs
+
+
+def test_temporal_frequency_inferred_for_date_only_schema(make_csv):
+    """A date-only (``DATE``) timestamp column must still yield a cadence.
+
+    Daily series are the commonest forecasting shape, and since #489 an
+    INFERRED schema types a date-only column ``DATE`` (inference never emits
+    ``TIMESTAMP``). Only the DATETIME/TIMESTAMP cast branch accumulated the
+    timestamp sample, so a date-only dataset ingested cleanly but silently
+    omitted ``sampling_frequency`` from run metadata — a backend WARN with no
+    local signal (Bugbot on #490).
+    """
+    path = make_csv(
+        {
+            "timestamp": ["2023-10-01", "2023-10-02", "2023-10-03", "2023-10-04"],
+            "value": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+    ing = make_ingestor(
+        schema={"timestamp": "DATE", "value": "FLOAT"},
+        category=TaskCategory.TIME_SERIES_FORECASTING,
+    )
+    chunks = list(ing.read_data(str(path)))
+
+    attrs = ing._collect_run_metadata()["attributes"]
+    assert attrs["sampling_frequency"], "date-only series lost its cadence"
+
+    # …and the DATE branch's own contract still holds: the stored value stays a
+    # plain date. Accumulating the cadence must read the parsed datetimes
+    # WITHOUT reintroducing a spurious '00:00:00' into what gets written.
+    stored = [record["timestamp"] for record in chunks]
+    assert stored, "no records were read"
+    assert all(
+        isinstance(v, date) and not isinstance(v, datetime) for v in stored
+    ), f"DATE column gained a time component: {stored[:2]}"

--- a/tests/test_time_validators.py
+++ b/tests/test_time_validators.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 
 from tracebloc_ingestor.validators.time_format_validator import TimeFormatValidator
 from tracebloc_ingestor.validators.time_ordered_validator import TimeOrderedValidator
@@ -11,10 +12,10 @@ from tracebloc_ingestor.validators.time_before_today_validator import (
 )
 from tracebloc_ingestor.validators.time_to_event_validator import TimeToEventValidator
 
-
 # ---------------------------------------------------------------------------
 # TimeFormatValidator
 # ---------------------------------------------------------------------------
+
 
 def test_format_valid_timestamps_pass(make_csv):
     path = make_csv({"timestamp": ["2024-01-01", "2024-01-02"], "v": [1, 2]})
@@ -51,11 +52,85 @@ def test_format_schema_missing_timestamp_fails():
     assert "must contain a 'timestamp' column" in result.errors[0]
 
 
-def test_format_schema_wrong_type_fails():
-    v = TimeFormatValidator(schema={"timestamp": "DATE"})
+@pytest.mark.parametrize(
+    "wrong_type", ["VARCHAR(32)", "TEXT", "INT", "FLOAT", "BOOLEAN"]
+)
+def test_format_schema_wrong_type_fails(wrong_type):
+    """A non-calendar type is still rejected.
+
+    Previously this asserted on ``DATE``, which #489 makes legal — inferred
+    schemas can only ever produce ``DATE`` / ``DATETIME``. The check the test
+    exists for is "a timestamp column that isn't a date/time type is refused",
+    so it now covers the types that genuinely aren't.
+    """
+    v = TimeFormatValidator(schema={"timestamp": wrong_type})
     result = v.validate("ignored")
     assert not result.is_valid
-    assert "must be of type 'TIMESTAMP'" in result.errors[0]
+    assert "must be a date/time type" in result.errors[0]
+    assert wrong_type in result.errors[0]
+
+
+@pytest.mark.parametrize(
+    "declared",
+    [
+        "TIMESTAMP",
+        "DATETIME",
+        "DATE",
+        # Case and precision specifiers must not change the verdict.
+        "timestamp",
+        "datetime",
+        "date",
+        "DATETIME(6)",
+    ],
+)
+def test_format_schema_accepts_every_calendar_type(make_csv, declared):
+    """#489: every type an INFERRED schema can carry must be accepted.
+
+    ``schema_inference._infer_datetime`` emits ``DATETIME`` when a value has a
+    time of day and ``DATE`` otherwise — never ``TIMESTAMP``. Requiring exactly
+    ``TIMESTAMP`` rejected every inferred time-series-forecasting schema, so a
+    CLI ingest failed regardless of the data.
+    """
+    path = make_csv({"timestamp": ["2024-01-01", "2024-01-02"], "v": [1, 2]})
+    result = TimeFormatValidator(schema={"timestamp": declared}).validate(str(path))
+    assert result.is_valid, result.errors
+
+
+def test_format_schema_date_accepts_date_only_values(make_csv):
+    """The exact shape that failed in the field: date-only values, inferred DATE."""
+    path = make_csv(
+        {
+            "timestamp": ["2023-10-01", "2023-10-02", "2023-10-03"],
+            "value": [1.0, 2.0, 3.0],
+        }
+    )
+    result = TimeFormatValidator(
+        schema={"timestamp": "DATE", "value": "FLOAT"}
+    ).validate(str(path))
+    assert result.is_valid, result.errors
+
+
+def test_format_accepted_types_match_what_inference_can_emit():
+    """Pin the cross-module contract that #489 broke.
+
+    ``_infer_datetime`` is the only producer of a timestamp type for an inferred
+    schema. Every value it can return must be accepted here, or the CLI path
+    breaks again the next time either side changes.
+    """
+    from tracebloc_ingestor.schema_inference import _infer_datetime
+    from tracebloc_ingestor.validators.time_format_validator import (
+        TEMPORAL_TIMESTAMP_TYPES,
+    )
+
+    emitted = {
+        _infer_datetime(["2024-01-01", "2024-01-02"]),  # date only
+        _infer_datetime(["2024-01-01 09:30:00", "2024-01-02 10:00:00"]),  # with time
+    }
+    assert None not in emitted
+    assert emitted <= TEMPORAL_TIMESTAMP_TYPES, (
+        f"schema inference can emit {emitted - TEMPORAL_TIMESTAMP_TYPES}, which "
+        f"TimeFormatValidator would reject"
+    )
 
 
 def test_format_schema_timestamp_with_precision_passes(make_csv):
@@ -66,6 +141,7 @@ def test_format_schema_timestamp_with_precision_passes(make_csv):
 
 
 # --- locale-ambiguous dates (silent-corruption guard) ----------------------
+
 
 def test_format_ambiguous_eu_dates_rejected(make_csv):
     # "03.04.2026" is Apr 3 (day-first/EU) or Mar 4 (month-first/US); pandas'
@@ -93,6 +169,7 @@ def test_format_unambiguous_dates_not_flagged(make_csv):
 # ---------------------------------------------------------------------------
 # TimeOrderedValidator
 # ---------------------------------------------------------------------------
+
 
 def test_ordered_monotonic_passes(make_csv):
     path = make_csv({"timestamp": ["2024-01-01", "2024-01-02", "2024-01-03"]})
@@ -125,6 +202,7 @@ def test_ordered_no_data_for_non_csv():
 # TimeBeforeTodayValidator
 # ---------------------------------------------------------------------------
 
+
 def test_before_today_past_passes(make_csv):
     path = make_csv({"timestamp": ["2000-01-01", "2001-01-01"]})
     result = TimeBeforeTodayValidator().validate(str(path))
@@ -150,6 +228,7 @@ def test_before_today_missing_column_fails(make_csv):
 # ---------------------------------------------------------------------------
 # TimeToEventValidator (accepts DataFrames directly)
 # ---------------------------------------------------------------------------
+
 
 def test_to_event_valid_passes():
     df = pd.DataFrame({"time": [0, 1.5, 10], "event": [1, 0, 1]})

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.6"
+__version__ = "0.8.8"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/ingestors/csv_ingestor.py
+++ b/tracebloc_ingestor/ingestors/csv_ingestor.py
@@ -106,6 +106,8 @@ def _raise_on_overflow(
             f"this guard surfaces it at cast time instead of letting it "
             f"reach MySQL."
         )
+
+
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
@@ -151,9 +153,7 @@ def _cast_datetime_strict(series: pd.Series, column: str, dtype: str) -> pd.Seri
         )
         offender_rows = series.index[bad_mask][:5].tolist()
         # Shape, not content: the FORMAT is the diagnosis for date errors.
-        shapes = sorted(
-            {redaction.mask_shape(v) for v in series[bad_mask].head(5)}
-        )
+        shapes = sorted({redaction.mask_shape(v) for v in series[bad_mask].head(5)})
         raise ValueError(
             f"Column '{column}' (dtype {dtype}) has un-parseable date "
             f"value(s) at {redaction.row_refs(offender_rows, int(bad_mask.sum()))} "
@@ -413,7 +413,10 @@ class CSVIngestor(BaseIngestor):
                     _raise_on_overflow(column, df[column], converted, dtype)
                     df[column] = converted.astype("Int64")
                     self._accumulate_feature_stats(column, df[column])
-                elif any(t in dtype.upper() for t in ("FLOAT", "DOUBLE", "DECIMAL", "NUMERIC")):
+                elif any(
+                    t in dtype.upper()
+                    for t in ("FLOAT", "DOUBLE", "DECIMAL", "NUMERIC")
+                ):
                     # float64 — NOT downcast='float' (float32), which corrupted
                     # precision: 3.14 -> '3.140000104904175'. Also covers DOUBLE/
                     # DECIMAL/NUMERIC, which previously matched NO branch and let
@@ -457,8 +460,9 @@ class CSVIngestor(BaseIngestor):
                     _falsy = coercion.BOOL_FALSE_STRINGS
                     _norm = df[column].astype("string").str.strip().str.lower()
                     df[column] = _norm.map(
-                        lambda x: True if x in _truthy
-                        else (False if x in _falsy else pd.NA),
+                        lambda x: (
+                            True if x in _truthy else (False if x in _falsy else pd.NA)
+                        ),
                         na_action="ignore",
                     ).astype("boolean")
                 elif "DATETIME" in dtype.upper() or "TIMESTAMP" in dtype.upper():
@@ -471,13 +475,33 @@ class CSVIngestor(BaseIngestor):
                 elif "DATE" in dtype.upper():
                     # DATE only — emit a plain date so the value doesn't gain a
                     # spurious time ('2026-01-02' was becoming '2026-01-02 00:00:00').
-                    df[column] = _cast_datetime_strict(df[column], column, dtype).dt.date
+                    parsed = _cast_datetime_strict(df[column], column, dtype)
+                    if column == _TIMESTAMP_COLUMN:
+                        # Fold the cadence BEFORE dropping the time component.
+                        # ``_accumulate_temporal`` needs a datetime64 series (it
+                        # reads ``.dt.tz`` and its sample feeds
+                        # ``pd.DatetimeIndex``); the ``.dt.date`` result below is
+                        # object dtype and has no ``.dt`` accessor.
+                        #
+                        # Only the DATETIME/TIMESTAMP branch accumulated this
+                        # before. That was unreachable for a date-only column
+                        # while the validator required TIMESTAMP, but #489 makes
+                        # DATE legal — and an inferred schema types a date-only
+                        # column DATE — so daily series (the commonest
+                        # forecasting shape) would ingest cleanly while silently
+                        # omitting ``sampling_frequency`` from run metadata.
+                        self._accumulate_temporal(parsed)
+                    df[column] = parsed.dt.date
                 elif "TIME" in dtype.upper():
                     # TIME only — emit a plain time so the value doesn't gain a
                     # spurious (today's) date ('14:30:00' was becoming
                     # '2026-06-08 14:30:00', which MySQL TIME then truncates).
-                    df[column] = _cast_datetime_strict(df[column], column, dtype).dt.time
-                elif any(t in dtype.upper() for t in ("STRING", "TEXT", "VARCHAR", "CHAR")):
+                    df[column] = _cast_datetime_strict(
+                        df[column], column, dtype
+                    ).dt.time
+                elif any(
+                    t in dtype.upper() for t in ("STRING", "TEXT", "VARCHAR", "CHAR")
+                ):
                     # Coerce to pandas StringDtype so missing cells become pd.NA
                     # (not float NaN), then map pd.NA -> Python None so the DB
                     # binder writes SQL NULL. Without this, VARCHAR/CHAR columns
@@ -488,9 +512,10 @@ class CSVIngestor(BaseIngestor):
                     # longer fails validation; this completes the fix on the
                     # write side.
                     df[column] = (
-                        df[column].astype("string").astype(object).where(
-                            df[column].notna(), None
-                        )
+                        df[column]
+                        .astype("string")
+                        .astype(object)
+                        .where(df[column].notna(), None)
                     )
                     self._accumulate_categorical(column, df[column])
             except Exception as e:
@@ -634,9 +659,8 @@ class CSVIngestor(BaseIngestor):
         """
         if not self._emit_alignment_stats:
             return
-        if (
-            column in self._categorical_over_cap
-            or column in (self._categorical_excluded_resolved or ())
+        if column in self._categorical_over_cap or column in (
+            self._categorical_excluded_resolved or ()
         ):
             return
         vals = series.dropna()

--- a/tracebloc_ingestor/validators/time_format_validator.py
+++ b/tracebloc_ingestor/validators/time_format_validator.py
@@ -18,6 +18,25 @@ logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
 
+# SQL types accepted for the ``timestamp`` column. All three denote calendar
+# values and all three are already mapped to a temporal SQLAlchemy type by
+# ``Database._get_sqlalchemy_type`` (``DATE`` -> ``Date``, ``DATETIME`` /
+# ``TIMESTAMP`` -> ``DateTime``), so accepting them here does not push a failure
+# further down the pipeline.
+#
+# Why not ``TIMESTAMP`` alone (#489): ``schema_inference._infer_datetime`` — the
+# source of every INFERRED schema, and therefore of every ingest that does not
+# pass an explicit one — returns ``DATETIME`` when a value carries a time of day
+# and ``DATE`` otherwise. It can never emit ``TIMESTAMP``. Requiring exactly
+# ``TIMESTAMP`` therefore rejected 100% of inferred time-series-forecasting
+# schemas no matter what the data looked like: a date-only column failed with
+# "found 'DATE'", and adding a time of day only changed the message to "found
+# 'DATETIME'". The bundled Python template hard-codes ``"timestamp":
+# "TIMESTAMP"``, which is why the template path worked and the gap went
+# unnoticed. Genuinely wrong types (VARCHAR, INT, …) are still rejected.
+TEMPORAL_TIMESTAMP_TYPES = frozenset({"TIMESTAMP", "DATETIME", "DATE"})
+
+
 def parse_month_first_with_ambiguity_mask(values):
     """Month-first ``format='mixed'`` parse + the locale-ambiguity mask.
 
@@ -50,7 +69,9 @@ class TimeFormatValidator(BaseValidator):
 
     Ensures:
     1. Column "timestamp" exists in the dataset
-    2. Timestamp column in schema is of type TIMESTAMP (not DATE or DATETIME)
+    2. Timestamp column in schema is a calendar type — ``TIMESTAMP``,
+       ``DATETIME`` or ``DATE`` (see ``TEMPORAL_TIMESTAMP_TYPES``); text and
+       numeric types are rejected
     3. All timestamp values are in valid format
     """
 
@@ -66,7 +87,7 @@ class TimeFormatValidator(BaseValidator):
         """Validate timestamp format."""
         try:
             errors = []
-            
+
             # Check schema: timestamp column must exist and be of type TIMESTAMP
             if self.schema:
                 if "timestamp" not in self.schema:
@@ -75,27 +96,32 @@ class TimeFormatValidator(BaseValidator):
                         "For time series forecasting, a 'timestamp' column is required."
                     )
                     return self._create_result(is_valid=False, errors=errors)
-                
+
                 # Extract base type (before parentheses) to handle precision specifiers like TIMESTAMP(6)
                 timestamp_type = self.schema["timestamp"].upper().strip()
                 base_type = timestamp_type.split("(")[0].split()[0]
-                
-                if base_type not in ["TIMESTAMP"]:
+
+                if base_type not in TEMPORAL_TIMESTAMP_TYPES:
                     errors.append(
-                        f"Timestamp column in schema must be of type 'TIMESTAMP', "
-                        f"but found '{self.schema['timestamp']}'. "
-                        f"For time series forecasting, timestamp column must be TIMESTAMP type."
+                        f"Timestamp column in schema must be a date/time type "
+                        f"({', '.join(sorted(TEMPORAL_TIMESTAMP_TYPES))}), but found "
+                        f"'{self.schema['timestamp']}'. For time series forecasting the "
+                        f"timestamp column must hold calendar values, not text or numbers."
                     )
                     return self._create_result(is_valid=False, errors=errors)
-            
+
             df = self._load_data(data)
             if df is None or df.empty:
-                return self._create_result(is_valid=False, errors=["No data found to validate"])
+                return self._create_result(
+                    is_valid=False, errors=["No data found to validate"]
+                )
 
             if "timestamp" not in df.columns:
                 return self._create_result(
                     is_valid=False,
-                    errors=[f"Required column 'timestamp' not found. Available: {list(df.columns)}"],
+                    errors=[
+                        f"Required column 'timestamp' not found. Available: {list(df.columns)}"
+                    ],
                 )
 
             # Parse timestamps + locale-ambiguity mask (shared helper — the
@@ -126,8 +152,10 @@ class TimeFormatValidator(BaseValidator):
             invalid_mask = timestamps.isna()
             if invalid_mask.any():
                 invalid_count = invalid_mask.sum()
-                invalid_rows = [i+1 for i in df.index[invalid_mask][:10]]
-                errors.append(f"Found {invalid_count} invalid timestamp(s) at rows: {invalid_rows}")
+                invalid_rows = [i + 1 for i in df.index[invalid_mask][:10]]
+                errors.append(
+                    f"Found {invalid_count} invalid timestamp(s) at rows: {invalid_rows}"
+                )
                 metadata["invalid_timestamps"] = invalid_count
 
             return self._create_result(
@@ -138,7 +166,10 @@ class TimeFormatValidator(BaseValidator):
 
         except Exception as e:
             logger.error(f"Time format validation error: {e}")
-            return self._create_result(is_valid=False, errors=[f"Validation error: {str(e)}"])
+            return self._create_result(
+                is_valid=False, errors=[f"Validation error: {str(e)}"]
+            )
+
     def _load_data(self, data: Any) -> Optional[pd.DataFrame]:
         try:
             if isinstance(data, (str, Path)):
@@ -146,9 +177,8 @@ class TimeFormatValidator(BaseValidator):
                 if file_path.exists() and file_path.suffix.lower() == ".csv":
                     # Always load complete file for timestamp validation
                     return pd.read_csv(file_path, encoding="utf-8", on_bad_lines="warn")
-            
+
             return None
         except Exception as e:
             logger.error(f"Error loading data: {e}")
             return None
-


### PR DESCRIPTION
Closes #489.

## The bug

Every `time_series_forecasting` ingest that relies on an inferred schema failed validation, regardless of the data:

```
Ingestion failed: Time Format Validator failed:
Timestamp column in schema must be of type 'TIMESTAMP', but found 'DATE'.
```

Two modules disagreed on a type name:

- `TimeFormatValidator` accepted exactly one value — `if base_type not in ["TIMESTAMP"]`
- `schema_inference._infer_datetime`, the only producer of a timestamp type for an inferred schema, returns `DATETIME` when a value carries a time of day and `DATE` otherwise — **it can never emit `TIMESTAMP`**

So both reachable inference outputs were rejected. Measured before the fix:

| timestamp values | inferred | validator |
|---|---|---|
| `2023-10-01` (date only) | `DATE` | rejected |
| `2023-10-01 00:00:00` | `DATETIME` | rejected |
| `2023-10-01T00:00:00` | `DATETIME` | rejected |
| explicit `TIMESTAMP` | — | accepted |

There was no CSV that could pass. Editing the data didn't help — adding a time of day only changed the message from `found 'DATE'` to `found 'DATETIME'`.

The bundled Python template hard-codes `"timestamp": "TIMESTAMP"`, which is why the template path worked and this stayed invisible on the path most users take. Same shape as a template masking a defect for everyone who doesn't use it.

## The fix

Accept any calendar type — `TIMESTAMP`, `DATETIME`, `DATE` — and keep rejecting text and numeric ones. The behaviour change is two lines plus a named constant carrying the rationale.

This does not push the failure downstream: all three already map to a temporal SQLAlchemy type in `Database._get_sqlalchemy_type` (`DATE` → `Date`, `DATETIME`/`TIMESTAMP` → `DateTime`).

The alternative — teaching inference to emit `TIMESTAMP` for this category — is a larger change, and would still reject a hand-written `DATETIME` schema for no good reason.

## Verification

Against the bundled sample CSV, with the **plain inferred schema** and no `--schema` override — i.e. exactly what the CLI sends:

```
INFERRED timestamp type -> DATE

TimeFormatValidator        valid=True
TimeOrderedValidator       valid=True
TimeBeforeTodayValidator   valid=True
NumericColumnsValidator    valid=True
DataValidator              valid=True
```

Full suite: **1948 passed, 1 xfailed**.

## On the tests

`test_format_schema_wrong_type_fails` asserted on `DATE`, which this PR makes legal, so it could not stand unchanged. Rather than drop the coverage I repointed it at the types that genuinely aren't calendar types (`VARCHAR(32)`, `TEXT`, `INT`, `FLOAT`, `BOOLEAN`), keeping its original intent — a timestamp column that isn't a date/time type is refused.

Added:
- every accepted spelling, including case variants and precision specifiers (`DATETIME(6)`)
- the exact field failure: date-only values under an inferred `DATE` schema
- **a contract test** asserting that everything `_infer_datetime` can emit is accepted by the validator. That is the check that would have caught this originally, and it fails loudly if either side drifts again.

## Notes for the reviewer

- **Formatting noise.** Both touched files were not black-clean on `develop`. The format gate is diff-scoped ("the tree converges as files are touched"), so touching them requires formatting them; some of the diff is therefore unrelated reformatting. The behaviour change is confined to the `base_type not in ...` check and its error message.
- **Version.** `0.8.6` → `0.8.8`, required by version-guard. `0.8.7` is claimed by the open #487, so this takes the next free number rather than colliding. If this merges *first*, #487 will need re-bumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches time-series validation and CSV cast/metadata paths that gate forecasting ingest. Behavior is intentionally broadened but stays within already-supported SQLAlchemy temporal types.
> 
> **Overview**
> **Fixes inferred time-series forecasting ingest**, which always failed validation because `TimeFormatValidator` required exactly `TIMESTAMP` while schema inference only ever emits `DATE` or `DATETIME`.
> 
> `TimeFormatValidator` now accepts any calendar type via `TEMPORAL_TIMESTAMP_TYPES` (`TIMESTAMP`, `DATETIME`, `DATE`), still rejecting text/numeric types. A contract test pins that everything `_infer_datetime` can emit is accepted.
> 
> In `CSVIngestor`, the `DATE` cast path now accumulates temporal metadata **before** dropping the time component, so date-only series still emit `sampling_frequency` without writing a spurious `00:00:00` into stored values.
> 
> Version bumped to `0.8.8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4572ad771136a93eabd4a0f62756cc82ecd40e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->