### PR TITLE
chore(repo): add the house pull-request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+<!-- 1–3 sentences. What does this PR do and why? -->
+
+## Related
+<!-- Same repo: Closes #123 · Cross-repo: Fixes tracebloc/backend#456 (owner-qualified — a bare backend#456 closes nothing). PRs land on develop, not the default branch, so closing keywords do not fire on merge — confirm the issue actually closed. -->
+
+## Type of change
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Tech-debt / refactor
+- [ ] Docs
+- [ ] Security / hardening
+- [ ] Breaking change
+
+## Test plan
+<!-- What did you test? `make check` (ruff + `pytest tests/`) is the local gate. Which extra commands or manual steps? -->
+
+## Screenshots / recordings
+<!-- For UI changes. Remove if N/A. -->
+
+## Deployment notes
+<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->
+
+## Checklist
+- [ ] `make check` passes locally (ruff + `pytest tests/`)
+- [ ] Tests added / updated for this change
+- [ ] Docs updated if behavior or config changed
+- [ ] No secrets / credentials in the diff
+- [ ] For security-sensitive paths: appropriate reviewer requested
+- [ ] Cross-repo issues use `Fixes tracebloc/<repo>#N` — a bare `repo#N` closes nothing
+- [ ] If this depends on a change in another repo: shipped **expand-then-contract** (additive first, consumers adopt later), or **Breaking change** ticked above with the rollout order in *Deployment notes* — repos promote independently, so the other change may not ship with this one
+- [ ] If this touches published paths (`tracebloc_ingestor/*`): version bumped in `tracebloc_ingestor/__init__.py` — the **Version bump gate** hard-fails an already-released version


### PR DESCRIPTION
## Summary

This repo had no `.github/pull_request_template.md`, so PRs opened here start from a blank box. The workspace `CLAUDE.md` already claims every repo has one ("summary / type / test plan / checklist") — this closes that gap. Part of a fleet sweep across the 8 train repos that were missing it.

## Related

Ref tracebloc/backend#1608

## Type of change
- [ ] Feature
- [ ] Bug fix
- [x] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Base template

Copied from **`tracebloc/client`'s** `.github/pull_request_template.md`, which is the most complete generic version of the house shape. All eight existing templates share the same skeleton (Summary / Related / Type of change / Test plan / Screenshots / Deployment notes / Checklist); they split into a shorter variant (`tracebloc-website`, `model-zoo`, `docs`, `start-training` — 4 checklist items) and a longer one (`client`, `cli`, `.github`, `e2e-test-agent`). `client` carries the fullest *generic* checklist, so it was used verbatim as the base rather than averaging the variants. `client`'s repo-specific `STYLE.md` line was dropped (it does not apply here).

## Adapted for this repo

Test plan + checklist name `make check` (ruff + `pytest tests/`), verified as the `check` target in this repo's `Makefile`. One repo-specific checklist line added for the **Version bump gate** (`.github/workflows/version-bump-gate-caller.yml`, `soft-fail: false`), which hard-fails a develop PR touching `tracebloc_ingestor/*` on an already-released version in `tracebloc_ingestor/__init__.py`.

**Test-plan command verified:** `make check` exists as a real target in this repo's `Makefile`, and `make -n check` was run to confirm the recipe it expands to. The template names only that command, so it cannot send anyone at something that does not exist here.

## Test plan

Documentation-only change — one new markdown file, no code paths touched. Verified: the file did not exist on `develop` before this branch, the branch is cut from the current tip of `develop`, and GitHub picks the template up from `.github/pull_request_template.md` by convention.

## Reviewer

**No reviewer requested on purpose.** This is 1 of 8 identical PRs opened in one sweep; requesting 8 reviews simultaneously would bury the team. @LukasWodka is assigned and will sequence review himself.

## Checklist
- [x] No secrets / credentials in the diff
- [x] Docs claim in the workspace `CLAUDE.md` becomes true once all 8 land
- [x] No code touched, so no test/lint impact
- [x] Does not conflict with any open PR in this repo (checked: no open PR touches `.github/pull_request_template.md`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, CI logic, or application code changes.
> 
> **Overview**
> Adds **`.github/pull_request_template.md`** so new PRs get a standard structure instead of an empty description.
> 
> The template follows the shared house shape (summary, related issues, change type, test plan, deployment notes, checklist), with **ingestor-specific** guidance: local gate **`make check`**, cross-repo **`Fixes tracebloc/<repo>#N`**, expand-then-contract for multi-repo deps, and a checklist item for the **version bump gate** on changes under `tracebloc_ingestor/*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31e036b702a661538bb7f6fba98295c4eb76f7ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->