### PR TITLE
feat(schema): publish the column-identifier grammar so the trainer can generate, not copy (backend#1780)

### DIFF
--- a/tests/test_column_identifier_contract.py
+++ b/tests/test_column_identifier_contract.py
@@ -1,7 +1,7 @@
 """Cross-repo column-identifier contract (ISSUE #382).
 
 This pins the canonical column-name grammar that BOTH the ingestor (here) and
-the trainer (``tracebloc-client`` core/utils/database.py) must agree on. The
+the trainer (``tracebloc-engine`` core/utils/database.py) must agree on. The
 trainer mirrors ``tracebloc_ingestor.identifiers`` verbatim and has its own copy
 of this table plus a pin test; together they keep the two repos from drifting.
 

--- a/tests/test_column_identifier_contract.py
+++ b/tests/test_column_identifier_contract.py
@@ -29,17 +29,17 @@ from tracebloc_ingestor.identifiers import (
 # The issue's parametrisation, plus the accept/reject verdict under the
 # reconciled grammar. (name, should_be_valid)
 CONTRACT_CASES = [
-    ("123_gene", True),                       # digit-leading — quotable
-    ("_ok", True),                            # leading underscore
-    ("feature-1", True),                      # hyphen — quotable
-    ("col name", True),                       # space — quotable
-    ("P08254|MMP3", True),                    # proteomics pipe header (#184/#185)
-    ("Körpergröße", True),                    # clinical unicode header (#739)
-    ("feature.1", True),                      # dot
-    ("a" * MAX_COLUMN_IDENTIFIER_LENGTH, True),       # exactly 64 — boundary OK
+    ("123_gene", True),  # digit-leading — quotable
+    ("_ok", True),  # leading underscore
+    ("feature-1", True),  # hyphen — quotable
+    ("col name", True),  # space — quotable
+    ("P08254|MMP3", True),  # proteomics pipe header (#184/#185)
+    ("Körpergröße", True),  # clinical unicode header (#739)
+    ("feature.1", True),  # dot
+    ("a" * MAX_COLUMN_IDENTIFIER_LENGTH, True),  # exactly 64 — boundary OK
     ("a" * (MAX_COLUMN_IDENTIFIER_LENGTH + 1), False),  # 65 chars — too long
-    ("", False),                              # empty
-    ("bad\x00col", False),                    # NUL — illegal in identifier
+    ("", False),  # empty
+    ("bad\x00col", False),  # NUL — illegal in identifier
 ]
 
 

--- a/tests/test_column_identifier_schema.py
+++ b/tests/test_column_identifier_schema.py
@@ -145,30 +145,45 @@ def test_the_declared_quoting_is_what_the_code_emits() -> None:
 def test_the_contract_covers_every_rule_the_code_enforces() -> None:
     """code → JSON: the file may not omit a constraint the code applies.
 
-    Derived from behaviour rather than from a list, so a NEW rule added to
-    identifiers.py without a contract entry fails here instead of quietly
-    shrinking what a consumer tests.
+    Checks each rule class the code is known to enforce against a concrete
+    entry in the contract, so removing that entry from the JSON — dropping the
+    empty-string case, ``max_length``, or NUL from ``forbidden_characters`` —
+    fails here instead of quietly shrinking what a consumer generating from the
+    file would test.
     """
     contract = _contract()
     declared_forbidden = {
         chr(int(e["codepoint"][2:], 16)) for e in contract["forbidden_characters"]
     }
+    declared_max_length = contract.get("max_length")
+    empty_is_a_declared_case = any(
+        c["name"] == "" and c["valid"] is False for c in contract["cases"]
+    )
     # Probe the code with one representative of each rule class it is known to
-    # apply. Every rejection found here must be explained by the contract.
-    unexplained = []
-    for probe, explained_by in (
-        ("", "empty strings are covered by the cases list"),
-        ("a" * (contract["max_length"] + 1), "max_length"),
-        ("bad\x00col", "forbidden_characters"),
+    # apply. Each probe must be BOTH (a) rejected by the code — so the rule is
+    # really enforced — AND (b) backed by a concrete entry in the contract, so a
+    # consumer generating from the file tests it too. The bug this guards
+    # against is the published grammar silently dropping a rule the code still
+    # applies: without (b), deleting the empty-string case, ``max_length``, or
+    # the NUL entry would leave this test green. Probes are built from the code
+    # (its own MAX constant, not the contract's number) so a missing contract
+    # entry surfaces as an uncovered rule here, never as a mis-built probe.
+    gaps = []
+    for probe, covered_by_contract, handle in (
+        ("", empty_is_a_declared_case, "an empty-string rejecting case"),
+        (
+            "a" * (MAX_COLUMN_IDENTIFIER_LENGTH + 1),
+            isinstance(declared_max_length, int),
+            "a max_length entry",
+        ),
+        ("bad\x00col", "\x00" in declared_forbidden, "NUL in forbidden_characters"),
     ):
-        if is_valid_column_identifier(probe):
-            unexplained.append(
-                f"code ACCEPTS {probe!r}, contract implies it should not"
-            )
-    assert not unexplained, unexplained
-    assert (
-        "\x00" in declared_forbidden
-    ), "the code rejects NUL but the contract does not declare it forbidden"
+        assert (
+            is_valid_column_identifier(probe) is False
+        ), f"code no longer rejects {probe!r}; the enforced rule vanished"
+        if not covered_by_contract:
+            gaps.append(f"code rejects {probe!r} but the contract omits {handle}")
+    assert not gaps, gaps
     # Non-string input is a rule too, and a consumer in a typed language would
     # not infer it from the case list.
     assert is_valid_column_identifier(None) is False

--- a/tests/test_column_identifier_schema.py
+++ b/tests/test_column_identifier_schema.py
@@ -1,0 +1,194 @@
+"""The published column grammar is pinned to the code, in BOTH directions.
+
+Why this file exists (backend#1780)
+-----------------------------------
+The column-identifier grammar was mirrored across two repos as two hand-copied
+case tables. Each side's comments claimed the other kept it honest:
+
+  ``tracebloc-engine/core/utils/database.py``
+      "MIRRORS tracebloc_ingestor/identifiers.py ... test_database.py pins this
+       against the canonical spec so the two can't drift."
+
+  this repo's ``tests/test_column_identifier_contract.py``
+      "The trainer mirrors tracebloc_ingestor.identifiers verbatim and has its
+       own copy of this table plus a pin test; together they keep the two repos
+       from drifting."
+
+**Nothing crossed the repo boundary.** The engine's test neither imports nor
+fetches ``identifiers.py`` — it pins a local *transcription* of the spec. So a
+change to ``MAX_COLUMN_IDENTIFIER_LENGTH``, to the NUL rule, or to the
+quote-and-allow reconciliation could land on either side with **both suites
+green** and the two repos silently disagreeing. That is exactly the mechanism
+that made ISSUE #382 *"silent until training — raising uncaught, after an
+experiment was already running."* The reconciliation fixed the values; it did
+not fix the thing that let them diverge.
+
+``schema/column_identifier.v1.json`` is the fix's first half: the grammar,
+published so the trainer can **generate** its cases instead of copying them —
+the same pattern ``runtime_env.v1.json`` already uses for the spawner contract
+(backend#1754 / #482).
+
+A published artifact is only worth as much as its pin, so this file asserts BOTH
+directions. One direction alone is a trap:
+
+  * code → JSON only: the JSON could omit a rule the code enforces, and a
+    consumer generating from it would under-test.
+  * JSON → code only: the JSON could declare a rule the code does not enforce,
+    and a consumer would trust a guarantee that does not exist.
+
+The second is the one that bites, because it is the direction that reads as
+reassuring.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# Loaded DIRECTLY BY PATH, not as `from tracebloc_ingestor.identifiers import
+# ...`. The package's __init__ imports database.py, which imports sqlalchemy, so
+# the plain import drags the whole DB stack in just to read a grammar. That
+# matters here beyond convenience: identifiers.py is deliberately
+# "dependency-light (stdlib only) so the trainer can mirror it verbatim", and a
+# test that cannot exercise it without sqlalchemy quietly contradicts that
+# promise. The sibling runtime_env contract test avoids the same problem by
+# ast-parsing its source; loading the module is strictly better, because it
+# tests real behaviour rather than the shape of the source text.
+import importlib.util as _ilu
+
+_IDENT_PATH = (
+    Path(__file__).resolve().parent.parent / "tracebloc_ingestor" / "identifiers.py"
+)
+_spec = _ilu.spec_from_file_location("_tb_identifiers", _IDENT_PATH)
+assert _spec and _spec.loader, f"cannot load {_IDENT_PATH}"
+_identifiers = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_identifiers)
+
+MAX_COLUMN_IDENTIFIER_LENGTH = _identifiers.MAX_COLUMN_IDENTIFIER_LENGTH
+InvalidColumnIdentifierError = _identifiers.InvalidColumnIdentifierError
+is_valid_column_identifier = _identifiers.is_valid_column_identifier
+quote_column_identifier = _identifiers.quote_column_identifier
+validate_column_identifier = _identifiers.validate_column_identifier
+
+CONTRACT = (
+    Path(__file__).resolve().parent.parent
+    / "tracebloc_ingestor"
+    / "schema"
+    / "column_identifier.v1.json"
+)
+
+SUPPORTED_VERSIONS = {"1"}
+
+
+def _contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def test_the_contract_ships_in_the_package() -> None:
+    # A schema that is not packaged cannot be vendored by a consumer, which is
+    # the whole point of publishing it.
+    assert CONTRACT.is_file(), f"{CONTRACT} is missing"
+
+
+def test_the_contract_is_a_version_we_understand() -> None:
+    assert _contract()["version"] in SUPPORTED_VERSIONS
+
+
+def test_the_declared_max_length_is_the_constant_the_code_enforces() -> None:
+    # THE pin. #382's disagreement was over legality; a silent change to this
+    # number is how the two repos would part company again.
+    assert _contract()["max_length"] == MAX_COLUMN_IDENTIFIER_LENGTH
+
+
+def test_the_declared_max_length_is_actually_the_boundary() -> None:
+    # Not just equal to the constant — equal to the code's real behaviour. A
+    # constant can be right while the comparison using it is off by one.
+    n = _contract()["max_length"]
+    assert is_valid_column_identifier("a" * n) is True
+    assert is_valid_column_identifier("a" * (n + 1)) is False
+
+
+@pytest.mark.parametrize("case", _contract()["cases"], ids=lambda c: repr(c["name"]))
+def test_every_declared_case_matches_the_code(case: dict) -> None:
+    """JSON → code: the file may not claim a verdict the code does not give."""
+    name, expected = case["name"], case["valid"]
+    assert is_valid_column_identifier(name) is expected, case["why"]
+    if expected:
+        assert validate_column_identifier(name) == name
+    else:
+        with pytest.raises(InvalidColumnIdentifierError):
+            validate_column_identifier(name)
+
+
+def test_every_forbidden_character_is_actually_rejected() -> None:
+    """JSON → code, for the rules rather than the cases."""
+    for entry in _contract()["forbidden_characters"]:
+        cp = entry["codepoint"]
+        assert cp.startswith("U+"), f"unparseable codepoint {cp!r}"
+        ch = chr(int(cp[2:], 16))
+        assert is_valid_column_identifier(f"bad{ch}col") is False, (
+            f"the contract forbids {entry['name']} but the code accepts it"
+        )
+
+
+def test_the_declared_quoting_is_what_the_code_emits() -> None:
+    """A consumer that quotes differently produces different DDL."""
+    q = _contract()["quoting"]
+    example = q["example"]
+    assert quote_column_identifier(example["input"]) == example["output"]
+    # And the escape rule itself, not only the one example.
+    assert quote_column_identifier("a`b") == "`a``b`"
+
+
+def test_the_contract_covers_every_rule_the_code_enforces() -> None:
+    """code → JSON: the file may not omit a constraint the code applies.
+
+    Derived from behaviour rather than from a list, so a NEW rule added to
+    identifiers.py without a contract entry fails here instead of quietly
+    shrinking what a consumer tests.
+    """
+    contract = _contract()
+    declared_forbidden = {
+        chr(int(e["codepoint"][2:], 16)) for e in contract["forbidden_characters"]
+    }
+    # Probe the code with one representative of each rule class it is known to
+    # apply. Every rejection found here must be explained by the contract.
+    unexplained = []
+    for probe, explained_by in (
+        ("", "empty strings are covered by the cases list"),
+        ("a" * (contract["max_length"] + 1), "max_length"),
+        ("bad\x00col", "forbidden_characters"),
+    ):
+        if is_valid_column_identifier(probe):
+            unexplained.append(f"code ACCEPTS {probe!r}, contract implies it should not")
+    assert not unexplained, unexplained
+    assert "\x00" in declared_forbidden, (
+        "the code rejects NUL but the contract does not declare it forbidden"
+    )
+    # Non-string input is a rule too, and a consumer in a typed language would
+    # not infer it from the case list.
+    assert is_valid_column_identifier(None) is False
+    assert is_valid_column_identifier(123) is False
+
+
+def test_the_case_list_is_not_trivially_one_sided() -> None:
+    """A table of all-accepts (or all-rejects) would pass everything above.
+
+    This is the guard that stops the contract decaying into a list that proves
+    nothing — the failure mode the two hand-copied tables were already drifting
+    toward.
+    """
+    verdicts = [c["valid"] for c in _contract()["cases"]]
+    assert any(verdicts), "no accepting case"
+    assert not all(verdicts), "no rejecting case"
+    assert len(verdicts) >= 8, "the case list has shrunk below the #382 set"
+
+
+def test_the_boundary_cases_are_present_by_construction() -> None:
+    """The off-by-one pair is the case most likely to be dropped as redundant."""
+    n = _contract()["max_length"]
+    names = {c["name"]: c["valid"] for c in _contract()["cases"]}
+    assert names.get("a" * n) is True, f"missing the exactly-{n} accepting case"
+    assert names.get("a" * (n + 1)) is False, f"missing the {n + 1} rejecting case"

--- a/tests/test_column_identifier_schema.py
+++ b/tests/test_column_identifier_schema.py
@@ -128,9 +128,9 @@ def test_every_forbidden_character_is_actually_rejected() -> None:
         cp = entry["codepoint"]
         assert cp.startswith("U+"), f"unparseable codepoint {cp!r}"
         ch = chr(int(cp[2:], 16))
-        assert is_valid_column_identifier(f"bad{ch}col") is False, (
-            f"the contract forbids {entry['name']} but the code accepts it"
-        )
+        assert (
+            is_valid_column_identifier(f"bad{ch}col") is False
+        ), f"the contract forbids {entry['name']} but the code accepts it"
 
 
 def test_the_declared_quoting_is_what_the_code_emits() -> None:
@@ -162,11 +162,13 @@ def test_the_contract_covers_every_rule_the_code_enforces() -> None:
         ("bad\x00col", "forbidden_characters"),
     ):
         if is_valid_column_identifier(probe):
-            unexplained.append(f"code ACCEPTS {probe!r}, contract implies it should not")
+            unexplained.append(
+                f"code ACCEPTS {probe!r}, contract implies it should not"
+            )
     assert not unexplained, unexplained
-    assert "\x00" in declared_forbidden, (
-        "the code rejects NUL but the contract does not declare it forbidden"
-    )
+    assert (
+        "\x00" in declared_forbidden
+    ), "the code rejects NUL but the contract does not declare it forbidden"
     # Non-string input is a rule too, and a consumer in a typed language would
     # not infer it from the case list.
     assert is_valid_column_identifier(None) is False

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.8"
+__version__ = "0.8.9"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/identifiers.py
+++ b/tracebloc_ingestor/identifiers.py
@@ -2,8 +2,15 @@
 
 This module is the authoritative definition of what counts as a valid *column*
 identifier across the tracebloc platform. It is deliberately dependency-light
-(stdlib only) so the trainer (``tracebloc-client``) can mirror it verbatim
-without taking a dependency on the rest of this package.
+(stdlib only) so the trainer (``tracebloc-engine`` — renamed from
+``tracebloc-client``) can mirror it verbatim without taking a dependency on the
+rest of this package.
+
+It is published machine-readably as ``schema/column_identifier.v1.json``, pinned
+to this module in both directions by ``tests/test_column_identifier_schema.py``.
+Consumers should GENERATE their cases from that file rather than transcribing
+the table below: two hand-copied copies is what let ISSUE #382's disagreement
+stay silent until training (backend#1780).
 
 The reconciliation (ISSUE #382)
 -------------------------------

--- a/tracebloc_ingestor/schema/column_identifier.v1.json
+++ b/tracebloc_ingestor/schema/column_identifier.v1.json
@@ -1,0 +1,81 @@
+{
+  "version": "1",
+  "description": "Canonical column-identifier grammar (ISSUE #382). The authoritative definition lives in tracebloc_ingestor/identifiers.py; this file is that definition published machine-readably so the trainer (tracebloc-engine) can GENERATE its contract cases from it instead of transcribing them. Before this file existed, both repos carried hand-copied copies of the case table below and each side's comments claimed the other kept it honest — but nothing crossed the repo boundary, so either could change and both suites would stay green. That is the mechanism that made #382 silent until training (backend#1780).",
+  "rule": "Quote-and-allow: a column name is valid iff it can be safely backtick-quoted for MySQL. Every character except NUL is permitted and made safe by quoting; length is the one constraint quoting cannot rescue.",
+  "max_length": 64,
+  "max_length_reason": "MySQL's maximum identifier length. The one column-name constraint that backtick-quoting cannot work around, so both repos hard-fail above it.",
+  "forbidden_characters": [
+    {
+      "codepoint": "U+0000",
+      "name": "NUL",
+      "reason": "illegal in a MySQL identifier"
+    }
+  ],
+  "quoting": {
+    "style": "backtick",
+    "escape": "double the backtick",
+    "example": {
+      "input": "we`ird",
+      "output": "`we``ird`"
+    },
+    "reason": "Matches MySQL's identifier quoting rules and what SQLAlchemy emits in the ingestor's CREATE TABLE DDL, so any valid name is rendered injection-safe."
+  },
+  "not_covered": "TABLE names, which are stricter and validated separately (TableNameValidator here, _validate_sql_identifier in the trainer). Table names are platform-controlled; column names come from raw user data.",
+  "cases": [
+    {
+      "name": "123_gene",
+      "valid": true,
+      "why": "digit-leading — quotable"
+    },
+    {
+      "name": "_ok",
+      "valid": true,
+      "why": "leading underscore"
+    },
+    {
+      "name": "feature-1",
+      "valid": true,
+      "why": "hyphen — quotable"
+    },
+    {
+      "name": "col name",
+      "valid": true,
+      "why": "space — quotable"
+    },
+    {
+      "name": "P08254|MMP3",
+      "valid": true,
+      "why": "proteomics pipe header (#184/#185)"
+    },
+    {
+      "name": "Körpergröße",
+      "valid": true,
+      "why": "clinical unicode header (#739)"
+    },
+    {
+      "name": "feature.1",
+      "valid": true,
+      "why": "dot"
+    },
+    {
+      "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "valid": true,
+      "why": "exactly 64 — boundary OK"
+    },
+    {
+      "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "valid": false,
+      "why": "65 characters — too long"
+    },
+    {
+      "name": "",
+      "valid": false,
+      "why": "empty"
+    },
+    {
+      "name": "bad\u0000col",
+      "valid": false,
+      "why": "NUL — illegal in a MySQL identifier"
+    }
+  ]
+}


### PR DESCRIPTION
Step 1 of tracebloc/backend#1780.

## The problem, verified rather than taken on trust

The column-identifier grammar is mirrored across two repos as **two hand-copied case tables**, and *both* sides claim the other keeps them honest:

> `tracebloc-engine/core/utils/database.py:73` — *"test_database.py pins this against the canonical spec so the two can't drift."*

> `tests/test_column_identifier_contract.py` — *"The trainer … has its own copy of this table plus a pin test; together they keep the two repos from drifting."*

**Nothing crosses the repo boundary.** I checked: `tracebloc-engine/core/tests/utils/test_database.py` imports nothing from `tracebloc_ingestor` — its imports are all `core.*`. So `database.py`'s claim is false: the test pins a local *transcription* of the spec, not the spec.

The consequence is that `MAX_COLUMN_IDENTIFIER_LENGTH`, the NUL rule, or the quote-and-allow reconciliation can change on either side and **both suites stay green** while the two repos disagree. That is exactly the mechanism that made ISSUE #382 *"silent until training — raising uncaught, after an experiment was already running."* The reconciliation fixed the **values**; it never fixed what let them diverge.

## What this adds

`schema/column_identifier.v1.json`, beside `layout.v1.json` / `ingest.v1.json` / `runtime_env.v1.json` — the same pattern backend#1754 / #482 used for the spawner contract.

It carries the **cases**, not only the rules, because the cases are what actually gets transcribed. The consumer's job becomes *generate*, not *copy*.

## Pinned in BOTH directions

One direction alone is a trap:

| direction | what it catches | what it misses |
|---|---|---|
| code → JSON | the file omitting a constraint the code applies | the file inventing one |
| JSON → code | the file claiming a guarantee the code does not give | the file being incomplete |

The second is the one that bites, because it is the direction that **reads as reassuring** — a consumer generating from it would trust a rule nobody enforces.

## `identifiers.py` is loaded by path, not imported

`from tracebloc_ingestor.identifiers import …` drags in `database.py` → `sqlalchemy`, so the plain import needs the whole DB stack to read a grammar. That matters beyond convenience: this module is deliberately *"dependency-light (stdlib only) so the trainer can mirror it verbatim"*, and a test that cannot exercise it without sqlalchemy quietly contradicts that promise.

It is also better than the sibling `test_runtime_env_contract.py`, which ast-parses its source to dodge the same problem: loading the module tests **real behaviour** rather than the shape of the source text.

## Tests — 20 cases, mutation-verified in both directions

```
code limit 64 → 128, JSON unchanged     4 failed    <- the #382 shape exactly
JSON limit 64 → 128, code unchanged     3 failed
JSON drops the NUL rule                 1 failed
JSON claims "" is valid                 1 failed
case table degraded to all-accepts      2 failed
quoting escape rule changed             1 failed
restored                               20 passed
```

The all-accepts mutation matters: a case table that only ever accepts would satisfy every other assertion here, and that is the direction two hand-copied tables were already drifting in. The boundary pair (exactly 64 / 65) is asserted present by construction, because it is the case most likely to be dropped as redundant.

**Packaging needed no change — verified, not assumed:** `setup.py`'s `package_data` declares `"tracebloc_ingestor.schema": ["*.json"]` and `MANIFEST.in` has `recursive-include tracebloc_ingestor/schema *.json`, so the new file ships in both wheel and sdist. A schema nobody can vendor would defeat the point.

Also fixes the stale pointer the ticket flagged: both comments called the trainer `tracebloc-client`, which was renamed **`tracebloc-engine`** — so the pointer a reader follows led to the wrong repo.

## Deliberately NOT in this PR

**Steps 2 and 3** — `tracebloc-engine` vendoring this file and generating its cases from it. Those must land **after** this merges: vendoring a schema that exists only on a branch arms a contract against a source the fleet does not have yet. That is the same ordering hazard that reddened the org audit for 2h20m on 2026-08-12, so it is worth being explicit about rather than doing both at once.

Until step 2 lands, the engine's transcribed table is unchanged and still passing — this PR adds the mechanism without changing any behaviour.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a published contract and tests without changing column validation or ingest runtime behavior.
> 
> **Overview**
> Publishes the column-name grammar as **`schema/column_identifier.v1.json`** (rules, quoting, and the #382 case table) so **tracebloc-engine** can generate contract tests instead of hand-copying them. **`tests/test_column_identifier_schema.py`** pins **`identifiers.py`** and the JSON **in both directions** (declared cases vs code, and code-enforced rules vs schema), loading **`identifiers.py`** by path so tests do not pull in SQLAlchemy.
> 
> Docs now point at the JSON artifact and rename the trainer repo from **`tracebloc-client`** to **`tracebloc-engine`**. **`test_column_identifier_contract.py`** only gets comment alignment and trivial formatting. Package version **0.8.8 → 0.8.9**; validation behavior is unchanged in this step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de56669337923c16b4bb8222f2fda7aeed32a2d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->