### PR TITLE
test(contract): pin the ingest→trainer storage contract (backend#1706)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ the file extension — drives validation and file transfer.
   - `api/` -- API client for communicating with tracebloc backend
   - `database.py` -- MySQL/SQLAlchemy database operations
   - `file_transfer.py` -- secure file transfer to cluster storage
+  - `storage_contract.py` -- the ingest→trainer storage contract (framework column names, `data_id` strategies, the on-disk naming rule). Stdlib-only and mirrored verbatim by tracebloc-engine's `core/utils/ingest_contract.py`; change it here first (backend#1706)
   - `config.py` -- configuration
   - `utils/` -- shared utilities (incl. `TaskCategory` constants, logging)
 - **`templates/`** -- ingestor scripts used inside Docker containers

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,6 +23,21 @@ The suite **auto-skips when no MySQL is reachable**, so the default `pytest`
 (unit) run is unaffected. CI runs it with a MySQL service in
 `.github/workflows/e2e.yml`.
 
+## Cross-repo contract suites
+
+Two files here assert not just "the ingest succeeded" but "what it stored is
+what the **training client** resolves", checked against the client's own
+derivation rule (transcribed in each file, since neither repo may import the
+other):
+
+- `test_semseg_client_contract_e2e.py` — the semseg `mask_id` contract
+  (backend#816).
+- `test_image_lookup_contract_e2e.py` — the image-lookup contract for every
+  file-bearing CV category: the file is named after `filename`, and `data_id`
+  names nothing on disk (tracebloc-engine#615, backend#1706). Its unit-level
+  sibling is `tests/test_ingest_storage_contract.py`, which also produces the
+  capture tracebloc-engine replays through its dataset readers.
+
 ## Known gaps (currently `xfail`)
 
 None — all 11 supported modalities ingest cleanly and are covered. The earlier

--- a/e2e/test_image_lookup_contract_e2e.py
+++ b/e2e/test_image_lookup_contract_e2e.py
@@ -1,0 +1,272 @@
+"""backend#1706 — the ingestor→trainer IMAGE-lookup contract, end to end.
+
+Sibling of ``test_semseg_client_contract_e2e.py``, which pins the same kind of
+boundary for ``mask_id``. Here the subject is the image itself, and the bug it
+guards against already shipped: tracebloc-engine#615, where keypoint and
+semantic-segmentation training crashed on the first batch of every
+CLI-ingested dataset because the trainer resolved images by ``data_id`` while
+this repo names the file after the manifest ``filename``.
+
+Why an e2e and not just ``tests/test_ingest_storage_contract.py``: that suite
+captures the rows as they are handed to ``Database.insert_batch``. The trainer
+does not read those dicts — it reads a MySQL table. Everything between (the
+generated DDL, column types, NULL handling, VARCHAR width) sits in the gap, and
+the gap is where a filename gets truncated or a column silently isn't created.
+So this ingests through the real YAML/CLI route into real MySQL and then
+resolves every SELECTed row against the real files on disk, using the
+**trainer's own rule** transcribed below.
+
+The trainer's rule (tracebloc-engine ``core/utils/general.py::resolve_image_path``,
+used by all four CV dataset readers since #615), per row::
+
+    for column in ("filename", "data_id"):        # filename FIRST
+        cell = row[column]                        # skip absent / NULL / blank
+        if isfile(dir/cell):        -> resolve    # value carrying its extension
+        stem = cell minus a RECOGNISED image suffix
+        if isfile(dir/stem + probed extension) -> resolve
+    else: FileNotFoundError                       # crashes the training batch
+
+Coverage: every file-bearing CV category under the DEFAULT ``data_id``
+strategy — the shape `tracebloc dataset push` produces and the one #615 broke —
+plus one case under the ``column`` alias the keypoint / semseg Python templates
+set, which is the coincidence that hid the bug.
+
+Skipped by conftest's ``collect_ignore_glob`` unless a MySQL is reachable.
+"""
+
+import os
+from pathlib import Path
+
+import mysql.connector
+import pytest
+import yaml
+
+from tracebloc_ingestor.cli import run
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.storage_contract import (
+    EXTENSION_COLUMN,
+    IMAGE_NAME_COLUMN,
+    IMAGE_NAME_COLUMNS,
+    RECOGNISED_IMAGE_SUFFIXES,
+    ROW_ID_COLUMN,
+    strip_image_extension,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+T = REPO / "templates"
+
+
+def _cfg(**kw):
+    base = {"apiVersion": "tracebloc.io/v1", "kind": "IngestConfig", "intent": "train"}
+    base.update(kw)
+    return base
+
+
+CASES = [
+    pytest.param(
+        _cfg(
+            table="e2e_lookup_img",
+            category="image_classification",
+            csv=str(T / "image_classification/data/labels_file_sample.csv"),
+            images=str(T / "image_classification/data/images"),
+            label="label",
+            spec={"file_options": {"extension": ".jpeg", "target_size": [256, 256]}},
+        ),
+        id="image_classification",
+    ),
+    pytest.param(
+        _cfg(
+            table="e2e_lookup_od",
+            category="object_detection",
+            csv=str(T / "object_detection/data/labels_file_sample.csv"),
+            images=str(T / "object_detection/data/images"),
+            annotations=str(T / "object_detection/data/annotations"),
+            label="image_label",
+            target_size=[1920, 1080],
+        ),
+        id="object_detection",
+    ),
+    pytest.param(
+        _cfg(
+            table="e2e_lookup_kp",
+            category="keypoint_detection",
+            csv=str(T / "keypoint_detection/data/labels_file_sample.csv"),
+            images=str(T / "keypoint_detection/data/images"),
+            label="image_label",
+            target_size=[448, 448],
+            number_of_keypoints=9,
+        ),
+        id="keypoint_detection",
+    ),
+    pytest.param(
+        _cfg(
+            table="e2e_lookup_seg",
+            category="semantic_segmentation",
+            csv=str(T / "semantic_segmentation/semantic_data/labels_file_sample.csv"),
+            images=str(T / "semantic_segmentation/semantic_data/images"),
+            masks=str(T / "semantic_segmentation/semantic_data/masks"),
+            label="image_label",
+            schema={"mask_id": "VARCHAR(255)"},
+        ),
+        id="semantic_segmentation",
+    ),
+    # The template alias: data_id == filename. The trainer must resolve this
+    # shape too — legacy datasets are full of it — so it stays covered.
+    pytest.param(
+        _cfg(
+            table="e2e_lookup_kp_alias",
+            category="keypoint_detection",
+            csv=str(T / "keypoint_detection/data/labels_file_sample.csv"),
+            images=str(T / "keypoint_detection/data/images"),
+            label="image_label",
+            target_size=[448, 448],
+            number_of_keypoints=9,
+            data_id={"strategy": "column", "column": "filename"},
+        ),
+        id="keypoint_detection-data_id_alias",
+    ),
+]
+
+
+def _connect():
+    return mysql.connector.connect(
+        host=os.environ["MYSQL_HOST"],
+        port=int(os.environ["MYSQL_PORT"]),
+        user=os.environ["DB_USER"],
+        password=os.environ["DB_PASSWORD"],
+        database=os.environ["DB_NAME"],
+    )
+
+
+def _drop(table):
+    conn = _connect()
+    conn.cursor().execute(f"DROP TABLE IF EXISTS `{table}`")
+    conn.commit()
+    conn.close()
+
+
+def _rows(table):
+    conn = _connect()
+    cur = conn.cursor(dictionary=True)
+    cur.execute(f"SELECT * FROM `{table}`")
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+def _is_blank(value) -> bool:
+    """A NULL / blank metadata cell — the trainer skips these and falls through
+    to the next candidate column rather than resolving the string ``"None"``."""
+    return value is None or not str(value).strip()
+
+
+def _trainer_resolves(data_dir: Path, row: dict):
+    """Transcription of tracebloc-engine's ``resolve_image_path``.
+
+    Returns the resolved path, or ``None`` — which is the trainer raising
+    ``FileNotFoundError`` and killing the training batch.
+    """
+    for column in IMAGE_NAME_COLUMNS:
+        if column not in row or _is_blank(row[column]):
+            continue
+        cell = str(row[column]).strip()
+        if (data_dir / cell).is_file():
+            return data_dir / cell
+        stem = strip_image_extension(cell)
+        for suffix in RECOGNISED_IMAGE_SUFFIXES:
+            for cased in (suffix, suffix.upper()):
+                if (data_dir / f"{stem}{cased}").is_file():
+                    return data_dir / f"{stem}{cased}"
+    return None
+
+
+def _ingest(cfg, tmp_path, monkeypatch) -> Path:
+    """Run the real YAML/CLI ingest; return the dataset directory on disk."""
+    config_path = tmp_path / "ingest.yaml"
+    config_path.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("INGEST_CONFIG", str(config_path))
+    rc = run.main()
+    assert rc == 0, f"{cfg['table']}: ingest exited {rc}"
+    return Path(Config.STORAGE_PATH) / cfg["table"]
+
+
+@pytest.mark.parametrize("cfg", CASES)
+def test_every_ingested_row_resolves_to_its_image(cfg, tmp_path, monkeypatch):
+    """The assertion #615 needed: every row SELECTed from the ingested table
+    resolves to a real file under the trainer's own rule."""
+    table = cfg["table"]
+    _drop(table)
+    dest = _ingest(cfg, tmp_path, monkeypatch)
+
+    rows = _rows(table)
+    assert rows, f"{table}: ingest stored no rows"
+
+    for row in rows:
+        assert not _is_blank(row.get(IMAGE_NAME_COLUMN)), (
+            f"{table}: NULL/blank {IMAGE_NAME_COLUMN} on "
+            f"{ROW_ID_COLUMN}={row.get(ROW_ID_COLUMN)!r} — the trainer has "
+            f"nothing to resolve the image by"
+        )
+        resolved = _trainer_resolves(dest, row)
+        assert resolved is not None, (
+            f"{table}: no image file for row "
+            f"{ {c: row.get(c) for c in IMAGE_NAME_COLUMNS} } under {dest} — "
+            f"the trainer's dataset reader would raise FileNotFoundError on "
+            f"the first training batch (tracebloc-engine#615). Directory holds "
+            f"{sorted(p.name for p in dest.iterdir())[:10]}"
+        )
+
+
+@pytest.mark.parametrize(
+    "cfg", [c for c in CASES if "alias" not in c.id], ids=lambda c: c["table"]
+)
+def test_a_data_id_keyed_reader_would_still_fail(cfg, tmp_path, monkeypatch):
+    """Negative control — without it the test above could pass vacuously.
+
+    Under the default strategy ``data_id`` names no file, so the pre-#615
+    reader (``data_id`` only) resolves nothing. If this ever starts failing,
+    something has re-aliased ``data_id`` to the on-disk name and the suite
+    above stopped proving anything.
+    """
+    table = cfg["table"]
+    _drop(table)
+    dest = _ingest(cfg, tmp_path, monkeypatch)
+
+    rows = _rows(table)
+    assert rows, f"{table}: ingest stored no rows"
+    for row in rows:
+        data_id_only = {ROW_ID_COLUMN: row[ROW_ID_COLUMN]}
+        assert _trainer_resolves(dest, data_id_only) is None, (
+            f"{table}: data_id {row[ROW_ID_COLUMN]!r} resolves to a file on "
+            f"disk. That coincidence is what hid tracebloc-engine#615 — the "
+            f"contract is that only {IMAGE_NAME_COLUMN} names the file."
+        )
+
+
+@pytest.mark.parametrize("cfg", CASES)
+def test_stored_filename_survives_the_mysql_round_trip(cfg, tmp_path, monkeypatch):
+    """``filename`` + ``extension`` come back out of MySQL naming the file the
+    ingest wrote — no truncation, no NULL, no dropped column.
+
+    This is the half the unit contract test cannot see: it captures the row
+    *before* the insert, and the trainer reads it *after*.
+    """
+    table = cfg["table"]
+    _drop(table)
+    dest = _ingest(cfg, tmp_path, monkeypatch)
+
+    rows = _rows(table)
+    assert rows, f"{table}: ingest stored no rows"
+    assert EXTENSION_COLUMN in rows[0], (
+        f"{table}: no {EXTENSION_COLUMN} column in the ingested table; "
+        f"columns = {sorted(rows[0])}"
+    )
+
+    on_disk = {p.name for p in dest.iterdir() if p.is_file()}
+    for row in rows:
+        stem = str(row[IMAGE_NAME_COLUMN])
+        extension = row[EXTENSION_COLUMN] or ""
+        assert f"{stem}{extension}" in on_disk or stem in on_disk, (
+            f"{table}: stored ({IMAGE_NAME_COLUMN}={stem!r}, "
+            f"{EXTENSION_COLUMN}={extension!r}) names no file under {dest}"
+        )

--- a/tests/fixtures/contracts/ingested_image_rows.json
+++ b/tests/fixtures/contracts/ingested_image_rows.json
@@ -1,0 +1,369 @@
+{
+  "_README": [
+    "Captured from REAL ingests by tests/test_ingest_storage_contract.py",
+    "(data-ingestors). Do not hand-edit: regenerate with",
+    "UPDATE_INGEST_CONTRACT_GOLDEN=1 pytest tests/test_ingest_storage_contract.py",
+    "",
+    "tracebloc-engine mirrors this file verbatim into",
+    "core/tests/contracts/ingested_image_rows.json and replays it through",
+    "its CV dataset readers (backend#1706). Carry any regeneration across.",
+    "",
+    "'ingestor_id' is dropped and a uuid-strategy data_id is masked as '<uuid4>' \u2014 both are random per run.",
+    "content_hash ids are computed under the fixed test salt '1706170617061706170617061706170617061706170617061706170617061706'.",
+    "'rows' holds the first 4 of 'total_rows_ingested'; the contract is per-row."
+  ],
+  "contract": {
+    "image_name_columns": [
+      "filename",
+      "data_id"
+    ],
+    "data_id_strategies": [
+      "content_hash",
+      "uuid",
+      "column"
+    ],
+    "default_data_id_strategy": "content_hash",
+    "opaque_data_id_strategies": [
+      "content_hash",
+      "uuid"
+    ],
+    "recognised_image_suffixes": [
+      ".jpeg",
+      ".jpg",
+      ".png"
+    ],
+    "uuid_sentinel": "<uuid4>"
+  },
+  "cases": [
+    {
+      "id": "image_classification-default",
+      "category": "image_classification",
+      "data_id_strategy": "content_hash",
+      "unique_id_column": null,
+      "total_rows_ingested": 576,
+      "dest_files": [
+        "cat1.jpeg",
+        "cat2.jpeg",
+        "cat3.jpeg",
+        "dog1.jpeg",
+        "dog2.jpeg",
+        "dog3.jpeg"
+      ],
+      "rows": [
+        {
+          "label": "cat",
+          "data_intent": "train",
+          "data_id": "815352a97dcb5a2e07f82a504b4b23843aca91c55e2cb495039c595f6239e36a",
+          "filename": "cat1",
+          "extension": ".jpeg"
+        },
+        {
+          "label": "cat",
+          "data_intent": "train",
+          "data_id": "671123fe6b39176eaa49e03d9e68b9ef2e089dc0b14d81070748c93966803179",
+          "filename": "cat2",
+          "extension": ".jpeg"
+        },
+        {
+          "label": "cat",
+          "data_intent": "train",
+          "data_id": "d028007b85eec04b5cc91003036a42ef09649c2394fed45d3f727a1294479013",
+          "filename": "cat3",
+          "extension": ".jpeg"
+        },
+        {
+          "label": "dog",
+          "data_intent": "train",
+          "data_id": "8a277e09492091bcf1fbaedc4614a7ea68e81e177c7bb8701f054c460fc4a2b0",
+          "filename": "dog1",
+          "extension": ".jpeg"
+        }
+      ]
+    },
+    {
+      "id": "image_classification-column",
+      "category": "image_classification",
+      "data_id_strategy": "column",
+      "unique_id_column": "filename",
+      "total_rows_ingested": 576,
+      "dest_files": [
+        "cat1.jpeg",
+        "cat2.jpeg",
+        "cat3.jpeg",
+        "dog1.jpeg",
+        "dog2.jpeg",
+        "dog3.jpeg"
+      ],
+      "rows": [
+        {
+          "label": "cat",
+          "data_intent": "train",
+          "data_id": "cat1.jpeg",
+          "filename": "cat1",
+          "extension": ".jpeg"
+        },
+        {
+          "label": "cat",
+          "data_intent": "train",
+          "data_id": "cat2.jpeg",
+          "filename": "cat2",
+          "extension": ".jpeg"
+        },
+        {
+          "label": "cat",
+          "data_intent": "train",
+          "data_id": "cat3.jpeg",
+          "filename": "cat3",
+          "extension": ".jpeg"
+        },
+        {
+          "label": "dog",
+          "data_intent": "train",
+          "data_id": "dog1.jpeg",
+          "filename": "dog1",
+          "extension": ".jpeg"
+        }
+      ]
+    },
+    {
+      "id": "object_detection-default",
+      "category": "object_detection",
+      "data_id_strategy": "uuid",
+      "unique_id_column": null,
+      "total_rows_ingested": 128,
+      "dest_files": [
+        "0000001_02999_d_0000005.jpg",
+        "0000001_02999_d_0000005.xml"
+      ],
+      "rows": [
+        {
+          "label": "car",
+          "data_intent": "train",
+          "data_id": "<uuid4>",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        },
+        {
+          "label": "car",
+          "data_intent": "train",
+          "data_id": "<uuid4>",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        },
+        {
+          "label": "car",
+          "data_intent": "train",
+          "data_id": "<uuid4>",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        },
+        {
+          "label": "motor",
+          "data_intent": "train",
+          "data_id": "<uuid4>",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        }
+      ]
+    },
+    {
+      "id": "object_detection-column",
+      "category": "object_detection",
+      "data_id_strategy": "column",
+      "unique_id_column": "filename",
+      "total_rows_ingested": 128,
+      "dest_files": [
+        "0000001_02999_d_0000005.jpg",
+        "0000001_02999_d_0000005.xml"
+      ],
+      "rows": [
+        {
+          "label": "car",
+          "data_intent": "train",
+          "data_id": "0000001_02999_d_0000005",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        },
+        {
+          "label": "car",
+          "data_intent": "train",
+          "data_id": "0000001_02999_d_0000005",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        },
+        {
+          "label": "car",
+          "data_intent": "train",
+          "data_id": "0000001_02999_d_0000005",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        },
+        {
+          "label": "motor",
+          "data_intent": "train",
+          "data_id": "0000001_02999_d_0000005",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        }
+      ]
+    },
+    {
+      "id": "keypoint_detection-default",
+      "category": "keypoint_detection",
+      "data_id_strategy": "content_hash",
+      "unique_id_column": null,
+      "total_rows_ingested": 3,
+      "dest_files": [
+        "person_001.jpg",
+        "person_002.jpg",
+        "person_003.jpg"
+      ],
+      "rows": [
+        {
+          "label": "person",
+          "data_intent": "train",
+          "annotation": "{\"nose\": [0.50, 0.20], \"left_eye\": [0.46, 0.16], \"right_eye\": [0.54, 0.16], \"left_shoulder\": [0.37, 0.39], \"right_shoulder\": [0.63, 0.39], \"left_elbow\": [0.31, 0.59], \"right_elbow\": [0.68, 0.59], \"left_wrist\": [0.27, 0.76], \"right_wrist\": [0.72, 0.76]}",
+          "data_id": "f2feb4ca9dd0b7add8beb306684b90f8fb484a270c7be49d81ca1713f4e0d758",
+          "filename": "person_001",
+          "extension": ".jpg"
+        },
+        {
+          "label": "athlete",
+          "data_intent": "train",
+          "annotation": "{\"nose\": [0.51, 0.21], \"left_eye\": [0.48, 0.18], \"right_eye\": [0.55, 0.18], \"left_shoulder\": [0.39, 0.43], \"right_shoulder\": [0.64, 0.41], \"left_elbow\": [0.33, 0.63], \"right_elbow\": [0.70, 0.61], \"left_wrist\": [0.29, 0.78], \"right_wrist\": [0.74, 0.78]}",
+          "data_id": "8382b4358710c9e3590794f54132302845b643be00a6e4ffb1e56622a003325b",
+          "filename": "person_002",
+          "extension": ".jpg"
+        },
+        {
+          "label": "dancer",
+          "data_intent": "train",
+          "annotation": "{\"nose\": [0.49, 0.19], \"left_eye\": [0.45, 0.16], \"right_eye\": [0.53, 0.16], \"left_shoulder\": [0.35, 0.37], \"right_shoulder\": [0.61, 0.38], \"left_elbow\": [0.30, 0.58], \"right_elbow\": [0.66, 0.57], \"left_wrist\": [0.25, 0.74], \"right_wrist\": [0.71, 0.75]}",
+          "data_id": "7ae2efd5c6b258e5795c1e22f2cb27d1d27fbd931e08aca4fdc0e20ece968b63",
+          "filename": "person_003",
+          "extension": ".jpg"
+        }
+      ]
+    },
+    {
+      "id": "keypoint_detection-column",
+      "category": "keypoint_detection",
+      "data_id_strategy": "column",
+      "unique_id_column": "filename",
+      "total_rows_ingested": 3,
+      "dest_files": [
+        "person_001.jpg",
+        "person_002.jpg",
+        "person_003.jpg"
+      ],
+      "rows": [
+        {
+          "label": "person",
+          "data_intent": "train",
+          "annotation": "{\"nose\": [0.50, 0.20], \"left_eye\": [0.46, 0.16], \"right_eye\": [0.54, 0.16], \"left_shoulder\": [0.37, 0.39], \"right_shoulder\": [0.63, 0.39], \"left_elbow\": [0.31, 0.59], \"right_elbow\": [0.68, 0.59], \"left_wrist\": [0.27, 0.76], \"right_wrist\": [0.72, 0.76]}",
+          "data_id": "person_001",
+          "filename": "person_001",
+          "extension": ".jpg"
+        },
+        {
+          "label": "athlete",
+          "data_intent": "train",
+          "annotation": "{\"nose\": [0.51, 0.21], \"left_eye\": [0.48, 0.18], \"right_eye\": [0.55, 0.18], \"left_shoulder\": [0.39, 0.43], \"right_shoulder\": [0.64, 0.41], \"left_elbow\": [0.33, 0.63], \"right_elbow\": [0.70, 0.61], \"left_wrist\": [0.29, 0.78], \"right_wrist\": [0.74, 0.78]}",
+          "data_id": "person_002",
+          "filename": "person_002",
+          "extension": ".jpg"
+        },
+        {
+          "label": "dancer",
+          "data_intent": "train",
+          "annotation": "{\"nose\": [0.49, 0.19], \"left_eye\": [0.45, 0.16], \"right_eye\": [0.53, 0.16], \"left_shoulder\": [0.35, 0.37], \"right_shoulder\": [0.61, 0.38], \"left_elbow\": [0.30, 0.58], \"right_elbow\": [0.66, 0.57], \"left_wrist\": [0.25, 0.74], \"right_wrist\": [0.71, 0.75]}",
+          "data_id": "person_003",
+          "filename": "person_003",
+          "extension": ".jpg"
+        }
+      ]
+    },
+    {
+      "id": "semantic_segmentation-default",
+      "category": "semantic_segmentation",
+      "data_id_strategy": "content_hash",
+      "unique_id_column": null,
+      "total_rows_ingested": 3,
+      "dest_files": [
+        "image_001.jpg",
+        "image_001_mask.png",
+        "image_002.jpg",
+        "image_002_mask.png",
+        "image_003.jpg",
+        "image_003_mask.png"
+      ],
+      "rows": [
+        {
+          "mask_id": "image_001_mask",
+          "label": "road",
+          "data_intent": "train",
+          "data_id": "756ea6b45b7ae0dee26cd003f641f35c3fe6a518ea6515c51d1864e81b87dbe3",
+          "filename": "image_001",
+          "extension": ".jpg"
+        },
+        {
+          "mask_id": "image_002_mask",
+          "label": "building",
+          "data_intent": "train",
+          "data_id": "be1d294cde6c11053dab3be7e231d5581f950bef5d778d4fc3fe151135e60241",
+          "filename": "image_002",
+          "extension": ".jpg"
+        },
+        {
+          "mask_id": "image_003_mask",
+          "label": "person",
+          "data_intent": "train",
+          "data_id": "8e1921fbdbbd521f26f2271d46d813af3fa4c15af731e9a4860be4b5767d6748",
+          "filename": "image_003",
+          "extension": ".jpg"
+        }
+      ]
+    },
+    {
+      "id": "semantic_segmentation-column",
+      "category": "semantic_segmentation",
+      "data_id_strategy": "column",
+      "unique_id_column": "filename",
+      "total_rows_ingested": 3,
+      "dest_files": [
+        "image_001.jpg",
+        "image_001_mask.png",
+        "image_002.jpg",
+        "image_002_mask.png",
+        "image_003.jpg",
+        "image_003_mask.png"
+      ],
+      "rows": [
+        {
+          "mask_id": "image_001_mask",
+          "label": "road",
+          "data_intent": "train",
+          "data_id": "image_001",
+          "filename": "image_001",
+          "extension": ".jpg"
+        },
+        {
+          "mask_id": "image_002_mask",
+          "label": "building",
+          "data_intent": "train",
+          "data_id": "image_002",
+          "filename": "image_002",
+          "extension": ".jpg"
+        },
+        {
+          "mask_id": "image_003_mask",
+          "label": "person",
+          "data_intent": "train",
+          "data_id": "image_003",
+          "filename": "image_003",
+          "extension": ".jpg"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_ingest_storage_contract.py
+++ b/tests/test_ingest_storage_contract.py
@@ -1,0 +1,545 @@
+"""backend#1706 — the ingest → trainer storage contract, pinned on real rows.
+
+WHY THIS FILE EXISTS
+--------------------
+tracebloc-engine#615: keypoint + semantic-segmentation training crashed on the
+first batch of every CLI-ingested dataset, because the trainer resolved images
+by ``data_id`` while this repo names the file after the manifest ``filename``.
+Three facts had to stay in agreement and **nothing pinned any of them**:
+
+1. the ingestor writes ``DEST_PATH/<manifest filename><ext>``,
+2. it stores that stem in ``filename`` and something unrelated in ``data_id``,
+3. so every trainer dataset reader must key on ``filename``.
+
+When #350 flipped the default ``data_id`` strategy ``uuid`` → ``content_hash``,
+nothing failed anywhere. The trainer's own fixtures were hand-authored with
+``data_id`` set to the on-disk stem and **no ``filename`` column at all** — a
+shape this repo has never produced — so they could not catch it either. The two
+shipped Python templates that set ``unique_id_column="filename"`` are exactly
+``keypoint_detection`` and ``semantic_segmentation``: the two categories whose
+readers keyed on ``data_id``. The templates were papering over the reader bug.
+
+WHAT THIS FILE PINS
+-------------------
+Each case runs a **real ingest** — the same ``cli.conventions.resolve`` →
+``cli.run._build_ingestor`` path ``tracebloc dataset push`` takes, with real
+validators, real record processing and real file transfer. Only MySQL and the
+backend API are faked, and only at their own boundary: every value asserted
+below is produced by production code.
+
+Per case we assert:
+
+* **naming** — every stored row resolves to a file at
+  ``DEST/<filename><extension>``;
+* **independence** — under an opaque ``data_id`` strategy the id names *no*
+  file in ``DEST``, so a reader that keys on ``data_id`` cannot work. That is
+  the property the two templates hid;
+* **stability** — the captured rows match a committed golden, which
+  ``tracebloc-engine`` mirrors verbatim into ``core/tests/contracts/`` and
+  replays through its four CV dataset readers. A change here that moves the
+  on-disk name or the id shape turns THIS suite red with a diff, and the fix
+  is to regenerate the golden and carry it across — which is the moment
+  someone looks at the trainer.
+
+Regenerate the golden after an intentional change::
+
+    UPDATE_INGEST_CONTRACT_GOLDEN=1 pytest tests/test_ingest_storage_contract.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid as uuid_mod
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from tracebloc_ingestor.cli import run as run_mod
+from tracebloc_ingestor.cli.conventions import resolve
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.storage_contract import (
+    DATA_ID_STRATEGIES,
+    DEFAULT_DATA_ID_STRATEGY,
+    EXTENSION_COLUMN,
+    IMAGE_NAME_COLUMN,
+    IMAGE_NAME_COLUMNS,
+    MASK_NAME_COLUMN,
+    OPAQUE_DATA_ID_STRATEGIES,
+    RECOGNISED_IMAGE_SUFFIXES,
+    ROW_ID_COLUMN,
+    has_recognised_extension,
+    stored_image_name,
+    strip_image_extension,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+T = REPO / "templates"
+GOLDEN_PATH = REPO / "tests" / "fixtures" / "contracts" / "ingested_image_rows.json"
+
+# Pinned so the content-hash ids in the golden are reproducible. Production
+# mints a random per-table salt (#225) that never leaves the cluster; its value
+# is irrelevant to the contract, only its fixedness is.
+TABLE_SALT = "1706" * 16
+
+# ``ingestor_id`` is a fresh UUID per run and carries no contract meaning.
+VOLATILE_COLUMNS = ("ingestor_id",)
+
+# A uuid-strategy ``data_id`` is random by construction, so the golden stores
+# this sentinel in its place. Everything the contract cares about — that the id
+# is opaque and names no file — is asserted directly in the test.
+UUID_SENTINEL = "<uuid4>"
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+def _cfg(**kw: Any) -> Dict[str, Any]:
+    base = {"apiVersion": "tracebloc.io/v1", "kind": "IngestConfig", "intent": "train"}
+    base.update(kw)
+    return base
+
+
+# The four file-bearing CV categories — the ones with an image-per-row on disk
+# and therefore a reader that has to resolve it. Configs match the bundled
+# template data (same shape the e2e suite uses).
+def _image_classification() -> Dict[str, Any]:
+    return _cfg(
+        table="contract_img",
+        category="image_classification",
+        csv=str(T / "image_classification/data/labels_file_sample.csv"),
+        images=str(T / "image_classification/data/images"),
+        label="label",
+        spec={"file_options": {"extension": ".jpeg", "target_size": [256, 256]}},
+    )
+
+
+def _object_detection() -> Dict[str, Any]:
+    return _cfg(
+        table="contract_od",
+        category="object_detection",
+        csv=str(T / "object_detection/data/labels_file_sample.csv"),
+        images=str(T / "object_detection/data/images"),
+        annotations=str(T / "object_detection/data/annotations"),
+        label="image_label",
+        target_size=[1920, 1080],
+    )
+
+
+def _keypoint_detection() -> Dict[str, Any]:
+    return _cfg(
+        table="contract_kp",
+        category="keypoint_detection",
+        csv=str(T / "keypoint_detection/data/labels_file_sample.csv"),
+        images=str(T / "keypoint_detection/data/images"),
+        label="image_label",
+        target_size=[448, 448],
+        number_of_keypoints=9,
+    )
+
+
+def _semantic_segmentation() -> Dict[str, Any]:
+    return _cfg(
+        table="contract_seg",
+        category="semantic_segmentation",
+        csv=str(T / "semantic_segmentation/semantic_data/labels_file_sample.csv"),
+        images=str(T / "semantic_segmentation/semantic_data/images"),
+        masks=str(T / "semantic_segmentation/semantic_data/masks"),
+        label="image_label",
+        schema={"mask_id": "VARCHAR(255)"},
+    )
+
+
+CATEGORY_CONFIGS = {
+    "image_classification": _image_classification,
+    "object_detection": _object_detection,
+    "keypoint_detection": _keypoint_detection,
+    "semantic_segmentation": _semantic_segmentation,
+}
+
+# (category, data_id spec, case id). Two strategies per category:
+#
+# - the category's DEFAULT (no ``data_id`` key at all) — what every
+#   `tracebloc dataset push` produces today, and the shape that broke #615;
+# - ``column`` over ``filename`` — the alias the keypoint / semseg Python
+#   templates set, i.e. the coincidence under which a ``data_id``-keyed reader
+#   accidentally worked. Kept so the trainer's replay covers BOTH shapes and a
+#   future reader can't regress into only handling one.
+CASES: List[Tuple[str, Dict[str, Any] | None, str]] = [
+    (category, data_id, f"{category}-{label}")
+    for category in CATEGORY_CONFIGS
+    for data_id, label in (
+        (None, "default"),
+        ({"strategy": "column", "column": "filename"}, "column"),
+    )
+]
+
+
+def _run_ingest(
+    category: str,
+    data_id: Dict[str, Any] | None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Tuple[Config, Any, List[Dict[str, Any]]]:
+    """Run one real ingest; return ``(config, resolved, stored_rows)``.
+
+    MySQL and the backend API are the only fakes, and each is faked at its own
+    boundary: rows are captured exactly as ``Database.insert_batch`` would
+    receive them, after real validation, real record processing and real file
+    transfer.
+    """
+    config = CATEGORY_CONFIGS[category]()
+    if data_id is not None:
+        config["data_id"] = data_id
+
+    resolved = resolve(config)
+    run_config = run_mod._resolve_config(resolved)
+
+    # DEST_PATH is ``STORAGE_PATH/<table>``; /data/shared isn't writable in CI.
+    storage = tmp_path / "shared"
+    storage.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Config, "STORAGE_PATH", str(storage))
+    monkeypatch.setenv("CLIENT_ENV", "local")
+
+    rows: List[Dict[str, Any]] = []
+
+    database = MagicMock(name="Database")
+    database.config = run_config
+    database.engine = MagicMock(name="Engine")
+    database.create_table.return_value = MagicMock(name="Table")
+    database.get_table_schema.return_value = resolved.schema
+    database.get_or_create_table_salt.return_value = TABLE_SALT
+
+    def _insert_batch(_table: str, records: List[Dict[str, Any]]):
+        rows.extend(dict(record) for record in records)
+        return list(range(len(records))), []
+
+    database.insert_batch.side_effect = _insert_batch
+
+    api_client = MagicMock(name="APIClient")
+    for method in (
+        "send_batch",
+        "send_generate_edge_label_meta",
+        "send_global_meta_meta",
+        "prepare_dataset",
+    ):
+        getattr(api_client, method).return_value = True
+    api_client.create_dataset.return_value = {"id": 1}
+
+    ingestor = run_mod._build_ingestor(database, api_client, resolved)
+    ingestor.ingest(resolved.source_path)
+
+    assert rows, f"{category}: the ingest stored no rows"
+    return run_config, resolved, rows
+
+
+def _normalise(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Drop per-run volatile fields and mask random uuid ids, so the capture is
+    comparable against a committed golden."""
+    out = []
+    for row in rows:
+        clean = {
+            key: value for key, value in row.items() if key not in VOLATILE_COLUMNS
+        }
+        row_id = str(clean.get(ROW_ID_COLUMN, ""))
+        if _UUID_RE.match(row_id):
+            clean[ROW_ID_COLUMN] = UUID_SENTINEL
+        out.append(json.loads(json.dumps(clean, default=str)))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The contract, asserted on real ingested rows.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "category,data_id",
+    [pytest.param(c, d, id=i) for c, d, i in CASES],
+)
+def test_every_stored_row_resolves_through_the_filename_column(
+    category, data_id, tmp_path, monkeypatch
+):
+    """FACT 1+2: the file on disk is named after ``filename``, always.
+
+    This is the single rule the trainer has to implement. It holds for every
+    category and every ``data_id`` strategy — the strategy is simply not part
+    of how a file is named.
+    """
+    run_config, _resolved, rows = _run_ingest(category, data_id, tmp_path, monkeypatch)
+    dest = run_config.DEST_PATH
+
+    for row in rows:
+        assert row[IMAGE_NAME_COLUMN], f"{category}: row stored a blank filename"
+        expected = stored_image_name(row[IMAGE_NAME_COLUMN], row[EXTENSION_COLUMN])
+        assert os.path.isfile(os.path.join(dest, expected)), (
+            f"{category}: no file at DEST/{expected} for stored row "
+            f"{row[IMAGE_NAME_COLUMN]!r} — the filename column no longer names "
+            f"the file the ingest wrote. DEST holds {sorted(os.listdir(dest))}"
+        )
+
+
+@pytest.mark.parametrize(
+    "category",
+    list(CATEGORY_CONFIGS),
+)
+def test_default_strategy_data_id_names_no_file_on_disk(
+    category, tmp_path, monkeypatch
+):
+    """FACT 3, stated as the negative: under the default strategy ``data_id``
+    resolves to nothing, so a ``data_id``-keyed reader is simply broken.
+
+    This is #615 reproduced at its source. The keypoint / semseg templates set
+    ``unique_id_column="filename"`` and so never exercised it; the CLI / YAML
+    path — the one customers use — always does.
+    """
+    run_config, resolved, rows = _run_ingest(category, None, tmp_path, monkeypatch)
+    if resolved.data_id_strategy not in OPAQUE_DATA_ID_STRATEGIES:
+        pytest.fail(
+            f"{category}: default strategy is {resolved.data_id_strategy!r}, which "
+            f"is not opaque — update OPAQUE_DATA_ID_STRATEGIES and re-read #615"
+        )
+
+    dest = run_config.DEST_PATH
+    on_disk = set(os.listdir(dest))
+    for row in rows:
+        row_id = str(row[ROW_ID_COLUMN])
+        assert row_id not in on_disk
+        stem = strip_image_extension(row_id)
+        for suffix in RECOGNISED_IMAGE_SUFFIXES:
+            assert f"{stem}{suffix}" not in on_disk, (
+                f"{category}: data_id {row_id!r} happens to name a file on disk. "
+                f"That coincidence is what hid tracebloc-engine#615 for two "
+                f"releases — do not let a reader depend on it."
+            )
+        assert row[IMAGE_NAME_COLUMN] != row_id
+
+
+@pytest.mark.parametrize(
+    "category",
+    list(CATEGORY_CONFIGS),
+)
+def test_column_strategy_aliases_data_id_to_filename(category, tmp_path, monkeypatch):
+    """The opt-in alias the templates relied on still works — and is opt-in.
+
+    Pinned so nobody "fixes" the divergence by making the alias the default:
+    that would re-hide the bug rather than remove it.
+    """
+    _config, resolved, rows = _run_ingest(
+        category, {"strategy": "column", "column": "filename"}, tmp_path, monkeypatch
+    )
+    assert resolved.unique_id_column == IMAGE_NAME_COLUMN
+    for row in rows:
+        assert strip_image_extension(row[ROW_ID_COLUMN]) == row[IMAGE_NAME_COLUMN]
+
+
+def test_semantic_segmentation_mask_resolves_through_its_own_column(
+    tmp_path, monkeypatch
+):
+    """``mask_id`` follows the same rule as ``filename`` (backend#816): it names
+    a file, ``data_id`` does not."""
+    run_config, _resolved, rows = _run_ingest(
+        "semantic_segmentation", None, tmp_path, monkeypatch
+    )
+    dest = run_config.DEST_PATH
+    for row in rows:
+        mask = row[MASK_NAME_COLUMN]
+        assert mask, "semseg row stored a blank mask_id"
+        stem = strip_image_extension(mask)
+        assert any(
+            os.path.isfile(os.path.join(dest, f"{stem}{suffix}"))
+            for suffix in RECOGNISED_IMAGE_SUFFIXES
+        ) or os.path.isfile(
+            os.path.join(dest, str(mask))
+        ), f"no mask file for mask_id {mask!r} in {sorted(os.listdir(dest))}"
+
+
+# ---------------------------------------------------------------------------
+# The golden — the artifact tracebloc-engine replays.
+# ---------------------------------------------------------------------------
+# The bundled manifests run to hundreds of rows (object detection lists one row
+# per OBJECT), and a golden nobody can read is a golden nobody checks. The
+# contract is per-row, so a handful exercises it exactly as well.
+GOLDEN_ROWS_PER_CASE = 4
+
+
+def _effective_strategy(resolved) -> str:
+    """The strategy that actually minted ``data_id``.
+
+    ``data_id: {strategy: column}`` sets ``unique_id_column`` and leaves
+    ``data_id_strategy`` at its default; the column wins at row time
+    (``RecordProcessor._map_unique_id``). Record what happened, not what the
+    unused field says.
+    """
+    return "column" if resolved.unique_id_column else resolved.data_id_strategy
+
+
+def _capture_all(tmp_path_factory, monkeypatch) -> Dict[str, Any]:
+    cases = []
+    for category, data_id, case_id in CASES:
+        tmp_path = tmp_path_factory.mktemp(case_id.replace("/", "_"))
+        run_config, resolved, rows = _run_ingest(
+            category, data_id, tmp_path, monkeypatch
+        )
+        cases.append(
+            {
+                "id": case_id,
+                "category": category,
+                "data_id_strategy": _effective_strategy(resolved),
+                "unique_id_column": resolved.unique_id_column,
+                "total_rows_ingested": len(rows),
+                "dest_files": sorted(os.listdir(run_config.DEST_PATH)),
+                "rows": _normalise(rows[:GOLDEN_ROWS_PER_CASE]),
+            }
+        )
+    return {
+        "_README": [
+            "Captured from REAL ingests by tests/test_ingest_storage_contract.py",
+            "(data-ingestors). Do not hand-edit: regenerate with",
+            "UPDATE_INGEST_CONTRACT_GOLDEN=1 pytest tests/test_ingest_storage_contract.py",
+            "",
+            "tracebloc-engine mirrors this file verbatim into",
+            "core/tests/contracts/ingested_image_rows.json and replays it through",
+            "its CV dataset readers (backend#1706). Carry any regeneration across.",
+            "",
+            f"'ingestor_id' is dropped and a uuid-strategy data_id is masked as "
+            f"'{UUID_SENTINEL}' — both are random per run.",
+            f"content_hash ids are computed under the fixed test salt {TABLE_SALT!r}.",
+            f"'rows' holds the first {GOLDEN_ROWS_PER_CASE} of "
+            f"'total_rows_ingested'; the contract is per-row.",
+        ],
+        "contract": {
+            "image_name_columns": list(IMAGE_NAME_COLUMNS),
+            "data_id_strategies": list(DATA_ID_STRATEGIES),
+            "default_data_id_strategy": DEFAULT_DATA_ID_STRATEGY,
+            "opaque_data_id_strategies": sorted(OPAQUE_DATA_ID_STRATEGIES),
+            "recognised_image_suffixes": list(RECOGNISED_IMAGE_SUFFIXES),
+            "uuid_sentinel": UUID_SENTINEL,
+        },
+        "cases": cases,
+    }
+
+
+def test_golden_matches_a_real_ingest(tmp_path_factory, monkeypatch):
+    """The committed golden IS what the pipeline produces, today.
+
+    The trainer's fixtures are built from this file rather than hand-authored,
+    which is the whole point: a hand-authored fixture can express a row shape
+    the ingestor never produces (and did — engine#615's keypoint fixture had no
+    ``filename`` column at all), so it proves nothing about the real boundary.
+    """
+    captured = _capture_all(tmp_path_factory, monkeypatch)
+
+    if os.environ.get("UPDATE_INGEST_CONTRACT_GOLDEN"):
+        GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+        GOLDEN_PATH.write_text(json.dumps(captured, indent=2) + "\n")
+        pytest.skip(f"golden regenerated at {GOLDEN_PATH}")
+
+    assert GOLDEN_PATH.is_file(), (
+        f"missing golden {GOLDEN_PATH}; regenerate with "
+        f"UPDATE_INGEST_CONTRACT_GOLDEN=1"
+    )
+    golden = json.loads(GOLDEN_PATH.read_text())
+    assert captured["contract"] == golden["contract"]
+    assert captured["cases"] == golden["cases"], (
+        "the ingest no longer produces the committed golden. If the change is "
+        "intended, regenerate with UPDATE_INGEST_CONTRACT_GOLDEN=1 AND copy the "
+        "file into tracebloc-engine core/tests/contracts/ — the trainer replays "
+        "it (backend#1706)."
+    )
+
+
+def test_golden_rows_carry_the_columns_a_reader_needs(tmp_path_factory):
+    """Guard against a golden that is technically current but useless: every
+    row must still carry the columns a trainer resolves files through."""
+    golden = json.loads(GOLDEN_PATH.read_text())
+    for case in golden["cases"]:
+        for row in case["rows"]:
+            assert IMAGE_NAME_COLUMN in row, case["id"]
+            assert ROW_ID_COLUMN in row, case["id"]
+            assert EXTENSION_COLUMN in row, case["id"]
+            name = stored_image_name(row[IMAGE_NAME_COLUMN], row[EXTENSION_COLUMN])
+            assert name in case["dest_files"], (
+                f"{case['id']}: golden row names {name!r}, which is not in the "
+                f"golden's own dest listing {case['dest_files']}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# The contract module itself — mirrored verbatim by tracebloc-engine's
+# core/tests/contracts/test_ingest_contract_mirror.py. Keep the two tables in
+# step; a divergence here is a divergence in what the trainer believes.
+# ---------------------------------------------------------------------------
+CONTRACT_VALUES = {
+    "IMAGE_NAME_COLUMN": "filename",
+    "ROW_ID_COLUMN": "data_id",
+    "EXTENSION_COLUMN": "extension",
+    "MASK_NAME_COLUMN": "mask_id",
+    "IMAGE_NAME_COLUMNS": ("filename", "data_id"),
+    "DATA_ID_STRATEGIES": ("content_hash", "uuid", "column"),
+    "DEFAULT_DATA_ID_STRATEGY": "content_hash",
+    "RECOGNISED_IMAGE_SUFFIXES": (".jpeg", ".jpg", ".png"),
+}
+
+# (value, stripped stem). Names with internal dots must survive: the pipeline
+# strips only a RECOGNISED trailing suffix, so a ``split(".")[0]`` reader would
+# look for a file that does not exist.
+STRIP_CASES = [
+    ("cat1.jpg", "cat1"),
+    ("cat1.JPEG", "cat1"),
+    ("image.001.jpg", "image.001"),
+    ("image.001", "image.001"),
+    ("no_extension", "no_extension"),
+    ("archive.tar", "archive.tar"),
+    ("", ""),
+]
+
+
+@pytest.mark.parametrize("name,expected", [(k, v) for k, v in CONTRACT_VALUES.items()])
+def test_contract_values(name, expected):
+    import tracebloc_ingestor.storage_contract as contract
+
+    assert getattr(contract, name) == expected
+
+
+@pytest.mark.parametrize("value,stem", STRIP_CASES)
+def test_strip_image_extension(value, stem):
+    assert strip_image_extension(value) == stem
+
+
+@pytest.mark.parametrize("value,stem", STRIP_CASES)
+def test_has_recognised_extension_agrees_with_strip(value, stem):
+    assert has_recognised_extension(value) is (strip_image_extension(value) != value)
+
+
+@pytest.mark.parametrize(
+    "filename,extension,expected",
+    [
+        ("cat1", ".jpg", "cat1.jpg"),
+        ("cat1.jpg", ".jpg", "cat1.jpg"),  # already suffixed — not doubled (#105)
+        ("cat1.JPEG", ".jpg", "cat1.JPEG"),  # keeps its own case + kind
+        ("image.001", ".png", "image.001.png"),
+    ],
+)
+def test_stored_image_name(filename, extension, expected):
+    assert stored_image_name(filename, extension) == expected
+
+
+def test_contract_agrees_with_the_transfer_code_it_describes():
+    """``storage_contract.has_recognised_extension`` must agree with
+    ``file_transfer._has_extension`` on IMAGE suffixes.
+
+    The transfer helper is deliberately broader (it also recognises the sidecar
+    ``.xml`` / ``.txt`` suffixes), so this pins agreement on the image subset
+    only — that is the subset the trainer mirrors.
+    """
+    from tracebloc_ingestor.file_transfer import _has_extension
+
+    for suffix in RECOGNISED_IMAGE_SUFFIXES:
+        for value in (f"cat1{suffix}", f"cat1{suffix.upper()}"):
+            assert has_recognised_extension(value) is _has_extension(value) is True
+    assert has_recognised_extension("cat1") is _has_extension("cat1") is False
+
+
+def test_uuid_sentinel_never_collides_with_a_real_id():
+    assert not _UUID_RE.match(UUID_SENTINEL)
+    assert _UUID_RE.match(str(uuid_mod.uuid4()))

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.8"
+__version__ = "0.8.9"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -20,6 +20,10 @@ from tenacity import (
 )
 
 from tracebloc_ingestor import Config
+from tracebloc_ingestor.storage_contract import (
+    EXTENSION_COLUMN,
+    IMAGE_NAME_COLUMN,
+)
 from tracebloc_ingestor.utils.fs import DEST_DIR_MODE as _DEST_DIR_MODE
 from tracebloc_ingestor.utils.fs import ensure_reclaimable_dir
 from tracebloc_ingestor.utils.constants import (
@@ -259,8 +263,12 @@ def image_transfer(
         # Copy file with retry logic
         _copy_file_with_retry(src_path, image_dest_path)
 
-        record["filename"] = os.path.splitext(filename_with_ext)[0]
-        record["extension"] = extension
+        # THE contract (backend#1706): the stem the file was just written under
+        # is what lands in the ``filename`` column, and that column — never
+        # ``data_id`` — is how the trainer resolves this row back to the file.
+        # See tracebloc_ingestor.storage_contract.
+        record[IMAGE_NAME_COLUMN] = os.path.splitext(filename_with_ext)[0]
+        record[EXTENSION_COLUMN] = extension
 
         logger.info(f"{GREEN}Successfully copied image: {filename}{RESET}")
         return record

--- a/tracebloc_ingestor/ingestors/record_processor.py
+++ b/tracebloc_ingestor/ingestors/record_processor.py
@@ -31,6 +31,11 @@ from typing import Any, Dict, Optional
 
 import pandas as pd
 
+from ..storage_contract import (
+    EXTENSION_COLUMN,
+    IMAGE_NAME_COLUMN,
+    ROW_ID_COLUMN,
+)
 from ..utils.constants import Intent
 
 logger = logging.getLogger(__name__)
@@ -189,16 +194,16 @@ class RecordProcessor:
                 # collide and the upsert would collapse the dataset. It is
                 # merged here (not read from cleaned_record) because process()
                 # attaches filename only AFTER this method returns.
-                cleaned_record["data_id"] = self._content_hash(
-                    {**cleaned_record, "filename": record.get("filename")}
+                cleaned_record[ROW_ID_COLUMN] = self._content_hash(
+                    {**cleaned_record, IMAGE_NAME_COLUMN: record.get(IMAGE_NAME_COLUMN)}
                 )
             else:
-                cleaned_record["data_id"] = str(uuid.uuid4())
+                cleaned_record[ROW_ID_COLUMN] = str(uuid.uuid4())
             return cleaned_record
 
         unique_id = record.get(self.unique_id_column)
         if unique_id is not None and str(unique_id).strip():
-            cleaned_record["data_id"] = str(unique_id).strip()
+            cleaned_record[ROW_ID_COLUMN] = str(unique_id).strip()
             return cleaned_record
         else:
             logger.warning(
@@ -295,8 +300,8 @@ class RecordProcessor:
 
             # Add ingestor_id to the record
             cleaned_record["ingestor_id"] = self.ingestor_id
-            cleaned_record["filename"] = record.get("filename")
-            cleaned_record["extension"] = record.get("extension")
+            cleaned_record[IMAGE_NAME_COLUMN] = record.get(IMAGE_NAME_COLUMN)
+            cleaned_record[EXTENSION_COLUMN] = record.get(EXTENSION_COLUMN)
             # The cleaned record carries ONLY schema-declared DB columns +
             # framework columns. A sidecar's link column is a table column IFF
             # the schema declares it: semantic_segmentation MUST declare mask_id

--- a/tracebloc_ingestor/storage_contract.py
+++ b/tracebloc_ingestor/storage_contract.py
@@ -1,0 +1,127 @@
+"""Canonical ingest → trainer STORAGE contract — the single source of truth.
+
+Where :mod:`tracebloc_ingestor.identifiers` pins what a column may be *called*,
+this module pins what the framework columns *mean* and how a stored row maps
+back to the sidecar file it describes. Same reason, same shape: it is
+deliberately dependency-light (stdlib only, no package imports) so the trainer
+(``tracebloc-engine``) can mirror it verbatim — see
+``core/utils/ingest_contract.py`` there, and the mirrored case table in
+``tests/test_ingest_storage_contract.py`` / ``core/tests/contracts/`` that keeps
+the two copies from drifting.
+
+The invariant
+-------------
+For a file-bearing category the ingestor copies the sidecar to::
+
+    <DEST_PATH>/<manifest filename><extension>
+
+and stores that stem in the **``filename``** column
+(``file_transfer.image_transfer``). Therefore:
+
+    **A trainer resolves a row to its file through ``filename``.
+    ``data_id`` names nothing on disk.**
+
+``data_id`` is an *independent* row identifier whose value depends on the run's
+``data_id`` strategy — a salted content hash (the default since #350), a UUID,
+or a copy of some source column. Only ``strategy=column`` over ``filename``
+makes the two coincide, and that coincidence is not part of the contract.
+
+Why this module exists (backend#1706, follow-up to tracebloc-engine#615)
+------------------------------------------------------------------------
+Two of the shipped Python templates — ``keypoint_detection`` and
+``semantic_segmentation`` — set ``unique_id_column="filename"``, aliasing
+``data_id`` to the on-disk stem. Those are precisely the two categories whose
+trainer readers keyed on ``data_id``; the templates were papering over the
+reader bug. When #350 flipped the default strategy ``uuid`` → ``content_hash``
+nothing failed here, and every CLI/YAML-ingested keypoint or semseg dataset
+crashed on the first training batch instead. Three facts had to agree and
+nothing pinned any of them. They are pinned here now.
+"""
+
+# ── Framework columns every ingested row carries ────────────────────────────
+# The stem of the sidecar file on disk. THE column a trainer resolves files
+# through.
+IMAGE_NAME_COLUMN = "filename"
+
+# The row's opaque identity. Independent of the on-disk name — see the module
+# docstring. Never use it to build a path.
+ROW_ID_COLUMN = "data_id"
+
+# The extension the sidecar was written with, e.g. ".jpg". Advisory: the
+# ingestor may write ``.jpeg`` where a training default says ``.jpg``, so a
+# reader probes rather than trusting this cell.
+EXTENSION_COLUMN = "extension"
+
+# Per-row semantic-segmentation mask file, resolved the same way as the image
+# (backend#816). Present only when the manifest declares it.
+MASK_NAME_COLUMN = "mask_id"
+
+# Per-row object-detection annotation payload / pointer.
+ANNOTATION_COLUMN = "annotation"
+
+# The columns that can name a file on disk, in the order a reader must try
+# them. ``filename`` first because it is what the file is actually named
+# after; ``data_id`` remains a fallback ONLY for legacy datasets ingested
+# before the ``filename`` column existed, and for template-built datasets
+# where the two coincide.
+IMAGE_NAME_COLUMNS = (IMAGE_NAME_COLUMN, ROW_ID_COLUMN)
+
+# ── data_id strategies ──────────────────────────────────────────────────────
+# Every way an ingest can mint ``data_id`` (``cli/conventions.py``,
+# ``RecordProcessor._map_unique_id``).
+DATA_ID_STRATEGIES = ("content_hash", "uuid", "column")
+
+# The default since #350 (commit 913dd7a, ships in v0.7.5+): a deterministic
+# salted SHA-256 so a retried k8s Job re-claims its rows instead of
+# duplicating them. It was ``uuid`` before.
+DEFAULT_DATA_ID_STRATEGY = "content_hash"
+
+# Strategies under which ``data_id`` is guaranteed NOT to name a file on disk.
+# ``column`` is absent not because it names one but because it *may* — when
+# pointed at ``filename`` — which is exactly the coincidence that hid #615.
+OPAQUE_DATA_ID_STRATEGIES = frozenset({"content_hash", "uuid"})
+
+# ── On-disk naming ──────────────────────────────────────────────────────────
+# Image suffixes the pipeline recognises, lower-cased. Matching is
+# case-insensitive on both sides: the ingestor lower-cases before comparing
+# (``file_transfer._has_extension``), the trainer probes the upper-cased
+# variants too.
+RECOGNISED_IMAGE_SUFFIXES = (".jpeg", ".jpg", ".png")
+
+
+def has_recognised_extension(name: object) -> bool:
+    """True when ``name`` already ends in a recognised image suffix (any case).
+
+    Splits on the LAST dot only, so a manifest name that carries dots of its
+    own (``image.001.jpg``) is judged on ``.jpg`` alone.
+    """
+    text = "" if name is None else str(name)
+    _head, dot, suffix = text.rpartition(".")
+    return bool(dot) and f".{suffix.lower()}" in RECOGNISED_IMAGE_SUFFIXES
+
+
+def strip_image_extension(name: object) -> str:
+    """Return ``name`` without a trailing **recognised** image extension.
+
+    Deliberately neither ``name.split(".")[0]`` nor ``Path(name).stem``: both
+    truncate at a dot belonging to the name itself, and manifests do carry
+    such names (``image.001.jpg``). The ingestor keeps them whole, so a stem
+    that dropped ``.001`` would name no file on disk.
+    """
+    text = str(name)
+    if not has_recognised_extension(text):
+        return text
+    return text.rpartition(".")[0]
+
+
+def stored_image_name(filename: object, extension: object) -> str:
+    """The basename the ingestor writes for ``filename`` under ``extension``.
+
+    Mirrors ``file_transfer._find_src``'s default (non-forced) mode: a manifest
+    value that already carries a recognised extension names that very file and
+    keeps it; a bare stem gets ``extension`` appended.
+    """
+    text = str(filename)
+    if has_recognised_extension(text):
+        return text
+    return f"{text}{extension}"


### PR DESCRIPTION
## Why

[tracebloc-engine#615](https://github.com/tracebloc/tracebloc-engine/issues/615): keypoint + semantic-segmentation training crashed on the first batch of **every CLI-ingested dataset**, because the trainer resolved images by `data_id` while this repo names the file after the manifest `filename`. The reader is fixed (engine#616). What was never fixed is *why the divergence survived two releases* — [backend#1706](https://github.com/tracebloc/backend/issues/1706).

Three facts have to stay in agreement, and nothing pinned any of them:

1. we write `DEST_PATH/<manifest filename><ext>`,
2. we store that stem in `filename` and something unrelated in `data_id`,
3. so every trainer dataset reader must key on `filename`.

When #350 flipped the default `data_id` strategy `uuid` → `content_hash`, nothing failed anywhere. It couldn't: the trainer's fixtures are hand-authored, and the shape they use (`data_id` set to the on-disk stem, **no `filename` column at all**) is one this repo has never produced. And the only two templates that set `unique_id_column="filename"` are `keypoint_detection` and `semantic_segmentation` — precisely the two categories whose readers keyed on `data_id`. That is not a coincidence; those templates were papering over the reader bug.

This PR is the **source-of-truth half**. tracebloc-engine carries the mirror and replays the capture through its dataset readers (paired PR linked below); the two are independent and can land in either order.

## What

| file | |
|---|---|
| `tracebloc_ingestor/storage_contract.py` | The framework column names, the `data_id` strategies, and the on-disk naming rule — one stdlib-only module the trainer can mirror verbatim, the same arrangement `identifiers.py` already uses for column-name legality. Wired into `image_transfer` and `RecordProcessor` so it is load-bearing, not documentation. |
| `tests/test_ingest_storage_contract.py` | Runs **real ingests** through the YAML/CLI route — real `resolve` → `_build_ingestor`, real validators, real record processing, real file transfer; only MySQL and the API are faked, each at its own boundary. 4 file-bearing CV categories × default + template-alias `data_id`. |
| `tests/fixtures/contracts/ingested_image_rows.json` | The capture those ingests produce. **Not a fixture** — regenerate with `UPDATE_INGEST_CONTRACT_GOLDEN=1` and carry it into tracebloc-engine `core/tests/contracts/`. |
| `e2e/test_image_lookup_contract_e2e.py` | The same contract through **real MySQL** — the trainer reads a table, not the dicts the unit suite captures, and the DDL/type/NULL/width gap in between is where a filename gets truncated. Resolves every SELECTed row with the trainer's own rule transcribed verbatim. Sibling of the semseg `mask_id` contract e2e (backend#816). |

### Behaviour change

None. Every literal replaced by a constant has an identical value, and the full suite is green either way. The version bump (0.8.8 → 0.8.9) is what `version-guard` requires for a `tracebloc_ingestor/` change.

### The assertions that matter

Both new suites carry a **negative control**, so neither can pass vacuously: under the default strategy `data_id` must name *no* file on disk. If that ever starts failing, something has re-aliased `data_id` to the on-disk name and every other assertion here has quietly gone hollow.

## Verification

```
pytest tests/     2021 passed, 1 xfailed
pytest e2e/         63 passed          (real MySQL, docker compose -f e2e/docker-compose.yml)
ruff check .        All checks passed
black --check       clean on every changed file
```

Refs tracebloc/backend#1706, tracebloc/tracebloc-engine#615

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No intentional runtime behavior change—constants replace identical literals; risk is mainly test/golden maintenance and keeping the mirrored contract in sync with tracebloc-engine.
> 
> **Overview**
> Pins the **ingest→trainer storage contract** so trainers resolve images via **`filename`**, not opaque **`data_id`** — the gap behind tracebloc-engine#615.
> 
> Adds **`storage_contract.py`** as the stdlib-only source of truth (column names, `data_id` strategies, on-disk naming helpers) for tracebloc-engine to mirror. **`file_transfer`** and **`RecordProcessor`** now use those constants instead of string literals; values are unchanged.
> 
> **`tests/test_ingest_storage_contract.py`** runs real ingests for four CV categories (default + `data_id` column alias), asserts naming/independence/semseg `mask_id`, and locks output in **`ingested_image_rows.json`** for cross-repo replay. **`e2e/test_image_lookup_contract_e2e.py`** repeats the check through real MySQL with the trainer’s `resolve_image_path` rule transcribed locally, including negative controls so `data_id`-only lookup cannot pass vacuously.
> 
> Docs note the new module and e2e contract suite; version **0.8.8 → 0.8.9**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91de0c8ed646fedbc47fa14ab911ef2def13f478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->