### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/workflows/add-to-kanban.yml
+++ b/.github/workflows/add-to-kanban.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
+    # NO GITHUB_TOKEN AT ALL (saadqbal, #2181). Every call in this job authenticates
+    # as the App, so the workflow token needs nothing -- and an empty grant is the
+    # only version of that claim a reader can check. Free, and it means the least-
+    # privilege story covers both credentials in the job rather than just the loud one.
+    permissions: {}
     steps:
       # Board writes authenticate as the tracebloc-release-train App (backend#2036),
       # not a human's PAT. `owner:` yields an ORG-scoped installation token; a
@@ -25,6 +30,60 @@ jobs:
           app-id: ${{ secrets.RELEASE_TRAIN_APP_ID }}
           private-key: ${{ secrets.RELEASE_TRAIN_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          # SCOPED TO THIS REPO, or the two reads below land org-wide (saadqbal,
+          # #2181). `owner:` alone does not narrow anything -- run 32239403796 says
+          # so in as many words: "Input 'repositories' is not set. Creating token for
+          # all repositories owned by tracebloc." A token calling itself
+          # least-privilege while carrying issue+PR read across all 19 installed
+          # repos is the claim this PR exists to stop making.
+          #
+          # `organization_projects` is an ORG-level permission and is not affected by
+          # repo scoping, so the board write should be unchanged -- but that is an
+          # assumption, and it is the same class of assumption that broke the first
+          # attempt, so the verification run is what settles it rather than this
+          # comment. If it is wrong the failure is LOUD (see below), which is what
+          # makes trying it cheap.
+          repositories: ${{ github.event.repository.name }}
+          # Least privilege (backend#2166): without any `permission-*` the token
+          # carries the App's FULL installation grant. actions/add-to-project needs
+          # THREE scopes, not one: it must RESOLVE the triggering issue/PR node
+          # before it can add it to the board, so it needs read on both content
+          # types (this workflow fires on `issues` and `pull_request`) in addition
+          # to the project write. Projects-write alone leaves the node unresolvable
+          # -- the add fails with "Could not resolve to a node with the global id".
+          #
+          # WHAT IS ACTUALLY DEMONSTRATED, and what is not. Stated narrowly because
+          # two earlier versions of this paragraph each overclaimed in a different
+          # direction, and this text is copied verbatim into 17 repos -- a wrong
+          # argument here is a wrong argument 17 times, in a byte-compared file
+          # nobody re-derives.
+          #
+          # DEMONSTRATED: a MISSING READ scope fails loudly. Run 32239403796 on this
+          # branch, at commit 218f0b13 (projects-write only), errored with
+          # `Could not resolve to a node with the global id` and the job went RED --
+          # `add-to-project` routes GraphQL errors through `setFailed`.
+          #
+          # NOT DEMONSTRATED: the case the FIRST version of this comment described --
+          # the token resolving the node fine and then 403ing the BOARD WRITE. No run
+          # has ever produced it. So "fails loudly" is proven for the read scopes and
+          # is an expectation, not a measurement, for the write.
+          #
+          # AND ONE RUN THAT LOOKED LIKE EVIDENCE IS NOT (aptracebloc). The previous
+          # wording cited run 32237283072 as a second scope failure. It is not one:
+          # it ran on `develop`, whose file at that sha passes NO `permission-*` at
+          # all (the App's full grant), and it failed on
+          # `Could not resolve to a node with the global id of I_kwDONNfQt88...` --
+          # a node a fully-privileged token also cannot see, i.e. an issue that no
+          # longer exists (this workflow fires on `issues: transferred`). Run
+          # 32237067262, the SAME develop sha, succeeded 2m34s earlier. A dead node,
+          # not a permission.
+          #
+          # The proof this is right is therefore still a LANDED CARD, not a passing
+          # mint: a mint can succeed with a scope the board write then needs and
+          # lacks, and that is the one path nothing here has exercised.
+          permission-issues: read
+          permission-pull-requests: read
+          permission-organization-projects: write
 
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -22,10 +22,12 @@ from sqlalchemy import (
     Table,
 )
 from sqlalchemy.dialects import mysql
+from sqlalchemy.engine import URL
 
 from tracebloc_ingestor import database as db_mod
 from tracebloc_ingestor.database import Database
 from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.identifiers import InvalidDatabaseIdentifierError
 
 
 @pytest.fixture
@@ -60,6 +62,144 @@ def test_init_builds_engine(db, mock_engine_factory):
     # CREATE DATABASE issued + committed during _create_engine.
     conn.execute.assert_called()
     conn.commit.assert_called()
+
+
+def test_create_database_ddl_backtick_quotes_db_name(mock_engine_factory):
+    # backend#952: DB_NAME is interpolated into a CREATE DATABASE DDL that
+    # can't be parameterized, so it must be backtick-quoted.
+    Database(
+        Config(
+            EDGE_ENV="local", DB_USER="tb_ingest", DB_PASSWORD="pw", DB_NAME="cust_db"
+        )
+    )
+    _, _, conn = mock_engine_factory
+    ddl = str(conn.execute.call_args_list[0].args[0])
+    assert ddl == "CREATE DATABASE IF NOT EXISTS `cust_db`"
+
+
+def test_create_database_ddl_escapes_injection_in_db_name(mock_engine_factory):
+    # A backtick in DB_NAME must be doubled (MySQL escaping), not passed raw —
+    # otherwise it breaks out of the identifier. backend#952.
+    Database(
+        Config(EDGE_ENV="local", DB_USER="tb_ingest", DB_PASSWORD="pw", DB_NAME="a`b")
+    )
+    _, _, conn = mock_engine_factory
+    ddl = str(conn.execute.call_args_list[0].args[0])
+    assert ddl == "CREATE DATABASE IF NOT EXISTS `a``b`"
+
+
+def test_engines_are_built_from_url_components_not_concatenation(mock_engine_factory):
+    # backend#952: both engines must be handed a URL built by URL.create, so
+    # SQLAlchemy escapes each component for its own grammar.
+    Database(
+        Config(
+            EDGE_ENV="local", DB_USER="tb_ingest", DB_PASSWORD="pw", DB_NAME="cust_db"
+        )
+    )
+    ce, _, _ = mock_engine_factory
+    base_url, db_url = (c.args[0] for c in ce.call_args_list)
+    assert isinstance(base_url, URL) and isinstance(db_url, URL)
+    # The server-level engine must NOT carry a database, or CREATE DATABASE
+    # would run against a schema that may not exist yet.
+    assert base_url.database is None
+    assert db_url.database == "cust_db"
+    for u in (base_url, db_url):
+        assert (u.username, u.password, u.drivername) == (
+            "tb_ingest",
+            "pw",
+            "mysql+mysqlconnector",
+        )
+
+
+@pytest.mark.parametrize(
+    "db_name",
+    [
+        "db?ssl_disabled=true",  # the TLS-downgrade vector
+        "db#frag",
+        "db/other",
+        "a`b",
+        "db name",
+    ],
+)
+def test_db_name_cannot_smuggle_connect_args_into_the_url(db_name, mock_engine_factory):
+    """A '?' in DB_NAME used to split into a query string (backend#952).
+
+    Concatenating DB_NAME onto the URL path meant "db?ssl_disabled=true"
+    connected to `db` AND handed ssl_disabled=true to the driver as a genuine
+    connect arg — an env-driven TLS downgrade, with neither failure raising.
+    Percent-encoding the segment is not the fix either: make_url leaves the
+    path escaped, so the driver would receive a literal '%3F' name that differs
+    from the database the DDL just created.
+    """
+    Database(
+        Config(
+            EDGE_ENV="local",
+            DB_USER="tb_ingest",
+            DB_PASSWORD="pw",
+            DB_NAME=db_name,
+        )
+    )
+    ce, _, conn = mock_engine_factory
+    db_url = ce.call_args_list[1].args[0]
+    # The name survives verbatim, and nothing leaked into the query string.
+    assert db_url.database == db_name
+    assert dict(db_url.query) == {}
+    # And it is the same name the DDL created, quoted for MySQL.
+    expected = "`" + db_name.replace("`", "``") + "`"
+    assert str(conn.execute.call_args_list[0].args[0]) == (
+        f"CREATE DATABASE IF NOT EXISTS {expected}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("user", "password"),
+    [
+        ("tb:admin", "pw"),  # ':' used to end the username early
+        ("tb@host", "pw"),  # '@' used to end the userinfo early
+        ("tb/x", "pw"),  # '/' used to make the username the host
+        ("tb_ingest", "p@ss:w/d"),
+    ],
+)
+def test_db_user_and_password_survive_url_construction(
+    user, password, mock_engine_factory
+):
+    # DB_USER was interpolated raw while DB_PASSWORD was hand-quoted; a ':' or
+    # '@' in the username mangled the userinfo section. backend#952.
+    Database(
+        Config(EDGE_ENV="local", DB_USER=user, DB_PASSWORD=password, DB_NAME="cust_db")
+    )
+    ce, _, _ = mock_engine_factory
+    for call in ce.call_args_list:
+        u = call.args[0]
+        assert (u.username, u.password) == (user, password)
+        assert u.host not in (user, None)
+
+
+@pytest.mark.parametrize(
+    ("db_name", "fragment"),
+    [
+        ("", "non-empty string"),
+        ("a" * 65, "65 characters"),
+        ("bad\x00name", "NUL"),
+    ],
+)
+def test_invalid_db_name_fails_with_a_db_worded_error(
+    db_name, fragment, mock_engine_factory
+):
+    # This raises before connecting, so the message is the operator's only
+    # diagnostic — it must name DB_NAME, not a column. backend#952.
+    with pytest.raises(InvalidDatabaseIdentifierError) as exc:
+        Database(
+            Config(
+                EDGE_ENV="local",
+                DB_USER="tb_ingest",
+                DB_PASSWORD="pw",
+                DB_NAME=db_name,
+            )
+        )
+    assert fragment in str(exc.value)
+    assert "DB_NAME" in str(exc.value)
+    assert "olumn" not in str(exc.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_database_identifier.py
+++ b/tests/test_database_identifier.py
@@ -1,0 +1,117 @@
+"""Database-name grammar (backend#952) — and its independence from columns.
+
+``DB_NAME`` reaches a ``CREATE DATABASE`` DDL that cannot be parameterised, so
+it has to be validated and backtick-quoted. It deliberately does NOT reuse
+``quote_column_identifier``: that entry point is the column grammar reconciled
+with ``tracebloc-engine`` and pinned to ``schema/column_identifier.v1.json``
+(ISSUE #382), so borrowing it would (a) report a ``DB_NAME`` misconfiguration
+as a *column* problem to the operator, and (b) couple DB_NAME's legality to a
+grammar that moves for unrelated reasons — a customer CSV header.
+
+The constraint sets are identical today. That is measured, not assumed: MySQL
+**5.7.44 and 8.0.46** both ACCEPT ``/``, ``\\``, ``.``, backtick, space and
+``?`` in a backtick-quoted database name (they are filename-encoded on disk),
+and both reject only length — ``ERROR 1059`` at 65 characters. So this grammar
+adds no character rejections; doing so would refuse names the server accepts.
+"""
+
+import pytest
+
+from tracebloc_ingestor.identifiers import (
+    MAX_DATABASE_IDENTIFIER_LENGTH,
+    InvalidColumnIdentifierError,
+    InvalidDatabaseIdentifierError,
+    is_valid_database_identifier,
+    quote_database_identifier,
+    validate_database_identifier,
+)
+
+# Verified against live MySQL 5.7.44 and 8.0.46: every one of these is created
+# successfully when backtick-quoted, so the validator must accept them.
+SERVER_ACCEPTS = [
+    "training_test_datasets",
+    "db/other",
+    "db\\other",
+    "db.other",
+    "a`b",
+    "db name",
+    "x?ssl_disabled=true",
+    "Körpergröße",
+    "a" * MAX_DATABASE_IDENTIFIER_LENGTH,
+]
+
+SERVER_REJECTS = [
+    "",
+    "a" * (MAX_DATABASE_IDENTIFIER_LENGTH + 1),
+    "bad\x00name",
+]
+
+
+@pytest.mark.parametrize("name", SERVER_ACCEPTS)
+def test_names_the_server_accepts_are_valid(name):
+    assert is_valid_database_identifier(name) is True
+    assert validate_database_identifier(name) == name
+
+
+@pytest.mark.parametrize("name", SERVER_REJECTS)
+def test_names_the_server_rejects_are_invalid(name):
+    assert is_valid_database_identifier(name) is False
+    with pytest.raises(InvalidDatabaseIdentifierError):
+        validate_database_identifier(name)
+
+
+@pytest.mark.parametrize("name", [None, 123, b"bytes"])
+def test_non_strings_are_invalid(name):
+    assert is_valid_database_identifier(name) is False
+    with pytest.raises(InvalidDatabaseIdentifierError):
+        validate_database_identifier(name)
+
+
+@pytest.mark.parametrize(
+    ("name", "quoted"),
+    [
+        ("cust_db", "`cust_db`"),
+        ("a`b", "`a``b`"),
+        ("a``b", "`a````b`"),
+        ("`", "````"),
+        ("x?ssl_disabled=true", "`x?ssl_disabled=true`"),
+    ],
+)
+def test_quoting_doubles_backticks(name, quoted):
+    assert quote_database_identifier(name) == quoted
+
+
+def test_the_error_names_db_name_and_never_a_column():
+    """The operator's only diagnostic — it must point at the env var they set.
+
+    This validation runs before any connection, so a misleading message sends
+    them hunting through CSV headers for a ``DB_NAME`` typo.
+    """
+    for bad in SERVER_REJECTS:
+        with pytest.raises(InvalidDatabaseIdentifierError) as exc:
+            validate_database_identifier(bad)
+        assert "DB_NAME" in str(exc.value)
+        assert "olumn" not in str(exc.value)
+
+
+def test_the_database_error_is_not_the_column_error():
+    # Distinct types, so a caller can handle one without swallowing the other,
+    # and neither is a subclass of the other by accident.
+    assert not issubclass(InvalidDatabaseIdentifierError, InvalidColumnIdentifierError)
+    assert not issubclass(InvalidColumnIdentifierError, InvalidDatabaseIdentifierError)
+    assert issubclass(InvalidDatabaseIdentifierError, ValueError)
+
+
+def test_the_length_limit_is_stated_independently_of_the_column_grammar():
+    """The decoupling this module exists for (backend#952).
+
+    ``MAX_DATABASE_IDENTIFIER_LENGTH`` must be its own literal, not an alias of
+    the column constant — otherwise loosening the pinned column grammar for a
+    customer header silently loosens DB_NAME too, which is the silent-divergence
+    class ISSUE #382 was closed to prevent. Asserting the boundary against the
+    database constant alone keeps this test honest if the two ever diverge.
+    """
+    n = MAX_DATABASE_IDENTIFIER_LENGTH
+    assert n == 64  # MySQL's identifier limit; ERROR 1059 above it
+    assert is_valid_database_identifier("a" * n) is True
+    assert is_valid_database_identifier("a" * (n + 1)) is False

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.11"
+__version__ = "0.8.12"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -19,9 +19,8 @@ from sqlalchemy import (
     Index,
     bindparam,
     inspect,
-
 )
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import URL, Engine
 from sqlalchemy import LargeBinary
 from sqlalchemy.dialects.mysql import insert, LONGBLOB, BLOB
 from sqlalchemy.exc import OperationalError, InterfaceError, DBAPIError
@@ -29,7 +28,6 @@ import logging
 import secrets
 
 from .utils import redaction
-from urllib.parse import quote
 from typing import List, Dict, Any, Optional
 from datetime import datetime
 from tenacity import (
@@ -40,7 +38,7 @@ from tenacity import (
     before_sleep_log,
 )
 from .config import Config
-from .identifiers import MAX_COLUMN_IDENTIFIER_LENGTH
+from .identifiers import MAX_COLUMN_IDENTIFIER_LENGTH, quote_database_identifier
 from .utils.typo_suggest import suggest_type as _suggest_type
 
 # Configure unified logging with config
@@ -99,9 +97,7 @@ def _execute_with_retry(connection, stmt):
             # Swallow it so the original transient error propagates to
             # tenacity for the retry (or, on the last attempt, to the
             # caller's existing error path).
-            logger.debug(
-                f"connection.rollback() failed between retries: {rb_exc}"
-            )
+            logger.debug(f"connection.rollback() failed between retries: {rb_exc}")
         raise
 
 
@@ -116,33 +112,48 @@ class Database:
         )
 
     def _create_engine(self) -> Engine:
-        # First create database if it doesn't exist
-        base_connection_string = (
-            f"mysql+mysqlconnector://{self.config.DB_USER}:{quote(self.config.DB_PASSWORD)}"
-            f"@{self.config.DB_HOST}:{self.config.DB_PORT}"
+        # Built from components, never by string concatenation: URL.create lets
+        # SQLAlchemy escape each part for its own grammar. Concatenating
+        # DB_NAME onto the URL path made a '?' in the name a query separator —
+        # so DB_NAME="db?ssl_disabled=true" silently connected to `db` AND
+        # handed ssl_disabled=true to the driver as a real connect arg, an
+        # env-driven TLS downgrade. Percent-encoding the segment is NOT the fix:
+        # make_url decodes userinfo but leaves the path escaped, so the driver
+        # would then receive the literal 'db%3Fssl_disabled%3Dtrue' — a
+        # different database from the one the DDL below creates (backend#952).
+        base_url = URL.create(
+            "mysql+mysqlconnector",
+            username=self.config.DB_USER,
+            password=self.config.DB_PASSWORD,
+            host=self.config.DB_HOST,
+            port=self.config.DB_PORT,
         )
         # hide_parameters: SQLAlchemy otherwise appends every statement
         # parameter — i.e. whole rows of customer data — to error strings
         # that get logged (#226).
-        engine = create_engine(
-            base_connection_string, pool_pre_ping=True, hide_parameters=True
-        )
+        engine = create_engine(base_url, pool_pre_ping=True, hide_parameters=True)
 
         with engine.connect() as connection:
+            # DB_NAME is operator/env-supplied and interpolated into DDL that
+            # can't be parameterized, so it must be quoted (backend#952).
             connection.execute(
-                text(f"CREATE DATABASE IF NOT EXISTS {self.config.DB_NAME}")
+                text(
+                    "CREATE DATABASE IF NOT EXISTS "
+                    f"{quote_database_identifier(self.config.DB_NAME)}"
+                )
             )
             connection.commit()
 
         # Now connect to the specific database
-        connection_string = f"{base_connection_string}/{self.config.DB_NAME}"
         return create_engine(
-            connection_string, pool_pre_ping=True, hide_parameters=True
+            base_url.set(database=self.config.DB_NAME),
+            pool_pre_ping=True,
+            hide_parameters=True,
         )
 
     def _get_sqlalchemy_type(self, mysql_type: str):
         """Convert MySQL type to SQLAlchemy type.
-        
+
         Extracts the base type (before parentheses) and matches exactly to avoid
         substring issues (e.g., "DATE" matching "DATETIME").
         """
@@ -169,10 +180,10 @@ class Database:
             "BLOB": BLOB,
             "LONGBLOB": LONGBLOB,
         }
-        
+
         mysql_type_upper = mysql_type.upper().strip()
         base_type = mysql_type_upper.split("(")[0].split()[0]
-        
+
         if base_type in type_mapping:
             alchemy_type = type_mapping[base_type]
             # Extract parenthesised arguments. Two shapes:
@@ -261,8 +272,16 @@ class Database:
         # is intentionally excluded — it's the user-facing label column the
         # framework maps onto the standard `label` column.
         _RESERVED = {
-            "id", "created_at", "updated_at", "status", "data_intent",
-            "data_id", "filename", "extension", "annotation", "ingestor_id",
+            "id",
+            "created_at",
+            "updated_at",
+            "status",
+            "data_intent",
+            "data_id",
+            "filename",
+            "extension",
+            "annotation",
+            "ingestor_id",
         }
         _collisions = sorted(_RESERVED & set(schema))
         if _collisions:
@@ -352,9 +371,17 @@ class Database:
             # to work around an unrelated error is exactly this case). Surface an
             # actionable error naming the drift instead.
             _STANDARD_COLUMNS = {
-                "id", "created_at", "updated_at", "status", "label",
-                "data_intent", "data_id", "filename", "extension",
-                "annotation", "ingestor_id",
+                "id",
+                "created_at",
+                "updated_at",
+                "status",
+                "label",
+                "data_intent",
+                "data_id",
+                "filename",
+                "extension",
+                "annotation",
+                "ingestor_id",
             }
             existing_features = {c.name for c in table.columns} - _STANDARD_COLUMNS
             expected_features = set(schema) - _STANDARD_COLUMNS
@@ -518,9 +545,7 @@ class Database:
                 # in #191 but dropped by the squash-merge — re-applying).
                 insert_stmt = insert(table)
                 update_dict = {
-                    column.name: text(
-                        f"VALUES(`{column.name.replace('`', '``')}`)"
-                    )
+                    column.name: text(f"VALUES(`{column.name.replace('`', '``')}`)")
                     for column in table.columns
                     if column.name not in ["id", "created_at", "data_id"]
                 }
@@ -578,9 +603,7 @@ class Database:
                             result["failures"].append(
                                 {
                                     "record": record,
-                                    "error": redaction.safe_db_error(
-                                        individual_error
-                                    ),
+                                    "error": redaction.safe_db_error(individual_error),
                                 }
                             )
                             connection.rollback()
@@ -964,7 +987,9 @@ class Database:
                             f"WHERE ingestor_id IS NOT NULL AND ingestor_id <> ''"
                         ),
                     ).fetchall()
-            except Exception as exc:  # noqa: BLE001 — skip the table, continue the sweep
+            except (
+                Exception
+            ) as exc:  # noqa: BLE001 — skip the table, continue the sweep
                 logger.warning(
                     "list_dataset_ingestor_ids: skipping table %s — could not read "
                     "ingestor_ids (%s)",
@@ -1174,7 +1199,10 @@ class Database:
                 ),
                 {"ingestor_id": ingestor_id, "limit": limit},
             ).fetchall()
-        return [{"data_id": row[0], "label": row[1] if row[1] is not None else ""} for row in rows]
+        return [
+            {"data_id": row[0], "label": row[1] if row[1] is not None else ""}
+            for row in rows
+        ]
 
     def get_table_schema(self, table_name: str) -> Dict[str, str]:
         """
@@ -1214,10 +1242,7 @@ class Database:
 
             # MySQL has no native BOOLEAN type: BOOL columns are created — and
             # therefore reflected — as TINYINT(1).
-            if (
-                type_name == "TINYINT"
-                and getattr(col_type, "display_width", None) == 1
-            ):
+            if type_name == "TINYINT" and getattr(col_type, "display_width", None) == 1:
                 schema[column["name"]] = "BOOLEAN"
                 continue
 

--- a/tracebloc_ingestor/identifiers.py
+++ b/tracebloc_ingestor/identifiers.py
@@ -37,15 +37,44 @@ SQLAlchemy emits in the ingestor's ``CREATE TABLE`` DDL.
 Note on *table* names: those are stricter and validated separately
 (``TableNameValidator`` here, ``_validate_sql_identifier`` in the trainer) —
 table names are platform-controlled, columns come from raw user data.
+
+Note on *database* names: ``validate_database_identifier`` /
+``quote_database_identifier`` below. They share the quoting mechanic but state
+their own constraints and raise their own error type — see the comment on
+``MAX_DATABASE_IDENTIFIER_LENGTH`` for why they deliberately do not reuse the
+column entry points (backend#952).
 """
 
 # MySQL's maximum identifier length. The one column-name constraint that
 # backtick-quoting cannot work around, so both repos hard-fail above it.
 MAX_COLUMN_IDENTIFIER_LENGTH = 64
 
+# Restated for *database* names rather than aliased to the column constant. The
+# column grammar above is reconciled with tracebloc-engine and pinned to
+# schema/column_identifier.v1.json (ISSUE #382); a future loosening there for
+# some customer CSV header must not silently loosen DB_NAME validation too, and
+# a DB-motivated tightening must not break the trainer contract.
+#
+# The two constraint sets happen to be identical today, and that is a measured
+# claim, not an assumption: MySQL 5.7.44 and 8.0.46 both ACCEPT ``/``, ``\``,
+# ``.``, backtick, space and ``?`` in a backtick-quoted database name (they are
+# filename-encoded on disk), and both reject only length — error 1059 at 65
+# characters. So there is deliberately no extra character rejection here;
+# adding one would refuse names the server itself accepts.
+MAX_DATABASE_IDENTIFIER_LENGTH = 64
+
 
 class InvalidColumnIdentifierError(ValueError):
     """Raised when a column name cannot be safely used as a MySQL identifier."""
+
+
+class InvalidDatabaseIdentifierError(ValueError):
+    """Raised when a database name cannot be safely used as a MySQL identifier."""
+
+
+def _backtick_quote(name: str) -> str:
+    """Backtick-quote an already-validated identifier, doubling any backtick."""
+    return "`" + name.replace("`", "``") + "`"
 
 
 def is_valid_column_identifier(name: object) -> bool:
@@ -86,4 +115,44 @@ def quote_column_identifier(name: str) -> str:
     quoting rules — so any valid name is rendered injection-safe.
     """
     validate_column_identifier(name)
-    return "`" + name.replace("`", "``") + "`"
+    return _backtick_quote(name)
+
+
+def is_valid_database_identifier(name: object) -> bool:
+    """Return True if ``name`` is a valid (safely quotable) database identifier."""
+    return (
+        isinstance(name, str)
+        and name != ""
+        and len(name) <= MAX_DATABASE_IDENTIFIER_LENGTH
+        and "\x00" not in name
+    )
+
+
+def validate_database_identifier(name: str) -> str:
+    """Validate a database name, returning it unchanged when valid.
+
+    Worded for the operator who sets ``DB_NAME``: this runs before any
+    connection is made, so the message is the only diagnostic they get.
+    """
+    if not isinstance(name, str) or name == "":
+        raise InvalidDatabaseIdentifierError(
+            f"Invalid database name {name!r}: DB_NAME must be a non-empty string."
+        )
+    if "\x00" in name:
+        raise InvalidDatabaseIdentifierError(
+            f"Invalid database name {name!r}: DB_NAME must not contain a NUL "
+            "character."
+        )
+    if len(name) > MAX_DATABASE_IDENTIFIER_LENGTH:
+        raise InvalidDatabaseIdentifierError(
+            f"Database name {name!r} is {len(name)} characters, exceeding "
+            f"MySQL's {MAX_DATABASE_IDENTIFIER_LENGTH}-character identifier "
+            "limit — shorten DB_NAME."
+        )
+    return name
+
+
+def quote_database_identifier(name: str) -> str:
+    """Return a MySQL backtick-quoted database identifier after validation."""
+    validate_database_identifier(name)
+    return _backtick_quote(name)


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ingestor changes alter how every deployment connects and creates databases—high impact if mis-scoped—but behavior is heavily tested; workflow token scope changes could break kanban adds until verified on a real run.
> 
> **Overview**
> This release-train promotion bundles **ingestor hardening for `DB_NAME` and MySQL URLs (backend#952)** with **least-privilege tweaks to the engineer kanban GitHub Action**.
> 
> **Ingestor:** MySQL engines are built with **`URL.create` / `base_url.set(database=...)`** instead of concatenating credentials and database names, closing cases where special characters in **`DB_USER`**, **`DB_PASSWORD`**, or **`DB_NAME`** mangled the URL or turned a `?` in the name into driver connect args (including a silent TLS-downgrade vector). **`CREATE DATABASE`** now uses a dedicated **`quote_database_identifier`** path with **`InvalidDatabaseIdentifierError`** messages that reference **`DB_NAME`**, decoupled from column identifier grammar. Coverage adds **`tests/test_database_identifier.py`** and database engine/DDL tests; package version **0.8.12**.
> 
> **CI:** **`add-to-kanban.yml`** sets **`permissions: {}`**, mints the GitHub App token **scoped to the triggering repo**, and grants only **issues read**, **pull requests read**, and **organization projects write** for **`add-to-project`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c300f5e7b341ba35789f16c0bce3e550447c812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->