### PR TITLE
release-train: staging -> main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,13 +47,21 @@ jobs:
           pip install -e .
 
       - name: Run pytest with coverage
-        run: |
-          pytest \
-            --cov=tracebloc_ingestor \
-            --cov-report=term \
-            --cov-report=xml \
-            --cov-report=html \
-            --cov-fail-under=95
+        # `make coverage` (backend#1606). The Makefile's comment on that target
+        # claimed it was "tests.yml exactly"; it was not — this step invoked a
+        # bare `pytest` while the target scoped to tests/. Now the claim is
+        # structural instead of maintained by hand.
+        #
+        # That scope change applies here: a bare `pytest` also collected e2e/,
+        # which SKIPS ITSELF in this job for want of a MySQL service. The e2e
+        # suite has its own required check (`e2e (real MySQL)`) that runs it
+        # against a real database, so nothing stops being tested — this job just
+        # stops collecting six files it was never going to execute.
+        #
+        # The scope is not a detail to "fix" back: a bare pytest on a developer
+        # machine with MySQL up runs real ingestion that creates and drops
+        # tables (Bugbot, #461), which is why the Makefile is the narrow one.
+        run: make coverage
 
       - name: Coverage summary
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,28 @@ lint:
 test:
 	$(PYTEST) tests/ -q
 
-# coverage: tests.yml exactly — the 95% floor included.
+# coverage: tests.yml's pytest job exactly — the 95% floor and the HTML report
+# it uploads as an artifact.
+#
+# "Exactly" is now STRUCTURAL: tests.yml calls this target (backend#1606). It
+# claimed "exactly" before and was not — the workflow invoked a bare `pytest`
+# and added --cov-report=html, so the two differed in both scope and output
+# while a comment here asserted they did not.
+#
+# THE tests/ SCOPE NOW APPLIES TO CI TOO, and that is the right direction of
+# travel rather than a concession. Scoping is the deliberate decision from
+# `test` above (Bugbot, #461): a bare `pytest` also collects e2e/, which on a
+# developer machine with a MySQL up would run real ingestion that creates and
+# drops tables. The Makefile must not widen to match CI.
+#
+# Narrowing CI loses nothing measurable: e2e/ skips itself in that job for want
+# of a MySQL, and the e2e suite has its own REQUIRED check (`e2e (real MySQL)`,
+# e2e.yml) that runs it against a real database. A unit-coverage job measuring
+# a suite that is skipped by construction was never the intent.
 .PHONY: coverage
 coverage:
-	$(PYTEST) tests/ --cov=tracebloc_ingestor --cov-report=term --cov-report=xml --cov-fail-under=95
+	$(PYTEST) tests/ --cov=tracebloc_ingestor --cov-report=term --cov-report=xml \
+	  --cov-report=html --cov-fail-under=95
 
 # e2e: e2e.yml — real ingestion against a real MySQL with an in-process
 # mock backend. Needs a database, hence the explicit target rather than

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ help:
 	@echo "  check       lint + the unit suite (~11 s) — run this before every push"
 	@echo "  check-all   everything CI runs, including the 95% coverage gate"
 	@echo "  setup       pip install -r requirements-dev.txt && pip install -e ."
+	@echo "  install-hooks  (re)install the git pre-push hook that runs 'make check'"
 	@echo
 	@echo "  individual: lint test coverage e2e"
 	@echo
@@ -69,6 +70,7 @@ setup:
 	$(PYTHON) -m pip install -e .
 	$(PYTHON) -m pip install "ruff==$(RUFF_VERSION)"
 	@echo "==> setup: dependencies installed; run 'make check'"
+	@$(MAKE) --no-print-directory install-hooks
 
 # ---- individual targets ------------------------------------------
 
@@ -127,3 +129,71 @@ coverage:
 .PHONY: e2e
 e2e:
 	$(PYTEST) e2e/ -v
+
+# install-hooks: put a pre-push hook in place that runs `make check`, so the
+# canon's "run the tests before you push" is carried by the tooling rather than
+# by memory. Factored out of `setup` so it is independently runnable and
+# testable, and so a contributor who only wants the hook need not rerun the
+# full `make setup`.
+#
+# Honest by design: the hook catches FORGETTING, not defiance — `git push
+# --no-verify` skips it and always will. And it refuses to clobber a pre-push
+# hook that is already there and not ours (e.g. one the pre-commit framework
+# manages), rather than silently stomping a contributor's setup.
+#
+# `git rev-parse --git-path hooks` (not a hard-coded `.git/hooks`) so it lands
+# in the right place inside a linked worktree or a submodule, where the git dir
+# is not `.git`.
+.PHONY: install-hooks
+install-hooks:
+	@if ! git rev-parse --git-dir >/dev/null 2>&1; then \
+	  echo "note: not a git checkout — skipping pre-push hook install"; \
+	elif hp="$$(git config --get core.hooksPath 2>/dev/null || true)"; [ -n "$$hp" ] && { \
+	       hd="$$(git rev-parse --git-path hooks)"; \
+	       case "$$hd" in /*) hdd="$$hd";; *) hdd="$$PWD/$$hd";; esac; \
+	       cpar="$$(cd "$$(dirname "$$hdd")" 2>/dev/null && pwd -P || true)"; \
+	       ctop="$$(cd "$$(git rev-parse --show-toplevel)" && pwd -P)"; \
+	       [ -z "$$cpar" ] || case "$$cpar/" in "$$ctop/"*) false;; *) true;; esac; \
+	     }; then \
+	  echo "note: core.hooksPath is set to '$$hp', outside this repo — skipping."; \
+	  echo "      That is a shared hooks dir; installing here would run 'make check' from every repo you push."; \
+	  echo "      Add 'make check' to that hook by hand if you want it everywhere."; \
+	else \
+	  hook="$$(git rev-parse --git-path hooks)/pre-push"; \
+	  if [ -e "$$hook" ] && ! grep -q 'tracebloc pre-push hook' "$$hook" 2>/dev/null; then \
+	    echo "note: $$hook already exists and is not ours — leaving it untouched."; \
+	    echo "      add 'make check' to it, or remove it and re-run 'make install-hooks'."; \
+	  else \
+	    mkdir -p "$$(dirname "$$hook")" && \
+	    printf '%s\n' \
+	      '#!/bin/sh' \
+	      '# tracebloc pre-push hook installed by make setup (backend#1606).' \
+	      '# Runs make check so a push that would be red in CI is caught locally first.' \
+	      '# It catches forgetting, not defiance: git push --no-verify skips it.' \
+	      '#' \
+	      '# Nothing to check on a delete/no-op push: a branch delete streams a' \
+	      '# local sha of all-zeros on stdin (no new commits). Skip so a red tree' \
+	      '# cannot block "git push --delete", and cleanup pushes stay free.' \
+	      'z=0000000000000000000000000000000000000000' \
+	      'had_update=0' \
+	      'while read -r _ local_sha _ _; do' \
+	      '  [ "$$local_sha" != "$$z" ] && had_update=1' \
+	      'done' \
+	      '[ "$$had_update" = 0 ] && exit 0' \
+	      '#' \
+	      '# Degrade gracefully when the toolchain is absent: GUI/IDE git clients' \
+	      '# (Tower, GitKraken, VS Code) launch hooks with a minimal PATH, so make' \
+	      '# may be missing — and several do not expose --no-verify. Skipping beats' \
+	      '# hard-blocking every push with "make: command not found".' \
+	      'command -v make >/dev/null 2>&1 || exit 0' \
+	      '#' \
+	      '# Git exports GIT_DIR/GIT_WORK_TREE/etc into hook processes; a nested git' \
+	      '# invocation (from a test, tool, or setuptools-scm) then fails in a linked' \
+	      '# worktree with exit status 128. Clear them so make check runs as from the shell.' \
+	      'unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY' \
+	      'exec make check' > "$$hook" && \
+	    chmod +x "$$hook" && \
+	    echo "==> pre-push hook installed at $$hook" && \
+	    echo "    'make check' now runs before each push (skip once with: git push --no-verify)"; \
+	  fi; \
+	fi

--- a/tests/test_error_redaction.py
+++ b/tests/test_error_redaction.py
@@ -121,6 +121,35 @@ def test_hot_loop_does_not_log_record_content(caplog):
     assert SECRET not in caplog.text
 
 
+def test_process_catch_all_never_logs_the_exception_message(caplog, monkeypatch):
+    """The catch-all in ``RecordProcessor.process`` is a content leak by default.
+
+    Everything raised inside that ``try`` has the record's own cells in scope: a
+    driver rejecting a value quotes it, and a plain ``ValueError`` from casting a
+    cell embeds it. So the handler must surface the exception CLASS, never its
+    message (backend#1879).
+
+    Pinned because the fix is a one-line substitution that reads like noise —
+    ``str(e)`` back in place would restore the leak silently, and the engine's
+    identical hole survived for exactly that reason: the concept existed, the
+    coverage did not.
+    """
+    rp = _rp()
+    monkeypatch.setattr(
+        rp,
+        "_map_unique_id",
+        lambda *a, **k: (_ for _ in ()).throw(
+            ValueError(f"bad value {SECRET!r} in column x")
+        ),
+    )
+    with caplog.at_level(logging.ERROR):
+        out = rp.process({"x": 1.0, "y": "a"})
+    assert out is None
+    assert SECRET not in caplog.text  # the whole point
+    assert "ValueError" in caplog.text  # the class is the actionable part
+    assert "Error processing record" in caplog.text
+
+
 def test_safe_db_error_names_classes_never_messages():
     from sqlalchemy.exc import OperationalError
 

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.9"
+__version__ = "0.8.10"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/ingestors/record_processor.py
+++ b/tracebloc_ingestor/ingestors/record_processor.py
@@ -36,6 +36,7 @@ from ..storage_contract import (
     IMAGE_NAME_COLUMN,
     ROW_ID_COLUMN,
 )
+from ..utils import redaction
 from ..utils.constants import Intent
 
 logger = logging.getLogger(__name__)
@@ -315,5 +316,11 @@ class RecordProcessor:
             return cleaned_record
 
         except Exception as e:
-            logger.error(f"Error processing record: {str(e)}")
+            # The residual raw-`str(e)` site in an otherwise-covered package
+            # (backend#1879). Everything raised in here has the record's own
+            # cells in scope, so the message is a content leak by default:
+            # a MySQL type rejection quotes the value, and a plain
+            # `ValueError` from casting a cell embeds it too. The exception
+            # class alone is the actionable part.
+            logger.error(f"Error processing record: {redaction.safe_db_error(e)}")
             return None


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-main` branch (a mirror of `staging`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The ingestor logging change affects error visibility during record processing (privacy-sensitive) but is a small, tested substitution; CI and hook changes alter how tests run locally and in CI without changing ingestion logic.
> 
> **Overview**
> **Release train promotion (0.8.10)** bundles developer workflow alignment, a logging privacy fix, and a version bump.
> 
> `RecordProcessor.process` no longer logs raw exception messages on failure; it uses **`redaction.safe_db_error(e)`** so cell values from driver or cast errors cannot leak into logs (**backend#1879**). A regression test pins that behavior.
> 
> **CI and Makefile** are structurally linked: the Tests workflow’s coverage step now runs **`make coverage`** instead of inline `pytest`, and coverage is scoped to **`tests/`** (with HTML report on the Makefile target) so local runs and CI match and e2e is not collected in the unit job—e2e remains on its dedicated MySQL check.
> 
> **`make install-hooks`** adds an optional pre-push hook (invoked from **`make setup`**) that runs **`make check`**, with guards for existing hooks, `core.hooksPath`, branch deletes, missing `make`, and git env vars in worktrees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d02da8c6c83f1616c4b6d45bff432a8b0668d215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->