### PR TITLE
fix(token-classification): count distinct BIO tags, not tag sequences (backend#1747)

### DIFF
--- a/tests/test_token_classification_tag_counts.py
+++ b/tests/test_token_classification_tag_counts.py
@@ -1,0 +1,224 @@
+"""token_classification output_classes = DISTINCT TAGS, not tag SEQUENCES
+(backend#1747).
+
+The ``label`` column stores the whole per-row BIO tag sequence (one tag per
+word — e.g. ``"O B-PER I-PER O"``), so the row-unit ``get_label_counts``
+(``GROUP BY label``) counts distinct SEQUENCE STRINGS as classes — dozens of
+them — and the trained model head, built on that class set, never links to the
+9-ish real tags. The task is then unrunnable end to end.
+
+The fix routes token_classification's ingest-summary count through
+``Database.get_tag_counts``, which explodes each sequence into its tags, gated
+on the ``label_is_tag_sequence`` ModalitySpec trait (never a category string).
+
+Covered here:
+- the registry trait (set on token_classification, and unique to it);
+- the trait does NOT leak into the CLI layout contract (unchanged surface);
+- the base.py count-path routing: token_classification queries the exploded
+  helper and ships its distinct-tag counts as ``labels``; a non-tag category
+  still uses the row-unit helper;
+- ``get_tag_counts`` itself — the explode-and-weight arithmetic (the 77→9
+  bug), NULL-label handling, and SQL shape.
+
+The DB boundary is mocked like the rest of the unit suite.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tracebloc_ingestor.config import Config
+from tracebloc_ingestor.database import Database
+from tracebloc_ingestor.ingestors import base as base_mod
+from tracebloc_ingestor.ingestors.base import BaseIngestor
+from tracebloc_ingestor.modalities import REGISTRY, spec_for
+from tracebloc_ingestor.modalities.layout import build_layout_contract
+from tracebloc_ingestor.utils.constants import TaskCategory
+
+TOKEN = TaskCategory.TOKEN_CLASSIFICATION
+
+
+# ---------------------------------------------------------------------------
+# Registry trait + layout contract
+# ---------------------------------------------------------------------------
+
+
+def test_token_classification_carries_tag_sequence_trait():
+    spec = spec_for(TOKEN)
+    assert spec.label_is_tag_sequence is True
+    # Sanity: it's still the file-bearing NLP text task it always was, and it is
+    # NOT a whole-sequence classifier (the per-token head has no single class).
+    assert spec.is_file_bearing and spec.is_nlp
+    assert not spec.is_classification and not spec.is_self_supervised
+
+
+def test_tag_sequence_trait_is_unique_to_token_classification():
+    # Today exactly one tag-sequence category. A second one is a deliberate
+    # registry decision — update this test when it lands.
+    tagged = {c for c, s in REGISTRY.items() if s.label_is_tag_sequence}
+    assert tagged == {TOKEN}
+
+
+def test_trait_does_not_leak_into_layout_contract():
+    # label_is_tag_sequence drives the ingest-summary count only; it is not part
+    # of the CLI's on-disk staging contract, so the layout JSON is untouched (no
+    # version bump, no new per-task key).
+    doc = build_layout_contract()
+    assert doc["version"] == "2"
+    assert "label_is_tag_sequence" not in doc["tasks"][TOKEN]
+
+
+# ---------------------------------------------------------------------------
+# base.py count-path routing (DB boundary mocked)
+# ---------------------------------------------------------------------------
+
+
+class _FakeIngestor(BaseIngestor):
+    """Concrete BaseIngestor whose read_data yields preset records."""
+
+    def __init__(self, records, **kwargs):
+        self._records = records
+        super().__init__(**kwargs)
+
+    def read_data(self, source: Any) -> Generator[Dict[str, Any], None, None]:
+        yield from self._records
+
+
+def _make_ingestor(records, **overrides):
+    db = MagicMock(name="Database")
+    # #350: content_hash is the default id strategy; the mock DB must return a
+    # real salt string (a MagicMock salt poisons the hash and drops every row).
+    db.get_or_create_table_salt.return_value = "0" * 64
+    db.create_table.return_value = MagicMock(name="table")
+    db.insert_batch.return_value = ([1, 2], [])  # ids, db_failures
+    db.get_table_schema.return_value = {"label": "VARCHAR(255)"}
+    db.get_samples.return_value = []
+    api = MagicMock(name="APIClient")
+    api.config.TITLE = None
+    api.send_ingest_summary.return_value = {"dataset_id": 1, "dataset_key": "k"}
+
+    kwargs = dict(
+        database=db,
+        api_client=api,
+        table_name="tok_tbl",
+        schema={"label": "VARCHAR(255)"},
+        label_column="label",
+        intent="train",
+        category=TOKEN,
+    )
+    kwargs.update(overrides)
+    return _FakeIngestor(records, **kwargs)
+
+
+def _run_ingest(ing, batch_size=10):
+    """Run ingest with Session / validation / file-transfer patched out so a
+    file-bearing category runs without a real filesystem."""
+    with patch.object(base_mod, "Session") as Sess, patch.object(
+        ing, "validate_data", return_value=True
+    ), patch.object(
+        base_mod,
+        "map_file_transfer",
+        side_effect=lambda c, r, o, cfg=None, source_record=None: r,
+    ):
+        Sess.return_value.__enter__.return_value = MagicMock()
+        return ing.ingest("src", batch_size=batch_size)
+
+
+def test_ingest_counts_distinct_tags_not_sequences():
+    """The whole bug: two rows carry DISTINCT BIO SEQUENCE strings but share the
+    same three TAGS. output_classes must be those tags, so the count path uses
+    the exploded helper and ships its result verbatim as ``labels`` — never the
+    row-unit or sequence-unit helpers."""
+    records = [
+        {"filename": "f1", "label": "O B-PER I-PER"},
+        {"filename": "f2", "label": "B-PER O O"},
+    ]
+    ing = _make_ingestor(records)
+    ing.database.get_tag_counts.return_value = {"O": 4, "B-PER": 2, "I-PER": 1}
+
+    failed = _run_ingest(ing)
+
+    assert failed == []
+    ing.database.get_tag_counts.assert_called_once_with("tok_tbl", ing.ingestor_id)
+    ing.database.get_label_counts.assert_not_called()
+    ing.database.get_label_sequence_counts.assert_not_called()
+
+    summary_kwargs = ing.api_client.send_ingest_summary.call_args.kwargs
+    # Distinct TAGS (3), not distinct sequence strings (2).
+    assert summary_kwargs["labels"] == {"O": 4, "B-PER": 2, "I-PER": 1}
+    assert summary_kwargs["category"] == TOKEN
+
+
+def test_non_tag_category_keeps_row_counts():
+    # Control: text_classification (a real single-class text task) still uses the
+    # row-unit helper — the explode is trait-gated, not global to text tasks.
+    records = [
+        {"filename": "f1", "label": "spam"},
+        {"filename": "f2", "label": "ham"},
+    ]
+    ing = _make_ingestor(records, category=TaskCategory.TEXT_CLASSIFICATION)
+    ing.database.get_label_counts.return_value = {"spam": 1, "ham": 1}
+
+    _run_ingest(ing)
+
+    ing.database.get_label_counts.assert_called_once()
+    ing.database.get_tag_counts.assert_not_called()
+    ing.database.get_label_sequence_counts.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Database.get_tag_counts (SQL shape + explode arithmetic; engine mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    with patch("tracebloc_ingestor.database.create_engine") as ce:
+        engine = MagicMock(name="engine")
+        conn = MagicMock(name="conn")
+        engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+        engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+        ce.return_value = engine
+        db = Database(Config(DB_USER="u", DB_PASSWORD="p", DB_NAME="d"))
+        conn.reset_mock()  # drop __init__'s CREATE DATABASE call
+        yield db, conn
+
+
+def test_get_tag_counts_explodes_and_weights_by_row_count(mock_db):
+    """Two distinct sequence strings (what GROUP BY label returns) explode into
+    the handful of distinct tags, each tag weighted by its occurrences × the
+    sequence's row count. This is the 77-sequences → 9-tags collapse."""
+    db, conn = mock_db
+    conn.execute.return_value.fetchall.return_value = [
+        ("O B-PER I-PER", 3),  # O×1, B-PER×1, I-PER×1, over 3 rows
+        ("O O B-PER", 2),  # O×2, B-PER×1, over 2 rows
+    ]
+    counts = db.get_tag_counts("t", "ing-1")
+    assert counts == {"O": 1 * 3 + 2 * 2, "B-PER": 1 * 3 + 1 * 2, "I-PER": 1 * 3}
+    # The heavy lifting still happens in SQL: GROUP BY bounds the row set to the
+    # distinct sequences, and the id is bound, not interpolated.
+    sql = str(conn.execute.call_args.args[0])
+    assert "GROUP BY label" in sql
+    assert conn.execute.call_args.args[1] == {"ingestor_id": "ing-1"}
+
+
+def test_get_tag_counts_skips_null_label(mock_db):
+    # A NULL label carries no tags (unlike get_label_counts, which folds NULL to
+    # the "" key — an empty class is meaningless for a per-token tag set).
+    db, conn = mock_db
+    conn.execute.return_value.fetchall.return_value = [
+        (None, 5),
+        ("O B-LOC", 2),
+    ]
+    assert db.get_tag_counts("t", "ing-1") == {"O": 2, "B-LOC": 2}
+
+
+def test_get_tag_counts_escapes_table_backticks(mock_db):
+    db, conn = mock_db
+    conn.execute.return_value.fetchall.return_value = []
+    db.get_tag_counts("we`ird", "ing-1")
+    sql = str(conn.execute.call_args.args[0])
+    assert "FROM `we``ird`" in sql

--- a/tracebloc_ingestor/database.py
+++ b/tracebloc_ingestor/database.py
@@ -1032,6 +1032,52 @@ class Database:
             counts[key] = counts.get(key, 0) + cnt
         return counts
 
+    def get_tag_counts(self, table_name: str, ingestor_id: str) -> Dict[str, int]:
+        """
+        Return ``{tag: token_count}`` for a token-classification run, exploding
+        each row's whitespace-joined BIO tag SEQUENCE into individual tags.
+
+        token_classification stores the whole per-row tag sequence (one tag per
+        word — e.g. ``"O B-PER I-PER O"``) in the ``label`` column, so the
+        row-unit :meth:`get_label_counts` counts distinct SEQUENCE STRINGS as
+        classes (dozens of them) instead of the handful of distinct TAGS the
+        model head is built on. output_classes must be the distinct tags, so
+        this explodes the sequence and tallies token occurrences per tag
+        (backend#1747).
+
+        The ``GROUP BY label`` still runs in SQL, so the row set materialised
+        here is bounded to the DISTINCT sequence strings; each is split once and
+        weighted by its row count, making the Python work O(distinct sequences),
+        not O(rows). A NULL/empty label carries no tags and contributes nothing
+        (unlike :meth:`get_label_counts`, which reports NULL under the ``""``
+        key — an empty class is meaningless for a per-token tag set).
+
+        Args:
+            table_name: Name of the table to query
+            ingestor_id: UUID of the current ingest run
+
+        Returns:
+            Dict mapping each distinct BIO tag to its total token-occurrence
+            count across the run's rows
+        """
+        with self.engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    f"SELECT label, COUNT(*) AS cnt "
+                    f"FROM `{table_name.replace('`', '``')}` "
+                    f"WHERE ingestor_id = :ingestor_id "
+                    f"GROUP BY label"
+                ),
+                {"ingestor_id": ingestor_id},
+            ).fetchall()
+        counts: Dict[str, int] = {}
+        for label, row_count in rows:
+            if label is None:
+                continue
+            for tag in str(label).split():
+                counts[tag] = counts.get(tag, 0) + row_count
+        return counts
+
     def get_label_sequence_counts(
         self, table_name: str, ingestor_id: str, group_column: str = "sequence_id"
     ) -> Dict[str, int]:

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -527,6 +527,19 @@ class BaseIngestor(ABC):
         return spec.grouping if spec is not None else None
 
     @property
+    def _label_is_tag_sequence(self) -> bool:
+        """Whether the category's ``label`` column holds a whitespace-joined
+        per-token tag SEQUENCE (token_classification BIO/IOB2), so its
+        output_classes are the DISTINCT TAGS — the sequence exploded — rather
+        than the distinct sequence strings a plain ``GROUP BY label`` would
+        count (backend#1747). Read trait-style from the registry, never via a
+        category string, so a future tag-sequence category is a registry entry,
+        not a base.py edit. Selects ``get_tag_counts`` over ``get_label_counts``
+        in the ingest-summary count path."""
+        spec = _MODALITY_REGISTRY.get(self.category)
+        return bool(spec is not None and spec.label_is_tag_sequence)
+
+    @property
     def _table_lock(self) -> TableLock:
         """The run's table lock (P5b). ``TableLock`` owns the file-lock
         lifecycle — compute path, atomic acquire with stale-reclaim, release —
@@ -1200,6 +1213,7 @@ class BaseIngestor(ABC):
                 # future grouped category counting rows falls through to the
                 # standard row counts like every non-grouped category.
                 if grouping is not None and grouping.count_unit == "sequences":
+                    counts_helper = "get_label_sequence_counts"
                     label_counts = self.database.get_label_sequence_counts(
                         self.physical_table_name,
                         self.ingestor_id,
@@ -1212,7 +1226,19 @@ class BaseIngestor(ABC):
                     self.file_options["number_of_sequences"] = sum(
                         label_counts.values()
                     )
+                elif self._label_is_tag_sequence:
+                    # token_classification: the ``label`` column holds the whole
+                    # per-token BIO tag SEQUENCE, so output_classes are the
+                    # DISTINCT TAGS. Explode the sequence (get_tag_counts) rather
+                    # than GROUP BY the raw sequence string, which would count
+                    # distinct sequences as classes — no model head links then,
+                    # and the task is unrunnable e2e (backend#1747).
+                    counts_helper = "get_tag_counts"
+                    label_counts = self.database.get_tag_counts(
+                        self.physical_table_name, self.ingestor_id
+                    )
                 else:
+                    counts_helper = "get_label_counts"
                     # CEILING (review on #487, tracked in #488): this GROUP BYs
                     # the RAW label, so a regression-class dataset with a
                     # continuous target yields up to one entry per distinct
@@ -1247,11 +1273,6 @@ class BaseIngestor(ABC):
                         "skipping ingest summary."
                     )
                 elif not label_counts:
-                    counts_helper = (
-                        "get_label_sequence_counts"
-                        if grouping is not None and grouping.count_unit == "sequences"
-                        else "get_label_counts"
-                    )
                     raise RuntimeError(
                         f"Inserted {stats['inserted_records']} row(s) but "
                         f"{counts_helper} returned nothing for "

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -100,6 +100,10 @@ _SPECS = (
         transfer=t.token_classification,
         is_nlp=True,
         file_subdir="texts",
+        # The label column holds the whole per-token BIO tag SEQUENCE, so
+        # output_classes are the DISTINCT TAGS (exploded), not the distinct
+        # sequence strings a GROUP BY label would count (backend#1747).
+        label_is_tag_sequence=True,
     ),
     # sentence_pair_classification is SUPERVISED text classification — the class
     # label travels in the labels CSV, exactly like text_classification (so

--- a/tracebloc_ingestor/modalities/spec.py
+++ b/tracebloc_ingestor/modalities/spec.py
@@ -115,3 +115,14 @@ class ModalitySpec:
     # None``, never on the category string. ``None`` for every per-row
     # category.
     grouping: Optional["Grouping"] = None
+    # Token-tagging label (backend#1747): the ``label`` column holds a
+    # whitespace-joined per-token tag SEQUENCE (token_classification's BIO/IOB2
+    # tags, one tag per word — e.g. ``"O B-PER I-PER O"``), not a single class
+    # value. The dataset's output_classes are therefore the DISTINCT TAGS, which
+    # ``ingestors/base.py`` counts by EXPLODING each sequence
+    # (``Database.get_tag_counts``) — a plain ``GROUP BY label``
+    # (``get_label_counts``) would instead count distinct sequence STRINGS as
+    # classes, so no model head links and the task is unrunnable e2e. Consumed
+    # trait-style (never on the category string), so a future tag-sequence
+    # category is a one-line registry entry. ``False`` for every other category.
+    label_is_tag_sequence: bool = False


### PR DESCRIPTION
Closes tracebloc/backend#1747

## Problem

`token_classification` stores the whole per-row **BIO tag SEQUENCE** (one tag per word, e.g. `"O B-PER I-PER O"`) in the `label` column. The ingest-summary count path ran `GROUP BY label` (`Database.get_label_counts`) over that column, so `output_classes` became the set of **distinct sequence strings** (e.g. 77) instead of the handful of **distinct tags** (e.g. 9) the model head is built on. No head links to that class set — the whole task type is unrunnable end to end.

## Fix

- **`Database.get_tag_counts`** — new count path that explodes each row's whitespace-joined tag sequence into individual tags and tallies token occurrences per tag. The `GROUP BY label` still runs in SQL, so the work is `O(distinct sequences)`, not `O(rows)`.
- **`ModalitySpec.label_is_tag_sequence`** — new trait, set on `token_classification` in the registry. `ingestors/base.py` selects `get_tag_counts` over `get_label_counts` **trait-style, never on a category string** — mirroring the existing `grouping` trait — so a future tag-sequence category is a one-line registry entry.
- The `counts_helper` error-label is now set once per branch (removes a duplicated ternary and stays truthful for the new branch).

This ports the tag-explosion logic from the deleted backend `global_meta/dataset_metadata_json_generator._explode_tags` into the ingestor's count path (that file is **not** restored). The CLI layout contract is untouched — the trait drives the count only, not on-disk staging.

## Existing datasets

Existing BIO datasets pick up correct `output_classes` on **re-ingest** through this path. The metadata-backfill runner (`metadata_backfill*.py`) deliberately does not carry row-level `labels` (its payload is schema + feature_stats only), so it is not extended here — correcting a stored `output_classes` without a re-ingest is a backend-endpoint change, out of this repo's scope.

## Testing

- New `tests/test_token_classification_tag_counts.py` (8 tests): the registry trait (set + unique + absent from the layout contract); base.py routing (token_classification ships distinct-tag counts, a non-tag text category keeps row counts); `get_tag_counts` explode-and-weight arithmetic (the 77→9 collapse), NULL-label handling, and SQL/escaping shape.
- Full suite green: **2159 passed, 1 xfailed**. `black --check` and `ruff check` clean.

## Known trade-off — backend record counts (accepted, tracked)

Thanks to @LukasWodka and @shujaatTracebloc for catching this. The `labels` dict does two jobs: its **keys** are the class vocabulary (fixed here), but the backend also infers a **record count** by summing its **values** (`sum(labels.values())`). Before this change that sum equalled the row count for `token_classification`; after it, it's the tagged-token count — so the backend's record-count fields (`total`, `unique_data_items_count`) inflate ~mean-tokens-per-row for this modality, on the single-edge path **and**, compounding, through `combine_datasets`.

Per-field: `count.label` becomes **right** (the point of this fix), `label_density` **better**, while `total` / `unique_data_items_count` become **wrong**. The class fix is the far more valuable half — an unrunnable task type is the worse failure — so this **ships with the inflated counts as a known, accepted consequence**, not a silent one. The real fix is cross-repo (carry an explicit row count in the summary payload and consume it instead of the sum for tag-sequence categories) and is **recorded on backend#1747** ([decision + full trace, both corrupted paths named](https://github.com/tracebloc/backend/issues/1747#issuecomment-5406738806)) as the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the ingest-summary class set for token classification, which drives backend `output_classes` and model-head linking. Scope is one modality and is covered by unit tests, but a wrong explode would still ship a bad class vocabulary.
> 
> **Overview**
> Fixes token classification ingest so `output_classes` are the distinct BIO **tags**, not distinct per-row tag **sequence strings** (backend#1747). That mismatch left the model head unlinked and the task unrunnable.
> 
> Adds `Database.get_tag_counts`, which still `GROUP BY`s sequences in SQL then explodes and weights tags in Python (`O(distinct sequences)`). A new `ModalitySpec.label_is_tag_sequence` trait (set only on `token_classification`) selects this helper in the ingest-summary path—trait-style, not a category string. The CLI layout contract is unchanged.
> 
> NULL labels contribute no tags. Existing datasets get correct classes on re-ingest; metadata backfill is out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea44b5b36fc66d1c0a4c8cb0cb67857897ec495f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
