### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+<!-- 1–3 sentences. What does this PR do and why? -->
+
+## Related
+<!-- Same repo: Closes #123 · Cross-repo: Fixes tracebloc/backend#456 (owner-qualified — a bare backend#456 closes nothing). PRs land on develop, not the default branch, so closing keywords do not fire on merge — confirm the issue actually closed. -->
+
+## Type of change
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Tech-debt / refactor
+- [ ] Docs
+- [ ] Security / hardening
+- [ ] Breaking change
+
+## Test plan
+<!-- What did you test? `make check` (ruff + `pytest tests/`) is the local gate. Which extra commands or manual steps? -->
+
+## Screenshots / recordings
+<!-- For UI changes. Remove if N/A. -->
+
+## Deployment notes
+<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->
+
+## Checklist
+- [ ] `make check` passes locally (ruff + `pytest tests/`)
+- [ ] Tests added / updated for this change
+- [ ] Docs updated if behavior or config changed
+- [ ] No secrets / credentials in the diff
+- [ ] For security-sensitive paths: appropriate reviewer requested
+- [ ] Cross-repo issues use `Fixes tracebloc/<repo>#N` — a bare `repo#N` closes nothing
+- [ ] If this depends on a change in another repo: shipped **expand-then-contract** (additive first, consumers adopt later), or **Breaking change** ticked above with the rollout order in *Deployment notes* — repos promote independently, so the other change may not ship with this one
+- [ ] If this touches published paths (`tracebloc_ingestor/*`): version bumped in `tracebloc_ingestor/__init__.py` — the **Version bump gate** hard-fails an already-released version


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to GitHub PR defaults; no runtime, auth, or deployment behavior is modified.
> 
> **Overview**
> Introduces **`.github/pull_request_template.md`** so new PRs open with a standard structure: summary, related issues, change type, test plan, optional screenshots and deployment notes, and a checklist.
> 
> The template encodes repo-specific expectations in comments and checklist items: local gate via **`make check`** (ruff + `pytest tests/`), owner-qualified cross-repo closing syntax (`Fixes tracebloc/<repo>#N`), expand-then-contract for multi-repo rollouts, and a version bump in **`tracebloc_ingestor/__init__.py`** when published ingestor paths change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d262c983516800c17bf4adbf0babc7e51f74da8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->