### PR TITLE
chore(devex): install a `make check` pre-push hook via `make setup` (backend#1606)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ help:
 	@echo "  check       lint + the unit suite (~11 s) — run this before every push"
 	@echo "  check-all   everything CI runs, including the 95% coverage gate"
 	@echo "  setup       pip install -r requirements-dev.txt && pip install -e ."
+	@echo "  install-hooks  (re)install the git pre-push hook that runs 'make check'"
 	@echo
 	@echo "  individual: lint test coverage e2e"
 	@echo
@@ -69,6 +70,7 @@ setup:
 	$(PYTHON) -m pip install -e .
 	$(PYTHON) -m pip install "ruff==$(RUFF_VERSION)"
 	@echo "==> setup: dependencies installed; run 'make check'"
+	@$(MAKE) --no-print-directory install-hooks
 
 # ---- individual targets ------------------------------------------
 
@@ -127,3 +129,71 @@ coverage:
 .PHONY: e2e
 e2e:
 	$(PYTEST) e2e/ -v
+
+# install-hooks: put a pre-push hook in place that runs `make check`, so the
+# canon's "run the tests before you push" is carried by the tooling rather than
+# by memory. Factored out of `setup` so it is independently runnable and
+# testable, and so a contributor who only wants the hook need not rerun the
+# full `make setup`.
+#
+# Honest by design: the hook catches FORGETTING, not defiance — `git push
+# --no-verify` skips it and always will. And it refuses to clobber a pre-push
+# hook that is already there and not ours (e.g. one the pre-commit framework
+# manages), rather than silently stomping a contributor's setup.
+#
+# `git rev-parse --git-path hooks` (not a hard-coded `.git/hooks`) so it lands
+# in the right place inside a linked worktree or a submodule, where the git dir
+# is not `.git`.
+.PHONY: install-hooks
+install-hooks:
+	@if ! git rev-parse --git-dir >/dev/null 2>&1; then \
+	  echo "note: not a git checkout — skipping pre-push hook install"; \
+	elif hp="$$(git config --get core.hooksPath 2>/dev/null || true)"; [ -n "$$hp" ] && { \
+	       hd="$$(git rev-parse --git-path hooks)"; \
+	       case "$$hd" in /*) hdd="$$hd";; *) hdd="$$PWD/$$hd";; esac; \
+	       cpar="$$(cd "$$(dirname "$$hdd")" 2>/dev/null && pwd -P || true)"; \
+	       ctop="$$(cd "$$(git rev-parse --show-toplevel)" && pwd -P)"; \
+	       [ -z "$$cpar" ] || case "$$cpar/" in "$$ctop/"*) false;; *) true;; esac; \
+	     }; then \
+	  echo "note: core.hooksPath is set to '$$hp', outside this repo — skipping."; \
+	  echo "      That is a shared hooks dir; installing here would run 'make check' from every repo you push."; \
+	  echo "      Add 'make check' to that hook by hand if you want it everywhere."; \
+	else \
+	  hook="$$(git rev-parse --git-path hooks)/pre-push"; \
+	  if [ -e "$$hook" ] && ! grep -q 'tracebloc pre-push hook' "$$hook" 2>/dev/null; then \
+	    echo "note: $$hook already exists and is not ours — leaving it untouched."; \
+	    echo "      add 'make check' to it, or remove it and re-run 'make install-hooks'."; \
+	  else \
+	    mkdir -p "$$(dirname "$$hook")" && \
+	    printf '%s\n' \
+	      '#!/bin/sh' \
+	      '# tracebloc pre-push hook installed by make setup (backend#1606).' \
+	      '# Runs make check so a push that would be red in CI is caught locally first.' \
+	      '# It catches forgetting, not defiance: git push --no-verify skips it.' \
+	      '#' \
+	      '# Nothing to check on a delete/no-op push: a branch delete streams a' \
+	      '# local sha of all-zeros on stdin (no new commits). Skip so a red tree' \
+	      '# cannot block "git push --delete", and cleanup pushes stay free.' \
+	      'z=0000000000000000000000000000000000000000' \
+	      'had_update=0' \
+	      'while read -r _ local_sha _ _; do' \
+	      '  [ "$$local_sha" != "$$z" ] && had_update=1' \
+	      'done' \
+	      '[ "$$had_update" = 0 ] && exit 0' \
+	      '#' \
+	      '# Degrade gracefully when the toolchain is absent: GUI/IDE git clients' \
+	      '# (Tower, GitKraken, VS Code) launch hooks with a minimal PATH, so make' \
+	      '# may be missing — and several do not expose --no-verify. Skipping beats' \
+	      '# hard-blocking every push with "make: command not found".' \
+	      'command -v make >/dev/null 2>&1 || exit 0' \
+	      '#' \
+	      '# Git exports GIT_DIR/GIT_WORK_TREE/etc into hook processes; a nested git' \
+	      '# invocation (from a test, tool, or setuptools-scm) then fails in a linked' \
+	      '# worktree with exit status 128. Clear them so make check runs as from the shell.' \
+	      'unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY' \
+	      'exec make check' > "$$hook" && \
+	    chmod +x "$$hook" && \
+	    echo "==> pre-push hook installed at $$hook" && \
+	    echo "    'make check' now runs before each push (skip once with: git push --no-verify)"; \
+	  fi; \
+	fi


### PR DESCRIPTION
Part of backend#1606, under epic backend#1680. Takes the pre-push hook fan-out from **10/16 repos to 16/16**.

## What this adds

`make install-hooks` — installs a git pre-push hook that runs `make check`, so "run the tests before you push" is carried by tooling rather than memory. `make setup` now calls it, and it stays independently runnable for a contributor who wants only the hook.

The target is **byte-identical to the one already in `backend`, `client-runtime`, `cli`, `model-zoo`, `tracebloc-engine` and `client`** — extracted verbatim rather than retyped, so this repo cannot start out drifted from the fleet.

## Honest by design

- Catches **forgetting, not defiance** — `git push --no-verify` skips it and always will.
- **Refuses to clobber** a pre-push hook that is already there and not ours (e.g. one `pre-commit` manages).
- **Skips delete/no-op pushes** — a branch delete streams an all-zeros local sha, so a red tree can't block `git push --delete`.
- **Degrades when `make` is absent** — GUI clients (Tower, GitKraken, VS Code) launch hooks with a minimal PATH and several don't expose `--no-verify`; skipping beats hard-blocking every push.
- Uses `git rev-parse --git-path hooks`, not a hard-coded `.git/hooks`, so it lands correctly in a linked worktree or submodule.
- Clears `GIT_DIR`/`GIT_WORK_TREE`/etc so a nested git call inside `make check` doesn't fail with status 128.

## Verification

Ran `make install-hooks` in a real checkout of this repo and asserted the hook is installed, executable, carries our marker, and its last line is `exec make check`.

Two refusal paths mutation-tested:

- planted a foreign `pre-push` and re-ran the target → **preserved**, with the "not ours — leaving it untouched" notice
- fed the hook an all-zeros local sha (a delete push) → **exit 0**, so cleanup pushes stay free

No CI behaviour changes: this adds a target and wires `setup` to it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only developer workflow change; no runtime, CI, or application code paths are modified.
> 
> **Overview**
> Adds **`make install-hooks`**, which installs a git **pre-push** hook that runs **`make check`** so local pushes are linted and unit-tested before they leave the machine. **`make setup`** now invokes it automatically, and **`make help`** documents the new target.
> 
> The installer is defensive: it no-ops outside a git checkout, skips when **`core.hooksPath`** points at a shared hooks dir outside the repo, and **does not overwrite** an existing foreign pre-push hook. The generated hook skips delete/no-op pushes (all-zero SHAs), exits cleanly if **`make`** is missing (common with GUI git clients), and unsets **`GIT_*`** env vars before **`exec make check`** so nested git calls work in linked worktrees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ae4ec13fce9d2a283fd383f3ba8db78c9c08cb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->