### PR TITLE
fix(ingestors): route the record_processor catch-all through safe_db_error (backend#1879)

### DIFF
--- a/tests/test_error_redaction.py
+++ b/tests/test_error_redaction.py
@@ -136,14 +136,17 @@ def test_process_catch_all_never_logs_the_exception_message(caplog, monkeypatch)
     """
     rp = _rp()
     monkeypatch.setattr(
-        rp, "_map_unique_id",
-        lambda *a, **k: (_ for _ in ()).throw(ValueError(f"bad value {SECRET!r} in column x")),
+        rp,
+        "_map_unique_id",
+        lambda *a, **k: (_ for _ in ()).throw(
+            ValueError(f"bad value {SECRET!r} in column x")
+        ),
     )
     with caplog.at_level(logging.ERROR):
         out = rp.process({"x": 1.0, "y": "a"})
     assert out is None
-    assert SECRET not in caplog.text          # the whole point
-    assert "ValueError" in caplog.text        # the class is the actionable part
+    assert SECRET not in caplog.text  # the whole point
+    assert "ValueError" in caplog.text  # the class is the actionable part
     assert "Error processing record" in caplog.text
 
 

--- a/tests/test_error_redaction.py
+++ b/tests/test_error_redaction.py
@@ -121,6 +121,32 @@ def test_hot_loop_does_not_log_record_content(caplog):
     assert SECRET not in caplog.text
 
 
+def test_process_catch_all_never_logs_the_exception_message(caplog, monkeypatch):
+    """The catch-all in ``RecordProcessor.process`` is a content leak by default.
+
+    Everything raised inside that ``try`` has the record's own cells in scope: a
+    driver rejecting a value quotes it, and a plain ``ValueError`` from casting a
+    cell embeds it. So the handler must surface the exception CLASS, never its
+    message (backend#1879).
+
+    Pinned because the fix is a one-line substitution that reads like noise —
+    ``str(e)`` back in place would restore the leak silently, and the engine's
+    identical hole survived for exactly that reason: the concept existed, the
+    coverage did not.
+    """
+    rp = _rp()
+    monkeypatch.setattr(
+        rp, "_map_unique_id",
+        lambda *a, **k: (_ for _ in ()).throw(ValueError(f"bad value {SECRET!r} in column x")),
+    )
+    with caplog.at_level(logging.ERROR):
+        out = rp.process({"x": 1.0, "y": "a"})
+    assert out is None
+    assert SECRET not in caplog.text          # the whole point
+    assert "ValueError" in caplog.text        # the class is the actionable part
+    assert "Error processing record" in caplog.text
+
+
 def test_safe_db_error_names_classes_never_messages():
     from sqlalchemy.exc import OperationalError
 

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.9"
+__version__ = "0.8.10"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/ingestors/record_processor.py
+++ b/tracebloc_ingestor/ingestors/record_processor.py
@@ -36,6 +36,7 @@ from ..storage_contract import (
     IMAGE_NAME_COLUMN,
     ROW_ID_COLUMN,
 )
+from ..utils import redaction
 from ..utils.constants import Intent
 
 logger = logging.getLogger(__name__)
@@ -315,5 +316,11 @@ class RecordProcessor:
             return cleaned_record
 
         except Exception as e:
-            logger.error(f"Error processing record: {str(e)}")
+            # The residual raw-`str(e)` site in an otherwise-covered package
+            # (backend#1879). Everything raised in here has the record's own
+            # cells in scope, so the message is a content leak by default:
+            # a MySQL type rejection quotes the value, and a plain
+            # `ValueError` from casting a cell embeds it too. The exception
+            # class alone is the actionable part.
+            logger.error(f"Error processing record: {redaction.safe_db_error(e)}")
             return None


### PR DESCRIPTION
Part of tracebloc/backend#1879 (part 2 of 2 — the engine half is
tracebloc/tracebloc-engine#642, where the bulk of the work is).

## What was wrong

`RecordProcessor.process()`'s catch-all logged `str(e)` verbatim:

```python
except Exception as e:
    logger.error(f"Error processing record: {str(e)}")
```

Everything raised inside that block has the record's own cells in scope, so the message is
a content leak by default — a MySQL type rejection quotes the value
(`Incorrect integer value: 'X' for column 'y'`), and a plain `ValueError` from casting a
cell embeds it too. This was the residual raw-exception site in a package that is
otherwise covered by #226 Phase 2 (65 call sites, pinned by `tests/test_error_redaction.py`,
and `.cursor/BUGBOT.md`'s "redaction is a product guarantee, not cosmetics").

## Verification

**Repro**, driving the catch-all with a synthetic cell whose comparison raises with its own
content in the message — the same shape as a MySQL type rejection:

```python
class SneakyCell:
    def __eq__(self, other):
        raise ValueError(f"Incorrect value: '{SECRET}' for column 'x'")
```

```
=== BEFORE (develop) ===
logged  : Error processing record: Incorrect value: 'synthetic-4711-Zurich' for column 'x'
returned: None
LEAKS   : True

=== AFTER (this branch) ===
logged  : Error processing record: ValueError (driver message suppressed: it can embed cell values, #226)
returned: None
LEAKS   : False
```

The `None` return is unchanged, so the caller's skip-this-record path is untouched.

**`black --check` (26.3.1):**

```
$ black --check tracebloc_ingestor/ingestors/record_processor.py tracebloc_ingestor/__init__.py
All done! ✨ 🍰 ✨
2 files would be left unchanged.
```

**The suites that cover `RecordProcessor`** (`test_error_redaction`, `test_content_hash_data_id`,
`test_semseg_mask_id_contract`, `test_coverage_gaps2`, `test_ingest_storage_contract`,
`test_ingestor_base`, `test_label_policy`, `test_conventions`): **369 passed**.

**Full suite:** `4 failed, 2047 passed, 1 xfailed`. All four are float/int-overflow tests
(`test_csv_ingestor.py` ×3, `test_adversarial_ingestion_harness.py` ×1) and they fail
**identically on unmodified `develop`** in this environment — local numpy is 1.26.4 rather
than the repo's pin, which changes overflow behaviour. Not related to this change; CI runs
the pinned set.

## Two things to flag

- **`__version__` bump (0.8.9 → 0.8.10) is a second file**, beyond the one this ticket
  scopes. It's not optional: `version-guard.yml` fails any PR touching `tracebloc_ingestor/`
  without a `+__version__` line, so a strictly single-file PR could never go green. Called
  out rather than slipped in.
- **No test added here.** The natural home is a case in `tests/test_error_redaction.py`
  asserting the catch-all can't echo a cell — roughly:

  ```python
  def test_process_catch_all_never_logs_the_exception_message(caplog):
      rp = _rp()
      with caplog.at_level(logging.ERROR):
          assert rp.process({"x": SneakyCell(), "y": "a"}) is None
      assert SECRET not in caplog.text
      assert "ValueError" in caplog.text
  ```

  I left it out because this ticket scopes data-ingestors to one file, and the repro above
  is the evidence in its place. Happy to add it in this PR if you'd rather have the gate —
  given BUGBOT.md's framing, I'd lean toward yes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single logging-path change on the existing failure branch (still returns None); aligns with established redaction helpers and adds pinned test coverage.
> 
> **Overview**
> Closes a **content-leak** in `RecordProcessor.process`: the broad `except` no longer logs `str(e)` and instead uses **`redaction.safe_db_error(e)`**, so driver or cast failures cannot echo cell values in install logs (backend#1879).
> 
> Adds **`test_process_catch_all_never_logs_the_exception_message`** in `tests/test_error_redaction.py` (monkeypatched `_map_unique_id` raising a `ValueError` with a secret in the message) to pin that only the exception class appears in ERROR logs while processing still returns `None`.
> 
> Bumps package **`__version__`** from `0.8.9` to **`0.8.10`** for the version-guard workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a7f500bddb490b6ed0c86828b03f5a9672b35d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->