### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/workflows/add-to-kanban.yml
+++ b/.github/workflows/add-to-kanban.yml
@@ -10,7 +10,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/tracebloc/projects/2
           github-token: ${{ secrets.PROJECTS_KANBAN_TOKEN }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -183,7 +183,15 @@ jobs:
           # The CLI has no --help: main() expects INGEST_CONFIG and says so.
           output=$(docker run --rm --entrypoint tracebloc-ingest "${IMAGE}@${DIGEST}" 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q "INGEST_CONFIG"
+          # MATCHED FROM A HERE-STRING, NOT THROUGH A PIPE -- same reason as
+          # release-image.yml (backend#1778). `echo "$output" | grep -q` under
+          # `set -euo pipefail` lets `grep -q` close the pipe on its first match;
+          # once $output outgrows the pipe buffer the `echo` subshell takes
+          # SIGPIPE, pipefail reports 141 and errexit fails the step. $output is
+          # unbounded container stdout+stderr, so a verbose traceback is all it
+          # would take -- and a 141 here reads as a broken image, failing the
+          # channel publish for a race rather than a packaging break.
+          grep -q "INGEST_CONFIG" <<<"$output"
 
       - name: Export digest
         env:
@@ -251,7 +259,14 @@ jobs:
           out=$(docker buildx imagetools inspect "${IMAGE}:${TAG}")
           echo "$out"
           for arch in amd64 arm64; do
-            printf '%s' "$out" | grep -q "linux/${arch}" || {
+            # Here-string, not a pipe: the third instance of the same shape
+            # (backend#1778). `grep -q` closes the pipe on its first match and a
+            # `printf` subshell killed by SIGPIPE makes the pipeline 141, which
+            # `||` reads as "this arch is missing" -- failing a correctly
+            # published multi-arch index. `imagetools inspect` output is small,
+            # so this has never tipped; leaving one instance of the bug in a file
+            # being fixed for it is the part worth avoiding.
+            grep -q "linux/${arch}" <<<"$out" || {
               echo "::error::published ${IMAGE}:${TAG} is missing linux/${arch}"
               exit 1
             }

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -315,7 +315,19 @@ jobs:
             -c "from tracebloc_ingestor.cli.run import _load_schema; print(_load_schema()['title'])"
           output=$(docker run --rm --entrypoint tracebloc-ingest "${IMAGE}@${DIGEST}" 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q "INGEST_CONFIG"
+          # MATCHED FROM A HERE-STRING, NOT THROUGH A PIPE. `echo "$output" |
+          # grep -q` under this step's `set -euo pipefail` is a trap: `grep -q`
+          # exits on its first match, and once $output no longer fits the pipe
+          # buffer the `echo` subshell dies of SIGPIPE, pipefail reports 141, and
+          # errexit fails the step (backend#1778). $output is `docker run ...
+          # 2>&1` -- measured at 147 bytes today against a 64 KiB buffer, so this
+          # is latent, not live. But it is unbounded container stdout+stderr and
+          # the match is on the FIRST line, so `grep -q` leaves early: one
+          # verbose traceback is all it would take to tip it. A 141
+          # here aborts the smoke gate before the cosign signing steps below, so
+          # the failure would read as "the image is broken" rather than "grep
+          # won the race". A here-string has no producer to signal.
+          grep -q "INGEST_CONFIG" <<<"$output"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only shell idiom and action pin bump; checks are unchanged, so release/publish behavior should be the same aside from avoiding false failures.
> 
> **Overview**
> Hardens image publish/release smoke checks against a latent `pipefail` race, and bumps the kanban project action.
> 
> In `release-image.yml` and `publish-images.yml`, smoke and multi-arch verify steps now match with `grep -q … <<<"$var"` instead of piping through `echo`/`printf`. Under `set -euo pipefail`, early `grep -q` exit could SIGPIPE the producer (exit 141) and falsely fail a good image or multi-arch index (backend#1778).
> 
> Also pins `actions/add-to-project` from v1.0.2 to **v2.0.0** in `add-to-kanban.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eac77edaa235fb9f47f1e7b2b56a0cd5b432ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->