### PR TITLE
ci(2272): mint with client-id, not the deprecated app-id

### DIFF
--- a/.github/workflows/add-to-kanban.yml
+++ b/.github/workflows/add-to-kanban.yml
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_TRAIN_APP_ID }}
+          client-id: ${{ secrets.RELEASE_TRAIN_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_TRAIN_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           # SCOPED TO THIS REPO, or the two reads below land org-wide (saadqbal,


### PR DESCRIPTION
Replaces the deprecated `app-id` input with `client-id` on every
`actions/create-github-app-token` mint in this repo (backend#2272).

The action deprecated `app-id` (`Input 'app-id' has been deprecated with message: Use
'client-id' instead.`), so every run currently prints that warning. A client id is a
**different value** from the numeric app id, so this needed a new secret before a single
line could change: **`RELEASE_TRAIN_APP_CLIENT_ID`** was created on 2026-08-25 at **both**
org Actions and org Dependabot scope, `visibility=all` — both scopes because GitHub gates
Dependabot-triggered workflows on a separate secret store. The private key
(`RELEASE_TRAIN_APP_PRIVATE_KEY`) is unchanged; only the identifier moves.

## What changed

- `.github/workflows/add-to-kanban.yml`

Exactly one line per mint:

```diff
-          app-id: ${{ secrets.RELEASE_TRAIN_APP_ID }}
+          client-id: ${{ secrets.RELEASE_TRAIN_APP_CLIENT_ID }}
```

Nothing else. In particular **no `permission-*` line is touched** — backend#2157 is
separate work on these same steps (four exemptions still stand there), and a stray scope
edit here would collide with it and muddy both.

## Ordering — this PR is **wave 1**; `tracebloc/.github` merges **LAST**

`add-to-kanban.yml` is a per-repo **copy**, and `caller-drift.py` compares each repo's
blob sha against `tracebloc/.github`'s copy as the source of truth. So every other repo
must merge **before** `.github`. This PR is in the first wave; the `.github` PR is
deliberately held until the rest have landed.

The org caller-drift audit **will report drift for the duration of the window**. That is
inherent to a byte-compared copy changing across repos and is the accepted cost — the
window is kept short by opening every PR together and merging in order.

## Verification

- `actionlint` — clean on 1 edited file(s).
- `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))"` — clean on 1 edited file(s).
- The pinned action `actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0`
  accepts `client-id` — confirmed by reading `action.yml` **at that exact SHA**, not from
  memory. All 42 mint steps across the org sit on this one pin, so no version bump is
  needed anywhere and none is made here.
- Diff is 1 file changed, 1 insertion(+), 1 deletion(-) — a pure 1:1 line swap.

### What this cannot prove

**A token mint can only be proven by a workflow actually running.** If the new secret's
value were wrong, this fails at mint time with an auth error; the first real board write
is the test. Stating that plainly rather than letting the green checks above imply
coverage they do not have.

Refs tracebloc/backend#2272

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: one credential identifier change on an existing mint step; wrong secret value fails at mint time rather than silently widening scope.
> 
> **Overview**
> Updates the **add-to-kanban** workflow so `actions/create-github-app-token` uses the **`client-id`** input and **`RELEASE_TRAIN_APP_CLIENT_ID`** instead of the deprecated **`app-id`** / **`RELEASE_TRAIN_APP_ID`**.
> 
> That is a single-line swap on the mint step; **`private-key`**, **`owner`**, **`repositories`**, and all **`permission-*`** lines are unchanged. The new secret must exist in both org Actions and Dependabot scopes so Dependabot-triggered runs still mint a token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9acb4848765d34bcb622507f00d34260f3358799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->