### PR TITLE
fix(layout): surface the time-ordering constraint in layout.v1.json (backend#1870)

### DIFF
--- a/tests/test_layout_contract.py
+++ b/tests/test_layout_contract.py
@@ -94,11 +94,13 @@ def test_record_format_only_on_text_tasks():
             ), f"{cat} has a record_format but isn't text"
 
 
-def test_ordering_agrees_with_the_single_source():
+def test_ordering_agrees_with_the_registry():
     # `ordering` is DERIVED, not hand-declared: its column is the category's
-    # entry in FIXED_TIME_COLUMN_BY_CATEGORY, and its scope follows whether the
-    # spec has a grouping trait — so it can't drift from what the validators and
-    # preflight enforce (backend#1870).
+    # entry in FIXED_TIME_COLUMN_BY_CATEGORY and its scope follows the spec's
+    # grouping trait, so mutating `_ordering` reddens this. This pins the
+    # derivation to the REGISTRY only — that scope actually matches the validator
+    # the ingestor runs is the separate, stronger guarantee in
+    # test_ordering_scope_is_anchored_to_the_enforcing_validator (backend#1870).
     for cat, layout in _contract().items():
         fixed = FIXED_TIME_COLUMN_BY_CATEGORY.get(cat)
         if fixed is None:
@@ -200,3 +202,53 @@ def test_time_ordering_constraint_is_discoverable():
     # contract must state that it is not subject to the ordering rule, so a
     # consumer no longer has to infer it from the validator's silence.
     assert contract["time_to_event_prediction"]["ordering"] is None
+
+
+def test_ordering_scope_is_anchored_to_the_enforcing_validator():
+    # The derivation ties `scope` to a CORRELATED trait (grouping), not to the
+    # thing that enforces ordering — the per-category validator factory, which
+    # hardcodes its choice (validators.py: TSF appends TimeOrderedValidator, TSC
+    # appends PerGroupTimeOrderedValidator; neither consults `grouping`). Today
+    # they agree only because TSC is the sole grouped category AND the sole
+    # per-group user — coincidence, not construction. A future grouped category
+    # wired to the global validator would make the contract declare `per_group`
+    # while the ingestor enforces dataset-wide ordering: the exact seam
+    # backend#1870 is about, reopened. Pin the two together so it's true by test.
+    #
+    # Instantiating a factory is side-effect-free (no DB/file), so we can read
+    # the validator types directly. The superset options satisfy every factory's
+    # required keys (extension/target_size for the image tasks); values are only
+    # touched at validate() time, which we never call.
+    from tracebloc_ingestor.utils.constants import FileExtension
+    from tracebloc_ingestor.validators.per_group_time_ordered_validator import (
+        PerGroupTimeOrderedValidator,
+    )
+    from tracebloc_ingestor.validators.time_ordered_validator import (
+        TimeOrderedValidator,
+    )
+
+    opts = {"schema": {}, "extension": FileExtension.JPG, "target_size": (1, 1)}
+    contract = _contract()
+    for cat, spec in REGISTRY.items():
+        validators = spec.build_validators(dict(opts))
+        # PerGroup does not subclass the global validator, but guard anyway so a
+        # later class change can't silently count a per-group run as dataset.
+        dataset_scoped = any(
+            isinstance(v, TimeOrderedValidator)
+            and not isinstance(v, PerGroupTimeOrderedValidator)
+            for v in validators
+        )
+        per_group_scoped = any(
+            isinstance(v, PerGroupTimeOrderedValidator) for v in validators
+        )
+        ordering = contract[cat]["ordering"]
+        if ordering is None:
+            assert not dataset_scoped and not per_group_scoped, (
+                f"{cat}: contract declares no ordering, but its factory runs a "
+                f"time-ordering validator"
+            )
+        elif ordering["scope"] == "per_group":
+            assert per_group_scoped and not dataset_scoped, cat
+        else:
+            assert ordering["scope"] == "dataset" and dataset_scoped, cat
+            assert not per_group_scoped, cat

--- a/tests/test_layout_contract.py
+++ b/tests/test_layout_contract.py
@@ -19,7 +19,10 @@ from tracebloc_ingestor.modalities.layout import (
     contract_path,
     render_contract,
 )
-from tracebloc_ingestor.modalities.registry import REGISTRY
+from tracebloc_ingestor.modalities.registry import (
+    FIXED_TIME_COLUMN_BY_CATEGORY,
+    REGISTRY,
+)
 from tracebloc_ingestor.utils.constants import TaskCategory
 
 
@@ -91,6 +94,22 @@ def test_record_format_only_on_text_tasks():
             ), f"{cat} has a record_format but isn't text"
 
 
+def test_ordering_agrees_with_the_single_source():
+    # `ordering` is DERIVED, not hand-declared: its column is the category's
+    # entry in FIXED_TIME_COLUMN_BY_CATEGORY, and its scope follows whether the
+    # spec has a grouping trait — so it can't drift from what the validators and
+    # preflight enforce (backend#1870).
+    for cat, layout in _contract().items():
+        fixed = FIXED_TIME_COLUMN_BY_CATEGORY.get(cat)
+        if fixed is None:
+            assert layout["ordering"] is None, cat
+        else:
+            assert layout["ordering"] == {
+                "column": fixed,
+                "scope": "per_group" if REGISTRY[cat].grouping else "dataset",
+            }, cat
+
+
 # 3. FAITHFULNESS (spot-checks vs the ingestor's real layout) -----------------
 
 
@@ -160,3 +179,24 @@ def test_tabular_family_is_data_csv_without_file_layout():
         assert layout["manifest"]["requires_filename_column"] is False, cat
         assert layout["primary_subdir"] is None, cat
         assert layout["sidecars"] == [] and layout["record_format"] is None, cat
+
+
+def test_time_ordering_constraint_is_discoverable():
+    # The seam backend#1870 closed: the ingestor enforces timestamp ordering in
+    # its validators, and now the contract says so. Forecasting is one merged
+    # series (global TimeOrderedValidator → dataset scope); classification is
+    # ordered within each sequence (PerGroupTimeOrderedValidator → per_group).
+    contract = _contract()
+    assert contract["time_series_forecasting"]["ordering"] == {
+        "column": "timestamp",
+        "scope": "dataset",
+    }
+    assert contract["time_series_classification"]["ordering"] == {
+        "column": "timestamp",
+        "scope": "per_group",
+    }
+    # time_to_event_prediction has a time column too, but it is a per-row
+    # duration validated by TimeToEventValidator — NOT a monotonic axis. The
+    # contract must state that it is not subject to the ordering rule, so a
+    # consumer no longer has to infer it from the validator's silence.
+    assert contract["time_to_event_prediction"]["ordering"] is None

--- a/tests/test_time_series_classification.py
+++ b/tests/test_time_series_classification.py
@@ -149,13 +149,16 @@ def test_grouping_is_unique_to_tsc():
 
 def test_layout_contract_carries_grouping():
     doc = build_layout_contract()
-    assert doc["version"] == "2"  # shape change: the grouping block
+    assert doc["version"] == "3"  # shape now carries grouping + ordering blocks
     tsc = doc["tasks"][TSC]
     assert tsc["grouping"] == {
         "group_column": "sequence_id",
         "time_column": "timestamp",
         "count_unit": "sequences",
     }
+    # TSC's timestamps must stay monotonic WITHIN each sequence — the per-group
+    # scope matches its PerGroupTimeOrderedValidator (backend#1870).
+    assert tsc["ordering"] == {"column": "timestamp", "scope": "per_group"}
     # Non-grouped categories emit an explicit null (mirrors record_format).
     assert doc["tasks"][TaskCategory.TABULAR_CLASSIFICATION]["grouping"] is None
     assert doc["tasks"][TaskCategory.TIME_SERIES_FORECASTING]["grouping"] is None
@@ -392,10 +395,7 @@ def test_partial_sequence_deleted_despite_header_spelling_drift(make_csv):
     def _insert(table, batch):
         ok, failed = [], []
         for i, record in enumerate(batch):
-            if (
-                record.get("Sequence_ID") == "p3"
-                and record.get("heart_rate") == "72.0"
-            ):
+            if record.get("Sequence_ID") == "p3" and record.get("heart_rate") == "72.0":
                 failed.append({"record": record, "error": "dup key"})
             else:
                 ok.append(i)

--- a/tests/test_token_classification_tag_counts.py
+++ b/tests/test_token_classification_tag_counts.py
@@ -64,10 +64,10 @@ def test_tag_sequence_trait_is_unique_to_token_classification():
 
 def test_trait_does_not_leak_into_layout_contract():
     # label_is_tag_sequence drives the ingest-summary count only; it is not part
-    # of the CLI's on-disk staging contract, so the layout JSON is untouched (no
-    # version bump, no new per-task key).
+    # of the CLI's on-disk staging contract, so it never surfaces as a per-task
+    # key in the layout JSON.
     doc = build_layout_contract()
-    assert doc["version"] == "2"
+    assert doc["version"] == "3"
     assert "label_is_tag_sequence" not in doc["tasks"][TOKEN]
 
 

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.13"
+__version__ = "0.8.14"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/modalities/layout.py
+++ b/tracebloc_ingestor/modalities/layout.py
@@ -35,7 +35,12 @@ from typing import Any, Dict, Optional, Tuple
 # not when a task's values change — those are caught by the drift test.
 # "2": added the per-task ``grouping`` block (sequence-grouped categories,
 #      backend#1054 Decision-4 — time_series_classification).
-LAYOUT_CONTRACT_VERSION = "2"
+# "3": added the per-task ``ordering`` block — the column the ingestor requires
+#      to stay monotonic and the scope it holds over (dataset-wide vs per
+#      group). Surfaces the time-ordering constraint that used to live only in
+#      the validators, so a consumer can read from the contract which tasks are
+#      subject to it (backend#1870).
+LAYOUT_CONTRACT_VERSION = "3"
 
 
 @dataclass(frozen=True)
@@ -124,7 +129,37 @@ def _grouping_dict(g: Grouping) -> Dict[str, Any]:
     }
 
 
-def _task_layout(spec: Any) -> Dict[str, Any]:
+def _ordering(spec: Any, fixed_time_column: Optional[str]) -> Optional[Dict[str, Any]]:
+    """The cross-row ordering the ingestor enforces on this task, or ``None``
+    when it enforces none (backend#1870).
+
+    ``column`` is the physical column that must be monotonically non-decreasing;
+    ``scope`` is ``"per_group"`` when that must hold WITHIN each
+    ``grouping.group_column`` (time_series_classification's
+    ``PerGroupTimeOrderedValidator``) and ``"dataset"`` when it must hold across
+    the whole manifest (time_series_forecasting's global ``TimeOrderedValidator``
+    — forecasting is treated as one merged series). A consumer that reshapes or
+    grows such a dataset now learns from the contract which column to keep
+    monotonic instead of discovering it from a validator rejection.
+
+    Derived, single-source: ``column`` is the category's entry in
+    ``registry.FIXED_TIME_COLUMN_BY_CATEGORY`` (the same map preflight rejects a
+    decorative ``time_column`` override against), and ``scope`` follows the
+    presence of a ``grouping`` trait. Tasks with no fixed ordering column emit
+    ``None`` — every non-time-series task, and ``time_to_event_prediction``
+    (whose ``time_column`` is a per-row duration, not a monotonic axis, and is
+    validated per-row by ``TimeToEventValidator``) — so the contract states,
+    rather than hides, that they are not subject to the rule.
+    """
+    if fixed_time_column is None:
+        return None
+    return {
+        "column": fixed_time_column,
+        "scope": "per_group" if spec.grouping is not None else "dataset",
+    }
+
+
+def _task_layout(spec: Any, fixed_time_column: Optional[str]) -> Dict[str, Any]:
     """Compose one task's layout: the two declared pieces (sidecars,
     record_format) plus the facts DERIVED from the spec's existing flags."""
     return {
@@ -149,6 +184,11 @@ def _task_layout(spec: Any) -> Dict[str, Any]:
         # item spans MANY manifest rows keyed by ``group_column`` and the
         # ingest summary counts sequences, not rows.
         "grouping": _grouping_dict(spec.grouping) if spec.grouping else None,
+        # Cross-row ordering the ingestor enforces (backend#1870): the column
+        # that must stay monotonic and whether that holds dataset-wide or per
+        # group. ``None`` for tasks with no such rule, so which tasks it applies
+        # to is readable from the contract, not only from the validators.
+        "ordering": _ordering(spec, fixed_time_column),
     }
 
 
@@ -158,9 +198,12 @@ def build_layout_contract() -> Dict[str, Any]:
 
     Imported lazily to avoid a circular import (registry.py imports this
     module's dataclasses)."""
-    from .registry import REGISTRY
+    from .registry import REGISTRY, FIXED_TIME_COLUMN_BY_CATEGORY
 
-    tasks = {cat: _task_layout(spec) for cat, spec in REGISTRY.items()}
+    tasks = {
+        cat: _task_layout(spec, FIXED_TIME_COLUMN_BY_CATEGORY.get(cat))
+        for cat, spec in REGISTRY.items()
+    }
     return {"version": LAYOUT_CONTRACT_VERSION, "tasks": tasks}
 
 

--- a/tracebloc_ingestor/modalities/registry.py
+++ b/tracebloc_ingestor/modalities/registry.py
@@ -323,14 +323,17 @@ NLP_CATEGORIES = frozenset(c for c, s in REGISTRY.items() if s.is_nlp)
 # Categories whose time column is a FIXED physical name (Decision-2,
 # backend#1054): rows are ALWAYS ordered by this column and a config
 # ``time_column`` is never consumed — the schema documents ``time_column`` as
-# time_to_event_prediction only. Maps each such category to its fixed column so
-# preflight can reject a decorative override that would otherwise give false
-# confidence a custom time column is honored (#441 review — saadqbal). TSC's
-# name is derived from its grouping trait (single source); TSF has no grouping,
-# so the literal ``timestamp`` its validators (TimeFormatValidator /
-# TimeOrderedValidator) hardcode is spelled here. time_to_event_prediction is
-# deliberately ABSENT — its ``time_column`` IS user-configurable and validated
-# (exactly) by TimeToEventValidator, so it must not be caught here.
+# time_to_event_prediction only. This map is the single source for two facts:
+# preflight rejects a decorative override that would otherwise give false
+# confidence a custom time column is honored (#441 review — saadqbal), and it
+# populates the layout contract's per-task ``ordering.column`` so the ordering
+# rule is discoverable from the contract, not only from the validators
+# (backend#1870). TSC's name is derived from its grouping trait (single source);
+# TSF has no grouping, so the literal ``timestamp`` its validators
+# (TimeFormatValidator / TimeOrderedValidator) hardcode is spelled here.
+# time_to_event_prediction is deliberately ABSENT — its ``time_column`` IS
+# user-configurable and validated (exactly) by TimeToEventValidator, so it must
+# not be caught here, and it correctly emits ``ordering: null`` in the contract.
 FIXED_TIME_COLUMN_BY_CATEGORY: Dict[str, str] = {
     TaskCategory.TIME_SERIES_FORECASTING: "timestamp",
     TaskCategory.TIME_SERIES_CLASSIFICATION: REGISTRY[

--- a/tracebloc_ingestor/schema/layout.v1.json
+++ b/tracebloc_ingestor/schema/layout.v1.json
@@ -8,6 +8,7 @@
         "kind": "labels_csv",
         "requires_filename_column": true
       },
+      "ordering": null,
       "primary_subdir": "texts",
       "record_format": {
         "enforced": false,
@@ -28,6 +29,7 @@
         "kind": "labels_csv",
         "requires_filename_column": true
       },
+      "ordering": null,
       "primary_subdir": "texts",
       "record_format": {
         "enforced": true,
@@ -49,6 +51,7 @@
         "kind": "labels_csv",
         "requires_filename_column": true
       },
+      "ordering": null,
       "primary_subdir": "images",
       "record_format": null,
       "sidecars": []
@@ -61,6 +64,7 @@
         "kind": "labels_csv",
         "requires_filename_column": true
       },
+      "ordering": null,
       "primary_subdir": "images",
       "record_format": null,
       "sidecars": []
@@ -73,6 +77,7 @@
         "kind": "labels_csv",
         "requires_filename_column": true
       },
+      "ordering": null,
       "primary_subdir": "sequences",
       "record_format": null,
       "sidecars": []
@@ -85,6 +90,7 @@
         "kind": "labels_csv",
         "requires_filename_column": true
       },
+      "ordering": null,
       "primary_subdir": "images",
       "record_format": null,
       "sidecars": [
@@ -104,6 +110,7 @@
         "kind": "labels_csv",
         "requires_filename_column": true
       },
+      "ordering": null,
       "primary_subdir": "images",
       "record_format": null,
       "sidecars": [
@@ -123,6 +130,7 @@
         "kind": "labels_csv",
         "requires_filename_column": true
       },
+      "ordering": null,
       "primary_subdir": "texts",
       "record_format": {
         "enforced": true,
@@ -143,6 +151,7 @@
         "kind": "labels_csv",
         "requires_filename_column": true
       },
+      "ordering": null,
       "primary_subdir": "texts",
       "record_format": {
         "enforced": false,
@@ -163,6 +172,7 @@
         "kind": "data_csv",
         "requires_filename_column": false
       },
+      "ordering": null,
       "primary_subdir": null,
       "record_format": null,
       "sidecars": []
@@ -175,6 +185,7 @@
         "kind": "data_csv",
         "requires_filename_column": false
       },
+      "ordering": null,
       "primary_subdir": null,
       "record_format": null,
       "sidecars": []
@@ -187,6 +198,7 @@
         "kind": "labels_csv",
         "requires_filename_column": true
       },
+      "ordering": null,
       "primary_subdir": "texts",
       "record_format": null,
       "sidecars": []
@@ -203,6 +215,10 @@
         "kind": "data_csv",
         "requires_filename_column": false
       },
+      "ordering": {
+        "column": "timestamp",
+        "scope": "per_group"
+      },
       "primary_subdir": null,
       "record_format": null,
       "sidecars": []
@@ -214,6 +230,10 @@
         "has_label_column": true,
         "kind": "data_csv",
         "requires_filename_column": false
+      },
+      "ordering": {
+        "column": "timestamp",
+        "scope": "dataset"
       },
       "primary_subdir": null,
       "record_format": null,
@@ -227,6 +247,7 @@
         "kind": "data_csv",
         "requires_filename_column": false
       },
+      "ordering": null,
       "primary_subdir": null,
       "record_format": null,
       "sidecars": []
@@ -239,10 +260,11 @@
         "kind": "labels_csv",
         "requires_filename_column": true
       },
+      "ordering": null,
       "primary_subdir": "texts",
       "record_format": null,
       "sidecars": []
     }
   },
-  "version": "2"
+  "version": "3"
 }


### PR DESCRIPTION
Closes tracebloc/backend#1870

## What & why

Fixes backend#1870. The ingestor's **Time Ordered Validator** rejects a
`time_series_forecasting` dataset whose `timestamp` column isn't monotonic
("Found N out-of-order timestamp pair(s)"), but `layout.v1.json` declared **no**
time column for the task — so a consumer that generates or reshapes such a
dataset had no declared way to know which column must stay ordered, and
`time_to_event_prediction` looked identical from the contract yet is *not*
subject to the rule. The layout described *structure* while the validators
enforced *ordering*, and that seam was invisible from outside.

## Ownership (the reassignment question in the issue)

Not the engine team's — no reassignment needed. `layout.v1.json` is **owned and
generated by this repo**: `modalities/layout.py` DERIVES it from the
`ModalitySpec` registry, and the CLI only *vendors and mirrors* it (see the
module docstring). So this is the ingestor's contract to fix.

## Decision — the issue's option (1), not (2)

The issue left the choice to the schema owner. I chose **(1) declare the
ordering column** over **(2) declare a `group_column`**:

- **Domain.** Forecasting is treated as **one merged series** — that's exactly
  what the global `TimeOrderedValidator` checks, and `PerGroupTimeOrderedValidator`'s
  own docstring calls the global check *"correct for forecasting's single merged
  series."* A mandatory `group_column` is wrong for the ordinary single-series
  dataset, which has no such key.
- **Blast radius.** A `grouping` trait is not passive here: it flips the ingest
  summary's label counting to `COUNT(DISTINCT group)` via `count_unit` (the
  double-duty-labels hazard that bit backend#1747), adds a composite index, and
  runs the post-insert group-integrity pass — and would *still* leave TSF on the
  global validator. Far too much behavior change for a contract-visibility bug.

## What changed

Implemented the issue's *"also consider making the constraint discoverable in
general"* ask as a first-class, **single-sourced** `ordering` block on each task:

- `column` = `registry.FIXED_TIME_COLUMN_BY_CATEGORY[cat]` — the *same* map
  preflight already rejects a decorative `time_column` override against.
- `scope` = `"per_group"` when the spec has a `grouping` trait, else `"dataset"`.

Result:

| task | `ordering` |
|---|---|
| `time_series_forecasting` | `{column: timestamp, scope: dataset}` |
| `time_series_classification` | `{column: timestamp, scope: per_group}` |
| `time_to_event_prediction` | `null` (per-row duration, not a monotonic axis) |
| all others | `null` |

Which tasks carry the ordering rule is now readable from the contract, not only
from the validators. **No ingest behavior changes** — this is pure contract
surfacing, derived so it can't drift (a test pins `ordering` to the source).

Contract SHAPE change → **version `2` → `3`**, `layout.v1.json` regenerated.

## Downstream (reviewer heads-up)

The CLI vendors this JSON and verifies its Go mirror against it. The added
`ordering` field + version bump is **additive**, but the CLI's mirror may need a
matching update — flagging so it can be tracked as a CLI follow-up (nothing in
this repo goes red; I checked there's no in-repo consumer that does whole-task
equality or hardcodes the version).

Also note: one **whitespace-only** hunk in
`tests/test_time_series_classification.py` (an unrelated `if` line joined) — the
code-quality black gate is *file-scoped*, and this file already failed
`black 26.3.1` on `develop`; touching the file requires bringing it into
compliance ("the tree converges as files are touched"). Reverting it would turn
CI red, so it stays.

## Verification

- Full suite: **2161 passed, 1 xfailed** (the one warning is pre-existing, unrelated).
- `black --check` (pinned `26.3.1`) clean on all changed files.
- `ruff check .` (pinned `0.15.20`) — all checks passed.
- Drift/congruence/faithfulness tests added or updated:
  `test_ordering_agrees_with_the_single_source`,
  `test_time_ordering_constraint_is_discoverable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract-only surfacing with derived fields and strong tests; ingest validators and runtime paths are unchanged.
> 
> **Overview**
> Adds a per-task **`ordering`** block to the machine-readable layout contract so consumers can see which column must stay monotonic and whether that applies **dataset-wide** or **per group**, instead of inferring it only from validator failures.
> 
> **`column`** comes from `FIXED_TIME_COLUMN_BY_CATEGORY`; **`scope`** is `per_group` when the spec has grouping, otherwise `dataset`. **TSF** gets `{timestamp, dataset}`; **TSC** gets `{timestamp, per_group}`; **time_to_event_prediction** and all other tasks get **`null`** (durations are not a monotonic ordering axis).
> 
> Contract shape bumps **version 2 → 3**, `layout.v1.json` is regenerated, and tests pin the derivation to the registry plus alignment between declared `scope` and the validator types each category’s factory actually runs. **No ingest validation behavior changes** — package version **0.8.14**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360b1dab0975dcc7ea6222f31563ce9a69a541d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->