### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -37,6 +37,8 @@ PyPI first. `RELEASING.md` documents how they stay aligned.
   suppressed" note (`ingestors/csv_ingestor.py:508`,
   `validators/per_group_time_ordered_validator.py:219`, `metadata_backfill_runner.py:195`).
 
+- **A telemetry attribute that could carry content.** A contract record (`tracebloc_ingestor/telemetry.py`) is a wire, and the same policy line applies to it. `exception.message` is never sent; `exception.stacktrace` is rendered with `traceback.format_tb`, whose frames are code, and NOT with `format_exc` / `format_exception`, which append `str(exc)`. Counts and closed `error.type` values are fine; a row, a cell, a driver message or an id derived from one is not.
+
 - **A validator that reads data differently from the ingestor.** Preflight readers must
   honor the run's `csv_options` via `utils/csv_dialect.read_dialect_kwargs` — a hardcoded
   `pd.read_csv(..., sep=",", encoding="utf-8")` passes or rejects manifests the real ingest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ the file extension — drives validation and file transfer.
   - `file_transfer.py` -- secure file transfer to cluster storage
   - `storage_contract.py` -- the ingest→trainer storage contract (framework column names, `data_id` strategies, the on-disk naming rule). Stdlib-only and mirrored verbatim by tracebloc-engine's `core/utils/ingest_contract.py`; change it here first (backend#1706)
   - `config.py` -- configuration
+  - `telemetry.py` -- the ingest Job's contract telemetry (RFC-BACKEND-1872 D2): `service.name=data-ingestors`, `tracebloc.component=ingest-job`, and the closed `ingest.job.*` event set the entry point emits. Every run reports exactly one terminal event; a failure record carries the exception's type and FRAMES and never its message, because the message is where a cell value would be
   - `utils/` -- shared utilities (incl. `TaskCategory` constants, logging)
 - **`templates/`** -- ingestor scripts used inside Docker containers
 - **`docker-entrypoint.sh`** -- waits for MySQL, then exec's the `tracebloc-ingest` console script
@@ -67,7 +68,7 @@ the file extension — drives validation and file transfer.
 
 ## Key Dependencies
 
-Python 3.11+, `sqlalchemy`, `mysql-connector-python`, `pandas`, `Pillow`, `requests`, `tenacity`, `tqdm`.
+Python 3.11+, `sqlalchemy`, `mysql-connector-python`, `pandas`, `Pillow`, `requests`, `tenacity`, `tqdm`, `tracebloc-telemetry` (the shared contract emitter; no dependencies of its own, and the OpenTelemetry SDK extra is deliberately not taken).
 
 <!-- org-standards:begin -->
 ## tracebloc engineering standards (org-wide)

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,5 +36,13 @@ jsonschema>=4.0.0
 # Structured logging
 python-json-logger>=2.0.0
 
+# The shared contract emitter (RFC-BACKEND-1872 D2), pinned exactly as the other
+# Python services pin it. Safe to add to a PUBLIC package's runtime deps: it is
+# published on PyPI and declares NO dependencies of its own — the OpenTelemetry
+# SDK is an optional [otlp] extra we deliberately do not take, so without it the
+# contract is still enforced and records go to the standard library logger, which
+# is the only route out of a customer's cluster this Job has anyway.
+tracebloc-telemetry==0.1.0
+
 # Progress bar
 tqdm>=4.65.0

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -567,3 +567,215 @@ def test_failed_records_yield_nonzero_exit(clean_env, mock_runtime, monkeypatch)
     rc = main()
 
     assert rc == 1  # not 0, not 2 (which is reserved for fail-fast)
+
+
+# ---------------------------------------------------------------------------
+# Contract telemetry (RFC-BACKEND-1872 D2)
+#
+# Every terminal path of the entrypoint reports exactly one contract event, and
+# says WHY in a closed, low-cardinality `error.type`. Driven through the real
+# paths — not through a stubbed `_run` — because the thing worth pinning is that
+# each concrete failure keeps its own classification all the way out.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def telemetry_records(caplog):
+    """The contract records a driven run produced, in order."""
+    import tracebloc_telemetry
+
+    from tracebloc_ingestor import telemetry as job_telemetry
+
+    tracebloc_telemetry.reset()
+    job_telemetry.reset()
+    caplog.set_level(logging.DEBUG, logger="tracebloc.telemetry")
+    yield lambda: [r.telemetry for r in caplog.records if hasattr(r, "telemetry")]
+    tracebloc_telemetry.reset()
+    job_telemetry.reset()
+
+
+def _attribute_text(record):
+    """Every attribute VALUE of a record, as text, unescaped.
+
+    Not ``json.dumps``: it escapes non-ASCII, so a leak assertion written
+    against a marker containing ``ü`` passes while the value sits in the
+    record. Found by mutating ``safe_stacktrace`` and watching three
+    end-to-end tests stay green.
+    """
+    return "\n".join(f"{key}={value!r}" for key, value in record.items())
+
+
+def _sole_terminal(records):
+    from tracebloc_ingestor import telemetry as job_telemetry
+
+    terminals = [r for r in records if r["event.name"] in job_telemetry.TERMINAL_EVENTS]
+    assert len(terminals) == 1, [r["event.name"] for r in records]
+    return terminals[0]
+
+
+def _path_config_missing(monkeypatch, tmp_path, mock_runtime):
+    """INGEST_CONFIG is not set at all (clean_env already removed it)."""
+
+
+def _path_config_not_found(monkeypatch, tmp_path, mock_runtime):
+    monkeypatch.setenv("INGEST_CONFIG", str(tmp_path / "absent.yaml"))
+
+
+def _path_config_unparseable(monkeypatch, tmp_path, mock_runtime):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("apiVersion: tracebloc.io/v1\n  kind: ::: invalid", encoding="utf-8")
+    monkeypatch.setenv("INGEST_CONFIG", str(bad))
+
+
+def _path_config_not_a_mapping(monkeypatch, tmp_path, mock_runtime):
+    bad = tmp_path / "list.yaml"
+    bad.write_text("- apiVersion: tracebloc.io/v1\n", encoding="utf-8")
+    monkeypatch.setenv("INGEST_CONFIG", str(bad))
+
+
+def _path_config_invalid(monkeypatch, tmp_path, mock_runtime):
+    bad = tmp_path / "incomplete.yaml"
+    bad.write_text(
+        "apiVersion: tracebloc.io/v1\n"
+        "kind: IngestConfig\n"
+        "category: image_classification\n"
+        "intent: train\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INGEST_CONFIG", str(bad))
+
+
+def _path_ingestion_failed(monkeypatch, tmp_path, mock_runtime):
+    monkeypatch.setenv("INGEST_CONFIG", str(EXAMPLES_DIR / "image_classification.yaml"))
+    mock_runtime["CSVIngestor"].return_value.ingest.side_effect = RuntimeError(
+        "the database went away"
+    )
+
+
+def _path_records_failed(monkeypatch, tmp_path, mock_runtime):
+    monkeypatch.setenv("INGEST_CONFIG", str(EXAMPLES_DIR / "image_classification.yaml"))
+    mock_runtime["CSVIngestor"].return_value.ingest.return_value = [
+        {"image_id": "broken"},
+        {"image_id": "also-broken"},
+    ]
+
+
+def _path_succeeded(monkeypatch, tmp_path, mock_runtime):
+    monkeypatch.setenv("INGEST_CONFIG", str(EXAMPLES_DIR / "image_classification.yaml"))
+
+
+#: (setup, exit code, expected error.type or None for the clean run). Written
+#: independently of `telemetry.ERROR_TYPES`, so the closure check below compares
+#: two sources rather than a list with itself.
+_TERMINAL_PATHS = [
+    (_path_config_missing, 2, "config_missing"),
+    (_path_config_not_found, 2, "config_not_found"),
+    (_path_config_unparseable, 2, "config_unparseable"),
+    (_path_config_not_a_mapping, 2, "config_not_a_mapping"),
+    (_path_config_invalid, 2, "config_invalid"),
+    (_path_ingestion_failed, 1, "ingestion_failed"),
+    (_path_records_failed, 1, "records_failed"),
+    (_path_succeeded, 0, None),
+]
+
+
+@pytest.mark.parametrize(
+    "setup, expected_code, expected_error_type",
+    _TERMINAL_PATHS,
+    ids=[case[0].__name__ for case in _TERMINAL_PATHS],
+)
+def test_every_terminal_path_reports_one_classified_event(
+    setup,
+    expected_code,
+    expected_error_type,
+    clean_env,
+    mock_runtime,
+    monkeypatch,
+    tmp_path,
+    telemetry_records,
+    capsys,
+):
+    from tracebloc_ingestor import telemetry as job_telemetry
+    from tracebloc_ingestor.cli.run import main
+
+    setup(monkeypatch, tmp_path, mock_runtime)
+    rc = main()
+    capsys.readouterr()
+
+    assert rc == expected_code
+    records = telemetry_records()
+    assert records[0]["event.name"] == job_telemetry.EVENT_JOB_STARTED
+
+    terminal = _sole_terminal(records)
+    if expected_error_type is None:
+        assert terminal["event.name"] == job_telemetry.EVENT_JOB_SUCCEEDED
+        assert "error.type" not in terminal
+    else:
+        assert terminal["error.type"] == expected_error_type
+        assert terminal["error.type"] in job_telemetry.ERROR_TYPES
+
+
+def test_the_driven_paths_cover_the_whole_error_vocabulary():
+    """Two sources compared, not a list against itself.
+
+    ``_TERMINAL_PATHS`` above is a hand-written list of the entrypoint's real
+    endings; ``ERROR_TYPES`` is the producer's declared vocabulary. Anything in
+    the vocabulary that no driven path reaches must be a classification the
+    FUNNEL produces, and those two are named here explicitly — so a new
+    classification that nothing can emit fails this test rather than sitting
+    unqueryable in a dashboard nobody can populate.
+    """
+    from tracebloc_ingestor import telemetry as job_telemetry
+
+    driven = {case[2] for case in _TERMINAL_PATHS if case[2] is not None}
+    funnel_only = {
+        job_telemetry.ERROR_UNHANDLED_EXCEPTION,
+        job_telemetry.ERROR_UNCLASSIFIED,
+    }
+    assert driven | funnel_only == job_telemetry.ERROR_TYPES
+    assert not driven & funnel_only
+
+
+def test_a_failed_ingestion_reports_frames_but_never_the_exception_message(
+    clean_env, mock_runtime, monkeypatch, tmp_path, telemetry_records, capsys
+):
+    """The end-to-end shape of the redaction rule, on the real failure path."""
+    secret = "patient-4711-Müller"
+    monkeypatch.setenv("INGEST_CONFIG", str(EXAMPLES_DIR / "image_classification.yaml"))
+    # side_effect, so the raising frame belongs to unittest.mock and this file's
+    # source line cannot be what carries the value into the traceback.
+    mock_runtime["CSVIngestor"].return_value.ingest.side_effect = ValueError(
+        f"Incorrect value {secret!r} for column x"
+    )
+
+    from tracebloc_ingestor.cli.run import main
+
+    assert main() == 1
+    # the operator's own console still gets the detail; it never leaves the
+    # cluster, and pinning it here keeps this test about the RECORD.
+    assert secret in capsys.readouterr().err
+
+    terminal = _sole_terminal(telemetry_records())
+    assert terminal["error.type"] == "ingestion_failed"
+    assert terminal["exception.type"] == "ValueError"
+    assert terminal["exception.stacktrace"]
+    assert "exception.message" not in terminal
+    assert secret not in _attribute_text(terminal)
+
+
+def test_the_failed_record_count_is_sent_but_never_the_records(
+    clean_env, mock_runtime, monkeypatch, tmp_path, telemetry_records
+):
+    monkeypatch.setenv("INGEST_CONFIG", str(EXAMPLES_DIR / "image_classification.yaml"))
+    mock_runtime["CSVIngestor"].return_value.ingest.return_value = [
+        {"image_id": "patient-4711"},
+        {"image_id": "patient-4712"},
+    ]
+
+    from tracebloc_ingestor.cli.run import main
+
+    assert main() == 1
+
+    terminal = _sole_terminal(telemetry_records())
+    assert terminal["tracebloc.ingest.failed_records"] == 2
+    assert "patient-4711" not in _attribute_text(terminal)

--- a/tests/test_error_redaction.py
+++ b/tests/test_error_redaction.py
@@ -250,3 +250,56 @@ def test_column_preview_caps_wide_panels():
     assert "gene_10" not in preview  # capped at 10
     # a single error line stays bounded no matter how wide the panel is
     assert len(preview) < 300
+
+
+# ---------------------------------------------------------------------------
+# Contract telemetry (RFC-BACKEND-1872 D2) — the emitter side of the same rule
+# ---------------------------------------------------------------------------
+
+
+def test_telemetry_failure_record_never_carries_the_exception_message(caplog):
+    """A contract event leaves the process; its exception message must not.
+
+    Pinned in THIS file rather than only next to the telemetry tests because it
+    is the same gate as everything above: a cell value must not reach anything
+    that egresses. The failure record is a new egress path, and the field that
+    would carry a value is the exception message — which is why the emitter is
+    handed the frames alone.
+
+    The mutation is a one-word substitution (``format_tb`` → ``format_exc``)
+    that reads like a tidy-up, which is precisely how the engine's identical
+    hole survived.
+    """
+    import tracebloc_telemetry
+
+    from tracebloc_ingestor import telemetry
+
+    def _caught(message):
+        # A VARIABLE, so the raising frame's source line cannot contain the
+        # value; a literal here would make this test prove the wrong thing.
+        try:
+            raise ValueError(message)
+        except ValueError as exc:
+            return exc
+
+    exc = _caught(f"Incorrect value {SECRET!r} for column x")
+
+    tracebloc_telemetry.reset()
+    telemetry.reset()
+    telemetry.configure_job()
+    caplog.set_level(logging.DEBUG, logger="tracebloc.telemetry")
+    telemetry.begin_run("run-1")
+    telemetry.job_failed(telemetry.ERROR_INGESTION_FAILED, exc)
+    records = [r.telemetry for r in caplog.records if hasattr(r, "telemetry")]
+    tracebloc_telemetry.reset()
+    telemetry.reset()
+
+    assert records, "no telemetry record was emitted — the test proves nothing"
+    # The attribute VALUES, not a json.dumps of them: json escapes non-ASCII,
+    # so a dump of this very record spells the marker "M\\u00fcller" and a
+    # `SECRET not in dump` assertion passes with the value still in the record.
+    emitted = "\n".join(f"{k}={v!r}" for k, v in records[-1].items())
+    assert SECRET not in emitted
+    # the class and the frames ARE the actionable part, and they are sent
+    assert records[-1]["exception.type"] == "ValueError"
+    assert records[-1]["exception.stacktrace"]

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,565 @@
+"""The ingest Job's contract telemetry.
+
+Three things are worth checking here and they are checked three different ways,
+because only one of them is a behaviour.
+
+1. **Agreement with the contract.** Every vocabulary these tests compare against
+   is READ from the emitter package's own registry and checked by the emitter's
+   own checkers. Nothing here holds a second copy of the service table, the
+   domain list or the outcome verbs: a hand-written copy agrees with itself
+   while drifting from the thing it claims to mirror.
+
+2. **Completeness of the classification.** The entrypoint is PARSED, so the set
+   of ``error.type`` constants it actually uses is derived from the code rather
+   than listed here. A constant that is declared and never used, a call site
+   that passes a bare string, and a constant missing from ``ERROR_TYPES`` are
+   all findings rather than things a reviewer has to notice.
+
+3. **Exactly one terminal event per run.** Driven over the whole outcome space
+   of ``_run`` — returns zero, returns non-zero, raises — because that is the
+   entirety of what the funnel has to cope with.
+
+Redaction has its own home in ``tests/test_error_redaction.py``, alongside the
+rest of the "a cell value can never reach this" gate; the leak-shaped assertions
+here are the emitter-side half and each one states its mutation anchor.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import signal
+import traceback
+from pathlib import Path
+
+import pytest
+
+import tracebloc_telemetry
+from tracebloc_ingestor import telemetry
+from tracebloc_ingestor.cli import run as cli_run
+
+SECRET = "patient-4711-Müller"
+
+RUN_PY = Path(cli_run.__file__)
+
+#: Every event this module can emit. Derived from the module rather than
+#: retyped, so a fifth event cannot be added without these checks seeing it.
+ALL_EVENTS = frozenset({telemetry.EVENT_JOB_STARTED}) | telemetry.TERMINAL_EVENTS
+
+
+@pytest.fixture(autouse=True)
+def fresh_telemetry(monkeypatch):
+    """A configured, non-exporting emitter and a closed run, per test."""
+    monkeypatch.delenv("TRACEBLOC_ENV", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    tracebloc_telemetry.reset()
+    telemetry.reset()
+    telemetry.configure_job()
+    yield
+    tracebloc_telemetry.reset()
+    telemetry.reset()
+
+
+@pytest.fixture
+def emitted(caplog):
+    """The contract records this test produced, in order."""
+    caplog.set_level(logging.DEBUG, logger="tracebloc.telemetry")
+
+    def _records():
+        return [
+            record.telemetry
+            for record in caplog.records
+            if hasattr(record, "telemetry")
+        ]
+
+    return _records
+
+
+def _error_constants() -> dict:
+    """``{attribute name: value}`` for every ``ERROR_*`` string in the module."""
+    return {
+        name: getattr(telemetry, name)
+        for name in dir(telemetry)
+        if name.startswith("ERROR_") and isinstance(getattr(telemetry, name), str)
+    }
+
+
+def _entrypoint_ast() -> ast.Module:
+    return ast.parse(RUN_PY.read_text(encoding="utf-8"))
+
+
+def _attribute_text(record: dict) -> str:
+    """Every attribute VALUE of a record, as text, unescaped.
+
+    Deliberately not ``json.dumps``: it escapes non-ASCII by default, so
+    ``"Müller"`` becomes ``"M\\u00fcller"`` and a leak assertion written
+    against the raw marker passes while the value is right there in the
+    record. Measured, not theorised — the first mutation run of
+    ``safe_stacktrace`` reddened only the unit test and sailed past three
+    end-to-end ones for exactly this reason.
+    """
+    return "\n".join(f"{key}={value!r}" for key, value in record.items())
+
+
+# ── the dependency itself ────────────────────────────────────────────────────
+
+
+def test_the_contract_emitter_is_installed_and_configures():
+    """Fails CLOSED on a missing dependency.
+
+    Without this, an absent ``tracebloc-telemetry`` would make every guarded
+    call below a silent no-op, and a suite that emits nothing and asserts
+    nothing about it looks exactly like a suite that passes.
+    """
+    assert telemetry.configure_job() is True
+    assert tracebloc_telemetry.current() is not None
+
+
+def test_the_resource_reports_the_package_version():
+    from tracebloc_ingestor import __version__
+
+    resource = tracebloc_telemetry.current().resource
+    assert resource["service.version"] == __version__
+    assert resource["service.version"] != tracebloc_telemetry.UNKNOWN_VERSION
+
+
+# ── agreement with the registry ──────────────────────────────────────────────
+
+
+def test_service_and_component_are_a_registered_pair():
+    from tracebloc_telemetry._registry import SERVICES
+
+    assert telemetry.SERVICE in SERVICES
+    assert telemetry.COMPONENT in SERVICES[telemetry.SERVICE]
+
+
+def test_every_event_name_passes_the_emitters_own_grammar_check():
+    from tracebloc_telemetry import ContractViolation
+    from tracebloc_telemetry._contract import check_event_name
+
+    for name in sorted(ALL_EVENTS):
+        check_event_name(name)
+
+    # ANCHOR: the checker above is armed. Without this, a check_event_name that
+    # had become a no-op would make the loop pass on any string at all, and the
+    # log would be indistinguishable from real coverage.
+    with pytest.raises(ContractViolation):
+        check_event_name("ingest.job.refreshed")
+
+
+def test_every_event_uses_the_registered_domain_and_outcome():
+    from tracebloc_telemetry._registry import DOMAINS, FAILURE_OUTCOMES, OUTCOMES
+
+    for name in sorted(ALL_EVENTS):
+        domain, _object, outcome = name.split(".")
+        assert domain in DOMAINS
+        assert outcome in OUTCOMES
+
+    # The two terminals that report a problem must be failure outcomes, because
+    # that is what obliges them to carry `error.type`; the success one must not.
+    for name in (telemetry.EVENT_JOB_REJECTED, telemetry.EVENT_JOB_FAILED):
+        assert name.rsplit(".", 1)[-1] in FAILURE_OUTCOMES
+    assert telemetry.EVENT_JOB_SUCCEEDED.rsplit(".", 1)[-1] not in FAILURE_OUTCOMES
+
+
+def test_every_terminal_event_pairs_with_the_started_event():
+    """One object, so a failure RATE is computable."""
+    assert telemetry.TERMINAL_EVENTS
+    subject = telemetry.EVENT_JOB_STARTED.rsplit(".", 1)[0]
+    for name in sorted(telemetry.TERMINAL_EVENTS):
+        assert name.rsplit(".", 1)[0] == subject
+
+
+# ── completeness of the classification, read off the entrypoint ──────────────
+
+
+def test_error_types_is_exactly_the_set_of_declared_constants():
+    declared = _error_constants()
+    assert set(declared.values()) == telemetry.ERROR_TYPES
+
+
+def test_the_entrypoint_uses_every_declared_error_constant_and_no_other():
+    """Derived from the code, not restated.
+
+    A constant added to the module and never used is a classification nothing
+    can ever produce; a call site naming a constant that does not exist is an
+    ``AttributeError`` in production. Both are read off the entrypoint's AST.
+    """
+    referenced = {
+        node.attr
+        for node in ast.walk(_entrypoint_ast())
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "telemetry"
+        and node.attr.startswith("ERROR_")
+    }
+    assert referenced, "the entrypoint references no telemetry.ERROR_* constant"
+    assert referenced == set(_error_constants())
+    for name in sorted(referenced):
+        assert getattr(telemetry, name) in telemetry.ERROR_TYPES
+
+
+def test_no_call_site_passes_a_literal_error_type():
+    """An event's classification is a compile-time constant, never a string.
+
+    A literal at the call site is how a closed vocabulary stops being closed:
+    it is spelled slightly differently once and the two spellings each get half
+    the count.
+    """
+    offenders = []
+    for node in ast.walk(_entrypoint_ast()):
+        if not isinstance(node, ast.Call):
+            continue
+        args = []
+        if isinstance(node.func, ast.Name) and node.func.id == "_fail":
+            args = node.args[1:2]
+        elif (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "telemetry"
+            and node.func.attr in ("job_failed", "job_rejected")
+        ):
+            args = node.args[:1]
+        for arg in args:
+            if isinstance(arg, ast.Constant):
+                offenders.append((node.lineno, arg.value))
+    assert offenders == []
+
+
+def test_every_rejection_path_classifies_itself():
+    """``_fail`` is the single rejection funnel, and it takes a classification.
+
+    Checked structurally so a sixth rejection path cannot be added silently:
+    every call to ``_fail`` must pass two arguments.
+    """
+    calls = [
+        node
+        for node in ast.walk(_entrypoint_ast())
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_fail"
+    ]
+    assert calls, "the entrypoint has no rejection path — did _fail get renamed?"
+    for node in calls:
+        assert len(node.args) == 2, f"_fail at line {node.lineno} names no error type"
+
+
+# ── exactly one terminal event, over the whole outcome space ─────────────────
+
+
+@pytest.mark.parametrize("outcome", ["returns_zero", "returns_nonzero", "raises"])
+def test_main_reports_exactly_one_terminal_event(outcome, emitted, monkeypatch):
+    """``_run`` returns an int or raises. That is the whole space; drive it."""
+    if outcome == "raises":
+
+        def _body(argv=None):
+            raise RuntimeError("boom")
+
+    else:
+        code = 0 if outcome == "returns_zero" else 7
+
+        def _body(argv=None, _code=code):
+            return _code
+
+    monkeypatch.setattr(cli_run, "_run", _body)
+
+    if outcome == "raises":
+        with pytest.raises(RuntimeError):
+            cli_run.main()
+    else:
+        cli_run.main()
+
+    names = [record["event.name"] for record in emitted()]
+    assert names.count(telemetry.EVENT_JOB_STARTED) == 1
+    terminals = [name for name in names if name in telemetry.TERMINAL_EVENTS]
+    assert len(terminals) == 1, names
+
+
+def test_sigterm_reports_the_run_as_cancelled(emitted, monkeypatch):
+    """A run the platform ends still says how it ended (backend#2417).
+
+    SIGTERM's default disposition terminates the interpreter WITHOUT unwinding —
+    no exception, no ``finally``, no ``atexit`` — so ``main``'s ``except
+    BaseException`` funnel never sees it. @shujaatTracebloc measured that on this
+    branch: SIGTERM at 3s produced ``ingest.job.started`` and nothing else, which
+    is the silence this whole change exists to remove, on the ending where the
+    record is most useful (eviction, drain, deadline).
+
+    Driven through the REAL handler the entrypoint installs rather than a copy of
+    it, so deleting `signal.signal(...)` from ``main`` reddens this.
+    """
+    installed = {}
+    real_signal = signal.signal
+
+    def _capture(signum, handler):
+        if signum == signal.SIGTERM:
+            installed["handler"] = handler
+        return real_signal(signum, handler)
+
+    monkeypatch.setattr(cli_run.signal, "signal", _capture)
+    monkeypatch.setattr(cli_run, "_run", lambda argv=None: 0)
+    cli_run.main()
+
+    assert "handler" in installed, "main() installed no SIGTERM handler"
+
+    # A fresh run, then the signal mid-flight.
+    telemetry.reset()
+    telemetry.configure_job()
+    telemetry.begin_run("corr-sigterm")
+    before = len(emitted())
+    with pytest.raises(SystemExit) as exit_info:
+        installed["handler"](signal.SIGTERM, None)
+
+    assert exit_info.value.code == 128 + signal.SIGTERM
+    names = [record["event.name"] for record in emitted()[before:]]
+    assert telemetry.EVENT_JOB_CANCELLED in names, names
+    terminals = [name for name in names if name in telemetry.TERMINAL_EVENTS]
+    assert len(terminals) == 1, names
+
+
+def test_a_cancelled_run_does_not_double_report(emitted, monkeypatch):
+    """If the signal lands while a classified path is mid-flight, one wins.
+
+    ``_terminal`` is what makes that true; this pins it for the signal path
+    specifically, because the handler runs outside every control-flow guarantee
+    the funnel relies on.
+    """
+    installed = {}
+    real_signal = signal.signal
+    monkeypatch.setattr(
+        cli_run.signal,
+        "signal",
+        lambda num, h: (
+            installed.__setitem__("handler", h) if num == signal.SIGTERM else None
+        )
+        or real_signal(num, h),
+    )
+    monkeypatch.setattr(cli_run, "_run", lambda argv=None: 0)
+    cli_run.main()  # emits succeeded, closing the terminal slot
+
+    before = len(emitted())
+    with pytest.raises(SystemExit):
+        installed["handler"](signal.SIGTERM, None)
+    assert [
+        r["event.name"] for r in emitted()[before:]
+    ] == [], "the terminal slot was already taken; cancelling after it must be dropped"
+
+
+def test_a_clean_run_reports_success(emitted, monkeypatch):
+    monkeypatch.setattr(cli_run, "_run", lambda argv=None: 0)
+    cli_run.main()
+    assert emitted()[-1]["event.name"] == telemetry.EVENT_JOB_SUCCEEDED
+
+
+def test_an_unclassified_nonzero_exit_says_so(emitted, monkeypatch):
+    """A run that cannot say why it failed says THAT, rather than nothing."""
+    monkeypatch.setattr(cli_run, "_run", lambda argv=None: 7)
+    cli_run.main()
+    record = emitted()[-1]
+    assert record["event.name"] == telemetry.EVENT_JOB_FAILED
+    assert record["error.type"] == telemetry.ERROR_UNCLASSIFIED
+
+
+def test_an_escaping_exception_is_reported_and_still_raised(emitted, monkeypatch):
+    def _body(argv=None):
+        raise RuntimeError("startup failed")
+
+    monkeypatch.setattr(cli_run, "_run", _body)
+    with pytest.raises(RuntimeError):
+        cli_run.main()
+
+    record = emitted()[-1]
+    assert record["event.name"] == telemetry.EVENT_JOB_FAILED
+    assert record["error.type"] == telemetry.ERROR_UNHANDLED_EXCEPTION
+    assert record["exception.type"] == "RuntimeError"
+    assert record["exception.stacktrace"]
+
+
+def test_the_funnel_never_overwrites_a_classified_failure(emitted, monkeypatch):
+    """The backstop drops its duplicate; it does not relabel the real reason."""
+
+    def _body(argv=None):
+        telemetry.job_failed(telemetry.ERROR_RECORDS_FAILED, failed_records=3)
+        return 1
+
+    monkeypatch.setattr(cli_run, "_run", _body)
+    cli_run.main()
+
+    terminals = [
+        record
+        for record in emitted()
+        if record["event.name"] in telemetry.TERMINAL_EVENTS
+    ]
+    assert len(terminals) == 1
+    assert terminals[0]["error.type"] == telemetry.ERROR_RECORDS_FAILED
+    assert terminals[0]["tracebloc.ingest.failed_records"] == 3
+
+
+def test_the_correlation_id_rides_every_record(emitted):
+    telemetry.begin_run("run-abc-123")
+    telemetry.job_succeeded()
+    records = emitted()
+    assert len(records) == 2
+    for record in records:
+        assert record["tracebloc.ingest.correlation_id"] == "run-abc-123"
+
+
+def test_an_absent_correlation_id_is_omitted_not_blanked(emitted):
+    telemetry.begin_run(None)
+    telemetry.job_succeeded()
+    for record in emitted():
+        assert "tracebloc.ingest.correlation_id" not in record
+
+
+# ── the exception message never leaves ───────────────────────────────────────
+
+
+def _caught(message: str) -> BaseException:
+    """An exception carrying ``message``, with a real traceback attached.
+
+    ``message`` is passed as a VARIABLE so the raising frame's source line reads
+    ``raise ValueError(message)``. A literal here would put the value into the
+    source line and the redaction assertions would be testing the wrong thing.
+    """
+    try:
+        raise ValueError(message)
+    except ValueError as exc:
+        return exc
+
+
+def test_safe_stacktrace_renders_frames_and_never_the_message():
+    exc = _caught(SECRET)
+    stack = telemetry.safe_stacktrace(exc)
+
+    assert stack
+    assert "test_telemetry.py" in stack
+    assert SECRET not in stack
+
+    # ANCHOR: the value really is in this exception, so the assertion above is
+    # not passing because there was nothing to leak. A switch back to
+    # format_exception / format_exc reddens the test.
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert SECRET in rendered
+
+
+def test_safe_stacktrace_has_nothing_to_say_about_a_bare_exception():
+    assert telemetry.safe_stacktrace(None) == ""
+    assert telemetry.safe_stacktrace(ValueError(SECRET)) == ""
+
+
+def test_a_failure_record_carries_the_type_and_frames_but_no_message(emitted):
+    exc = _caught(SECRET)
+    telemetry.begin_run("run-1")
+    telemetry.job_failed(telemetry.ERROR_INGESTION_FAILED, exc)
+
+    record = emitted()[-1]
+    assert record["exception.type"] == "ValueError"
+    assert record["exception.stacktrace"]
+    assert "exception.message" not in record
+    assert SECRET not in _attribute_text(record)
+
+
+def test_an_exception_without_frames_sends_neither_half(emitted):
+    """Both, or neither — a type with no stacktrace is a half-populated record."""
+    telemetry.begin_run("run-1")
+    telemetry.job_failed(telemetry.ERROR_INGESTION_FAILED, ValueError(SECRET))
+
+    record = emitted()[-1]
+    assert "exception.type" not in record
+    assert "exception.stacktrace" not in record
+    assert record["error.type"] == telemetry.ERROR_INGESTION_FAILED
+
+
+# ── telemetry never fails an ingest ──────────────────────────────────────────
+
+
+def test_a_new_run_reopens_the_terminal_slot():
+    """The at-most-once rule is per RUN, not per process."""
+    telemetry.begin_run("run-1")
+    assert telemetry.job_succeeded() is True
+    assert telemetry.terminal_emitted() is True
+    assert telemetry.job_failed(telemetry.ERROR_UNCLASSIFIED) is False
+
+    telemetry.begin_run("run-2")
+    assert telemetry.terminal_emitted() is False
+    assert telemetry.job_failed(telemetry.ERROR_UNCLASSIFIED) is True
+
+
+def test_a_refusing_emitter_does_not_fail_the_run(monkeypatch, caplog):
+    # ANCHOR: with a working emitter the very same call returns True, so the
+    # False below is the refusal being absorbed — not a duplicate terminal
+    # being dropped, which would make this test pass while proving nothing.
+    assert telemetry.job_failed(telemetry.ERROR_INGESTION_FAILED) is True
+    telemetry.reset()
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError(SECRET)
+
+    monkeypatch.setattr(tracebloc_telemetry, "emit", _boom)
+    caplog.set_level(logging.WARNING)
+
+    assert telemetry.job_failed(telemetry.ERROR_INGESTION_FAILED) is False
+
+    text = caplog.text
+    assert telemetry.EVENT_JOB_FAILED in text
+    assert "RuntimeError" in text
+    # The diagnostic names the exception's CLASS, never its message — the same
+    # rule the records themselves obey.
+    assert SECRET not in text
+
+
+def test_emitting_into_an_unconfigured_process_is_reported_not_raised(caplog):
+    tracebloc_telemetry.reset()
+    caplog.set_level(logging.WARNING)
+
+    assert telemetry.begin_run("run-1") is False
+    assert telemetry.job_succeeded() is False
+    assert "telemetry" in caplog.text
+
+
+# ── the environment is read raw, and is not guessed ──────────────────────────
+
+
+def test_the_exporting_environments_agree_with_config(monkeypatch):
+    """Agreement with ``Config``, derived from the registry's own set."""
+    from tracebloc_telemetry._registry import EXPORTING_ENVIRONMENTS
+
+    from tracebloc_ingestor.config import Config
+
+    for environment in sorted(EXPORTING_ENVIRONMENTS):
+        monkeypatch.setenv(telemetry.ENVIRONMENT_ENV, environment)
+        tracebloc_telemetry.reset()
+        telemetry.configure_job()
+
+        resource = tracebloc_telemetry.current().resource
+        assert resource["deployment.environment"] == environment
+        assert Config().EDGE_ENV == environment
+
+
+def test_an_unset_environment_is_not_guessed_as_prod(monkeypatch):
+    """The one place this module deliberately disagrees with ``Config``."""
+    from tracebloc_ingestor.config import Config
+
+    monkeypatch.delenv(telemetry.ENVIRONMENT_ENV, raising=False)
+    monkeypatch.delenv("TRACEBLOC_ENV", raising=False)
+    tracebloc_telemetry.reset()
+    telemetry.configure_job()
+
+    configured = tracebloc_telemetry.current()
+    assert "deployment.environment" not in configured.resource
+    assert configured.decision.export is False
+
+    # ANCHOR: Config really does default to prod, which is why the variable is
+    # read raw above. Were that not so, the assertions above would be proving
+    # nothing.
+    assert Config().EDGE_ENV == "prod"
+
+
+def test_a_non_exporting_environment_stays_on_the_console(monkeypatch):
+    from tracebloc_telemetry._registry import NON_EXPORTING_ENVIRONMENTS
+
+    for environment in sorted(NON_EXPORTING_ENVIRONMENTS):
+        monkeypatch.setenv(telemetry.ENVIRONMENT_ENV, environment)
+        tracebloc_telemetry.reset()
+        telemetry.configure_job()
+        assert tracebloc_telemetry.current().decision.export is False

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.12"
+__version__ = "0.8.13"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/cli/run.py
+++ b/tracebloc_ingestor/cli/run.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import signal
 import sys
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
@@ -47,10 +48,12 @@ from typing import Any, Dict, Iterable, List, Optional
 import yaml
 from jsonschema import Draft7Validator, ValidationError
 
+from .. import telemetry
 from ..api.client import APIClient
 from ..config import Config
 from ..database import Database
 from ..ingestors import CSVIngestor, JSONIngestor
+from ..utils.correlation import resolve_correlation_id
 from ..utils.logging import setup_logging
 from .conventions import ResolvedConfig, resolve
 
@@ -68,12 +71,21 @@ _SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schema" / "ingest.v1.js
 # ---------------------------------------------------------------------------
 
 
-def main(argv: List[str] | None = None) -> int:  # pragma: no cover - thin shell
+def main(argv: List[str] | None = None) -> int:
     """Entrypoint registered as the ``tracebloc-ingest`` console script.
 
     Returns the process exit code. A non-zero return is converted to
     ``sys.exit`` by the console-script wrapper; using a return value (rather
     than raising) keeps the function testable from inside pytest.
+
+    THIS IS THE TELEMETRY FUNNEL, and that is the only reason the run itself
+    lives in ``_run``. Every path out of this function — a clean exit, a
+    classified failure, an exception nobody caught — reports exactly one
+    terminal event, because the funnel reports one on every branch and
+    ``telemetry._terminal`` drops the duplicate when the path already
+    classified itself. A run that ends without saying how it ended is
+    indistinguishable from a run that never started, and that silence is the
+    thing worth removing.
     """
     # Group-writable by default (umask 002) so every directory and file the run
     # writes under DEST_PATH can be reclaimed by the `data delete` teardown
@@ -83,32 +95,88 @@ def main(argv: List[str] | None = None) -> int:  # pragma: no cover - thin shell
     # containing directories do, which this guarantees for the whole tree.
     os.umask(0o002)
 
+    telemetry.configure_job()
+    # Resolved here as well as in BaseIngestor, so the config-rejection paths
+    # below — which end the run before an ingestor exists — can still name their
+    # run. The only cost is that a MALFORMED id logs its warning twice, which is
+    # cheaper than a second copy of the id's validation rule.
+    telemetry.begin_run(resolve_correlation_id())
+
+    def _on_sigterm(signum, _frame):  # pragma: no cover - driven by a real signal
+        # A run the platform ended is still a run that ended, and SIGTERM's
+        # default disposition unwinds NOTHING -- no exception, no `finally`, no
+        # `atexit` -- so the terminal event is emitted here or not at all. The
+        # funnel below catches BaseException, which covers every way Python
+        # leaves the frame and none of the ways a signal does. Measured on this
+        # branch by @shujaatTracebloc: SIGTERM at 3s gave `started` and silence.
+        #
+        # In Kubernetes this is the common ending, not an edge case: eviction,
+        # node drain and `activeDeadlineSeconds` all send SIGTERM. SIGKILL
+        # cannot be caught, so an OOMKilled run still reports `started` alone —
+        # `_terminal`'s docstring says so rather than implying otherwise.
+        #
+        # `_terminal` makes this safe against double-reporting if the signal
+        # lands while a classified path is already mid-flight.
+        telemetry.job_cancelled()
+        raise SystemExit(128 + signum)
+
+    signal.signal(signal.SIGTERM, _on_sigterm)
+
+    try:
+        code = _run(argv)
+    except BaseException as exc:
+        # Startup failures live here: a missing DB credential or missing backend
+        # auth raises out of Database() / APIClient() construction, and until now
+        # produced a raw traceback and no event whatsoever.
+        telemetry.job_failed(telemetry.ERROR_UNHANDLED_EXCEPTION, exc)
+        raise
+
+    if code == 0:
+        telemetry.job_succeeded()
+    else:
+        telemetry.job_failed(telemetry.ERROR_UNCLASSIFIED)
+    return code
+
+
+def _run(argv: List[str] | None = None) -> int:
+    """The run itself. See ``main`` for why it is a separate function."""
     config_path = os.environ.get("INGEST_CONFIG")
     if not config_path:
         return _fail(
             "INGEST_CONFIG env var not set. The official image expects the "
             "Helm subchart (client#86) to mount the ingest.yaml and set "
-            "INGEST_CONFIG to its path."
+            "INGEST_CONFIG to its path.",
+            telemetry.ERROR_CONFIG_MISSING,
         )
 
     raw_path = Path(config_path)
     if not raw_path.is_file():
-        return _fail(f"INGEST_CONFIG points to {config_path} which does not exist.")
+        return _fail(
+            f"INGEST_CONFIG points to {config_path} which does not exist.",
+            telemetry.ERROR_CONFIG_NOT_FOUND,
+        )
 
     try:
         raw_config = yaml.safe_load(raw_path.read_text(encoding="utf-8"))
     except yaml.YAMLError as e:
-        return _fail(f"ingest.yaml is not valid YAML:\n  {e}")
+        return _fail(
+            f"ingest.yaml is not valid YAML:\n  {e}",
+            telemetry.ERROR_CONFIG_UNPARSEABLE,
+        )
 
     if not isinstance(raw_config, dict):
         return _fail(
             "ingest.yaml must be a mapping at the top level "
-            "(apiVersion / kind / category / ...)."
+            "(apiVersion / kind / category / ...).",
+            telemetry.ERROR_CONFIG_NOT_A_MAPPING,
         )
 
     errors = list(_validate(raw_config))
     if errors:
-        return _fail("ingest.yaml validation failed:\n" + _format_errors(errors))
+        return _fail(
+            "ingest.yaml validation failed:\n" + _format_errors(errors),
+            telemetry.ERROR_CONFIG_INVALID,
+        )
 
     resolved = resolve(raw_config)
 
@@ -166,12 +234,18 @@ def main(argv: List[str] | None = None) -> int:  # pragma: no cover - thin shell
             # the exception into a clean, single-line non-zero exit rather than a
             # raw traceback, so the CLI's live log stream shows an actionable
             # reason and marks the Job failed.
+            telemetry.job_failed(telemetry.ERROR_INGESTION_FAILED, exc)
             print(f"\nIngestion failed: {exc}", file=sys.stderr)
             return 1
         if failed:
             logger.warning(
                 "%d record(s) failed during ingestion; see logs for details.",
                 len(failed),
+            )
+            # The COUNT, never the records: counts are dataset structure and may
+            # be reported, the rows themselves may not.
+            telemetry.job_failed(
+                telemetry.ERROR_RECORDS_FAILED, failed_records=len(failed)
             )
             return 1
 
@@ -369,11 +443,18 @@ def _build_ingestor(
 # ---------------------------------------------------------------------------
 
 
-def _fail(message: str) -> int:
+def _fail(message: str, error_type: str) -> int:
     """Print to stderr and return non-zero. Logger may not be configured yet
     when validation fails (it depends on Config() which depends on env
-    being set), so a plain stderr write is the most reliable channel."""
+    being set), so a plain stderr write is the most reliable channel.
+
+    The single funnel for "the configuration was refused and no data was read",
+    so a rejection path cannot be added without also classifying itself.
+    ``error_type`` is a constant from ``telemetry.ERROR_TYPES``; a literal here
+    is a finding, and ``tests/test_telemetry.py`` reads this module to say so.
+    """
     print(message, file=sys.stderr)
+    telemetry.job_rejected(error_type)
     return 2
 
 

--- a/tracebloc_ingestor/telemetry.py
+++ b/tracebloc_ingestor/telemetry.py
@@ -1,0 +1,331 @@
+"""Contract telemetry for the ingest Job (RFC-BACKEND-1872 D2).
+
+The ingest Job emitted nothing. Every other Python service in the platform
+adopted the shared contract emitter; this one was never wired up, so an ingest
+that failed produced free-text log lines and no countable, groupable event.
+
+    configure_job()          # once, at the entry point
+    begin_run(correlation_id)
+    ... exactly one of job_succeeded() / job_rejected() / job_failed() ...
+
+WHERE THESE RECORDS ACTUALLY GO, stated plainly rather than implied. This
+process runs as a Job inside the CUSTOMER's cluster. Its stdout is collected by
+the node-level collector, and that collector takes control-plane containers
+only: ingestion is a lower-collection class and stays out until content
+redaction ships. So for now these records land in the customer's own cluster
+logs and reach nothing of ours. That is a real limitation and not a defect of
+this module: the records exist, are contract-shaped, and become visible the
+moment collection is widened. Emitting them now is what makes that widening a
+configuration change rather than a code change.
+
+WHY THE EXCEPTION MESSAGE IS NEVER EMITTED. This package's standing policy
+(``utils/redaction.py``) is that cell VALUES never appear in errors or logs;
+column names, file names, counts, dtypes and row indices may. Every exception
+raised on the ingestion path has the customer's own cells in scope -- a MySQL
+type rejection quotes the offending value, a cast error embeds it -- so
+``str(exc)`` is a content leak by default, which is why the package already logs
+``type(exc).__name__`` and suppresses the message.
+
+The contract requires a failure record to carry its ``exception.type`` and its
+``exception.stacktrace`` once an exception was caught, and it explicitly exempts
+``exception.message`` from that set. ``safe_stacktrace`` below is what makes
+those two safe to send: it renders the FRAMES only. A frame is file, line,
+function and the SOURCE LINE -- code, never data -- whereas the message is the
+one part of a rendered traceback that interpolates a value. So the contract's
+required half is satisfied exactly, and the exempt field is the one omitted.
+
+TELEMETRY NEVER FAILS AN INGEST. Every call here is guarded. The package's own
+rule for the correlation id says it best: observability must never fail an
+ingest. A contract violation in a constant defined in this module is a
+programming error caught by ``tests/test_telemetry.py``, which checks these
+constants against the emitter's real registry -- not something a customer's
+ingest run should discover.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import traceback
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+#: The registry rows for this repo, hard-coded here at the entry point. Never
+#: derived from a process, module, container or host name -- deriving service
+#: identity from the process is the defect the contract exists to close.
+SERVICE = "data-ingestors"
+COMPONENT = "ingest-job"
+
+#: The environment variable this package already reads for its deployment
+#: environment (see ``Config.EDGE_ENV``). Read RAW here rather than through
+#: ``Config``, and the difference is deliberate: ``Config.EDGE_ENV`` defaults to
+#: ``"prod"`` when the variable is unset, which is the right default for picking
+#: an API endpoint and the wrong one for stamping a record. The contract's rule
+#: is that an unrecognised environment disables the exporter and says so, never
+#: that it is guessed -- records landing under a guessed value is the defect
+#: being fixed, not a convenience. So an unset variable here means "no
+#: environment, do not export", not "prod".
+ENVIRONMENT_ENV = "CLIENT_ENV"
+
+#: Event names: ``<domain>.<object>.<outcome>``, three segments, compile-time
+#: constants. ``ingest`` is the registered domain for this service and the
+#: outcome verbs are the registered ones. ONE object (``job``) on purpose: it
+#: makes the pairing rule -- every operation that can fail reports a terminal
+#: event on every path, so a failure RATE is computable -- a property of this
+#: four-name set rather than a convention someone has to remember.
+EVENT_JOB_STARTED = "ingest.job.started"
+EVENT_JOB_SUCCEEDED = "ingest.job.succeeded"
+EVENT_JOB_REJECTED = "ingest.job.rejected"
+EVENT_JOB_FAILED = "ingest.job.failed"
+#: A run the platform ended: evicted, drained, or past `activeDeadlineSeconds`.
+#: `cancelled` is already in the emitter registry's closed OUTCOMES set, so this
+#: validates without a registry change.
+EVENT_JOB_CANCELLED = "ingest.job.cancelled"
+
+#: The four ways a run ends. Exactly one is emitted per run (see ``_terminal``).
+TERMINAL_EVENTS = frozenset(
+    {
+        EVENT_JOB_SUCCEEDED,
+        EVENT_JOB_REJECTED,
+        EVENT_JOB_FAILED,
+        EVENT_JOB_CANCELLED,
+    }
+)
+
+#: ``error.type`` -- a stable, low-cardinality classification, closed for this
+#: domain. Not the exception class name: that is an implementation detail with
+#: unbounded cardinality, and grouping failures by it is what stops a failure
+#: mode having a count.
+#:
+#: The first five are the entrypoint's config-rejection paths, which end the run
+#: before any data is read. The last three are run failures.
+ERROR_CONFIG_MISSING = "config_missing"
+ERROR_CONFIG_NOT_FOUND = "config_not_found"
+ERROR_CONFIG_UNPARSEABLE = "config_unparseable"
+ERROR_CONFIG_NOT_A_MAPPING = "config_not_a_mapping"
+ERROR_CONFIG_INVALID = "config_invalid"
+ERROR_INGESTION_FAILED = "ingestion_failed"
+ERROR_RECORDS_FAILED = "records_failed"
+#: An exception escaped the run entirely. This is not a theoretical bucket: a
+#: missing DB credential or missing backend auth raises out of ``Database()`` /
+#: ``APIClient()`` construction, and today that produces a raw traceback and no
+#: event at all.
+ERROR_UNHANDLED_EXCEPTION = "unhandled_exception"
+#: A non-zero exit that reached the funnel without classifying itself. Reported
+#: rather than hidden: a path that forgets to say why it failed is a finding,
+#: and "cannot tell" must be visible instead of looking like a clean run.
+ERROR_UNCLASSIFIED = "unclassified"
+
+ERROR_TYPES = frozenset(
+    {
+        ERROR_CONFIG_MISSING,
+        ERROR_CONFIG_NOT_FOUND,
+        ERROR_CONFIG_UNPARSEABLE,
+        ERROR_CONFIG_NOT_A_MAPPING,
+        ERROR_CONFIG_INVALID,
+        ERROR_INGESTION_FAILED,
+        ERROR_RECORDS_FAILED,
+        ERROR_UNHANDLED_EXCEPTION,
+        ERROR_UNCLASSIFIED,
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Per-run state
+# ---------------------------------------------------------------------------
+
+# The correlation id is record scope, not resource scope: it identifies the RUN,
+# not the process, so it is attached per record rather than baked into the
+# resource by configure(). Held here so no call site has to thread it through.
+_correlation_id: Optional[str] = None
+_terminal_emitted: bool = False
+
+
+def terminal_emitted() -> bool:
+    """Has this run already reported how it ended?"""
+    return _terminal_emitted
+
+
+def reset() -> None:
+    """Forget the current run. For tests, and for re-entry.
+
+    Module state that survives between runs is how a test can assert "no event
+    was emitted" and be right for the wrong reason — the terminal flag left
+    standing by the previous run suppresses the emit the test was checking for,
+    and a vacuous pass looks exactly like a real one.
+    """
+    global _correlation_id, _terminal_emitted
+    _correlation_id = None
+    _terminal_emitted = False
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+def safe_stacktrace(exc: Optional[BaseException]) -> str:
+    """The frames of ``exc``, and never its message.
+
+    ``traceback.format_exception`` / ``format_exc`` append
+    ``<Type>: <str(exc)>`` -- the one part of a rendered traceback that
+    interpolates a runtime value, and on this package's paths that value is a
+    customer cell. ``format_tb`` renders the frame list alone: file, line,
+    function and the source line, all of which are code.
+
+    Returns ``""`` when there is nothing to render, which is also the signal the
+    caller uses to omit the whole exception attribute set rather than send half
+    of it.
+    """
+    if exc is None:
+        return ""
+    tb = getattr(exc, "__traceback__", None)
+    if tb is None:
+        return ""
+    return "".join(traceback.format_tb(tb)).strip()
+
+
+# ---------------------------------------------------------------------------
+# Emission
+# ---------------------------------------------------------------------------
+
+
+def configure_job() -> bool:
+    """Set up this process's telemetry. Call once, at the entry point.
+
+    Returns whether telemetry is available, so a test can fail closed on a
+    missing dependency instead of quietly asserting nothing.
+    """
+    try:
+        from tracebloc_telemetry import configure
+
+        from . import __version__
+
+        configure(
+            service=SERVICE,
+            component=COMPONENT,
+            # The released artifact's identity for this service is the package
+            # version -- the same literal setup.py parses, so the wheel, the
+            # image built from it and this record cannot disagree.
+            version=__version__,
+            environment=os.environ.get(ENVIRONMENT_ENV),
+        )
+        return True
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "telemetry: could not configure (%s); this run will report no "
+            "events. Ingestion is unaffected.",
+            type(exc).__name__,
+        )
+        return False
+
+
+def begin_run(correlation_id: Optional[str] = None) -> bool:
+    """Open the run: remember its correlation id and report that it started."""
+    global _correlation_id, _terminal_emitted
+    _correlation_id = correlation_id or None
+    _terminal_emitted = False
+    return _emit(EVENT_JOB_STARTED, "INFO")
+
+
+def job_cancelled() -> bool:
+    """The platform ended this run: evicted, drained, or deadline-exceeded.
+
+    Distinct from ``job_failed``: nothing about the ingest went wrong, and
+    counting these as failures would make the failure rate a function of cluster
+    pressure. Distinct from ``job_succeeded`` for the obvious reason.
+    """
+    return _terminal(EVENT_JOB_CANCELLED, "WARN")
+
+
+def job_succeeded() -> bool:
+    """The run finished with every record ingested."""
+    return _terminal(EVENT_JOB_SUCCEEDED, "INFO")
+
+
+def job_rejected(error_type: str) -> bool:
+    """The run never started: its configuration was refused."""
+    return _terminal(EVENT_JOB_REJECTED, "ERROR", error_type=error_type)
+
+
+def job_failed(
+    error_type: str,
+    exc: Optional[BaseException] = None,
+    failed_records: Optional[int] = None,
+) -> bool:
+    """The run started and did not finish cleanly.
+
+    ``failed_records`` is a COUNT. Counts, like column names and row indices,
+    are dataset structure and may be reported; the records themselves may not.
+    """
+    attributes: Dict[str, Any] = {"error_type": error_type}
+
+    # Both, or neither. The contract requires the type and the stacktrace
+    # together once an exception was caught, so sending the type without a
+    # renderable stacktrace would be a half-populated failure record -- the
+    # shape that makes an error report undiagnosable.
+    stack = safe_stacktrace(exc)
+    if stack:
+        attributes["exception__type"] = type(exc).__name__
+        attributes["exception__stacktrace"] = stack
+
+    if failed_records is not None:
+        attributes["tracebloc__ingest__failed_records"] = int(failed_records)
+
+    return _terminal(EVENT_JOB_FAILED, "ERROR", **attributes)
+
+
+def _terminal(event_name: str, severity: str, **attributes: Any) -> bool:
+    """Emit the run's terminal event, at most once.
+
+    THIS IS WHY THE PAIRING RULE HOLDS STRUCTURALLY rather than by review. The
+    entrypoint's funnel reports a terminal event on every path it can take,
+    including the ones that already classified themselves; this drops the
+    duplicate. So a run emits exactly one terminal event -- never two, and never
+    zero, even down a path added later that forgot to say anything.
+
+    SCOPED, because "structurally" was over-claimed here and it matters. The
+    funnel catches ``BaseException``, which covers every way PYTHON leaves the
+    frame. It does not cover a signal, whose default disposition terminates the
+    interpreter without unwinding -- no exception, no ``finally``, no
+    ``atexit``. @shujaatTracebloc measured that on this branch: SIGTERM at 3s
+    produced ``ingest.job.started`` and nothing else. ``main`` now handles
+    SIGTERM for exactly that reason.
+
+    What remains uncovered, stated rather than implied: **SIGKILL cannot be
+    caught**, so an OOM-killed run still emits ``started`` alone. In Kubernetes
+    that is the OOMKilled path specifically -- eviction, node drain and
+    ``activeDeadlineSeconds`` all send SIGTERM first and are now covered.
+
+    The flag is set BEFORE the emit, deliberately: a run whose terminal record
+    could not be delivered is still a run that ended, and letting the funnel's
+    backstop fire behind it would report the same ending twice under two
+    different classifications.
+    """
+    global _terminal_emitted
+    if _terminal_emitted:
+        return False
+    _terminal_emitted = True
+    return _emit(event_name, severity, **attributes)
+
+
+def _emit(event_name: str, severity: str, **attributes: Any) -> bool:
+    """Hand one record to the contract emitter. Never raises."""
+    try:
+        from tracebloc_telemetry import emit
+
+        if _correlation_id:
+            attributes["tracebloc__ingest__correlation_id"] = _correlation_id
+        emit(event_name, severity=severity, **attributes)
+        return True
+    except Exception as exc:
+        # The exception's CLASS only, following this package's standing pattern:
+        # a contract violation names the attribute it refused, and an attribute
+        # is the thing likeliest to be holding customer data at this point.
+        logger.warning(
+            "telemetry: could not emit %s (%s); ingestion is unaffected.",
+            event_name,
+            type(exc).__name__,
+        )
+        return False


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green. <!-- release-train:base-at-cut=5b01ed2e3a8dc9b520000d3f26aafe17f8b8ae3a -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new egress path from a customer-cluster Job and a SIGTERM handler on the console entrypoint. Telemetry is guarded so emit failures cannot fail ingest, but redaction mistakes would leak cell content.
> 
> **Overview**
> Adds RFC-BACKEND-1872 D2 contract telemetry to the ingest Job so every run reports `ingest.job.started` plus exactly one terminal event (`succeeded` / `rejected` / `failed` / `cancelled`).
> 
> `main` is now a funnel around `_run`: config rejections classify via `_fail`, ingest exceptions and failed-record counts emit `job_failed`, unclassified non-zero exits and unhandled startup exceptions are backstops, and SIGTERM reports `cancelled` (Kubernetes eviction/drain/deadline). Duplicate terminals are dropped. Failure records send exception type and frames (`format_tb` only) and never `exception.message` or row content; only a failed-record count is allowed.
> 
> Depends on pinned `tracebloc-telemetry==0.1.0` (no OTLP extra). Package version is `0.8.13`. Tests pin vocabulary completeness, one-terminal-per-run, SIGTERM, and redaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c795af51729359d2cde48f2c5d6a03b311f6311d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->