### PR TITLE
fix(validators): delete the three private column resolvers, route through the canonical rule (backend#1828)

### DIFF
--- a/tests/test_bio_label_validator.py
+++ b/tests/test_bio_label_validator.py
@@ -185,3 +185,39 @@ def test_iob2_check_skipped_when_tag_format_invalid(validator, texts_dir):
     assert not result.is_valid
     assert any("invalid BIO tag" in e for e in result.errors)
     assert not result.warnings
+
+
+def test_csv_padded_header_still_resolves_label(texts_dir, tmp_path):
+    """``filename, label`` — the header Excel writes by default — must resolve,
+    not report the label column missing.
+
+    Regression (backend#1828): BIOLabelValidator carried a private
+    ``_resolve_column`` that lower-cased but did NOT strip, so pandas' parsed
+    header ``[" label"]`` never matched the configured ``label``. The dataset
+    was rejected for a column the user can see in their file, on
+    token_classification only, while sibling validators in the same preflight
+    run resolved it fine. Exercised through the real CSV read path (a raw file,
+    not a DataFrame) because that is where the padding survives —
+    ``BaseValidator._load_data`` calls ``pd.read_csv`` without
+    ``skipinitialspace``.
+    """
+    _write(texts_dir, "s1", "John Smith")
+    path = tmp_path / "padded.csv"
+    path.write_text("filename, label\ns1,B-PER I-PER\n", encoding="utf-8")
+
+    result = BIOLabelValidator().validate(str(path))
+
+    assert result.is_valid, result.errors
+    assert result.metadata["rows_checked"] == 1
+
+
+def test_csv_padded_filename_header_still_resolves(texts_dir, tmp_path):
+    """The same strip must apply to the ``filename`` column, which is padded
+    whenever it is not the first CSV field (backend#1828)."""
+    _write(texts_dir, "s1", "John Smith")
+    path = tmp_path / "padded_fn.csv"
+    path.write_text("label, filename\nB-PER I-PER,s1\n", encoding="utf-8")
+
+    result = BIOLabelValidator().validate(str(path))
+
+    assert result.is_valid, result.errors

--- a/tests/test_contrastive_pairs_validator.py
+++ b/tests/test_contrastive_pairs_validator.py
@@ -40,9 +40,7 @@ def _validate(filenames, staged):
 def test_valid_pair_and_triplet_pass(staged):
     texts, make_csv = staged
     (texts / "pair.txt").write_text("anchor text\tpositive text\n", encoding="utf-8")
-    (texts / "triplet.txt").write_text(
-        "anchor\tpositive\tnegative\n", encoding="utf-8"
-    )
+    (texts / "triplet.txt").write_text("anchor\tpositive\tnegative\n", encoding="utf-8")
     result = _validate(["pair", "triplet"], staged)
     assert result.is_valid, result.errors
     assert result.metadata["rows_checked"] == 2
@@ -186,3 +184,25 @@ def test_error_cap_summarizes(staged):
     assert not result.is_valid
     assert any("further errors suppressed" in e for e in result.errors)
     assert len(result.errors) <= 51
+
+
+def test_csv_padded_filename_header_still_resolves(staged, tmp_path):
+    """A padded ``filename`` header (``id, filename``) must resolve, not report
+    the column missing.
+
+    Regression (backend#1828): TabSeparatedRecordValidator — this validator's
+    base — carried a private ``_resolve_column`` that lower-cased but did NOT
+    strip, so pandas' parsed header ``" filename"`` never matched. ``embeddings``
+    then rejected a manifest for a column visibly present, while sibling
+    validators in the same preflight run resolved it. ``filename`` is padded
+    whenever it is not the first CSV field. Written as a raw file: pandas keeps
+    the space because ``_load_data`` does not pass ``skipinitialspace``.
+    """
+    texts, _ = staged
+    (texts / "pair.txt").write_text("anchor text\tpositive text\n", encoding="utf-8")
+    path = tmp_path / "padded.csv"
+    path.write_text("id, filename\n1,pair\n", encoding="utf-8")
+
+    result = ContrastivePairsValidator(texts_path="texts").validate(str(path))
+
+    assert result.is_valid, result.errors

--- a/tests/test_no_shadowed_column_resolver.py
+++ b/tests/test_no_shadowed_column_resolver.py
@@ -1,0 +1,104 @@
+"""Structural guard: no validator may carry its own column resolver.
+
+``tracebloc_ingestor.utils.columns.resolve_column`` is the single column-name
+matching rule, reached by validators through
+``BaseValidator._match_column``. Three validators once carried private
+``_resolve_column`` copies instead, and two of them dropped the ``.strip()`` —
+so ``token_classification`` / ``sentence_pair_classification`` / ``embeddings``
+false-rejected the header Excel writes by default (``filename, label``) as a
+missing column, while sibling validators in the SAME preflight run resolved it
+(backend#1828, reintroducing #340 / bugbot #252).
+
+The per-category regressions live next to each validator's own tests. This file
+guards the *class* of bug rather than the three instances: a shadowing copy is
+invisible to a reader — nothing about a call to ``self._resolve_column(...)``
+suggests it bypasses the canonical rule — so the guard has to be mechanical.
+It fails on ANY new private resolver, including a faithful one, because a
+faithful copy is exactly how the broken ones got there (the third copy, in
+``LabelDiversityValidator``, was faithful and was still deleted).
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+
+import pytest
+
+import tracebloc_ingestor.validators as validators_pkg
+from tracebloc_ingestor.utils.columns import resolve_column
+from tracebloc_ingestor.validators.base import BaseValidator
+
+
+def _validator_classes():
+    """Every BaseValidator subclass defined under tracebloc_ingestor.validators."""
+    found = {}
+    for mod_info in pkgutil.iter_modules(validators_pkg.__path__):
+        module = importlib.import_module(f"{validators_pkg.__name__}.{mod_info.name}")
+        for name, obj in vars(module).items():
+            if (
+                inspect.isclass(obj)
+                and issubclass(obj, BaseValidator)
+                and obj.__module__.startswith(validators_pkg.__name__)
+            ):
+                found[f"{obj.__module__}.{obj.__qualname__}"] = obj
+    return found
+
+
+# Names a private resolver has historically been spelled with. ``_match_column``
+# is deliberately absent — that IS the sanctioned accessor.
+_FORBIDDEN = ("_resolve_column", "_resolve_col", "_find_column", "_lookup_column")
+
+
+def test_validator_classes_are_discovered():
+    """Guard the guard: an import error or a renamed package would otherwise
+    make the shadowing assertions below vacuously pass."""
+    classes = _validator_classes()
+    assert len(classes) >= 20, sorted(classes)
+    assert any(c.endswith("BIOLabelValidator") for c in classes), sorted(classes)
+    assert any(c.endswith("TabSeparatedRecordValidator") for c in classes), sorted(
+        classes
+    )
+    assert any(c.endswith("LabelDiversityValidator") for c in classes), sorted(classes)
+
+
+@pytest.mark.parametrize("attr", _FORBIDDEN)
+def test_no_validator_defines_a_private_column_resolver(attr):
+    """No validator class may define its own column resolver — route through
+    ``BaseValidator._match_column`` (backend#1828)."""
+    offenders = [
+        qualname for qualname, cls in _validator_classes().items() if attr in vars(cls)
+    ]
+    assert not offenders, (
+        f"{offenders} define a private {attr!r}. The column-matching rule is "
+        f"single-sourced in tracebloc_ingestor.utils.columns.resolve_column; "
+        f"call self._match_column(df.columns, name) instead. A private copy "
+        f"silently diverges (backend#1828: two copies dropped the .strip() and "
+        f"false-rejected a padded CSV header on 3 of 16 categories)."
+    )
+
+
+def test_match_column_delegates_to_the_canonical_rule():
+    """``_match_column`` must BE the canonical rule, not a reimplementation of
+    it — otherwise deleting the copies just moved the divergence up one level.
+
+    Includes the padded-header case (``" label"`` resolved from ``"label"``)
+    that the deleted copies got wrong, and the non-string column label that
+    made them raise ``AttributeError`` where the canonical rule returns a hit.
+    """
+    cases = [
+        (["filename", " label"], "label", " label"),
+        (["label", " filename"], "filename", " filename"),
+        (["filename ", " label"], "filename", "filename "),
+        (["Label"], " label ", "Label"),
+        (["label"], "LABEL", "label"),
+        (["a", "b"], "missing", None),
+        ([0, 1], "0", 0),
+    ]
+    for columns, name, expected in cases:
+        assert BaseValidator._match_column(columns, name) == expected, (
+            columns,
+            name,
+        )
+        assert resolve_column(columns, name) == expected, (columns, name)

--- a/tests/test_sentence_pair_validator.py
+++ b/tests/test_sentence_pair_validator.py
@@ -188,3 +188,23 @@ def test_error_cap_summarizes(staged):
     assert not result.is_valid
     assert any("further errors suppressed" in e for e in result.errors)
     assert len(result.errors) <= 51
+
+
+def test_csv_padded_filename_header_still_resolves(staged, tmp_path):
+    """A padded ``filename`` header (``label, filename``) must resolve, not
+    report the column missing.
+
+    Regression (backend#1828): the shared TabSeparatedRecordValidator base
+    carried a private ``_resolve_column`` that lower-cased without stripping,
+    so ``sentence_pair_classification`` rejected a manifest whose ``filename``
+    column was visibly present but not the first CSV field. Mirrors
+    tests/test_contrastive_pairs_validator.py.
+    """
+    texts, _ = staged
+    (texts / "pair.txt").write_text("text a\ttext b\n", encoding="utf-8")
+    path = tmp_path / "padded.csv"
+    path.write_text("label, filename\npos,pair\n", encoding="utf-8")
+
+    result = SentencePairValidator(texts_path="texts").validate(str(path))
+
+    assert result.is_valid, result.errors

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.8"
+__version__ = "0.8.9"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/validators/base.py
+++ b/tracebloc_ingestor/validators/base.py
@@ -168,15 +168,26 @@ class BaseValidator(ABC):
         because ``CSVIngestor`` strips header whitespace on read
         (``chunk.columns.str.strip()``) — so a header like ``" label "`` is
         ingested as ``label`` and must resolve here too, or a manifest that
-        ingests fine fails preflight as if the column were missing (matches
-        ``LabelDiversityValidator._resolve_column``). The ORIGINAL column name
-        is returned so callers can still index the (un-stripped) raw frame.
+        ingests fine fails preflight as if the column were missing. The
+        ORIGINAL column name is returned so callers can still index the
+        (un-stripped) raw frame.
 
         The rule is single-sourced in
         :func:`tracebloc_ingestor.utils.columns.resolve_column` so the ingest
         read path resolves the label column identically — the two used to
         diverge (validators case-insensitive, ``RecordProcessor`` exact),
         silently nulling every label (#340).
+
+        **This method is the ONLY resolver a validator may use.** Three
+        validators once carried private ``_resolve_column`` copies instead;
+        two of them dropped the ``.strip()``, so ``token_classification`` /
+        ``sentence_pair_classification`` / ``embeddings`` false-rejected a
+        header Excel writes by default (``filename, label``) as a missing
+        column, while sibling validators in the SAME preflight run resolved it
+        (backend#1828, reintroducing #340 / bugbot #252). The copies are gone
+        and ``tests/test_no_shadowed_column_resolver.py`` fails if one comes
+        back — a shadow is invisible to a reader, so the guard is structural,
+        not a review convention.
         """
         from ..utils.columns import resolve_column
 

--- a/tracebloc_ingestor/validators/bio_label_validator.py
+++ b/tracebloc_ingestor/validators/bio_label_validator.py
@@ -22,7 +22,7 @@ whitespace-tokenized word per token):
 import logging
 import os
 import re
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Tuple
 
 import pandas as pd
 
@@ -80,8 +80,8 @@ class BIOLabelValidator(BaseValidator):
                     is_valid=False, errors=["No data found to validate"]
                 )
 
-            filename_col = self._resolve_column(df, self.filename_column)
-            label_col = self._resolve_column(df, self.label_column)
+            filename_col = self._match_column(df.columns, self.filename_column)
+            label_col = self._match_column(df.columns, self.label_column)
             missing = []
             if filename_col is None:
                 missing.append(self.filename_column)
@@ -215,11 +215,3 @@ class BIOLabelValidator(BaseValidator):
             f"type). Valid under IOB1 but malformed under IOB2; if you intended "
             f"IOB2, the entity should start with 'B-'."
         ]
-
-    @staticmethod
-    def _resolve_column(df: pd.DataFrame, name: str) -> Optional[str]:
-        """Return the actual column name matching ``name`` case-insensitively."""
-        if name in df.columns:
-            return name
-        lowered = {c.lower(): c for c in df.columns}
-        return lowered.get(name.lower())

--- a/tracebloc_ingestor/validators/label_diversity_validator.py
+++ b/tracebloc_ingestor/validators/label_diversity_validator.py
@@ -81,7 +81,7 @@ class LabelDiversityValidator(BaseValidator):
                     metadata={"rows_checked": 0, "label_column": self.label_column},
                 )
 
-            col = self._resolve_column(df, self.label_column)
+            col = self._match_column(df.columns, self.label_column)
             if col is None:
                 # The label column isn't in the CSV — caller's
                 # responsibility to surface (DataValidator or the
@@ -219,7 +219,7 @@ class LabelDiversityValidator(BaseValidator):
                 # #252, medium) — or (b) build a ``usecols`` spelling
                 # pandas then rejected, erroring the read.
                 header_df = pd.read_csv(path, nrows=0, encoding="utf-8")
-                actual = self._resolve_column(header_df, self.label_column)
+                actual = self._match_column(header_df.columns, self.label_column)
                 if actual is None:
                     # Label column genuinely absent — benign skip; the
                     # ingestor / DataValidator report the missing column.
@@ -309,22 +309,4 @@ class LabelDiversityValidator(BaseValidator):
             return self.schema[actual]
         target = str(actual).strip().lower()
         normalised = {str(k).strip().lower(): v for k, v in self.schema.items()}
-        return normalised.get(target)
-
-    @staticmethod
-    def _resolve_column(df: pd.DataFrame, name: str) -> Optional[str]:
-        """Return the actual column name matching ``name`` case- AND
-        whitespace-insensitively.
-
-        CSVIngestor strips column-name whitespace on read
-        (``chunk.columns.str.strip()``), so a header like ``" label "`` is
-        ingested as ``label``. Resolving against the raw header without the
-        same strip treated the column as missing, skipped the diversity check
-        with a warning, and let a single-class CSV pass preflight (bugbot
-        #252). Match the strip here so the gate sees the same column the
-        ingestor does."""
-        if name in df.columns:
-            return name
-        target = str(name).strip().lower()
-        normalised = {str(c).strip().lower(): c for c in df.columns}
         return normalised.get(target)

--- a/tracebloc_ingestor/validators/tab_separated_record_validator.py
+++ b/tracebloc_ingestor/validators/tab_separated_record_validator.py
@@ -104,7 +104,7 @@ class TabSeparatedRecordValidator(BaseValidator):
                 # IngestableRecordsValidator's job, not this one.
                 return self._create_result(is_valid=True, metadata={"rows_checked": 0})
 
-            filename_col = self._resolve_column(df, self.filename_column)
+            filename_col = self._match_column(df.columns, self.filename_column)
             if filename_col is None:
                 return self._create_result(
                     is_valid=False,
@@ -219,11 +219,3 @@ class TabSeparatedRecordValidator(BaseValidator):
             )
 
         return None
-
-    @staticmethod
-    def _resolve_column(df: Any, name: str) -> Optional[str]:
-        """Return the actual column name matching ``name`` case-insensitively."""
-        if name in df.columns:
-            return name
-        lowered = {c.lower(): c for c in df.columns}
-        return lowered.get(name.lower())


### PR DESCRIPTION
Fixes tracebloc/backend#1828.

## The bug

`tracebloc_ingestor/utils/columns.py:resolve_column` is the one column-matching rule, reached by validators through `BaseValidator._match_column`. Three validators carried private `_resolve_column` copies instead, and **two dropped the `.strip()`**:

| copy | categories it gates |
|---|---|
| `BIOLabelValidator` | `token_classification` |
| `TabSeparatedRecordValidator` | `sentence_pair_classification`, `embeddings` |

`BaseValidator._load_data` reads the manifest with `pd.read_csv` and **no `skipinitialspace`**, so `filename, label` — the header Excel writes by default — parses as `["filename", " label"]`. The case-only copies never matched, so 3 of 16 categories rejected a dataset for a column visibly present in the file, while sibling validators in the *same preflight run* resolved it fine. This is the #340 / bugbot #252 divergence returning through a side door.

## Reproduced before the fix

```
raw parsed columns: ['filename', ' label']
BIOLabelValidator       valid=False errors=['Missing required column(s): label']
LabelDiversity(correct) valid=True  errors=[]      <- same header, sibling validator
```

`filename` is padded whenever it is not the first CSV field, which is what reaches the other two:

```
  parsed cols: ['label', ' filename']
  SentencePair  'label, filename'      valid=False errors=['Missing required column: filename']
  parsed cols: ['filename ', ' label']
  SentencePair  'filename , label'     valid=False errors=['Missing required column: filename']
  parsed cols: ['id', ' filename']
  Contrastive   'id, filename'         valid=False errors=['Missing required column: filename']
```

## How far the copies diverge

Differential run of each copy against canonical over a grid of header/name pairs:

```
LabelDiversity copy mismatches vs canonical: 0   <- faithful
BIO shadow      mismatches vs canonical: 23      <- the bug
```

A second divergence, measured: the shadows **raise** where canonical returns a hit.

```
canonical resolve_column(df.columns, '0') -> 0
shadow  _resolve_column(df, '0')          -> AttributeError: 'int' object has no attribute 'lower'
```

Not independently reachable through the CSV path (`pd.read_csv` always yields str headers), so I am **not** claiming it as a second live bug — but it is why patching the copies was the wrong fix.

## Design: delete, don't sync

All three copies are deleted and every call site routes through `self._match_column(df.columns, name)`.

The third copy (`LabelDiversityValidator._resolve_column`) was **faithful** — 0 divergences — and is deleted anyway. A faithful copy is exactly how the two broken ones came to exist; leaving one keeps the class of bug representable. Its `#252` rationale moved onto `_match_column`, which is now the documented sole resolver. (`_resolve_schema_column`, which maps over `self.schema` keys rather than a header, is a different lookup and is untouched.)

Two kinds of test, because the per-category regressions alone would not have caught this:

1. **Per affected category** — the padded-header case, exercised through the real CSV read path (a raw file, not a DataFrame), which is where the padding survives. The ticket notes the regression test existed only on the *one copy that was correct*, which is precisely how the divergence survived.
2. **`tests/test_no_shadowed_column_resolver.py`** — walks every `BaseValidator` subclass and fails if any defines a private resolver. A shadow is invisible to a reader (nothing about `self._resolve_column(...)` says "bypasses the canonical rule"), so the guard is mechanical, not a review convention. It includes a *guard-the-guard* assertion so a broken import cannot make it vacuously pass.

## Test evidence

Full suite, this branch:

```
4 failed, 1980 passed, 1 xfailed, 2 warnings in 19.75s
```

Baseline `origin/develop`, same machine:

```
4 failed, 1970 passed, 1 xfailed, 2 warnings in 20.66s
```

+10 tests, and **the same 4 failures** — all `float_overflow` cases, pre-existing and unrelated (a local numpy version difference; verified failing on a clean `origin/develop` worktree).

### Mutation testing — the fix is not inert

**1. Strip the `.strip()` from the canonical rule** (recreate the bug at its source):

```
FAILED tests/test_no_shadowed_column_resolver.py::test_match_column_delegates_to_the_canonical_rule
FAILED tests/test_bio_label_validator.py::test_csv_padded_header_still_resolves_label
FAILED tests/test_bio_label_validator.py::test_csv_padded_filename_header_still_resolves
FAILED tests/test_contrastive_pairs_validator.py::test_csv_padded_filename_header_still_resolves
FAILED tests/test_sentence_pair_validator.py::test_csv_padded_filename_header_still_resolves
FAILED tests/test_label_diversity_validator.py::test_csv_whitespace_header_still_checked
FAILED tests/test_label_diversity_validator.py::test_csv_whitespace_header_schema_na_rules_apply
FAILED tests/test_columns.py::test_resolve_column[cols2-label- label ]
FAILED tests/test_columns.py::test_resolve_column[cols4- label -label]
9 failed, 86 passed
```

**2. Re-shadow `_resolve_column` on `BIOLabelValidator`** (the exact regression the guard exists for):

```
FAILED tests/test_no_shadowed_column_resolver.py::test_no_validator_defines_a_private_column_resolver[_resolve_column]
FAILED tests/test_bio_label_validator.py::test_csv_padded_header_still_resolves_label
FAILED tests/test_bio_label_validator.py::test_csv_padded_filename_header_still_resolves
3 failed, 22 passed
```

Both the structural guard *and* the behavioral tests fire.

**3. Make class discovery return nothing** (would render the shadow checks vacuous):

```
FAILED tests/test_no_shadowed_column_resolver.py::test_validator_classes_are_discovered
E       assert 0 >= 20
1 failed, 5 passed
```

## Gates

- **Version bump**: `0.8.8` → **`0.8.9`**. Patch: a false-reject bug fix with no API or schema change; nothing added to the public surface.
- **`black` (26.3.1, diff-scoped)**: `9 files would be left unchanged`.
- **Heads-up on one unrelated hunk**: `tests/test_contrastive_pairs_validator.py` was **already** non-conforming on `origin/develop` (verified), and appending a test drags it into the diff-scoped gate. The reformat is one `write_text(...)` call collapsed onto a single line — noted so it doesn't read as scope creep.

## Not claimed

The ticket calls the two copies "byte-identical"; they differ in the annotation only (`df: pd.DataFrame` vs `df: Any`) — bodies are identical. The ticket also names the class `BioLabelValidator`; it is `BIOLabelValidator`. Neither affects the finding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted preflight column-matching fix with no public API change; risk is limited to manifest header resolution behavior.
> 
> **Overview**
> Fixes **false “missing column” preflight failures** when CSV headers include spaces after commas (e.g. Excel’s `filename, label`), which `pd.read_csv` keeps as `" label"` / `" filename"` because `_load_data` does not use `skipinitialspace`.
> 
> **`BIOLabelValidator`**, **`TabSeparatedRecordValidator`** (sentence pairs / contrastive embeddings), and **`LabelDiversityValidator`** no longer use private `_resolve_column` helpers; they call **`BaseValidator._match_column`** → **`resolve_column`** (strip + case-insensitive match). The two broken copies only lower-cased and never matched padded headers, so **token_classification**, **sentence_pair_classification**, and **embeddings** could fail while other validators in the same run passed.
> 
> Adds **CSV regression tests** per affected validator and **`tests/test_no_shadowed_column_resolver.py`** to forbid new private column resolvers on any `BaseValidator` subclass. **`_match_column`** docs now state it is the sole resolver. Version **0.8.8 → 0.8.9**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26621113a0c905e7a20fded8eb2994004d4bcd2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->