### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/workflows/add-to-kanban.yml
+++ b/.github/workflows/add-to-kanban.yml
@@ -10,7 +10,24 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
+      # Board writes authenticate as the tracebloc-release-train App (backend#2036),
+      # not a human's PAT. `owner:` yields an ORG-scoped installation token; a
+      # repo-scoped one cannot write the org project. No fallback to the PAT: a
+      # fallback would let a broken App path keep working silently.
+      #
+      # This workflow also fires on DEPENDABOT PRs, which GitHub gates on a separate
+      # secret scope -- both app secrets are set there too, or Dependabot PRs would
+      # stop reaching the board with `Input required and not supplied`.
+      - name: Mint an installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_TRAIN_APP_ID }}
+          private-key: ${{ secrets.RELEASE_TRAIN_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/tracebloc/projects/2
-          github-token: ${{ secrets.PROJECTS_KANBAN_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
+

--- a/tests/test_duplicate_validator_extra.py
+++ b/tests/test_duplicate_validator_extra.py
@@ -36,7 +36,10 @@ def test_is_directory_empty_true(tmp_path):
 
 def test_is_directory_empty_handles_missing(tmp_path):
     # iterdir on a nonexistent dir raises -> caught -> returns False.
-    assert DuplicateValidator(dest_path=str(tmp_path / "nope"))._is_directory_empty() is False
+    assert (
+        DuplicateValidator(dest_path=str(tmp_path / "nope"))._is_directory_empty()
+        is False
+    )
 
 
 def test_create_directory_if_needed(tmp_path):
@@ -101,3 +104,93 @@ def test_within_csv_none_input_is_noop(tmp_path):
     result = DuplicateValidator(dest_path=str(dest)).validate(None)
     assert result.is_valid
     assert result.metadata["within_csv_duplicate_filenames"] is False
+
+
+# --- The duplicate warning must match the run's data_id strategy (#377) ---
+#
+# #350 flipped the default strategy from uuid to content_hash, which made the
+# old blanket "these will be ingested as separate records" wording wrong for
+# byte-identical rows: those now collapse via the data_id UNIQUE upsert (#225).
+
+
+def _dup_warning(tmp_path, make_csv, **kwargs) -> str:
+    """Run the validator over a CSV with a repeated filename, return the warning."""
+    path = make_csv(
+        [
+            {"filename": "a", "label": "x"},
+            {"filename": "a", "label": "y"},
+        ]
+    )
+    result = DuplicateValidator(
+        dest_path=str(tmp_path / "new_table"), **kwargs
+    ).validate(str(path))
+    assert result.is_valid  # still warning-only
+    matches = [w for w in result.warnings if "appear more than once" in w]
+    assert len(matches) == 1, result.warnings
+    return matches[0]
+
+
+def test_duplicate_warning_content_hash_says_identical_rows_collapse(
+    tmp_path, make_csv
+):
+    warning = _dup_warning(tmp_path, make_csv, data_id_strategy="content_hash")
+    assert "'content_hash'" in warning
+    assert "collapse into a single stored record" in warning
+    # ...and is explicit that differing content still lands separately.
+    assert "ingested separately" in warning
+    assert "will be ingested as separate records" not in warning
+
+
+def test_duplicate_warning_uuid_keeps_every_row(tmp_path, make_csv):
+    warning = _dup_warning(tmp_path, make_csv, data_id_strategy="uuid")
+    assert "ingested as separate records" in warning
+    assert "'uuid'" in warning
+    assert "collapse" not in warning
+
+
+def test_duplicate_warning_id_column_wins_over_strategy(tmp_path, make_csv):
+    # unique_id_column wins over data_id_strategy in RecordProcessor, so the
+    # warning must not claim content_hash collapsing.
+    warning = _dup_warning(
+        tmp_path, make_csv, data_id_strategy="content_hash", unique_id_column="row_id"
+    )
+    assert "'row_id'" in warning
+    assert "ingested separately" in warning
+    assert "collapse" not in warning
+
+
+def test_duplicate_warning_unknown_strategy_describes_both_outcomes(tmp_path, make_csv):
+    # Direct construction (no map_validators): don't assert either outcome.
+    warning = _dup_warning(tmp_path, make_csv)
+    assert "content_hash" in warning and "uuid" in warning
+    assert "collapse into one stored record" in warning
+    assert "ingested as separate records" in warning
+
+
+def test_duplicate_warning_filename_as_id_column_says_rows_collapse(tmp_path, make_csv):
+    """bugbot #510: unique_id_column="filename" is what keypoint_detection and
+    semantic_segmentation ship, and it makes duplicate filenames duplicate
+    data_ids — so the upsert collapses them. Promising "each row keeps its own
+    record" there asserts the exact opposite of what ingest does."""
+    warning = _dup_warning(
+        tmp_path, make_csv, data_id_strategy="uuid", unique_id_column="filename"
+    )
+    assert "collapses into ONE stored record" in warning
+    assert "keeps only the last one" in warning
+    assert "Each row keeps its own record" not in warning
+
+
+def test_duplicate_warning_filename_as_id_column_matches_case_insensitively(
+    tmp_path, make_csv
+):
+    """The id column is resolved with _match_column, the same case/whitespace-
+    insensitive resolver that found the filename column — so a "FileName"
+    header and a "filename" id config are the same column."""
+    import pandas as pd
+
+    path = make_csv(pd.DataFrame({"FileName": ["a", "a"]}))
+    result = DuplicateValidator(
+        dest_path=str(tmp_path / "new_table"), unique_id_column=" filename "
+    ).validate(str(path))
+    warning = next(w for w in result.warnings if "appear more than once" in w)
+    assert "collapses into ONE stored record" in warning

--- a/tests/test_validators_mapping.py
+++ b/tests/test_validators_mapping.py
@@ -722,3 +722,29 @@ def test_common_validator_frame_composed_for_every_category():
             assert types[-3] is LabelDiversityValidator, cat
         else:
             assert LabelDiversityValidator not in types, cat
+
+
+def test_duplicate_validator_receives_the_runs_data_id_source():
+    """#377: the tail DuplicateValidator gets the run's data_id strategy and id
+    column, so its duplicate-filename warning describes what actually happens
+    (content_hash collapses byte-identical rows; uuid / an id column don't)."""
+    opts = {
+        "extension": ".jpg",
+        "target_size": [64, 64],
+        "number_of_keypoints": 5,
+        "data_id_strategy": "content_hash",
+        "unique_id_column": "row_id",
+    }
+    for cat in ALL_CATEGORIES:
+        dup = map_validators(cat, opts)[-1]
+        assert isinstance(dup, DuplicateValidator), cat
+        assert dup._data_id_strategy == "content_hash", cat
+        assert dup._unique_id_column == "row_id", cat
+
+
+def test_duplicate_validator_data_id_source_defaults_to_unknown():
+    """Callers that omit the keys (tests, direct callers) leave the validator on
+    its strategy-agnostic wording rather than asserting a wrong outcome."""
+    dup = map_validators(TaskCategory.TABULAR_CLASSIFICATION, {})[-1]
+    assert dup._data_id_strategy is None
+    assert dup._unique_id_column is None

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.10"
+__version__ = "0.8.11"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -608,6 +608,11 @@ class BaseIngestor(ABC):
                 # default UUID / content_hash strategies; non-grouped
                 # factories ignore the key.
                 "unique_id_column": self.unique_id_column,
+                # The run's data_id strategy, so DuplicateValidator's
+                # within-CSV duplicate-filename warning describes the real
+                # outcome: 'content_hash' collapses byte-identical rows via
+                # the data_id UNIQUE upsert, 'uuid' keeps them all (#377).
+                "data_id_strategy": self.data_id_strategy,
             },
             # Inject the run's resolved Config so path-reading validators
             # (SRC_PATH / DEST_PATH / TABLE_NAME) use it instead of a

--- a/tracebloc_ingestor/utils/validators_mapping.py
+++ b/tracebloc_ingestor/utils/validators_mapping.py
@@ -70,8 +70,17 @@ def map_validators(
     # Classification-family datasets need >= 2 distinct labels.
     if spec.is_classification:
         validators.append(label_diversity_validator(options))
-    # Universal tail: a unique table name + de-duplicated record IDs.
-    validators += [TableNameValidator(), DuplicateValidator()]
+    # Universal tail: a unique table name + de-duplicated record IDs. The
+    # duplicate warning's wording depends on how ``data_id`` is derived — an
+    # explicit id column and 'uuid' keep every duplicate row, 'content_hash'
+    # collapses the byte-identical ones — so thread both through (#377).
+    validators += [
+        TableNameValidator(),
+        DuplicateValidator(
+            data_id_strategy=options.get("data_id_strategy"),
+            unique_id_column=options.get("unique_id_column"),
+        ),
+    ]
 
     # Inject the run's Config into every validator (P4b). Optional so direct
     # callers / tests that omit it keep the prior behavior: the path-reading

--- a/tracebloc_ingestor/validators/duplicate_validator.py
+++ b/tracebloc_ingestor/validators/duplicate_validator.py
@@ -29,15 +29,29 @@ class DuplicateValidator(BaseValidator):
     """
 
     def __init__(
-        self, dest_path: Optional[str] = None, name: str = "Duplicate Validator"
+        self,
+        dest_path: Optional[str] = None,
+        name: str = "Duplicate Validator",
+        data_id_strategy: Optional[str] = None,
+        unique_id_column: Optional[str] = None,
     ):
         """Initialize the duplicate validator.
 
         Args:
             dest_path: Destination path to check (defaults to config.DEST_PATH)
             name: Human-readable name of the validator
+            data_id_strategy: The run's ``data_id`` strategy (``"content_hash"``
+                / ``"uuid"``), threaded in by ``map_validators`` so the
+                within-CSV duplicate warning describes what actually happens to
+                a duplicate row (#377). ``None`` (direct construction) keeps a
+                strategy-agnostic wording that covers both outcomes.
+            unique_id_column: The run's ``data_id`` source column, if any. It
+                wins over ``data_id_strategy`` in ``RecordProcessor``, so it
+                wins here too.
         """
         super().__init__(name)
+        self._data_id_strategy = data_id_strategy
+        self._unique_id_column = unique_id_column
         # Store the explicit override only; the config-backed default is
         # resolved lazily in the ``dest_path`` property so the run's injected
         # Config (bound by ``map_validators`` AFTER construction, P4b) wins.
@@ -162,12 +176,74 @@ class DuplicateValidator(BaseValidator):
         extra = int(duplicated.sum() - len(duplicated))  # rows beyond the first
         sample = list(duplicated.index[:10])
         suffix = " …" if len(duplicated) > 10 else ""
+        # Does the run's data_id column IS the filename column? Then duplicate
+        # filenames are duplicate data_ids and the upsert collapses them — the
+        # opposite of what an id column usually means (bugbot #510).
+        # ``_match_column`` is the ONLY sanctioned resolver (see base.py), and
+        # resolving both sides through it keeps the comparison consistent with
+        # how the filename column itself was found.
+        id_is_filename = bool(
+            self._unique_id_column
+            and self._match_column(header, self._unique_id_column) == filename_col
+        )
         return [
             f"{len(duplicated)} filename(s) appear more than once in the CSV "
-            f"({extra} duplicate row(s)): {sample}{suffix}. These will be "
-            f"ingested as separate records — remove the duplicates if this is "
-            f"unintended."
+            f"({extra} duplicate row(s)): {sample}{suffix}. "
+            f"{self._duplicate_outcome_sentence(id_is_filename)} Remove the "
+            f"duplicates if this is unintended."
         ]
+
+    def _duplicate_outcome_sentence(self, id_is_filename: bool = False) -> str:
+        """What actually happens to a repeated filename, per ``data_id`` source.
+
+        Under the ``content_hash`` default (#350) the warning's old "these will
+        be ingested as separate records" is only half-true: byte-identical rows
+        now collapse into one stored row via the ``data_id`` UNIQUE upsert
+        (#225), while same-filename/different-content rows still land
+        separately. ``uuid`` keeps every row, and so does an id column — UNLESS
+        that column IS the filename, in which case duplicate filenames are
+        duplicate ids and the upsert collapses them hardest of all (#377).
+
+        Args:
+            id_is_filename: The run's ``unique_id_column`` resolves to the
+                CSV's filename column. ``keypoint_detection`` and
+                ``semantic_segmentation`` both ship ``unique_id_column=
+                "filename"``, so this is the shipped default for two of the
+                categories this warning fires on — not a corner case.
+        """
+        if id_is_filename:
+            return (
+                f"Every duplicate collapses into ONE stored record: data_id "
+                f"comes from the {self._unique_id_column!r} column, so rows "
+                f"sharing a filename share a data_id and the UNIQUE upsert "
+                f"keeps only the last one — regardless of their content."
+            )
+        if self._unique_id_column:
+            return (
+                f"Each row keeps its own record — data_id comes from the "
+                f"{self._unique_id_column!r} column, so rows with distinct ids "
+                f"are ingested separately."
+            )
+        if self._data_id_strategy == "uuid":
+            return (
+                "These will be ingested as separate records (data_id strategy "
+                "'uuid' assigns a fresh id per row)."
+            )
+        if self._data_id_strategy == "content_hash":
+            return (
+                "Under data_id strategy 'content_hash', rows that are identical "
+                "in both filename and content collapse into a single stored "
+                "record; rows sharing a filename but differing in content (e.g. "
+                "a different label) are ingested separately."
+            )
+        # Strategy unknown (validator constructed outside ``map_validators``):
+        # describe both outcomes rather than assert the wrong one.
+        return (
+            "Depending on the run's data_id strategy these either collapse into "
+            "one stored record (content_hash, when filename AND content are "
+            "identical — or any id column that IS the filename) or are ingested "
+            "as separate records (uuid, or an id column with distinct values)."
+        )
 
     def _check_directory_exists(self) -> bool:
         """Check if the destination directory exists.


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only preflight warning copy and CI authentication for the kanban workflow; ingest upsert behavior is unchanged, but operators rely on these warnings and the workflow needs the new App secrets (including Dependabot).
> 
> **Overview**
> **DuplicateValidator** within-CSV duplicate-filename warnings now reflect how the run actually derives `data_id`, instead of always saying rows become separate records. `map_validators` and `BaseIngestor.validate_data` pass `data_id_strategy` and `unique_id_column` into the tail `DuplicateValidator`; wording covers `content_hash` collapse vs separate rows, `uuid`, a distinct id column, and the case where the id column is the filename (upsert keeps one row — #510).
> 
> The **add-to-kanban** workflow mints an org-scoped GitHub App installation token (`RELEASE_TRAIN_APP_*`) for project board writes and drops the `PROJECTS_KANBAN_TOKEN` PAT, with notes on Dependabot secret scope.
> 
> Package version **0.8.10 → 0.8.11**; tests lock the new warning text and factory wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e72adbde97e0a64ac258d1ae5b01213b9cc77f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->