### PR TITLE
sec(2157): scope the add-to-kanban App token to least privilege

### DIFF
--- a/.github/workflows/add-to-kanban.yml
+++ b/.github/workflows/add-to-kanban.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
+    # NO GITHUB_TOKEN AT ALL (saadqbal, #2181). Every call in this job authenticates
+    # as the App, so the workflow token needs nothing -- and an empty grant is the
+    # only version of that claim a reader can check. Free, and it means the least-
+    # privilege story covers both credentials in the job rather than just the loud one.
+    permissions: {}
     steps:
       # Board writes authenticate as the tracebloc-release-train App (backend#2036),
       # not a human's PAT. `owner:` yields an ORG-scoped installation token; a
@@ -25,6 +30,60 @@ jobs:
           app-id: ${{ secrets.RELEASE_TRAIN_APP_ID }}
           private-key: ${{ secrets.RELEASE_TRAIN_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          # SCOPED TO THIS REPO, or the two reads below land org-wide (saadqbal,
+          # #2181). `owner:` alone does not narrow anything -- run 32239403796 says
+          # so in as many words: "Input 'repositories' is not set. Creating token for
+          # all repositories owned by tracebloc." A token calling itself
+          # least-privilege while carrying issue+PR read across all 19 installed
+          # repos is the claim this PR exists to stop making.
+          #
+          # `organization_projects` is an ORG-level permission and is not affected by
+          # repo scoping, so the board write should be unchanged -- but that is an
+          # assumption, and it is the same class of assumption that broke the first
+          # attempt, so the verification run is what settles it rather than this
+          # comment. If it is wrong the failure is LOUD (see below), which is what
+          # makes trying it cheap.
+          repositories: ${{ github.event.repository.name }}
+          # Least privilege (backend#2166): without any `permission-*` the token
+          # carries the App's FULL installation grant. actions/add-to-project needs
+          # THREE scopes, not one: it must RESOLVE the triggering issue/PR node
+          # before it can add it to the board, so it needs read on both content
+          # types (this workflow fires on `issues` and `pull_request`) in addition
+          # to the project write. Projects-write alone leaves the node unresolvable
+          # -- the add fails with "Could not resolve to a node with the global id".
+          #
+          # WHAT IS ACTUALLY DEMONSTRATED, and what is not. Stated narrowly because
+          # two earlier versions of this paragraph each overclaimed in a different
+          # direction, and this text is copied verbatim into 17 repos -- a wrong
+          # argument here is a wrong argument 17 times, in a byte-compared file
+          # nobody re-derives.
+          #
+          # DEMONSTRATED: a MISSING READ scope fails loudly. Run 32239403796 on this
+          # branch, at commit 218f0b13 (projects-write only), errored with
+          # `Could not resolve to a node with the global id` and the job went RED --
+          # `add-to-project` routes GraphQL errors through `setFailed`.
+          #
+          # NOT DEMONSTRATED: the case the FIRST version of this comment described --
+          # the token resolving the node fine and then 403ing the BOARD WRITE. No run
+          # has ever produced it. So "fails loudly" is proven for the read scopes and
+          # is an expectation, not a measurement, for the write.
+          #
+          # AND ONE RUN THAT LOOKED LIKE EVIDENCE IS NOT (aptracebloc). The previous
+          # wording cited run 32237283072 as a second scope failure. It is not one:
+          # it ran on `develop`, whose file at that sha passes NO `permission-*` at
+          # all (the App's full grant), and it failed on
+          # `Could not resolve to a node with the global id of I_kwDONNfQt88...` --
+          # a node a fully-privileged token also cannot see, i.e. an issue that no
+          # longer exists (this workflow fires on `issues: transferred`). Run
+          # 32237067262, the SAME develop sha, succeeded 2m34s earlier. A dead node,
+          # not a permission.
+          #
+          # The proof this is right is therefore still a LANDED CARD, not a passing
+          # mint: a mint can succeed with a scope the board write then needs and
+          # lacks, and that is the one path nothing here has exercised.
+          permission-issues: read
+          permission-pull-requests: read
+          permission-organization-projects: write
 
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:


### PR DESCRIPTION
Refs backend#2157. One of 18 — `add-to-kanban.yml` is a **byte-compared copy**, so least privilege cannot be applied to one repo without splitting the fleet.

## Why this exists

Without any `permission-*`, the mint carried the App's **full installation grant** — contents + pull-requests write across every installed repo. And the App holds `bypass_reviews` on staging and prod fleet-wide, so the blast radius was *merge past review*, not merely write.

```yaml
repositories: ${{ github.event.repository.name }}   # reads stop being org-wide
permission-issues: read                             # add-to-project must RESOLVE
permission-pull-requests: read                      #   the node before adding it
permission-organization-projects: write
permissions: {}                                     # the job needs no GITHUB_TOKEN
```

## Byte-identical to `backend`'s copy, deliberately

That copy is the one that survived review. @saadqbal caught that `owner:` narrows nothing — the run log says it verbatim, `Input 'repositories' is not set. Creating token for all repositories owned by tracebloc` — and @aptracebloc caught a run I had cited as evidence that was not one. Copying the corrected version instead of re-deriving it is the whole point of a byte-compared file.

## Verified, not assumed

The open question was whether `repositories:` scoping clips `organization_projects` (an org-level permission). It does not: [run 32255581084](https://github.com/tracebloc/backend/actions/runs/32255581084) on backend#2181's head exercised these exact scopes and **landed the card** — `Status=Code review`. A landed card, not a passing mint, is the assertion.

## The drift window

`caller-drift` compares copies against `.github`'s, so findings **rise** as this sweep lands and reach 0 only when `.github` goes last. That is deliberate and is the same ordering the App migration used. **Do not dispatch caller-drift remediation during the window** — it would propose reverting these files.

Measured before starting: the fleet was split three ways, and the audit was already red at 2 findings ([run 32268082510](https://github.com/tracebloc/.github/actions/runs/32268082510)) — `backend` and `frontend-app` carried *different* partial fixes. `frontend-app`'s was missing `repositories:` entirely, so it looked scoped and its reads were still org-wide.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI authentication for org project writes; behavior was validated on backend but mis-scoping would break kanban automation fleet-wide via the byte-identical workflow copy.
> 
> **Overview**
> **Hardens the engineer kanban workflow** so it no longer relies on broad credentials when issues or PRs open.
> 
> The job now sets **`permissions: {}`**, so the default `GITHUB_TOKEN` is unused; board actions use only the **tracebloc-release-train** App installation token.
> 
> That mint step is narrowed with **`repositories: ${{ github.event.repository.name }}`** (so reads are not org-wide) and explicit **`permission-issues` / `permission-pull-requests` read** plus **`permission-organization-projects` write**, matching what `actions/add-to-project` needs to resolve the triggering node and add it to the org project. Inline comments document prior failure modes and what was verified vs assumed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1076ef11ff76f45fc04f60a4b0a9dbcae2ccd541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->