### PR TITLE
release-train: staging -> main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+<!-- 1–3 sentences. What does this PR do and why? -->
+
+## Related
+<!-- Same repo: Closes #123 · Cross-repo: Fixes tracebloc/backend#456 (owner-qualified — a bare backend#456 closes nothing). PRs land on develop, not the default branch, so closing keywords do not fire on merge — confirm the issue actually closed. -->
+
+## Type of change
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Tech-debt / refactor
+- [ ] Docs
+- [ ] Security / hardening
+- [ ] Breaking change
+
+## Test plan
+<!-- What did you test? `make check` (ruff + `pytest tests/`) is the local gate. Which extra commands or manual steps? -->
+
+## Screenshots / recordings
+<!-- For UI changes. Remove if N/A. -->
+
+## Deployment notes
+<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->
+
+## Checklist
+- [ ] `make check` passes locally (ruff + `pytest tests/`)
+- [ ] Tests added / updated for this change
+- [ ] Docs updated if behavior or config changed
+- [ ] No secrets / credentials in the diff
+- [ ] For security-sensitive paths: appropriate reviewer requested
+- [ ] Cross-repo issues use `Fixes tracebloc/<repo>#N` — a bare `repo#N` closes nothing
+- [ ] If this depends on a change in another repo: shipped **expand-then-contract** (additive first, consumers adopt later), or **Breaking change** ticked above with the rollout order in *Deployment notes* — repos promote independently, so the other change may not ship with this one
+- [ ] If this touches published paths (`tracebloc_ingestor/*`): version bumped in `tracebloc_ingestor/__init__.py` — the **Version bump gate** hard-fails an already-released version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ the file extension — drives validation and file transfer.
   - `api/` -- API client for communicating with tracebloc backend
   - `database.py` -- MySQL/SQLAlchemy database operations
   - `file_transfer.py` -- secure file transfer to cluster storage
+  - `storage_contract.py` -- the ingest→trainer storage contract (framework column names, `data_id` strategies, the on-disk naming rule). Stdlib-only and mirrored verbatim by tracebloc-engine's `core/utils/ingest_contract.py`; change it here first (backend#1706)
   - `config.py` -- configuration
   - `utils/` -- shared utilities (incl. `TaskCategory` constants, logging)
 - **`templates/`** -- ingestor scripts used inside Docker containers

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,6 +23,21 @@ The suite **auto-skips when no MySQL is reachable**, so the default `pytest`
 (unit) run is unaffected. CI runs it with a MySQL service in
 `.github/workflows/e2e.yml`.
 
+## Cross-repo contract suites
+
+Two files here assert not just "the ingest succeeded" but "what it stored is
+what the **training client** resolves", checked against the client's own
+derivation rule (transcribed in each file, since neither repo may import the
+other):
+
+- `test_semseg_client_contract_e2e.py` — the semseg `mask_id` contract
+  (backend#816).
+- `test_image_lookup_contract_e2e.py` — the image-lookup contract for every
+  file-bearing CV category: the file is named after `filename`, and `data_id`
+  names nothing on disk (tracebloc-engine#615, backend#1706). Its unit-level
+  sibling is `tests/test_ingest_storage_contract.py`, which also produces the
+  capture tracebloc-engine replays through its dataset readers.
+
 ## Known gaps (currently `xfail`)
 
 None — all 11 supported modalities ingest cleanly and are covered. The earlier

--- a/e2e/test_image_lookup_contract_e2e.py
+++ b/e2e/test_image_lookup_contract_e2e.py
@@ -1,0 +1,272 @@
+"""backend#1706 — the ingestor→trainer IMAGE-lookup contract, end to end.
+
+Sibling of ``test_semseg_client_contract_e2e.py``, which pins the same kind of
+boundary for ``mask_id``. Here the subject is the image itself, and the bug it
+guards against already shipped: tracebloc-engine#615, where keypoint and
+semantic-segmentation training crashed on the first batch of every
+CLI-ingested dataset because the trainer resolved images by ``data_id`` while
+this repo names the file after the manifest ``filename``.
+
+Why an e2e and not just ``tests/test_ingest_storage_contract.py``: that suite
+captures the rows as they are handed to ``Database.insert_batch``. The trainer
+does not read those dicts — it reads a MySQL table. Everything between (the
+generated DDL, column types, NULL handling, VARCHAR width) sits in the gap, and
+the gap is where a filename gets truncated or a column silently isn't created.
+So this ingests through the real YAML/CLI route into real MySQL and then
+resolves every SELECTed row against the real files on disk, using the
+**trainer's own rule** transcribed below.
+
+The trainer's rule (tracebloc-engine ``core/utils/general.py::resolve_image_path``,
+used by all four CV dataset readers since #615), per row::
+
+    for column in ("filename", "data_id"):        # filename FIRST
+        cell = row[column]                        # skip absent / NULL / blank
+        if isfile(dir/cell):        -> resolve    # value carrying its extension
+        stem = cell minus a RECOGNISED image suffix
+        if isfile(dir/stem + probed extension) -> resolve
+    else: FileNotFoundError                       # crashes the training batch
+
+Coverage: every file-bearing CV category under the DEFAULT ``data_id``
+strategy — the shape `tracebloc dataset push` produces and the one #615 broke —
+plus one case under the ``column`` alias the keypoint / semseg Python templates
+set, which is the coincidence that hid the bug.
+
+Skipped by conftest's ``collect_ignore_glob`` unless a MySQL is reachable.
+"""
+
+import os
+from pathlib import Path
+
+import mysql.connector
+import pytest
+import yaml
+
+from tracebloc_ingestor.cli import run
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.storage_contract import (
+    EXTENSION_COLUMN,
+    IMAGE_NAME_COLUMN,
+    IMAGE_NAME_COLUMNS,
+    RECOGNISED_IMAGE_SUFFIXES,
+    ROW_ID_COLUMN,
+    strip_image_extension,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+T = REPO / "templates"
+
+
+def _cfg(**kw):
+    base = {"apiVersion": "tracebloc.io/v1", "kind": "IngestConfig", "intent": "train"}
+    base.update(kw)
+    return base
+
+
+CASES = [
+    pytest.param(
+        _cfg(
+            table="e2e_lookup_img",
+            category="image_classification",
+            csv=str(T / "image_classification/data/labels_file_sample.csv"),
+            images=str(T / "image_classification/data/images"),
+            label="label",
+            spec={"file_options": {"extension": ".jpeg", "target_size": [256, 256]}},
+        ),
+        id="image_classification",
+    ),
+    pytest.param(
+        _cfg(
+            table="e2e_lookup_od",
+            category="object_detection",
+            csv=str(T / "object_detection/data/labels_file_sample.csv"),
+            images=str(T / "object_detection/data/images"),
+            annotations=str(T / "object_detection/data/annotations"),
+            label="image_label",
+            target_size=[1920, 1080],
+        ),
+        id="object_detection",
+    ),
+    pytest.param(
+        _cfg(
+            table="e2e_lookup_kp",
+            category="keypoint_detection",
+            csv=str(T / "keypoint_detection/data/labels_file_sample.csv"),
+            images=str(T / "keypoint_detection/data/images"),
+            label="image_label",
+            target_size=[448, 448],
+            number_of_keypoints=9,
+        ),
+        id="keypoint_detection",
+    ),
+    pytest.param(
+        _cfg(
+            table="e2e_lookup_seg",
+            category="semantic_segmentation",
+            csv=str(T / "semantic_segmentation/semantic_data/labels_file_sample.csv"),
+            images=str(T / "semantic_segmentation/semantic_data/images"),
+            masks=str(T / "semantic_segmentation/semantic_data/masks"),
+            label="image_label",
+            schema={"mask_id": "VARCHAR(255)"},
+        ),
+        id="semantic_segmentation",
+    ),
+    # The template alias: data_id == filename. The trainer must resolve this
+    # shape too — legacy datasets are full of it — so it stays covered.
+    pytest.param(
+        _cfg(
+            table="e2e_lookup_kp_alias",
+            category="keypoint_detection",
+            csv=str(T / "keypoint_detection/data/labels_file_sample.csv"),
+            images=str(T / "keypoint_detection/data/images"),
+            label="image_label",
+            target_size=[448, 448],
+            number_of_keypoints=9,
+            data_id={"strategy": "column", "column": "filename"},
+        ),
+        id="keypoint_detection-data_id_alias",
+    ),
+]
+
+
+def _connect():
+    return mysql.connector.connect(
+        host=os.environ["MYSQL_HOST"],
+        port=int(os.environ["MYSQL_PORT"]),
+        user=os.environ["DB_USER"],
+        password=os.environ["DB_PASSWORD"],
+        database=os.environ["DB_NAME"],
+    )
+
+
+def _drop(table):
+    conn = _connect()
+    conn.cursor().execute(f"DROP TABLE IF EXISTS `{table}`")
+    conn.commit()
+    conn.close()
+
+
+def _rows(table):
+    conn = _connect()
+    cur = conn.cursor(dictionary=True)
+    cur.execute(f"SELECT * FROM `{table}`")
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+def _is_blank(value) -> bool:
+    """A NULL / blank metadata cell — the trainer skips these and falls through
+    to the next candidate column rather than resolving the string ``"None"``."""
+    return value is None or not str(value).strip()
+
+
+def _trainer_resolves(data_dir: Path, row: dict):
+    """Transcription of tracebloc-engine's ``resolve_image_path``.
+
+    Returns the resolved path, or ``None`` — which is the trainer raising
+    ``FileNotFoundError`` and killing the training batch.
+    """
+    for column in IMAGE_NAME_COLUMNS:
+        if column not in row or _is_blank(row[column]):
+            continue
+        cell = str(row[column]).strip()
+        if (data_dir / cell).is_file():
+            return data_dir / cell
+        stem = strip_image_extension(cell)
+        for suffix in RECOGNISED_IMAGE_SUFFIXES:
+            for cased in (suffix, suffix.upper()):
+                if (data_dir / f"{stem}{cased}").is_file():
+                    return data_dir / f"{stem}{cased}"
+    return None
+
+
+def _ingest(cfg, tmp_path, monkeypatch) -> Path:
+    """Run the real YAML/CLI ingest; return the dataset directory on disk."""
+    config_path = tmp_path / "ingest.yaml"
+    config_path.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("INGEST_CONFIG", str(config_path))
+    rc = run.main()
+    assert rc == 0, f"{cfg['table']}: ingest exited {rc}"
+    return Path(Config.STORAGE_PATH) / cfg["table"]
+
+
+@pytest.mark.parametrize("cfg", CASES)
+def test_every_ingested_row_resolves_to_its_image(cfg, tmp_path, monkeypatch):
+    """The assertion #615 needed: every row SELECTed from the ingested table
+    resolves to a real file under the trainer's own rule."""
+    table = cfg["table"]
+    _drop(table)
+    dest = _ingest(cfg, tmp_path, monkeypatch)
+
+    rows = _rows(table)
+    assert rows, f"{table}: ingest stored no rows"
+
+    for row in rows:
+        assert not _is_blank(row.get(IMAGE_NAME_COLUMN)), (
+            f"{table}: NULL/blank {IMAGE_NAME_COLUMN} on "
+            f"{ROW_ID_COLUMN}={row.get(ROW_ID_COLUMN)!r} — the trainer has "
+            f"nothing to resolve the image by"
+        )
+        resolved = _trainer_resolves(dest, row)
+        assert resolved is not None, (
+            f"{table}: no image file for row "
+            f"{ {c: row.get(c) for c in IMAGE_NAME_COLUMNS} } under {dest} — "
+            f"the trainer's dataset reader would raise FileNotFoundError on "
+            f"the first training batch (tracebloc-engine#615). Directory holds "
+            f"{sorted(p.name for p in dest.iterdir())[:10]}"
+        )
+
+
+@pytest.mark.parametrize(
+    "cfg", [c for c in CASES if "alias" not in c.id], ids=lambda c: c["table"]
+)
+def test_a_data_id_keyed_reader_would_still_fail(cfg, tmp_path, monkeypatch):
+    """Negative control — without it the test above could pass vacuously.
+
+    Under the default strategy ``data_id`` names no file, so the pre-#615
+    reader (``data_id`` only) resolves nothing. If this ever starts failing,
+    something has re-aliased ``data_id`` to the on-disk name and the suite
+    above stopped proving anything.
+    """
+    table = cfg["table"]
+    _drop(table)
+    dest = _ingest(cfg, tmp_path, monkeypatch)
+
+    rows = _rows(table)
+    assert rows, f"{table}: ingest stored no rows"
+    for row in rows:
+        data_id_only = {ROW_ID_COLUMN: row[ROW_ID_COLUMN]}
+        assert _trainer_resolves(dest, data_id_only) is None, (
+            f"{table}: data_id {row[ROW_ID_COLUMN]!r} resolves to a file on "
+            f"disk. That coincidence is what hid tracebloc-engine#615 — the "
+            f"contract is that only {IMAGE_NAME_COLUMN} names the file."
+        )
+
+
+@pytest.mark.parametrize("cfg", CASES)
+def test_stored_filename_survives_the_mysql_round_trip(cfg, tmp_path, monkeypatch):
+    """``filename`` + ``extension`` come back out of MySQL naming the file the
+    ingest wrote — no truncation, no NULL, no dropped column.
+
+    This is the half the unit contract test cannot see: it captures the row
+    *before* the insert, and the trainer reads it *after*.
+    """
+    table = cfg["table"]
+    _drop(table)
+    dest = _ingest(cfg, tmp_path, monkeypatch)
+
+    rows = _rows(table)
+    assert rows, f"{table}: ingest stored no rows"
+    assert EXTENSION_COLUMN in rows[0], (
+        f"{table}: no {EXTENSION_COLUMN} column in the ingested table; "
+        f"columns = {sorted(rows[0])}"
+    )
+
+    on_disk = {p.name for p in dest.iterdir() if p.is_file()}
+    for row in rows:
+        stem = str(row[IMAGE_NAME_COLUMN])
+        extension = row[EXTENSION_COLUMN] or ""
+        assert f"{stem}{extension}" in on_disk or stem in on_disk, (
+            f"{table}: stored ({IMAGE_NAME_COLUMN}={stem!r}, "
+            f"{EXTENSION_COLUMN}={extension!r}) names no file under {dest}"
+        )

--- a/tests/fixtures/contracts/ingested_image_rows.json
+++ b/tests/fixtures/contracts/ingested_image_rows.json
@@ -1,0 +1,369 @@
+{
+  "_README": [
+    "Captured from REAL ingests by tests/test_ingest_storage_contract.py",
+    "(data-ingestors). Do not hand-edit: regenerate with",
+    "UPDATE_INGEST_CONTRACT_GOLDEN=1 pytest tests/test_ingest_storage_contract.py",
+    "",
+    "tracebloc-engine mirrors this file verbatim into",
+    "core/tests/contracts/ingested_image_rows.json and replays it through",
+    "its CV dataset readers (backend#1706). Carry any regeneration across.",
+    "",
+    "'ingestor_id' is dropped and a uuid-strategy data_id is masked as '<uuid4>' \u2014 both are random per run.",
+    "content_hash ids are computed under the fixed test salt '1706170617061706170617061706170617061706170617061706170617061706'.",
+    "'rows' holds the first 4 of 'total_rows_ingested'; the contract is per-row."
+  ],
+  "contract": {
+    "image_name_columns": [
+      "filename",
+      "data_id"
+    ],
+    "data_id_strategies": [
+      "content_hash",
+      "uuid",
+      "column"
+    ],
+    "default_data_id_strategy": "content_hash",
+    "opaque_data_id_strategies": [
+      "content_hash",
+      "uuid"
+    ],
+    "recognised_image_suffixes": [
+      ".jpeg",
+      ".jpg",
+      ".png"
+    ],
+    "uuid_sentinel": "<uuid4>"
+  },
+  "cases": [
+    {
+      "id": "image_classification-default",
+      "category": "image_classification",
+      "data_id_strategy": "content_hash",
+      "unique_id_column": null,
+      "total_rows_ingested": 576,
+      "dest_files": [
+        "cat1.jpeg",
+        "cat2.jpeg",
+        "cat3.jpeg",
+        "dog1.jpeg",
+        "dog2.jpeg",
+        "dog3.jpeg"
+      ],
+      "rows": [
+        {
+          "label": "cat",
+          "data_intent": "train",
+          "data_id": "815352a97dcb5a2e07f82a504b4b23843aca91c55e2cb495039c595f6239e36a",
+          "filename": "cat1",
+          "extension": ".jpeg"
+        },
+        {
+          "label": "cat",
+          "data_intent": "train",
+          "data_id": "671123fe6b39176eaa49e03d9e68b9ef2e089dc0b14d81070748c93966803179",
+          "filename": "cat2",
+          "extension": ".jpeg"
+        },
+        {
+          "label": "cat",
+          "data_intent": "train",
+          "data_id": "d028007b85eec04b5cc91003036a42ef09649c2394fed45d3f727a1294479013",
+          "filename": "cat3",
+          "extension": ".jpeg"
+        },
+        {
+          "label": "dog",
+          "data_intent": "train",
+          "data_id": "8a277e09492091bcf1fbaedc4614a7ea68e81e177c7bb8701f054c460fc4a2b0",
+          "filename": "dog1",
+          "extension": ".jpeg"
+        }
+      ]
+    },
+    {
+      "id": "image_classification-column",
+      "category": "image_classification",
+      "data_id_strategy": "column",
+      "unique_id_column": "filename",
+      "total_rows_ingested": 576,
+      "dest_files": [
+        "cat1.jpeg",
+        "cat2.jpeg",
+        "cat3.jpeg",
+        "dog1.jpeg",
+        "dog2.jpeg",
+        "dog3.jpeg"
+      ],
+      "rows": [
+        {
+          "label": "cat",
+          "data_intent": "train",
+          "data_id": "cat1.jpeg",
+          "filename": "cat1",
+          "extension": ".jpeg"
+        },
+        {
+          "label": "cat",
+          "data_intent": "train",
+          "data_id": "cat2.jpeg",
+          "filename": "cat2",
+          "extension": ".jpeg"
+        },
+        {
+          "label": "cat",
+          "data_intent": "train",
+          "data_id": "cat3.jpeg",
+          "filename": "cat3",
+          "extension": ".jpeg"
+        },
+        {
+          "label": "dog",
+          "data_intent": "train",
+          "data_id": "dog1.jpeg",
+          "filename": "dog1",
+          "extension": ".jpeg"
+        }
+      ]
+    },
+    {
+      "id": "object_detection-default",
+      "category": "object_detection",
+      "data_id_strategy": "uuid",
+      "unique_id_column": null,
+      "total_rows_ingested": 128,
+      "dest_files": [
+        "0000001_02999_d_0000005.jpg",
+        "0000001_02999_d_0000005.xml"
+      ],
+      "rows": [
+        {
+          "label": "car",
+          "data_intent": "train",
+          "data_id": "<uuid4>",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        },
+        {
+          "label": "car",
+          "data_intent": "train",
+          "data_id": "<uuid4>",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        },
+        {
+          "label": "car",
+          "data_intent": "train",
+          "data_id": "<uuid4>",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        },
+        {
+          "label": "motor",
+          "data_intent": "train",
+          "data_id": "<uuid4>",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        }
+      ]
+    },
+    {
+      "id": "object_detection-column",
+      "category": "object_detection",
+      "data_id_strategy": "column",
+      "unique_id_column": "filename",
+      "total_rows_ingested": 128,
+      "dest_files": [
+        "0000001_02999_d_0000005.jpg",
+        "0000001_02999_d_0000005.xml"
+      ],
+      "rows": [
+        {
+          "label": "car",
+          "data_intent": "train",
+          "data_id": "0000001_02999_d_0000005",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        },
+        {
+          "label": "car",
+          "data_intent": "train",
+          "data_id": "0000001_02999_d_0000005",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        },
+        {
+          "label": "car",
+          "data_intent": "train",
+          "data_id": "0000001_02999_d_0000005",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        },
+        {
+          "label": "motor",
+          "data_intent": "train",
+          "data_id": "0000001_02999_d_0000005",
+          "filename": "0000001_02999_d_0000005",
+          "extension": ".jpg"
+        }
+      ]
+    },
+    {
+      "id": "keypoint_detection-default",
+      "category": "keypoint_detection",
+      "data_id_strategy": "content_hash",
+      "unique_id_column": null,
+      "total_rows_ingested": 3,
+      "dest_files": [
+        "person_001.jpg",
+        "person_002.jpg",
+        "person_003.jpg"
+      ],
+      "rows": [
+        {
+          "label": "person",
+          "data_intent": "train",
+          "annotation": "{\"nose\": [0.50, 0.20], \"left_eye\": [0.46, 0.16], \"right_eye\": [0.54, 0.16], \"left_shoulder\": [0.37, 0.39], \"right_shoulder\": [0.63, 0.39], \"left_elbow\": [0.31, 0.59], \"right_elbow\": [0.68, 0.59], \"left_wrist\": [0.27, 0.76], \"right_wrist\": [0.72, 0.76]}",
+          "data_id": "f2feb4ca9dd0b7add8beb306684b90f8fb484a270c7be49d81ca1713f4e0d758",
+          "filename": "person_001",
+          "extension": ".jpg"
+        },
+        {
+          "label": "athlete",
+          "data_intent": "train",
+          "annotation": "{\"nose\": [0.51, 0.21], \"left_eye\": [0.48, 0.18], \"right_eye\": [0.55, 0.18], \"left_shoulder\": [0.39, 0.43], \"right_shoulder\": [0.64, 0.41], \"left_elbow\": [0.33, 0.63], \"right_elbow\": [0.70, 0.61], \"left_wrist\": [0.29, 0.78], \"right_wrist\": [0.74, 0.78]}",
+          "data_id": "8382b4358710c9e3590794f54132302845b643be00a6e4ffb1e56622a003325b",
+          "filename": "person_002",
+          "extension": ".jpg"
+        },
+        {
+          "label": "dancer",
+          "data_intent": "train",
+          "annotation": "{\"nose\": [0.49, 0.19], \"left_eye\": [0.45, 0.16], \"right_eye\": [0.53, 0.16], \"left_shoulder\": [0.35, 0.37], \"right_shoulder\": [0.61, 0.38], \"left_elbow\": [0.30, 0.58], \"right_elbow\": [0.66, 0.57], \"left_wrist\": [0.25, 0.74], \"right_wrist\": [0.71, 0.75]}",
+          "data_id": "7ae2efd5c6b258e5795c1e22f2cb27d1d27fbd931e08aca4fdc0e20ece968b63",
+          "filename": "person_003",
+          "extension": ".jpg"
+        }
+      ]
+    },
+    {
+      "id": "keypoint_detection-column",
+      "category": "keypoint_detection",
+      "data_id_strategy": "column",
+      "unique_id_column": "filename",
+      "total_rows_ingested": 3,
+      "dest_files": [
+        "person_001.jpg",
+        "person_002.jpg",
+        "person_003.jpg"
+      ],
+      "rows": [
+        {
+          "label": "person",
+          "data_intent": "train",
+          "annotation": "{\"nose\": [0.50, 0.20], \"left_eye\": [0.46, 0.16], \"right_eye\": [0.54, 0.16], \"left_shoulder\": [0.37, 0.39], \"right_shoulder\": [0.63, 0.39], \"left_elbow\": [0.31, 0.59], \"right_elbow\": [0.68, 0.59], \"left_wrist\": [0.27, 0.76], \"right_wrist\": [0.72, 0.76]}",
+          "data_id": "person_001",
+          "filename": "person_001",
+          "extension": ".jpg"
+        },
+        {
+          "label": "athlete",
+          "data_intent": "train",
+          "annotation": "{\"nose\": [0.51, 0.21], \"left_eye\": [0.48, 0.18], \"right_eye\": [0.55, 0.18], \"left_shoulder\": [0.39, 0.43], \"right_shoulder\": [0.64, 0.41], \"left_elbow\": [0.33, 0.63], \"right_elbow\": [0.70, 0.61], \"left_wrist\": [0.29, 0.78], \"right_wrist\": [0.74, 0.78]}",
+          "data_id": "person_002",
+          "filename": "person_002",
+          "extension": ".jpg"
+        },
+        {
+          "label": "dancer",
+          "data_intent": "train",
+          "annotation": "{\"nose\": [0.49, 0.19], \"left_eye\": [0.45, 0.16], \"right_eye\": [0.53, 0.16], \"left_shoulder\": [0.35, 0.37], \"right_shoulder\": [0.61, 0.38], \"left_elbow\": [0.30, 0.58], \"right_elbow\": [0.66, 0.57], \"left_wrist\": [0.25, 0.74], \"right_wrist\": [0.71, 0.75]}",
+          "data_id": "person_003",
+          "filename": "person_003",
+          "extension": ".jpg"
+        }
+      ]
+    },
+    {
+      "id": "semantic_segmentation-default",
+      "category": "semantic_segmentation",
+      "data_id_strategy": "content_hash",
+      "unique_id_column": null,
+      "total_rows_ingested": 3,
+      "dest_files": [
+        "image_001.jpg",
+        "image_001_mask.png",
+        "image_002.jpg",
+        "image_002_mask.png",
+        "image_003.jpg",
+        "image_003_mask.png"
+      ],
+      "rows": [
+        {
+          "mask_id": "image_001_mask",
+          "label": "road",
+          "data_intent": "train",
+          "data_id": "756ea6b45b7ae0dee26cd003f641f35c3fe6a518ea6515c51d1864e81b87dbe3",
+          "filename": "image_001",
+          "extension": ".jpg"
+        },
+        {
+          "mask_id": "image_002_mask",
+          "label": "building",
+          "data_intent": "train",
+          "data_id": "be1d294cde6c11053dab3be7e231d5581f950bef5d778d4fc3fe151135e60241",
+          "filename": "image_002",
+          "extension": ".jpg"
+        },
+        {
+          "mask_id": "image_003_mask",
+          "label": "person",
+          "data_intent": "train",
+          "data_id": "8e1921fbdbbd521f26f2271d46d813af3fa4c15af731e9a4860be4b5767d6748",
+          "filename": "image_003",
+          "extension": ".jpg"
+        }
+      ]
+    },
+    {
+      "id": "semantic_segmentation-column",
+      "category": "semantic_segmentation",
+      "data_id_strategy": "column",
+      "unique_id_column": "filename",
+      "total_rows_ingested": 3,
+      "dest_files": [
+        "image_001.jpg",
+        "image_001_mask.png",
+        "image_002.jpg",
+        "image_002_mask.png",
+        "image_003.jpg",
+        "image_003_mask.png"
+      ],
+      "rows": [
+        {
+          "mask_id": "image_001_mask",
+          "label": "road",
+          "data_intent": "train",
+          "data_id": "image_001",
+          "filename": "image_001",
+          "extension": ".jpg"
+        },
+        {
+          "mask_id": "image_002_mask",
+          "label": "building",
+          "data_intent": "train",
+          "data_id": "image_002",
+          "filename": "image_002",
+          "extension": ".jpg"
+        },
+        {
+          "mask_id": "image_003_mask",
+          "label": "person",
+          "data_intent": "train",
+          "data_id": "image_003",
+          "filename": "image_003",
+          "extension": ".jpg"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_bio_label_validator.py
+++ b/tests/test_bio_label_validator.py
@@ -185,3 +185,39 @@ def test_iob2_check_skipped_when_tag_format_invalid(validator, texts_dir):
     assert not result.is_valid
     assert any("invalid BIO tag" in e for e in result.errors)
     assert not result.warnings
+
+
+def test_csv_padded_header_still_resolves_label(texts_dir, tmp_path):
+    """``filename, label`` — the header Excel writes by default — must resolve,
+    not report the label column missing.
+
+    Regression (backend#1828): BIOLabelValidator carried a private
+    ``_resolve_column`` that lower-cased but did NOT strip, so pandas' parsed
+    header ``[" label"]`` never matched the configured ``label``. The dataset
+    was rejected for a column the user can see in their file, on
+    token_classification only, while sibling validators in the same preflight
+    run resolved it fine. Exercised through the real CSV read path (a raw file,
+    not a DataFrame) because that is where the padding survives —
+    ``BaseValidator._load_data`` calls ``pd.read_csv`` without
+    ``skipinitialspace``.
+    """
+    _write(texts_dir, "s1", "John Smith")
+    path = tmp_path / "padded.csv"
+    path.write_text("filename, label\ns1,B-PER I-PER\n", encoding="utf-8")
+
+    result = BIOLabelValidator().validate(str(path))
+
+    assert result.is_valid, result.errors
+    assert result.metadata["rows_checked"] == 1
+
+
+def test_csv_padded_filename_header_still_resolves(texts_dir, tmp_path):
+    """The same strip must apply to the ``filename`` column, which is padded
+    whenever it is not the first CSV field (backend#1828)."""
+    _write(texts_dir, "s1", "John Smith")
+    path = tmp_path / "padded_fn.csv"
+    path.write_text("label, filename\nB-PER I-PER,s1\n", encoding="utf-8")
+
+    result = BIOLabelValidator().validate(str(path))
+
+    assert result.is_valid, result.errors

--- a/tests/test_column_identifier_contract.py
+++ b/tests/test_column_identifier_contract.py
@@ -1,7 +1,7 @@
 """Cross-repo column-identifier contract (ISSUE #382).
 
 This pins the canonical column-name grammar that BOTH the ingestor (here) and
-the trainer (``tracebloc-client`` core/utils/database.py) must agree on. The
+the trainer (``tracebloc-engine`` core/utils/database.py) must agree on. The
 trainer mirrors ``tracebloc_ingestor.identifiers`` verbatim and has its own copy
 of this table plus a pin test; together they keep the two repos from drifting.
 
@@ -29,17 +29,17 @@ from tracebloc_ingestor.identifiers import (
 # The issue's parametrisation, plus the accept/reject verdict under the
 # reconciled grammar. (name, should_be_valid)
 CONTRACT_CASES = [
-    ("123_gene", True),                       # digit-leading — quotable
-    ("_ok", True),                            # leading underscore
-    ("feature-1", True),                      # hyphen — quotable
-    ("col name", True),                       # space — quotable
-    ("P08254|MMP3", True),                    # proteomics pipe header (#184/#185)
-    ("Körpergröße", True),                    # clinical unicode header (#739)
-    ("feature.1", True),                      # dot
-    ("a" * MAX_COLUMN_IDENTIFIER_LENGTH, True),       # exactly 64 — boundary OK
+    ("123_gene", True),  # digit-leading — quotable
+    ("_ok", True),  # leading underscore
+    ("feature-1", True),  # hyphen — quotable
+    ("col name", True),  # space — quotable
+    ("P08254|MMP3", True),  # proteomics pipe header (#184/#185)
+    ("Körpergröße", True),  # clinical unicode header (#739)
+    ("feature.1", True),  # dot
+    ("a" * MAX_COLUMN_IDENTIFIER_LENGTH, True),  # exactly 64 — boundary OK
     ("a" * (MAX_COLUMN_IDENTIFIER_LENGTH + 1), False),  # 65 chars — too long
-    ("", False),                              # empty
-    ("bad\x00col", False),                    # NUL — illegal in identifier
+    ("", False),  # empty
+    ("bad\x00col", False),  # NUL — illegal in identifier
 ]
 
 

--- a/tests/test_column_identifier_schema.py
+++ b/tests/test_column_identifier_schema.py
@@ -1,0 +1,211 @@
+"""The published column grammar is pinned to the code, in BOTH directions.
+
+Why this file exists (backend#1780)
+-----------------------------------
+The column-identifier grammar was mirrored across two repos as two hand-copied
+case tables. Each side's comments claimed the other kept it honest:
+
+  ``tracebloc-engine/core/utils/database.py``
+      "MIRRORS tracebloc_ingestor/identifiers.py ... test_database.py pins this
+       against the canonical spec so the two can't drift."
+
+  this repo's ``tests/test_column_identifier_contract.py``
+      "The trainer mirrors tracebloc_ingestor.identifiers verbatim and has its
+       own copy of this table plus a pin test; together they keep the two repos
+       from drifting."
+
+**Nothing crossed the repo boundary.** The engine's test neither imports nor
+fetches ``identifiers.py`` — it pins a local *transcription* of the spec. So a
+change to ``MAX_COLUMN_IDENTIFIER_LENGTH``, to the NUL rule, or to the
+quote-and-allow reconciliation could land on either side with **both suites
+green** and the two repos silently disagreeing. That is exactly the mechanism
+that made ISSUE #382 *"silent until training — raising uncaught, after an
+experiment was already running."* The reconciliation fixed the values; it did
+not fix the thing that let them diverge.
+
+``schema/column_identifier.v1.json`` is the fix's first half: the grammar,
+published so the trainer can **generate** its cases instead of copying them —
+the same pattern ``runtime_env.v1.json`` already uses for the spawner contract
+(backend#1754 / #482).
+
+A published artifact is only worth as much as its pin, so this file asserts BOTH
+directions. One direction alone is a trap:
+
+  * code → JSON only: the JSON could omit a rule the code enforces, and a
+    consumer generating from it would under-test.
+  * JSON → code only: the JSON could declare a rule the code does not enforce,
+    and a consumer would trust a guarantee that does not exist.
+
+The second is the one that bites, because it is the direction that reads as
+reassuring.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# Loaded DIRECTLY BY PATH, not as `from tracebloc_ingestor.identifiers import
+# ...`. The package's __init__ imports database.py, which imports sqlalchemy, so
+# the plain import drags the whole DB stack in just to read a grammar. That
+# matters here beyond convenience: identifiers.py is deliberately
+# "dependency-light (stdlib only) so the trainer can mirror it verbatim", and a
+# test that cannot exercise it without sqlalchemy quietly contradicts that
+# promise. The sibling runtime_env contract test avoids the same problem by
+# ast-parsing its source; loading the module is strictly better, because it
+# tests real behaviour rather than the shape of the source text.
+import importlib.util as _ilu
+
+_IDENT_PATH = (
+    Path(__file__).resolve().parent.parent / "tracebloc_ingestor" / "identifiers.py"
+)
+_spec = _ilu.spec_from_file_location("_tb_identifiers", _IDENT_PATH)
+assert _spec and _spec.loader, f"cannot load {_IDENT_PATH}"
+_identifiers = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_identifiers)
+
+MAX_COLUMN_IDENTIFIER_LENGTH = _identifiers.MAX_COLUMN_IDENTIFIER_LENGTH
+InvalidColumnIdentifierError = _identifiers.InvalidColumnIdentifierError
+is_valid_column_identifier = _identifiers.is_valid_column_identifier
+quote_column_identifier = _identifiers.quote_column_identifier
+validate_column_identifier = _identifiers.validate_column_identifier
+
+CONTRACT = (
+    Path(__file__).resolve().parent.parent
+    / "tracebloc_ingestor"
+    / "schema"
+    / "column_identifier.v1.json"
+)
+
+SUPPORTED_VERSIONS = {"1"}
+
+
+def _contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def test_the_contract_ships_in_the_package() -> None:
+    # A schema that is not packaged cannot be vendored by a consumer, which is
+    # the whole point of publishing it.
+    assert CONTRACT.is_file(), f"{CONTRACT} is missing"
+
+
+def test_the_contract_is_a_version_we_understand() -> None:
+    assert _contract()["version"] in SUPPORTED_VERSIONS
+
+
+def test_the_declared_max_length_is_the_constant_the_code_enforces() -> None:
+    # THE pin. #382's disagreement was over legality; a silent change to this
+    # number is how the two repos would part company again.
+    assert _contract()["max_length"] == MAX_COLUMN_IDENTIFIER_LENGTH
+
+
+def test_the_declared_max_length_is_actually_the_boundary() -> None:
+    # Not just equal to the constant — equal to the code's real behaviour. A
+    # constant can be right while the comparison using it is off by one.
+    n = _contract()["max_length"]
+    assert is_valid_column_identifier("a" * n) is True
+    assert is_valid_column_identifier("a" * (n + 1)) is False
+
+
+@pytest.mark.parametrize("case", _contract()["cases"], ids=lambda c: repr(c["name"]))
+def test_every_declared_case_matches_the_code(case: dict) -> None:
+    """JSON → code: the file may not claim a verdict the code does not give."""
+    name, expected = case["name"], case["valid"]
+    assert is_valid_column_identifier(name) is expected, case["why"]
+    if expected:
+        assert validate_column_identifier(name) == name
+    else:
+        with pytest.raises(InvalidColumnIdentifierError):
+            validate_column_identifier(name)
+
+
+def test_every_forbidden_character_is_actually_rejected() -> None:
+    """JSON → code, for the rules rather than the cases."""
+    for entry in _contract()["forbidden_characters"]:
+        cp = entry["codepoint"]
+        assert cp.startswith("U+"), f"unparseable codepoint {cp!r}"
+        ch = chr(int(cp[2:], 16))
+        assert (
+            is_valid_column_identifier(f"bad{ch}col") is False
+        ), f"the contract forbids {entry['name']} but the code accepts it"
+
+
+def test_the_declared_quoting_is_what_the_code_emits() -> None:
+    """A consumer that quotes differently produces different DDL."""
+    q = _contract()["quoting"]
+    example = q["example"]
+    assert quote_column_identifier(example["input"]) == example["output"]
+    # And the escape rule itself, not only the one example.
+    assert quote_column_identifier("a`b") == "`a``b`"
+
+
+def test_the_contract_covers_every_rule_the_code_enforces() -> None:
+    """code → JSON: the file may not omit a constraint the code applies.
+
+    Checks each rule class the code is known to enforce against a concrete
+    entry in the contract, so removing that entry from the JSON — dropping the
+    empty-string case, ``max_length``, or NUL from ``forbidden_characters`` —
+    fails here instead of quietly shrinking what a consumer generating from the
+    file would test.
+    """
+    contract = _contract()
+    declared_forbidden = {
+        chr(int(e["codepoint"][2:], 16)) for e in contract["forbidden_characters"]
+    }
+    declared_max_length = contract.get("max_length")
+    empty_is_a_declared_case = any(
+        c["name"] == "" and c["valid"] is False for c in contract["cases"]
+    )
+    # Probe the code with one representative of each rule class it is known to
+    # apply. Each probe must be BOTH (a) rejected by the code — so the rule is
+    # really enforced — AND (b) backed by a concrete entry in the contract, so a
+    # consumer generating from the file tests it too. The bug this guards
+    # against is the published grammar silently dropping a rule the code still
+    # applies: without (b), deleting the empty-string case, ``max_length``, or
+    # the NUL entry would leave this test green. Probes are built from the code
+    # (its own MAX constant, not the contract's number) so a missing contract
+    # entry surfaces as an uncovered rule here, never as a mis-built probe.
+    gaps = []
+    for probe, covered_by_contract, handle in (
+        ("", empty_is_a_declared_case, "an empty-string rejecting case"),
+        (
+            "a" * (MAX_COLUMN_IDENTIFIER_LENGTH + 1),
+            isinstance(declared_max_length, int),
+            "a max_length entry",
+        ),
+        ("bad\x00col", "\x00" in declared_forbidden, "NUL in forbidden_characters"),
+    ):
+        assert (
+            is_valid_column_identifier(probe) is False
+        ), f"code no longer rejects {probe!r}; the enforced rule vanished"
+        if not covered_by_contract:
+            gaps.append(f"code rejects {probe!r} but the contract omits {handle}")
+    assert not gaps, gaps
+    # Non-string input is a rule too, and a consumer in a typed language would
+    # not infer it from the case list.
+    assert is_valid_column_identifier(None) is False
+    assert is_valid_column_identifier(123) is False
+
+
+def test_the_case_list_is_not_trivially_one_sided() -> None:
+    """A table of all-accepts (or all-rejects) would pass everything above.
+
+    This is the guard that stops the contract decaying into a list that proves
+    nothing — the failure mode the two hand-copied tables were already drifting
+    toward.
+    """
+    verdicts = [c["valid"] for c in _contract()["cases"]]
+    assert any(verdicts), "no accepting case"
+    assert not all(verdicts), "no rejecting case"
+    assert len(verdicts) >= 8, "the case list has shrunk below the #382 set"
+
+
+def test_the_boundary_cases_are_present_by_construction() -> None:
+    """The off-by-one pair is the case most likely to be dropped as redundant."""
+    n = _contract()["max_length"]
+    names = {c["name"]: c["valid"] for c in _contract()["cases"]}
+    assert names.get("a" * n) is True, f"missing the exactly-{n} accepting case"
+    assert names.get("a" * (n + 1)) is False, f"missing the {n + 1} rejecting case"

--- a/tests/test_contrastive_pairs_validator.py
+++ b/tests/test_contrastive_pairs_validator.py
@@ -40,9 +40,7 @@ def _validate(filenames, staged):
 def test_valid_pair_and_triplet_pass(staged):
     texts, make_csv = staged
     (texts / "pair.txt").write_text("anchor text\tpositive text\n", encoding="utf-8")
-    (texts / "triplet.txt").write_text(
-        "anchor\tpositive\tnegative\n", encoding="utf-8"
-    )
+    (texts / "triplet.txt").write_text("anchor\tpositive\tnegative\n", encoding="utf-8")
     result = _validate(["pair", "triplet"], staged)
     assert result.is_valid, result.errors
     assert result.metadata["rows_checked"] == 2
@@ -186,3 +184,25 @@ def test_error_cap_summarizes(staged):
     assert not result.is_valid
     assert any("further errors suppressed" in e for e in result.errors)
     assert len(result.errors) <= 51
+
+
+def test_csv_padded_filename_header_still_resolves(staged, tmp_path):
+    """A padded ``filename`` header (``id, filename``) must resolve, not report
+    the column missing.
+
+    Regression (backend#1828): TabSeparatedRecordValidator — this validator's
+    base — carried a private ``_resolve_column`` that lower-cased but did NOT
+    strip, so pandas' parsed header ``" filename"`` never matched. ``embeddings``
+    then rejected a manifest for a column visibly present, while sibling
+    validators in the same preflight run resolved it. ``filename`` is padded
+    whenever it is not the first CSV field. Written as a raw file: pandas keeps
+    the space because ``_load_data`` does not pass ``skipinitialspace``.
+    """
+    texts, _ = staged
+    (texts / "pair.txt").write_text("anchor text\tpositive text\n", encoding="utf-8")
+    path = tmp_path / "padded.csv"
+    path.write_text("id, filename\n1,pair\n", encoding="utf-8")
+
+    result = ContrastivePairsValidator(texts_path="texts").validate(str(path))
+
+    assert result.is_valid, result.errors

--- a/tests/test_ingest_storage_contract.py
+++ b/tests/test_ingest_storage_contract.py
@@ -1,0 +1,545 @@
+"""backend#1706 — the ingest → trainer storage contract, pinned on real rows.
+
+WHY THIS FILE EXISTS
+--------------------
+tracebloc-engine#615: keypoint + semantic-segmentation training crashed on the
+first batch of every CLI-ingested dataset, because the trainer resolved images
+by ``data_id`` while this repo names the file after the manifest ``filename``.
+Three facts had to stay in agreement and **nothing pinned any of them**:
+
+1. the ingestor writes ``DEST_PATH/<manifest filename><ext>``,
+2. it stores that stem in ``filename`` and something unrelated in ``data_id``,
+3. so every trainer dataset reader must key on ``filename``.
+
+When #350 flipped the default ``data_id`` strategy ``uuid`` → ``content_hash``,
+nothing failed anywhere. The trainer's own fixtures were hand-authored with
+``data_id`` set to the on-disk stem and **no ``filename`` column at all** — a
+shape this repo has never produced — so they could not catch it either. The two
+shipped Python templates that set ``unique_id_column="filename"`` are exactly
+``keypoint_detection`` and ``semantic_segmentation``: the two categories whose
+readers keyed on ``data_id``. The templates were papering over the reader bug.
+
+WHAT THIS FILE PINS
+-------------------
+Each case runs a **real ingest** — the same ``cli.conventions.resolve`` →
+``cli.run._build_ingestor`` path ``tracebloc dataset push`` takes, with real
+validators, real record processing and real file transfer. Only MySQL and the
+backend API are faked, and only at their own boundary: every value asserted
+below is produced by production code.
+
+Per case we assert:
+
+* **naming** — every stored row resolves to a file at
+  ``DEST/<filename><extension>``;
+* **independence** — under an opaque ``data_id`` strategy the id names *no*
+  file in ``DEST``, so a reader that keys on ``data_id`` cannot work. That is
+  the property the two templates hid;
+* **stability** — the captured rows match a committed golden, which
+  ``tracebloc-engine`` mirrors verbatim into ``core/tests/contracts/`` and
+  replays through its four CV dataset readers. A change here that moves the
+  on-disk name or the id shape turns THIS suite red with a diff, and the fix
+  is to regenerate the golden and carry it across — which is the moment
+  someone looks at the trainer.
+
+Regenerate the golden after an intentional change::
+
+    UPDATE_INGEST_CONTRACT_GOLDEN=1 pytest tests/test_ingest_storage_contract.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid as uuid_mod
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from tracebloc_ingestor.cli import run as run_mod
+from tracebloc_ingestor.cli.conventions import resolve
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.storage_contract import (
+    DATA_ID_STRATEGIES,
+    DEFAULT_DATA_ID_STRATEGY,
+    EXTENSION_COLUMN,
+    IMAGE_NAME_COLUMN,
+    IMAGE_NAME_COLUMNS,
+    MASK_NAME_COLUMN,
+    OPAQUE_DATA_ID_STRATEGIES,
+    RECOGNISED_IMAGE_SUFFIXES,
+    ROW_ID_COLUMN,
+    has_recognised_extension,
+    stored_image_name,
+    strip_image_extension,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+T = REPO / "templates"
+GOLDEN_PATH = REPO / "tests" / "fixtures" / "contracts" / "ingested_image_rows.json"
+
+# Pinned so the content-hash ids in the golden are reproducible. Production
+# mints a random per-table salt (#225) that never leaves the cluster; its value
+# is irrelevant to the contract, only its fixedness is.
+TABLE_SALT = "1706" * 16
+
+# ``ingestor_id`` is a fresh UUID per run and carries no contract meaning.
+VOLATILE_COLUMNS = ("ingestor_id",)
+
+# A uuid-strategy ``data_id`` is random by construction, so the golden stores
+# this sentinel in its place. Everything the contract cares about — that the id
+# is opaque and names no file — is asserted directly in the test.
+UUID_SENTINEL = "<uuid4>"
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+def _cfg(**kw: Any) -> Dict[str, Any]:
+    base = {"apiVersion": "tracebloc.io/v1", "kind": "IngestConfig", "intent": "train"}
+    base.update(kw)
+    return base
+
+
+# The four file-bearing CV categories — the ones with an image-per-row on disk
+# and therefore a reader that has to resolve it. Configs match the bundled
+# template data (same shape the e2e suite uses).
+def _image_classification() -> Dict[str, Any]:
+    return _cfg(
+        table="contract_img",
+        category="image_classification",
+        csv=str(T / "image_classification/data/labels_file_sample.csv"),
+        images=str(T / "image_classification/data/images"),
+        label="label",
+        spec={"file_options": {"extension": ".jpeg", "target_size": [256, 256]}},
+    )
+
+
+def _object_detection() -> Dict[str, Any]:
+    return _cfg(
+        table="contract_od",
+        category="object_detection",
+        csv=str(T / "object_detection/data/labels_file_sample.csv"),
+        images=str(T / "object_detection/data/images"),
+        annotations=str(T / "object_detection/data/annotations"),
+        label="image_label",
+        target_size=[1920, 1080],
+    )
+
+
+def _keypoint_detection() -> Dict[str, Any]:
+    return _cfg(
+        table="contract_kp",
+        category="keypoint_detection",
+        csv=str(T / "keypoint_detection/data/labels_file_sample.csv"),
+        images=str(T / "keypoint_detection/data/images"),
+        label="image_label",
+        target_size=[448, 448],
+        number_of_keypoints=9,
+    )
+
+
+def _semantic_segmentation() -> Dict[str, Any]:
+    return _cfg(
+        table="contract_seg",
+        category="semantic_segmentation",
+        csv=str(T / "semantic_segmentation/semantic_data/labels_file_sample.csv"),
+        images=str(T / "semantic_segmentation/semantic_data/images"),
+        masks=str(T / "semantic_segmentation/semantic_data/masks"),
+        label="image_label",
+        schema={"mask_id": "VARCHAR(255)"},
+    )
+
+
+CATEGORY_CONFIGS = {
+    "image_classification": _image_classification,
+    "object_detection": _object_detection,
+    "keypoint_detection": _keypoint_detection,
+    "semantic_segmentation": _semantic_segmentation,
+}
+
+# (category, data_id spec, case id). Two strategies per category:
+#
+# - the category's DEFAULT (no ``data_id`` key at all) — what every
+#   `tracebloc dataset push` produces today, and the shape that broke #615;
+# - ``column`` over ``filename`` — the alias the keypoint / semseg Python
+#   templates set, i.e. the coincidence under which a ``data_id``-keyed reader
+#   accidentally worked. Kept so the trainer's replay covers BOTH shapes and a
+#   future reader can't regress into only handling one.
+CASES: List[Tuple[str, Dict[str, Any] | None, str]] = [
+    (category, data_id, f"{category}-{label}")
+    for category in CATEGORY_CONFIGS
+    for data_id, label in (
+        (None, "default"),
+        ({"strategy": "column", "column": "filename"}, "column"),
+    )
+]
+
+
+def _run_ingest(
+    category: str,
+    data_id: Dict[str, Any] | None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Tuple[Config, Any, List[Dict[str, Any]]]:
+    """Run one real ingest; return ``(config, resolved, stored_rows)``.
+
+    MySQL and the backend API are the only fakes, and each is faked at its own
+    boundary: rows are captured exactly as ``Database.insert_batch`` would
+    receive them, after real validation, real record processing and real file
+    transfer.
+    """
+    config = CATEGORY_CONFIGS[category]()
+    if data_id is not None:
+        config["data_id"] = data_id
+
+    resolved = resolve(config)
+    run_config = run_mod._resolve_config(resolved)
+
+    # DEST_PATH is ``STORAGE_PATH/<table>``; /data/shared isn't writable in CI.
+    storage = tmp_path / "shared"
+    storage.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Config, "STORAGE_PATH", str(storage))
+    monkeypatch.setenv("CLIENT_ENV", "local")
+
+    rows: List[Dict[str, Any]] = []
+
+    database = MagicMock(name="Database")
+    database.config = run_config
+    database.engine = MagicMock(name="Engine")
+    database.create_table.return_value = MagicMock(name="Table")
+    database.get_table_schema.return_value = resolved.schema
+    database.get_or_create_table_salt.return_value = TABLE_SALT
+
+    def _insert_batch(_table: str, records: List[Dict[str, Any]]):
+        rows.extend(dict(record) for record in records)
+        return list(range(len(records))), []
+
+    database.insert_batch.side_effect = _insert_batch
+
+    api_client = MagicMock(name="APIClient")
+    for method in (
+        "send_batch",
+        "send_generate_edge_label_meta",
+        "send_global_meta_meta",
+        "prepare_dataset",
+    ):
+        getattr(api_client, method).return_value = True
+    api_client.create_dataset.return_value = {"id": 1}
+
+    ingestor = run_mod._build_ingestor(database, api_client, resolved)
+    ingestor.ingest(resolved.source_path)
+
+    assert rows, f"{category}: the ingest stored no rows"
+    return run_config, resolved, rows
+
+
+def _normalise(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Drop per-run volatile fields and mask random uuid ids, so the capture is
+    comparable against a committed golden."""
+    out = []
+    for row in rows:
+        clean = {
+            key: value for key, value in row.items() if key not in VOLATILE_COLUMNS
+        }
+        row_id = str(clean.get(ROW_ID_COLUMN, ""))
+        if _UUID_RE.match(row_id):
+            clean[ROW_ID_COLUMN] = UUID_SENTINEL
+        out.append(json.loads(json.dumps(clean, default=str)))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The contract, asserted on real ingested rows.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "category,data_id",
+    [pytest.param(c, d, id=i) for c, d, i in CASES],
+)
+def test_every_stored_row_resolves_through_the_filename_column(
+    category, data_id, tmp_path, monkeypatch
+):
+    """FACT 1+2: the file on disk is named after ``filename``, always.
+
+    This is the single rule the trainer has to implement. It holds for every
+    category and every ``data_id`` strategy — the strategy is simply not part
+    of how a file is named.
+    """
+    run_config, _resolved, rows = _run_ingest(category, data_id, tmp_path, monkeypatch)
+    dest = run_config.DEST_PATH
+
+    for row in rows:
+        assert row[IMAGE_NAME_COLUMN], f"{category}: row stored a blank filename"
+        expected = stored_image_name(row[IMAGE_NAME_COLUMN], row[EXTENSION_COLUMN])
+        assert os.path.isfile(os.path.join(dest, expected)), (
+            f"{category}: no file at DEST/{expected} for stored row "
+            f"{row[IMAGE_NAME_COLUMN]!r} — the filename column no longer names "
+            f"the file the ingest wrote. DEST holds {sorted(os.listdir(dest))}"
+        )
+
+
+@pytest.mark.parametrize(
+    "category",
+    list(CATEGORY_CONFIGS),
+)
+def test_default_strategy_data_id_names_no_file_on_disk(
+    category, tmp_path, monkeypatch
+):
+    """FACT 3, stated as the negative: under the default strategy ``data_id``
+    resolves to nothing, so a ``data_id``-keyed reader is simply broken.
+
+    This is #615 reproduced at its source. The keypoint / semseg templates set
+    ``unique_id_column="filename"`` and so never exercised it; the CLI / YAML
+    path — the one customers use — always does.
+    """
+    run_config, resolved, rows = _run_ingest(category, None, tmp_path, monkeypatch)
+    if resolved.data_id_strategy not in OPAQUE_DATA_ID_STRATEGIES:
+        pytest.fail(
+            f"{category}: default strategy is {resolved.data_id_strategy!r}, which "
+            f"is not opaque — update OPAQUE_DATA_ID_STRATEGIES and re-read #615"
+        )
+
+    dest = run_config.DEST_PATH
+    on_disk = set(os.listdir(dest))
+    for row in rows:
+        row_id = str(row[ROW_ID_COLUMN])
+        assert row_id not in on_disk
+        stem = strip_image_extension(row_id)
+        for suffix in RECOGNISED_IMAGE_SUFFIXES:
+            assert f"{stem}{suffix}" not in on_disk, (
+                f"{category}: data_id {row_id!r} happens to name a file on disk. "
+                f"That coincidence is what hid tracebloc-engine#615 for two "
+                f"releases — do not let a reader depend on it."
+            )
+        assert row[IMAGE_NAME_COLUMN] != row_id
+
+
+@pytest.mark.parametrize(
+    "category",
+    list(CATEGORY_CONFIGS),
+)
+def test_column_strategy_aliases_data_id_to_filename(category, tmp_path, monkeypatch):
+    """The opt-in alias the templates relied on still works — and is opt-in.
+
+    Pinned so nobody "fixes" the divergence by making the alias the default:
+    that would re-hide the bug rather than remove it.
+    """
+    _config, resolved, rows = _run_ingest(
+        category, {"strategy": "column", "column": "filename"}, tmp_path, monkeypatch
+    )
+    assert resolved.unique_id_column == IMAGE_NAME_COLUMN
+    for row in rows:
+        assert strip_image_extension(row[ROW_ID_COLUMN]) == row[IMAGE_NAME_COLUMN]
+
+
+def test_semantic_segmentation_mask_resolves_through_its_own_column(
+    tmp_path, monkeypatch
+):
+    """``mask_id`` follows the same rule as ``filename`` (backend#816): it names
+    a file, ``data_id`` does not."""
+    run_config, _resolved, rows = _run_ingest(
+        "semantic_segmentation", None, tmp_path, monkeypatch
+    )
+    dest = run_config.DEST_PATH
+    for row in rows:
+        mask = row[MASK_NAME_COLUMN]
+        assert mask, "semseg row stored a blank mask_id"
+        stem = strip_image_extension(mask)
+        assert any(
+            os.path.isfile(os.path.join(dest, f"{stem}{suffix}"))
+            for suffix in RECOGNISED_IMAGE_SUFFIXES
+        ) or os.path.isfile(
+            os.path.join(dest, str(mask))
+        ), f"no mask file for mask_id {mask!r} in {sorted(os.listdir(dest))}"
+
+
+# ---------------------------------------------------------------------------
+# The golden — the artifact tracebloc-engine replays.
+# ---------------------------------------------------------------------------
+# The bundled manifests run to hundreds of rows (object detection lists one row
+# per OBJECT), and a golden nobody can read is a golden nobody checks. The
+# contract is per-row, so a handful exercises it exactly as well.
+GOLDEN_ROWS_PER_CASE = 4
+
+
+def _effective_strategy(resolved) -> str:
+    """The strategy that actually minted ``data_id``.
+
+    ``data_id: {strategy: column}`` sets ``unique_id_column`` and leaves
+    ``data_id_strategy`` at its default; the column wins at row time
+    (``RecordProcessor._map_unique_id``). Record what happened, not what the
+    unused field says.
+    """
+    return "column" if resolved.unique_id_column else resolved.data_id_strategy
+
+
+def _capture_all(tmp_path_factory, monkeypatch) -> Dict[str, Any]:
+    cases = []
+    for category, data_id, case_id in CASES:
+        tmp_path = tmp_path_factory.mktemp(case_id.replace("/", "_"))
+        run_config, resolved, rows = _run_ingest(
+            category, data_id, tmp_path, monkeypatch
+        )
+        cases.append(
+            {
+                "id": case_id,
+                "category": category,
+                "data_id_strategy": _effective_strategy(resolved),
+                "unique_id_column": resolved.unique_id_column,
+                "total_rows_ingested": len(rows),
+                "dest_files": sorted(os.listdir(run_config.DEST_PATH)),
+                "rows": _normalise(rows[:GOLDEN_ROWS_PER_CASE]),
+            }
+        )
+    return {
+        "_README": [
+            "Captured from REAL ingests by tests/test_ingest_storage_contract.py",
+            "(data-ingestors). Do not hand-edit: regenerate with",
+            "UPDATE_INGEST_CONTRACT_GOLDEN=1 pytest tests/test_ingest_storage_contract.py",
+            "",
+            "tracebloc-engine mirrors this file verbatim into",
+            "core/tests/contracts/ingested_image_rows.json and replays it through",
+            "its CV dataset readers (backend#1706). Carry any regeneration across.",
+            "",
+            f"'ingestor_id' is dropped and a uuid-strategy data_id is masked as "
+            f"'{UUID_SENTINEL}' — both are random per run.",
+            f"content_hash ids are computed under the fixed test salt {TABLE_SALT!r}.",
+            f"'rows' holds the first {GOLDEN_ROWS_PER_CASE} of "
+            f"'total_rows_ingested'; the contract is per-row.",
+        ],
+        "contract": {
+            "image_name_columns": list(IMAGE_NAME_COLUMNS),
+            "data_id_strategies": list(DATA_ID_STRATEGIES),
+            "default_data_id_strategy": DEFAULT_DATA_ID_STRATEGY,
+            "opaque_data_id_strategies": sorted(OPAQUE_DATA_ID_STRATEGIES),
+            "recognised_image_suffixes": list(RECOGNISED_IMAGE_SUFFIXES),
+            "uuid_sentinel": UUID_SENTINEL,
+        },
+        "cases": cases,
+    }
+
+
+def test_golden_matches_a_real_ingest(tmp_path_factory, monkeypatch):
+    """The committed golden IS what the pipeline produces, today.
+
+    The trainer's fixtures are built from this file rather than hand-authored,
+    which is the whole point: a hand-authored fixture can express a row shape
+    the ingestor never produces (and did — engine#615's keypoint fixture had no
+    ``filename`` column at all), so it proves nothing about the real boundary.
+    """
+    captured = _capture_all(tmp_path_factory, monkeypatch)
+
+    if os.environ.get("UPDATE_INGEST_CONTRACT_GOLDEN"):
+        GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+        GOLDEN_PATH.write_text(json.dumps(captured, indent=2) + "\n")
+        pytest.skip(f"golden regenerated at {GOLDEN_PATH}")
+
+    assert GOLDEN_PATH.is_file(), (
+        f"missing golden {GOLDEN_PATH}; regenerate with "
+        f"UPDATE_INGEST_CONTRACT_GOLDEN=1"
+    )
+    golden = json.loads(GOLDEN_PATH.read_text())
+    assert captured["contract"] == golden["contract"]
+    assert captured["cases"] == golden["cases"], (
+        "the ingest no longer produces the committed golden. If the change is "
+        "intended, regenerate with UPDATE_INGEST_CONTRACT_GOLDEN=1 AND copy the "
+        "file into tracebloc-engine core/tests/contracts/ — the trainer replays "
+        "it (backend#1706)."
+    )
+
+
+def test_golden_rows_carry_the_columns_a_reader_needs(tmp_path_factory):
+    """Guard against a golden that is technically current but useless: every
+    row must still carry the columns a trainer resolves files through."""
+    golden = json.loads(GOLDEN_PATH.read_text())
+    for case in golden["cases"]:
+        for row in case["rows"]:
+            assert IMAGE_NAME_COLUMN in row, case["id"]
+            assert ROW_ID_COLUMN in row, case["id"]
+            assert EXTENSION_COLUMN in row, case["id"]
+            name = stored_image_name(row[IMAGE_NAME_COLUMN], row[EXTENSION_COLUMN])
+            assert name in case["dest_files"], (
+                f"{case['id']}: golden row names {name!r}, which is not in the "
+                f"golden's own dest listing {case['dest_files']}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# The contract module itself — mirrored verbatim by tracebloc-engine's
+# core/tests/contracts/test_ingest_contract_mirror.py. Keep the two tables in
+# step; a divergence here is a divergence in what the trainer believes.
+# ---------------------------------------------------------------------------
+CONTRACT_VALUES = {
+    "IMAGE_NAME_COLUMN": "filename",
+    "ROW_ID_COLUMN": "data_id",
+    "EXTENSION_COLUMN": "extension",
+    "MASK_NAME_COLUMN": "mask_id",
+    "IMAGE_NAME_COLUMNS": ("filename", "data_id"),
+    "DATA_ID_STRATEGIES": ("content_hash", "uuid", "column"),
+    "DEFAULT_DATA_ID_STRATEGY": "content_hash",
+    "RECOGNISED_IMAGE_SUFFIXES": (".jpeg", ".jpg", ".png"),
+}
+
+# (value, stripped stem). Names with internal dots must survive: the pipeline
+# strips only a RECOGNISED trailing suffix, so a ``split(".")[0]`` reader would
+# look for a file that does not exist.
+STRIP_CASES = [
+    ("cat1.jpg", "cat1"),
+    ("cat1.JPEG", "cat1"),
+    ("image.001.jpg", "image.001"),
+    ("image.001", "image.001"),
+    ("no_extension", "no_extension"),
+    ("archive.tar", "archive.tar"),
+    ("", ""),
+]
+
+
+@pytest.mark.parametrize("name,expected", [(k, v) for k, v in CONTRACT_VALUES.items()])
+def test_contract_values(name, expected):
+    import tracebloc_ingestor.storage_contract as contract
+
+    assert getattr(contract, name) == expected
+
+
+@pytest.mark.parametrize("value,stem", STRIP_CASES)
+def test_strip_image_extension(value, stem):
+    assert strip_image_extension(value) == stem
+
+
+@pytest.mark.parametrize("value,stem", STRIP_CASES)
+def test_has_recognised_extension_agrees_with_strip(value, stem):
+    assert has_recognised_extension(value) is (strip_image_extension(value) != value)
+
+
+@pytest.mark.parametrize(
+    "filename,extension,expected",
+    [
+        ("cat1", ".jpg", "cat1.jpg"),
+        ("cat1.jpg", ".jpg", "cat1.jpg"),  # already suffixed — not doubled (#105)
+        ("cat1.JPEG", ".jpg", "cat1.JPEG"),  # keeps its own case + kind
+        ("image.001", ".png", "image.001.png"),
+    ],
+)
+def test_stored_image_name(filename, extension, expected):
+    assert stored_image_name(filename, extension) == expected
+
+
+def test_contract_agrees_with_the_transfer_code_it_describes():
+    """``storage_contract.has_recognised_extension`` must agree with
+    ``file_transfer._has_extension`` on IMAGE suffixes.
+
+    The transfer helper is deliberately broader (it also recognises the sidecar
+    ``.xml`` / ``.txt`` suffixes), so this pins agreement on the image subset
+    only — that is the subset the trainer mirrors.
+    """
+    from tracebloc_ingestor.file_transfer import _has_extension
+
+    for suffix in RECOGNISED_IMAGE_SUFFIXES:
+        for value in (f"cat1{suffix}", f"cat1{suffix.upper()}"):
+            assert has_recognised_extension(value) is _has_extension(value) is True
+    assert has_recognised_extension("cat1") is _has_extension("cat1") is False
+
+
+def test_uuid_sentinel_never_collides_with_a_real_id():
+    assert not _UUID_RE.match(UUID_SENTINEL)
+    assert _UUID_RE.match(str(uuid_mod.uuid4()))

--- a/tests/test_no_shadowed_column_resolver.py
+++ b/tests/test_no_shadowed_column_resolver.py
@@ -1,0 +1,104 @@
+"""Structural guard: no validator may carry its own column resolver.
+
+``tracebloc_ingestor.utils.columns.resolve_column`` is the single column-name
+matching rule, reached by validators through
+``BaseValidator._match_column``. Three validators once carried private
+``_resolve_column`` copies instead, and two of them dropped the ``.strip()`` —
+so ``token_classification`` / ``sentence_pair_classification`` / ``embeddings``
+false-rejected the header Excel writes by default (``filename, label``) as a
+missing column, while sibling validators in the SAME preflight run resolved it
+(backend#1828, reintroducing #340 / bugbot #252).
+
+The per-category regressions live next to each validator's own tests. This file
+guards the *class* of bug rather than the three instances: a shadowing copy is
+invisible to a reader — nothing about a call to ``self._resolve_column(...)``
+suggests it bypasses the canonical rule — so the guard has to be mechanical.
+It fails on ANY new private resolver, including a faithful one, because a
+faithful copy is exactly how the broken ones got there (the third copy, in
+``LabelDiversityValidator``, was faithful and was still deleted).
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+
+import pytest
+
+import tracebloc_ingestor.validators as validators_pkg
+from tracebloc_ingestor.utils.columns import resolve_column
+from tracebloc_ingestor.validators.base import BaseValidator
+
+
+def _validator_classes():
+    """Every BaseValidator subclass defined under tracebloc_ingestor.validators."""
+    found = {}
+    for mod_info in pkgutil.iter_modules(validators_pkg.__path__):
+        module = importlib.import_module(f"{validators_pkg.__name__}.{mod_info.name}")
+        for name, obj in vars(module).items():
+            if (
+                inspect.isclass(obj)
+                and issubclass(obj, BaseValidator)
+                and obj.__module__.startswith(validators_pkg.__name__)
+            ):
+                found[f"{obj.__module__}.{obj.__qualname__}"] = obj
+    return found
+
+
+# Names a private resolver has historically been spelled with. ``_match_column``
+# is deliberately absent — that IS the sanctioned accessor.
+_FORBIDDEN = ("_resolve_column", "_resolve_col", "_find_column", "_lookup_column")
+
+
+def test_validator_classes_are_discovered():
+    """Guard the guard: an import error or a renamed package would otherwise
+    make the shadowing assertions below vacuously pass."""
+    classes = _validator_classes()
+    assert len(classes) >= 20, sorted(classes)
+    assert any(c.endswith("BIOLabelValidator") for c in classes), sorted(classes)
+    assert any(c.endswith("TabSeparatedRecordValidator") for c in classes), sorted(
+        classes
+    )
+    assert any(c.endswith("LabelDiversityValidator") for c in classes), sorted(classes)
+
+
+@pytest.mark.parametrize("attr", _FORBIDDEN)
+def test_no_validator_defines_a_private_column_resolver(attr):
+    """No validator class may define its own column resolver — route through
+    ``BaseValidator._match_column`` (backend#1828)."""
+    offenders = [
+        qualname for qualname, cls in _validator_classes().items() if attr in vars(cls)
+    ]
+    assert not offenders, (
+        f"{offenders} define a private {attr!r}. The column-matching rule is "
+        f"single-sourced in tracebloc_ingestor.utils.columns.resolve_column; "
+        f"call self._match_column(df.columns, name) instead. A private copy "
+        f"silently diverges (backend#1828: two copies dropped the .strip() and "
+        f"false-rejected a padded CSV header on 3 of 16 categories)."
+    )
+
+
+def test_match_column_delegates_to_the_canonical_rule():
+    """``_match_column`` must BE the canonical rule, not a reimplementation of
+    it — otherwise deleting the copies just moved the divergence up one level.
+
+    Includes the padded-header case (``" label"`` resolved from ``"label"``)
+    that the deleted copies got wrong, and the non-string column label that
+    made them raise ``AttributeError`` where the canonical rule returns a hit.
+    """
+    cases = [
+        (["filename", " label"], "label", " label"),
+        (["label", " filename"], "filename", " filename"),
+        (["filename ", " label"], "filename", "filename "),
+        (["Label"], " label ", "Label"),
+        (["label"], "LABEL", "label"),
+        (["a", "b"], "missing", None),
+        ([0, 1], "0", 0),
+    ]
+    for columns, name, expected in cases:
+        assert BaseValidator._match_column(columns, name) == expected, (
+            columns,
+            name,
+        )
+        assert resolve_column(columns, name) == expected, (columns, name)

--- a/tests/test_sentence_pair_validator.py
+++ b/tests/test_sentence_pair_validator.py
@@ -188,3 +188,23 @@ def test_error_cap_summarizes(staged):
     assert not result.is_valid
     assert any("further errors suppressed" in e for e in result.errors)
     assert len(result.errors) <= 51
+
+
+def test_csv_padded_filename_header_still_resolves(staged, tmp_path):
+    """A padded ``filename`` header (``label, filename``) must resolve, not
+    report the column missing.
+
+    Regression (backend#1828): the shared TabSeparatedRecordValidator base
+    carried a private ``_resolve_column`` that lower-cased without stripping,
+    so ``sentence_pair_classification`` rejected a manifest whose ``filename``
+    column was visibly present but not the first CSV field. Mirrors
+    tests/test_contrastive_pairs_validator.py.
+    """
+    texts, _ = staged
+    (texts / "pair.txt").write_text("text a\ttext b\n", encoding="utf-8")
+    path = tmp_path / "padded.csv"
+    path.write_text("label, filename\npos,pair\n", encoding="utf-8")
+
+    result = SentencePairValidator(texts_path="texts").validate(str(path))
+
+    assert result.is_valid, result.errors

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.8"
+__version__ = "0.8.9"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/file_transfer.py
+++ b/tracebloc_ingestor/file_transfer.py
@@ -20,6 +20,10 @@ from tenacity import (
 )
 
 from tracebloc_ingestor import Config
+from tracebloc_ingestor.storage_contract import (
+    EXTENSION_COLUMN,
+    IMAGE_NAME_COLUMN,
+)
 from tracebloc_ingestor.utils.fs import DEST_DIR_MODE as _DEST_DIR_MODE
 from tracebloc_ingestor.utils.fs import ensure_reclaimable_dir
 from tracebloc_ingestor.utils.constants import (
@@ -259,8 +263,12 @@ def image_transfer(
         # Copy file with retry logic
         _copy_file_with_retry(src_path, image_dest_path)
 
-        record["filename"] = os.path.splitext(filename_with_ext)[0]
-        record["extension"] = extension
+        # THE contract (backend#1706): the stem the file was just written under
+        # is what lands in the ``filename`` column, and that column — never
+        # ``data_id`` — is how the trainer resolves this row back to the file.
+        # See tracebloc_ingestor.storage_contract.
+        record[IMAGE_NAME_COLUMN] = os.path.splitext(filename_with_ext)[0]
+        record[EXTENSION_COLUMN] = extension
 
         logger.info(f"{GREEN}Successfully copied image: {filename}{RESET}")
         return record

--- a/tracebloc_ingestor/identifiers.py
+++ b/tracebloc_ingestor/identifiers.py
@@ -2,8 +2,15 @@
 
 This module is the authoritative definition of what counts as a valid *column*
 identifier across the tracebloc platform. It is deliberately dependency-light
-(stdlib only) so the trainer (``tracebloc-client``) can mirror it verbatim
-without taking a dependency on the rest of this package.
+(stdlib only) so the trainer (``tracebloc-engine`` — renamed from
+``tracebloc-client``) can mirror it verbatim without taking a dependency on the
+rest of this package.
+
+It is published machine-readably as ``schema/column_identifier.v1.json``, pinned
+to this module in both directions by ``tests/test_column_identifier_schema.py``.
+Consumers should GENERATE their cases from that file rather than transcribing
+the table below: two hand-copied copies is what let ISSUE #382's disagreement
+stay silent until training (backend#1780).
 
 The reconciliation (ISSUE #382)
 -------------------------------

--- a/tracebloc_ingestor/ingestors/record_processor.py
+++ b/tracebloc_ingestor/ingestors/record_processor.py
@@ -31,6 +31,11 @@ from typing import Any, Dict, Optional
 
 import pandas as pd
 
+from ..storage_contract import (
+    EXTENSION_COLUMN,
+    IMAGE_NAME_COLUMN,
+    ROW_ID_COLUMN,
+)
 from ..utils.constants import Intent
 
 logger = logging.getLogger(__name__)
@@ -189,16 +194,16 @@ class RecordProcessor:
                 # collide and the upsert would collapse the dataset. It is
                 # merged here (not read from cleaned_record) because process()
                 # attaches filename only AFTER this method returns.
-                cleaned_record["data_id"] = self._content_hash(
-                    {**cleaned_record, "filename": record.get("filename")}
+                cleaned_record[ROW_ID_COLUMN] = self._content_hash(
+                    {**cleaned_record, IMAGE_NAME_COLUMN: record.get(IMAGE_NAME_COLUMN)}
                 )
             else:
-                cleaned_record["data_id"] = str(uuid.uuid4())
+                cleaned_record[ROW_ID_COLUMN] = str(uuid.uuid4())
             return cleaned_record
 
         unique_id = record.get(self.unique_id_column)
         if unique_id is not None and str(unique_id).strip():
-            cleaned_record["data_id"] = str(unique_id).strip()
+            cleaned_record[ROW_ID_COLUMN] = str(unique_id).strip()
             return cleaned_record
         else:
             logger.warning(
@@ -295,8 +300,8 @@ class RecordProcessor:
 
             # Add ingestor_id to the record
             cleaned_record["ingestor_id"] = self.ingestor_id
-            cleaned_record["filename"] = record.get("filename")
-            cleaned_record["extension"] = record.get("extension")
+            cleaned_record[IMAGE_NAME_COLUMN] = record.get(IMAGE_NAME_COLUMN)
+            cleaned_record[EXTENSION_COLUMN] = record.get(EXTENSION_COLUMN)
             # The cleaned record carries ONLY schema-declared DB columns +
             # framework columns. A sidecar's link column is a table column IFF
             # the schema declares it: semantic_segmentation MUST declare mask_id

--- a/tracebloc_ingestor/schema/column_identifier.v1.json
+++ b/tracebloc_ingestor/schema/column_identifier.v1.json
@@ -1,0 +1,81 @@
+{
+  "version": "1",
+  "description": "Canonical column-identifier grammar (ISSUE #382). The authoritative definition lives in tracebloc_ingestor/identifiers.py; this file is that definition published machine-readably so the trainer (tracebloc-engine) can GENERATE its contract cases from it instead of transcribing them. Before this file existed, both repos carried hand-copied copies of the case table below and each side's comments claimed the other kept it honest — but nothing crossed the repo boundary, so either could change and both suites would stay green. That is the mechanism that made #382 silent until training (backend#1780).",
+  "rule": "Quote-and-allow: a column name is valid iff it can be safely backtick-quoted for MySQL. Every character except NUL is permitted and made safe by quoting; length is the one constraint quoting cannot rescue.",
+  "max_length": 64,
+  "max_length_reason": "MySQL's maximum identifier length. The one column-name constraint that backtick-quoting cannot work around, so both repos hard-fail above it.",
+  "forbidden_characters": [
+    {
+      "codepoint": "U+0000",
+      "name": "NUL",
+      "reason": "illegal in a MySQL identifier"
+    }
+  ],
+  "quoting": {
+    "style": "backtick",
+    "escape": "double the backtick",
+    "example": {
+      "input": "we`ird",
+      "output": "`we``ird`"
+    },
+    "reason": "Matches MySQL's identifier quoting rules and what SQLAlchemy emits in the ingestor's CREATE TABLE DDL, so any valid name is rendered injection-safe."
+  },
+  "not_covered": "TABLE names, which are stricter and validated separately (TableNameValidator here, _validate_sql_identifier in the trainer). Table names are platform-controlled; column names come from raw user data.",
+  "cases": [
+    {
+      "name": "123_gene",
+      "valid": true,
+      "why": "digit-leading — quotable"
+    },
+    {
+      "name": "_ok",
+      "valid": true,
+      "why": "leading underscore"
+    },
+    {
+      "name": "feature-1",
+      "valid": true,
+      "why": "hyphen — quotable"
+    },
+    {
+      "name": "col name",
+      "valid": true,
+      "why": "space — quotable"
+    },
+    {
+      "name": "P08254|MMP3",
+      "valid": true,
+      "why": "proteomics pipe header (#184/#185)"
+    },
+    {
+      "name": "Körpergröße",
+      "valid": true,
+      "why": "clinical unicode header (#739)"
+    },
+    {
+      "name": "feature.1",
+      "valid": true,
+      "why": "dot"
+    },
+    {
+      "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "valid": true,
+      "why": "exactly 64 — boundary OK"
+    },
+    {
+      "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "valid": false,
+      "why": "65 characters — too long"
+    },
+    {
+      "name": "",
+      "valid": false,
+      "why": "empty"
+    },
+    {
+      "name": "bad\u0000col",
+      "valid": false,
+      "why": "NUL — illegal in a MySQL identifier"
+    }
+  ]
+}

--- a/tracebloc_ingestor/storage_contract.py
+++ b/tracebloc_ingestor/storage_contract.py
@@ -1,0 +1,127 @@
+"""Canonical ingest → trainer STORAGE contract — the single source of truth.
+
+Where :mod:`tracebloc_ingestor.identifiers` pins what a column may be *called*,
+this module pins what the framework columns *mean* and how a stored row maps
+back to the sidecar file it describes. Same reason, same shape: it is
+deliberately dependency-light (stdlib only, no package imports) so the trainer
+(``tracebloc-engine``) can mirror it verbatim — see
+``core/utils/ingest_contract.py`` there, and the mirrored case table in
+``tests/test_ingest_storage_contract.py`` / ``core/tests/contracts/`` that keeps
+the two copies from drifting.
+
+The invariant
+-------------
+For a file-bearing category the ingestor copies the sidecar to::
+
+    <DEST_PATH>/<manifest filename><extension>
+
+and stores that stem in the **``filename``** column
+(``file_transfer.image_transfer``). Therefore:
+
+    **A trainer resolves a row to its file through ``filename``.
+    ``data_id`` names nothing on disk.**
+
+``data_id`` is an *independent* row identifier whose value depends on the run's
+``data_id`` strategy — a salted content hash (the default since #350), a UUID,
+or a copy of some source column. Only ``strategy=column`` over ``filename``
+makes the two coincide, and that coincidence is not part of the contract.
+
+Why this module exists (backend#1706, follow-up to tracebloc-engine#615)
+------------------------------------------------------------------------
+Two of the shipped Python templates — ``keypoint_detection`` and
+``semantic_segmentation`` — set ``unique_id_column="filename"``, aliasing
+``data_id`` to the on-disk stem. Those are precisely the two categories whose
+trainer readers keyed on ``data_id``; the templates were papering over the
+reader bug. When #350 flipped the default strategy ``uuid`` → ``content_hash``
+nothing failed here, and every CLI/YAML-ingested keypoint or semseg dataset
+crashed on the first training batch instead. Three facts had to agree and
+nothing pinned any of them. They are pinned here now.
+"""
+
+# ── Framework columns every ingested row carries ────────────────────────────
+# The stem of the sidecar file on disk. THE column a trainer resolves files
+# through.
+IMAGE_NAME_COLUMN = "filename"
+
+# The row's opaque identity. Independent of the on-disk name — see the module
+# docstring. Never use it to build a path.
+ROW_ID_COLUMN = "data_id"
+
+# The extension the sidecar was written with, e.g. ".jpg". Advisory: the
+# ingestor may write ``.jpeg`` where a training default says ``.jpg``, so a
+# reader probes rather than trusting this cell.
+EXTENSION_COLUMN = "extension"
+
+# Per-row semantic-segmentation mask file, resolved the same way as the image
+# (backend#816). Present only when the manifest declares it.
+MASK_NAME_COLUMN = "mask_id"
+
+# Per-row object-detection annotation payload / pointer.
+ANNOTATION_COLUMN = "annotation"
+
+# The columns that can name a file on disk, in the order a reader must try
+# them. ``filename`` first because it is what the file is actually named
+# after; ``data_id`` remains a fallback ONLY for legacy datasets ingested
+# before the ``filename`` column existed, and for template-built datasets
+# where the two coincide.
+IMAGE_NAME_COLUMNS = (IMAGE_NAME_COLUMN, ROW_ID_COLUMN)
+
+# ── data_id strategies ──────────────────────────────────────────────────────
+# Every way an ingest can mint ``data_id`` (``cli/conventions.py``,
+# ``RecordProcessor._map_unique_id``).
+DATA_ID_STRATEGIES = ("content_hash", "uuid", "column")
+
+# The default since #350 (commit 913dd7a, ships in v0.7.5+): a deterministic
+# salted SHA-256 so a retried k8s Job re-claims its rows instead of
+# duplicating them. It was ``uuid`` before.
+DEFAULT_DATA_ID_STRATEGY = "content_hash"
+
+# Strategies under which ``data_id`` is guaranteed NOT to name a file on disk.
+# ``column`` is absent not because it names one but because it *may* — when
+# pointed at ``filename`` — which is exactly the coincidence that hid #615.
+OPAQUE_DATA_ID_STRATEGIES = frozenset({"content_hash", "uuid"})
+
+# ── On-disk naming ──────────────────────────────────────────────────────────
+# Image suffixes the pipeline recognises, lower-cased. Matching is
+# case-insensitive on both sides: the ingestor lower-cases before comparing
+# (``file_transfer._has_extension``), the trainer probes the upper-cased
+# variants too.
+RECOGNISED_IMAGE_SUFFIXES = (".jpeg", ".jpg", ".png")
+
+
+def has_recognised_extension(name: object) -> bool:
+    """True when ``name`` already ends in a recognised image suffix (any case).
+
+    Splits on the LAST dot only, so a manifest name that carries dots of its
+    own (``image.001.jpg``) is judged on ``.jpg`` alone.
+    """
+    text = "" if name is None else str(name)
+    _head, dot, suffix = text.rpartition(".")
+    return bool(dot) and f".{suffix.lower()}" in RECOGNISED_IMAGE_SUFFIXES
+
+
+def strip_image_extension(name: object) -> str:
+    """Return ``name`` without a trailing **recognised** image extension.
+
+    Deliberately neither ``name.split(".")[0]`` nor ``Path(name).stem``: both
+    truncate at a dot belonging to the name itself, and manifests do carry
+    such names (``image.001.jpg``). The ingestor keeps them whole, so a stem
+    that dropped ``.001`` would name no file on disk.
+    """
+    text = str(name)
+    if not has_recognised_extension(text):
+        return text
+    return text.rpartition(".")[0]
+
+
+def stored_image_name(filename: object, extension: object) -> str:
+    """The basename the ingestor writes for ``filename`` under ``extension``.
+
+    Mirrors ``file_transfer._find_src``'s default (non-forced) mode: a manifest
+    value that already carries a recognised extension names that very file and
+    keeps it; a bare stem gets ``extension`` appended.
+    """
+    text = str(filename)
+    if has_recognised_extension(text):
+        return text
+    return f"{text}{extension}"

--- a/tracebloc_ingestor/validators/base.py
+++ b/tracebloc_ingestor/validators/base.py
@@ -168,15 +168,26 @@ class BaseValidator(ABC):
         because ``CSVIngestor`` strips header whitespace on read
         (``chunk.columns.str.strip()``) — so a header like ``" label "`` is
         ingested as ``label`` and must resolve here too, or a manifest that
-        ingests fine fails preflight as if the column were missing (matches
-        ``LabelDiversityValidator._resolve_column``). The ORIGINAL column name
-        is returned so callers can still index the (un-stripped) raw frame.
+        ingests fine fails preflight as if the column were missing. The
+        ORIGINAL column name is returned so callers can still index the
+        (un-stripped) raw frame.
 
         The rule is single-sourced in
         :func:`tracebloc_ingestor.utils.columns.resolve_column` so the ingest
         read path resolves the label column identically — the two used to
         diverge (validators case-insensitive, ``RecordProcessor`` exact),
         silently nulling every label (#340).
+
+        **This method is the ONLY resolver a validator may use.** Three
+        validators once carried private ``_resolve_column`` copies instead;
+        two of them dropped the ``.strip()``, so ``token_classification`` /
+        ``sentence_pair_classification`` / ``embeddings`` false-rejected a
+        header Excel writes by default (``filename, label``) as a missing
+        column, while sibling validators in the SAME preflight run resolved it
+        (backend#1828, reintroducing #340 / bugbot #252). The copies are gone
+        and ``tests/test_no_shadowed_column_resolver.py`` fails if one comes
+        back — a shadow is invisible to a reader, so the guard is structural,
+        not a review convention.
         """
         from ..utils.columns import resolve_column
 

--- a/tracebloc_ingestor/validators/bio_label_validator.py
+++ b/tracebloc_ingestor/validators/bio_label_validator.py
@@ -22,7 +22,7 @@ whitespace-tokenized word per token):
 import logging
 import os
 import re
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Tuple
 
 import pandas as pd
 
@@ -80,8 +80,8 @@ class BIOLabelValidator(BaseValidator):
                     is_valid=False, errors=["No data found to validate"]
                 )
 
-            filename_col = self._resolve_column(df, self.filename_column)
-            label_col = self._resolve_column(df, self.label_column)
+            filename_col = self._match_column(df.columns, self.filename_column)
+            label_col = self._match_column(df.columns, self.label_column)
             missing = []
             if filename_col is None:
                 missing.append(self.filename_column)
@@ -215,11 +215,3 @@ class BIOLabelValidator(BaseValidator):
             f"type). Valid under IOB1 but malformed under IOB2; if you intended "
             f"IOB2, the entity should start with 'B-'."
         ]
-
-    @staticmethod
-    def _resolve_column(df: pd.DataFrame, name: str) -> Optional[str]:
-        """Return the actual column name matching ``name`` case-insensitively."""
-        if name in df.columns:
-            return name
-        lowered = {c.lower(): c for c in df.columns}
-        return lowered.get(name.lower())

--- a/tracebloc_ingestor/validators/label_diversity_validator.py
+++ b/tracebloc_ingestor/validators/label_diversity_validator.py
@@ -81,7 +81,7 @@ class LabelDiversityValidator(BaseValidator):
                     metadata={"rows_checked": 0, "label_column": self.label_column},
                 )
 
-            col = self._resolve_column(df, self.label_column)
+            col = self._match_column(df.columns, self.label_column)
             if col is None:
                 # The label column isn't in the CSV — caller's
                 # responsibility to surface (DataValidator or the
@@ -219,7 +219,7 @@ class LabelDiversityValidator(BaseValidator):
                 # #252, medium) — or (b) build a ``usecols`` spelling
                 # pandas then rejected, erroring the read.
                 header_df = pd.read_csv(path, nrows=0, encoding="utf-8")
-                actual = self._resolve_column(header_df, self.label_column)
+                actual = self._match_column(header_df.columns, self.label_column)
                 if actual is None:
                     # Label column genuinely absent — benign skip; the
                     # ingestor / DataValidator report the missing column.
@@ -309,22 +309,4 @@ class LabelDiversityValidator(BaseValidator):
             return self.schema[actual]
         target = str(actual).strip().lower()
         normalised = {str(k).strip().lower(): v for k, v in self.schema.items()}
-        return normalised.get(target)
-
-    @staticmethod
-    def _resolve_column(df: pd.DataFrame, name: str) -> Optional[str]:
-        """Return the actual column name matching ``name`` case- AND
-        whitespace-insensitively.
-
-        CSVIngestor strips column-name whitespace on read
-        (``chunk.columns.str.strip()``), so a header like ``" label "`` is
-        ingested as ``label``. Resolving against the raw header without the
-        same strip treated the column as missing, skipped the diversity check
-        with a warning, and let a single-class CSV pass preflight (bugbot
-        #252). Match the strip here so the gate sees the same column the
-        ingestor does."""
-        if name in df.columns:
-            return name
-        target = str(name).strip().lower()
-        normalised = {str(c).strip().lower(): c for c in df.columns}
         return normalised.get(target)

--- a/tracebloc_ingestor/validators/tab_separated_record_validator.py
+++ b/tracebloc_ingestor/validators/tab_separated_record_validator.py
@@ -104,7 +104,7 @@ class TabSeparatedRecordValidator(BaseValidator):
                 # IngestableRecordsValidator's job, not this one.
                 return self._create_result(is_valid=True, metadata={"rows_checked": 0})
 
-            filename_col = self._resolve_column(df, self.filename_column)
+            filename_col = self._match_column(df.columns, self.filename_column)
             if filename_col is None:
                 return self._create_result(
                     is_valid=False,
@@ -219,11 +219,3 @@ class TabSeparatedRecordValidator(BaseValidator):
             )
 
         return None
-
-    @staticmethod
-    def _resolve_column(df: Any, name: str) -> Optional[str]:
-        """Return the actual column name matching ``name`` case-insensitively."""
-        if name in df.columns:
-            return name
-        lowered = {c.lower(): c for c in df.columns}
-        return lowered.get(name.lower())


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-main` branch (a mirror of `staging`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes published package semantics (storage columns, preflight validation) and cross-repo artifacts tracebloc-engine must mirror; risk is mitigated by extensive contract/e2e tests and the version bump, but coordinated engine rollout matters.
> 
> **Overview**
> **Release train promotion** bundling cross-repo contract work, a preflight bugfix, and **0.8.8 → 0.8.9**.
> 
> Adds **`storage_contract.py`** as the stdlib-only source of truth for framework columns (`filename`, `data_id`, `extension`, etc.) and the rule that on-disk images are named from **`filename`**, not opaque **`data_id`** — wired through **`file_transfer`** and **`record_processor`**. Unit tests plus golden **`ingested_image_rows.json`** pin real ingest output; **`e2e/test_image_lookup_contract_e2e.py`** checks MySQL round-trips against the trainer’s image-resolution rule (backend#1706 / engine#615).
> 
> Publishes **`schema/column_identifier.v1.json`** and **`tests/test_column_identifier_schema.py`** so column-identifier grammar is machine-readable and bidirectionally pinned to **`identifiers.py`** (backend#1780).
> 
> **backend#1828:** removes duplicate **`_resolve_column`** helpers from BIO/tab-separated/label-diversity validators in favor of **`BaseValidator._match_column`** (fixes padded CSV headers like `filename, label`); adds **`test_no_shadowed_column_resolver.py`** and per-validator regressions.
> 
> Also adds a GitHub **PR template**, documents **`storage_contract`** in **CLAUDE.md** / **e2e README**, and minor formatting in existing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de93c3d3b8124ecde474f83d0fa2670d7161f8d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->