### PR TITLE
feat(2284): give the Bugbot gate a caller here (advisory)

### DIFF
--- a/.github/workflows/bugbot-gate-caller.yml
+++ b/.github/workflows/bugbot-gate-caller.yml
@@ -1,0 +1,107 @@
+name: Bugbot gate
+
+# THIN CALLER. The FLEET ROLLOUT of tracebloc/backend#2284 -- step 2 of the
+# three-step arming order the reusable's own header sets out, continued from the
+# pilot onto the rest of the org.
+#
+# WHERE THIS SITS. `bugbot-gate.yml` reached `.github`'s `main` in #305/#312 and
+# then executed NOWHERE, because a reusable with no caller runs on nothing: every
+# `repo-inventory.yml` row read `exempt`. claude-skills#36 gave it its first
+# caller on 2026-08-25, on one low-traffic private repo chosen by measured PR
+# volume. That pilot is the evidence this file rides on -- the gate was observed
+# running against real PRs before going fleet-wide, which is CLAUDE.md rule 4
+# (arm while green) done in the only order that lets a misbehaviour be attributed
+# to one repo instead of twenty. This is the other nineteen.
+#
+# THIS IS ADVICE, NOT A GATE, AND SAYING SO IS THE POINT -- it is the whole of
+# what backend#2284 asks for at this step. `bugbot / review` is NOT added to this
+# repo's required status contexts, and the PR carrying this file touches no
+# branch protection at all. Step 3 is deliberately NOT taken here, and one
+# measurement is why:
+#
+#   BUGBOT DOES NOT REVIEW DEPENDABOT PRs. Sampled 2026-08-25 over the last 30
+#   PRs each of .github, cli, release-train, tracebloc-website, averaging-service
+#   and backend: every NON-DRAFT pull request with no `Cursor Bugbot` check run
+#   on its head was authored by dependabot (cli#574, cli#575,
+#   tracebloc-website#510). The only other misses were drafts, which this gate
+#   passes by design. Bugbot re-runs only on a push or an explicit `bugbot run`
+#   comment, so a REQUIRED `bugbot / review` would park every Dependabot PR at a
+#   red check with no route to green. That question is unanswered, so the verdict
+#   is reported and nothing is required. As ADVICE the same PRs still go red --
+#   after the callee's 900s wait, visible and costing only runner minutes, which
+#   is the honest way to leave a question open.
+#
+# `repo-inventory.yml` IS NOT TOUCHED BY THIS PR. `.github`'s caller state is
+# read from its audit branch over the API, so a caller and its `required` row
+# cannot land together: the row would be checked against a branch the caller is
+# not on yet. Caller first, entry after -- the two-step blocked-gate and
+# backend#2396 were both forced into. BETWEEN THE TWO, a caller sitting against
+# an `exempt` row IS the stale-exemption finding and the org audit goes red. That
+# window is the cost of this order rather than an oversight (the alternative is a
+# PR that can never go green), and FLIPPING THE ROW TO `required` IS THE REQUIRED
+# FOLLOW-UP -- one PR against tracebloc/.github for the whole fleet.
+#
+# NO INPUTS PASSED. The callee declares four -- `min-severity` (default `high`),
+# `wait-seconds` (900), `poll-seconds` (20), `quality-ref` (`main`) -- and every
+# one is left at its default, `min-severity` DELIBERATELY. Passing `high`
+# explicitly would restate the callee's own default in twenty files, so changing
+# the fleet threshold would take twenty PRs and would silently half-apply if one
+# were missed: derive, never restate (CLAUDE.md rule 1). `high` is also the right
+# threshold today precisely because it is green fleet-wide --
+# `required_conversation_resolution` is true on every measured branch, so no
+# mergeable PR carries an open finding of ANY severity and starting stricter
+# would buy nothing while risking a red gate on day one. A caller may only pass
+# inputs the `@main` callee declares; passing one it does not have kills the run
+# at `startup_failure`. Verified before writing this line: `bugbot-gate.yml` is
+# blob 936771bb on `.github`'s `main` and `develop` alike, and declares all four.
+#
+# NO `paths:` FILTER, and none may be added. A path-filtered check never reports
+# on a PR the filter skips, so once required it parks that PR at "Expected --
+# waiting for status" forever. This org has hit that twice (client#665,
+# pii-gate/pii-check); the reusable's header, code-quality.yml's and
+# selftests.yml's all carry the same warning.
+#
+# `ready_for_review` IS LOAD-BEARING, not boilerplate. The gate deliberately
+# PASSES a draft -- a draft cannot merge, and Bugbot's behaviour on drafts is not
+# this gate's business -- so leaving that type out means the exemption is never
+# lifted and the check stays permanently green on anything opened as a draft.
+#
+# NO `secrets: inherit` -- RFC-BACKEND-1405 Q5. The callee runs on `github.token`
+# with exactly the three read scopes granted below; inheriting would hand it
+# every secret this repo holds, for no gain.
+#
+# NO `workflow_dispatch`. The callee reads `github.event.pull_request.number`,
+# which a dispatch does not carry -- the run would abort with "PR_NUMBER must be
+# a number" rather than checking anything. When the failure message says to
+# RE-RUN this check after resolving a thread, it means "Re-run jobs" on the
+# existing run, which replays the original pull_request payload. (Resolving a
+# thread is a `pull_request_review_thread` event, which actionlint 1.7.12 -- a
+# required check in tracebloc/.github -- does not know, so no caller can trigger
+# on it yet.)
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+# Per-PR: `github.ref` is `refs/pull/<n>/merge` on a pull_request event. The
+# callee polls for up to 900s, so without this a superseded run keeps a poll
+# alive against a head nobody is merging.
+concurrency:
+  group: bugbot-gate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# All three are load-bearing and a called workflow cannot hold more than its
+# caller: `checks: read` reads the head's check runs, `pull-requests: read`
+# reads the review threads, `contents: read` checks out the shared checker.
+permissions:
+  contents: read
+  checks: read
+  pull-requests: read
+
+# The job id below and the callee's job id (`review`) together are the check
+# CONTEXT name, `bugbot / review` -- which is the string branch protection would
+# key on at step 3. Required checks reference job ids, never filenames, so this
+# file may be renamed and that name may not.
+jobs:
+  bugbot:
+    uses: tracebloc/.github/.github/workflows/bugbot-gate.yml@main

--- a/.github/workflows/bugbot-gate-caller.yml
+++ b/.github/workflows/bugbot-gate-caller.yml
@@ -13,6 +13,26 @@ name: Bugbot gate
 # (arm while green) done in the only order that lets a misbehaviour be attributed
 # to one repo instead of twenty. This is the other nineteen.
 #
+# WHAT THE PILOT DOES NOT COVER, said here rather than inherited
+# (shujaatTracebloc, model-zoo#179). The pilot repo is PRIVATE and NOT on the
+# release train. Most repos taking this caller are one or both of the opposite,
+# and the gap is real on two axes rather than rhetorical:
+#
+#   PUBLIC repos -- a misfiring advisory check is visible outside the org, which
+#   it structurally could not be on the pilot. The pilot's own safety argument
+#   leaned partly on that privacy, so the property does not carry forward and is
+#   not being claimed here. Accepted because the check blocks nothing: the verdict
+#   is reported, never enforced.
+#
+#   TRAIN repos -- promotion PRs (`develop -> staging`, `staging -> main`) are a
+#   whole class the pilot never saw, because it has no train. Whatever this gate
+#   does on one is therefore UNEXERCISED, not proven benign. Also advisory, so an
+#   unexpected result costs a red tick and no merge.
+#
+# Neither is an argument against arming it as advice. Both are limits the pilot's
+# evidence does not reach, and step 3 must not be taken on any repo until they
+# have been measured THERE.
+#
 # THIS IS ADVICE, NOT A GATE, AND SAYING SO IS THE POINT -- it is the whole of
 # what backend#2284 asks for at this step. `bugbot / review` is NOT added to this
 # repo's required status contexts, and the PR carrying this file touches no
@@ -102,6 +122,16 @@ permissions:
 # CONTEXT name, `bugbot / review` -- which is the string branch protection would
 # key on at step 3. Required checks reference job ids, never filenames, so this
 # file may be renamed and that name may not.
+#
+# THE JOB ID IS THE CONTRACT AND MUST NOT GAIN A `name:` (shujaatTracebloc,
+# start-training#73). `bugbot / review` is built from the job ID only because
+# `jobs.bugbot` carries no `name:` -- the `name:` at the top of this file is the
+# WORKFLOW's and never enters the context. Adding a cosmetic `name: Bugbot review`
+# to the job below would rename the context to `Bugbot review / review`, and once
+# step 3 arms the old string as required, that check would silently never report
+# again. Note what the clause above does and does not buy: it forbids renaming the
+# FILE, which is the one change that would NOT move the context. This is the one
+# that would.
 jobs:
   bugbot:
     uses: tracebloc/.github/.github/workflows/bugbot-gate.yml@main


### PR DESCRIPTION
## What this is

One of **19 sibling PRs** rolling `bugbot-gate.yml` out to the rest of the org — the fleet half of **tracebloc/backend#2284**, following the `claude-skills` pilot (claude-skills#36).

This is **step 2 of the three-step arming order** the reusable's own header sets out: (1) the reusable reaches `.github`'s `main` — done in #305/#312; (2) callers, **advisory**; (3) the `bugbot / review` required context — **not taken here**.

## This is advice, not a gate — and that is deliberate

**No branch protection is touched by this PR, and `bugbot / review` is not added to any required-context list.** One measurement is why step 3 is not taken:

> **Bugbot does not review Dependabot PRs.** Sampled 2026-08-25 over the last 30 PRs each of `.github`, `cli`, `release-train`, `tracebloc-website`, `averaging-service` and `backend`: every **non-draft** PR with no `Cursor Bugbot` check run on its head was authored by `dependabot` (`cli#574`, `cli#575`, `tracebloc-website#510`). The only other misses were **drafts**, which this gate passes by design.

Bugbot re-runs only on a push or an explicit `bugbot run` comment, so a *required* `bugbot / review` would park every Dependabot PR at a red check **with no route to green**. Until that is answered the verdict is reported and nothing is required.

## Why it is safe to arm here

- **Bugbot demonstrably runs in this repo.** Derived rather than assumed: the `cursor` GitHub App is installed on the org with `repository_selection: all`, and a per-repo sample of the last 15 PRs found a terminal `Cursor Bugbot` check on every non-draft, non-Dependabot head. A repo where Bugbot never runs would only ever measure the gate's own 900s timeout.
- **The pilot ran first.** `claude-skills#36` put the gate on real PRs on one low-traffic private repo before this went fleet-wide — CLAUDE.md rule 4 (arm while green), in the order that lets a misbehaviour be attributed to one repo rather than twenty.

## `repo-inventory.yml` is not touched here — the flip is the required follow-up

**Caller first, inventory entry after.** `.github`'s caller state is read from its audit branch over the API, so a caller and its `required` row cannot land in one PR: the row would be checked against a branch the caller is not on yet. Same two-step `blocked-gate` and backend#2396 were forced into.

**Between the two, a caller against an `exempt` row is the stale-exemption finding and the org audit is red.** That window is the accepted cost of this order — the alternative is a PR that can never go green — and **flipping every row to `required` is the required follow-up**, one PR against `tracebloc/.github` covering all 20 repos.

## Verification

- `actionlint` **1.7.12** — the version pinned as a required check in `tracebloc/.github` — clean on this file.
- `python3 -c "import yaml; yaml.safe_load(...)"` clean.
- The `uses:` target resolves: `bugbot-gate.yml` is blob `936771bb` on `.github`'s **`main`** and **`develop`** alike, and really declares all four inputs this caller declines to pass.
- Below the header, this file is **byte-identical** to the proven pilot caller.
- No `paths:` filter · `ready_for_review` present · no `secrets: inherit` · no `workflow_dispatch` · no inputs passed (all four defaulted, `min-severity: high` included — restating the callee's default in 20 files is CLAUDE.md rule 1 in reverse).

## What to watch on this PR

This PR is its own first observation: the caller is on the head, so the gate runs against it. Expected — `bugbot / review` reports, having read `Cursor Bugbot`'s terminal verdict on the head, and passes with no findings open at or above `high`.

Refs tracebloc/backend#2284

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an advisory CI caller only—no branch protection, no required checks, and no application code changes. Main operational risk is extra runner time on PRs where Bugbot never runs (e.g. Dependabot), which shows as a red advisory check rather than blocking merge.
> 
> **Overview**
> Adds **`bugbot-gate-caller.yml`**, a thin GitHub Actions caller that invokes the org reusable **`tracebloc/.github/.github/workflows/bugbot-gate.yml@main`** on pull requests. This is **step 2** of the Bugbot gate fleet rollout (after the `claude-skills` pilot): the **`bugbot / review`** check runs and reports Cursor Bugbot’s verdict, but **branch protection is not changed** and the check is **not required**—so merges are not blocked.
> 
> The workflow fires on **`opened`**, **`reopened`**, **`synchronize`**, and **`ready_for_review`** (drafts stay exempt until marked ready), uses **concurrency** with **cancel-in-progress** for superseded heads, and grants only **`contents`**, **`checks`**, and **`pull-requests`** read scopes. It passes **no inputs** (callee defaults, including **`min-severity: high`**), omits **`paths:`** filters, **`secrets: inherit`**, and **`workflow_dispatch`**. The job id **`bugbot`** (no cosmetic **`name:`**) preserves the **`bugbot / review`** status context string for a future step 3.
> 
> **`repo-inventory.yml` is untouched**; flipping inventory rows to **`required`** is documented as a separate follow-up PR to `tracebloc/.github`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72b9a5d5a65585d8b9bcf0af8798b32bd3b6408d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->