### PR TITLE
ci: move checkout and setup-python off Node 20 before the fallback goes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,9 @@ jobs:
           --health-timeout=3s
           --health-retries=20
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
           cache: pip

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -20,10 +20,10 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -133,7 +133,7 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -30,10 +30,10 @@ jobs:
     # repo secrets -- is best closed by PyPI Trusted Publishing (OIDC), which removes
     # the token entirely with no blocking step; flagged for follow-up, not a settings pass.
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -178,7 +178,7 @@ jobs:
           done
           echo "Dispatcher $ACTOR (triggering: $TRIGGERING_ACTOR) is on the allowlist."
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
           # cosign + buildkit reproducibility benefit from full history.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,9 @@ jobs:
         python: ['3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python }}
           cache: pip

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -17,7 +17,7 @@ jobs:
     name: package change ⇒ __version__ bump
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Require a __version__ bump when the package changes


### PR DESCRIPTION
Part of the fleet-wide sweep tracked in tracebloc/backend#2004. Sibling of tracebloc/backend#2005, which is green.

## Why

Every job in this repo emits:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24.

The forced run is a **temporary GitHub fallback**. When it is withdrawn, every job using these two actions fails. Same defect class as tracebloc/backend#1816, which moved `add-to-project` off `using: node20`.

## Measured, from each tag's own `action.yml`

Read `runs.using` at the tag rather than trusting release prose:

| action | tag | `using:` |
|---|---|---|
| checkout | v4.x *(was pinned here)* | `node20` |
| checkout | v5.1.0 / v6.1.0 / v7.0.1 | `node24` |
| setup-python | v5.x *(was pinned here)* | `node20` |
| setup-python | v6.0.0 / v6.3.0 / v7.0.0 | `node24` |

checkout needs **v5+**, setup-python needs **v6+**. Note v4.4.0 was published 2026-07-20 *alongside* v5.1.0/v6.1.0/v7.0.1 — the v4 line is still maintained but stays on node20, so waiting does not fix this.

## Why latest rather than the minimal v5/v6 hop

- **`cli` already ran exactly these two SHAs** before this sweep, so latest is proven in the org, and the fleet converges on **one pin per action** instead of gaining a third variant.
- One bump instead of two.
- **Neither v7 breaking change applies** — checked per repo, not assumed:
  - *setup-python v7 drops the `pip-install` input* → unused anywhere in the org.
  - *checkout v7 blocks fork-PR checkout under `pull_request_target`/`workflow_run`* → every workflow's **resolved triggers were parsed as YAML**, not grepped, so a comment naming a trigger cannot be mistaken for using one. No workflow in this repo pairs those triggers with a checkout.

This also normalises the pin comments: some lines carried a bare `# v4`, which is a mutable major alias in comment form rather than the full-semver convention.

## Verification

- `git diff -U0` inspected: **only `uses:` lines changed**, in either direction
- Every workflow in the repo still parses as YAML
- Anchor asserted: no occurrence of any old SHA survives under `.github/workflows/`
- CI on this PR is the real proof **for the two actions in scope**: `checkout` and `setup-python` no longer appear in the run's Node 20 deprecation annotation, with no other behavioural change.
- **The annotation itself does not disappear, and should not be read as the pass/fail signal.** This repo still pins 3 other action(s) whose `action.yml` declares `using: node20` (`actions/upload-artifact` ×2, `actions/download-artifact` ×1, `actions/stale` ×1) — out of scope here, measured the same way (read `runs.using` at the pinned SHA).
- In caller repos the `quality / *` jobs come from `code-quality.yml@main`, so their annotation also keeps naming the old `checkout` pin until `.github` promotes develop → main. That is a sequencing artefact of the reusable, not a defect in this PR.

## Ordering

No sequencing constraint. `caller-drift.py` byte-compares only the entries marked `copies:` in `repo-inventory.yml`, and **there are none fleet-wide** — so these PRs may merge in any order, including `.github`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin updates with no application or secret-handling changes; behavior should match aside from the Node runtime for those actions.
> 
> **Overview**
> Updates **GitHub Actions** pins fleet-wide so jobs stop running on deprecated Node 20 (and avoid failure when GitHub removes the forced Node 24 fallback).
> 
> **`actions/checkout`** moves from v4.4.0 to **v7.0.1** in `e2e`, `publish-dev`, `publish-images`, `publish-main`, `release-image`, `tests`, and `version-guard`. **`actions/setup-python`** moves from v5.6.0 to **v7.0.0** everywhere it appears (`e2e`, `publish-dev`, `publish-main`, `tests`). No step inputs, triggers, or job logic change—only the `uses:` SHAs and version comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03cda240f52e353b5cc3fa304329264fb3fb8df5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
