### PR TITLE
ci(1606): tests.yml calls `make coverage`, and the "exactly" claim becomes true

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,13 +47,21 @@ jobs:
           pip install -e .
 
       - name: Run pytest with coverage
-        run: |
-          pytest \
-            --cov=tracebloc_ingestor \
-            --cov-report=term \
-            --cov-report=xml \
-            --cov-report=html \
-            --cov-fail-under=95
+        # `make coverage` (backend#1606). The Makefile's comment on that target
+        # claimed it was "tests.yml exactly"; it was not — this step invoked a
+        # bare `pytest` while the target scoped to tests/. Now the claim is
+        # structural instead of maintained by hand.
+        #
+        # That scope change applies here: a bare `pytest` also collected e2e/,
+        # which SKIPS ITSELF in this job for want of a MySQL service. The e2e
+        # suite has its own required check (`e2e (real MySQL)`) that runs it
+        # against a real database, so nothing stops being tested — this job just
+        # stops collecting six files it was never going to execute.
+        #
+        # The scope is not a detail to "fix" back: a bare pytest on a developer
+        # machine with MySQL up runs real ingestion that creates and drops
+        # tables (Bugbot, #461), which is why the Makefile is the narrow one.
+        run: make coverage
 
       - name: Coverage summary
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,28 @@ lint:
 test:
 	$(PYTEST) tests/ -q
 
-# coverage: tests.yml exactly — the 95% floor included.
+# coverage: tests.yml's pytest job exactly — the 95% floor and the HTML report
+# it uploads as an artifact.
+#
+# "Exactly" is now STRUCTURAL: tests.yml calls this target (backend#1606). It
+# claimed "exactly" before and was not — the workflow invoked a bare `pytest`
+# and added --cov-report=html, so the two differed in both scope and output
+# while a comment here asserted they did not.
+#
+# THE tests/ SCOPE NOW APPLIES TO CI TOO, and that is the right direction of
+# travel rather than a concession. Scoping is the deliberate decision from
+# `test` above (Bugbot, #461): a bare `pytest` also collects e2e/, which on a
+# developer machine with a MySQL up would run real ingestion that creates and
+# drops tables. The Makefile must not widen to match CI.
+#
+# Narrowing CI loses nothing measurable: e2e/ skips itself in that job for want
+# of a MySQL, and the e2e suite has its own REQUIRED check (`e2e (real MySQL)`,
+# e2e.yml) that runs it against a real database. A unit-coverage job measuring
+# a suite that is skipped by construction was never the intent.
 .PHONY: coverage
 coverage:
-	$(PYTEST) tests/ --cov=tracebloc_ingestor --cov-report=term --cov-report=xml --cov-fail-under=95
+	$(PYTEST) tests/ --cov=tracebloc_ingestor --cov-report=term --cov-report=xml \
+	  --cov-report=html --cov-fail-under=95
 
 # e2e: e2e.yml — real ingestion against a real MySQL with an in-process
 # mock backend. Needs a database, hence the explicit target rather than


### PR DESCRIPTION
Part of backend#1606, under epic backend#1680. Fourth repo in the CI-parity fan-out (backend#1962, client-runtime#329, averaging-service#346) — and the first where the two sides **genuinely differed** rather than being identical copies.

## A comment that asserted parity over a pair that had drifted

The Makefile said, in so many words:

```make
# coverage: tests.yml exactly — the 95% floor included.
```

It was not exactly:

| | Makefile `coverage` | `tests.yml` |
|---|---|---|
| scope | `pytest tests/` | **bare `pytest`** (also collects `e2e/`) |
| html report | — | `--cov-report=html` |

A comment claiming parity, over a pair that had drifted in both scope and output, is the *docstring-that-should-be-a-machine-check* pattern the workspace rules call out. This makes the claim structural: tests.yml calls the target.

## The scope moves CI-ward, not Makefile-ward — deliberately

`tests/` is a **safety decision** (Bugbot, #461). A bare `pytest` also collects `e2e/`, so on a developer machine with MySQL up — or `DB_NAME`/`DB_USER` exported — `make check` would quietly run real ingestion that **creates and drops tables**. Widening the Makefile to match CI would reintroduce exactly that hazard.

**Narrowing CI loses nothing measurable:**

- `e2e/conftest.py` skips the suite unless a MySQL is reachable, and the `pytest` job has no MySQL service — so those 6 files are collected and never executed
- the e2e suite has its **own required check**, `e2e (real MySQL)` (e2e.yml), which runs it against a real database

So this job stops collecting six files it was never going to run, and nothing stops being tested.

`--cov-report=html` moves into the target so the artifact upload still finds `htmlcov/`.

## Job name and matrix untouched

`pytest (3.11)` and `pytest (3.12)` are **required status checks**, matched by name. The job id, name and 3.11/3.12 matrix all re-parse unchanged.

## Verification

- `make -n coverage` now carries every flag this step had, including `--cov-report=html`
- 6 test files confirmed under `e2e/`, 91 under `tests/`; `e2e/conftest.py`'s skip-without-MySQL logic read directly
- YAML re-parsed: job name and matrix preserved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only test orchestration change; behavior tightens to the existing Makefile target with no production code touched.
> 
> **Overview**
> **CI now runs `make coverage` instead of duplicating pytest flags in the workflow**, so local `make check-all` and the `pytest` matrix job share one definition for the 95% floor, XML/term/HTML coverage output, and `tests/`-only collection.
> 
> The workflow step documents why scope narrows from bare `pytest` to **`tests/`**: e2e was only collected in CI without MySQL (skipped anyway) while a bare invoke on a dev machine with MySQL could run destructive ingestion (#461). **`make coverage` adds `--cov-report=html`** so the existing HTML artifact upload still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9808170cc7ac24e3b29722dfc7df9ad7a556be03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->