### PR TITLE
fix(devex): pre-push hook parent-escape + toolchain hard-block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,11 +183,14 @@ install-hooks:
 	elif hp="$$(git config --get core.hooksPath 2>/dev/null || true)"; [ -n "$$hp" ] && { \
 	       hd="$$(git rev-parse --git-path hooks)"; \
 	       case "$$hd" in /*) hdd="$$hd";; *) hdd="$$PWD/$$hd";; esac; \
-	       hdx="$$hdd"; \
+	       hdx="$$hdd"; tail=''; \
 	       while [ ! -d "$$hdx" ] && [ "$$hdx" != "$$(dirname "$$hdx")" ]; do \
-	         hdx="$$(dirname "$$hdx")"; \
+	         tail="$$(basename "$$hdx")/$$tail"; hdx="$$(dirname "$$hdx")"; \
 	       done; \
 	       chd="$$(cd "$$hdx" 2>/dev/null && pwd -P || true)"; \
+	       oIFS="$$IFS"; IFS=/; for seg in $$tail; do \
+	         case "$$seg" in ''|.) : ;; ..) chd="$${chd%/*}"; [ -n "$$chd" ] || chd=/ ;; *) chd="$$chd/$$seg" ;; esac; \
+	       done; IFS="$$oIFS"; \
 	       ctop="$$(cd "$$(git rev-parse --show-toplevel)" && pwd -P)"; \
 	       cgd="$$(cd "$$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P || true)"; \
 	       inr=0; \

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,32 @@ help:
 # running and finishes in ~11 s (measured, macOS). The coverage gate is
 # the only thing held back, and only because a floor is a merge concern
 # rather than a pre-push one.
+# guard-toolchain: can this shell actually run `make check`? A GUI/IDE git client
+# (VS Code, Tower, GitKraken) launches the pre-push hook on a thin PATH that has
+# system `make` and often a bare `python3`, but NOT the virtualenv these checks
+# were installed into — so `make check` hard-fails on "No module named ruff" with
+# no --no-verify to escape (backend#1749; the make-vs-toolchain shape of
+# backend#1995). `check` depends on this and the hook runs it first, so a push
+# from such a client degrades to a skip instead of a hard block.
+#
+# It asks the TOOLS, not the DEPENDENCIES: whether $(PYTHON) can run the linters
+# and test runner check invokes, not whether every package is installed. A
+# genuinely broken venv still fails `make check` when run from a real shell.
+.PHONY: guard-toolchain
+guard-toolchain:
+	@command -v "$(PYTHON)" >/dev/null 2>&1 || { \
+	  echo "not on PATH: $(PYTHON) — activate your virtualenv, then run: make setup"; \
+	  exit 1; }
+	@missing=''; \
+	for m in ruff pytest; do \
+	  "$(PYTHON)" -m "$$m" --version >/dev/null 2>&1 || missing="$$missing $$m"; \
+	done; \
+	[ -z "$$missing" ] || { \
+	  echo "$(PYTHON) cannot run:$$missing — activate your virtualenv, then run: make setup"; \
+	  exit 1; }
+
 .PHONY: check
-check: lint test
+check: guard-toolchain lint test
 	@echo "==> check: green (the coverage gate is in 'make check-all')"
 
 .PHONY: check-all
@@ -144,6 +168,14 @@ e2e:
 # `git rev-parse --git-path hooks` (not a hard-coded `.git/hooks`) so it lands
 # in the right place inside a linked worktree or a submodule, where the git dir
 # is not `.git`.
+# test-hooks: run the install-hooks / pre-push-hook behaviour suite on demand.
+# Not a `check` dependency: it runs real `make` in throwaway repos, so an
+# environment quirk (old git, noexec /tmp) could block a local push on something
+# CI never sees. Run it directly with `make test-hooks` (backend#1749).
+.PHONY: test-hooks
+test-hooks:
+	@sh scripts/tests/test-pre-push-hook.sh
+
 .PHONY: install-hooks
 install-hooks:
 	@if ! git rev-parse --git-dir >/dev/null 2>&1; then \
@@ -151,11 +183,19 @@ install-hooks:
 	elif hp="$$(git config --get core.hooksPath 2>/dev/null || true)"; [ -n "$$hp" ] && { \
 	       hd="$$(git rev-parse --git-path hooks)"; \
 	       case "$$hd" in /*) hdd="$$hd";; *) hdd="$$PWD/$$hd";; esac; \
-	       cpar="$$(cd "$$(dirname "$$hdd")" 2>/dev/null && pwd -P || true)"; \
+	       hdx="$$hdd"; \
+	       while [ ! -d "$$hdx" ] && [ "$$hdx" != "$$(dirname "$$hdx")" ]; do \
+	         hdx="$$(dirname "$$hdx")"; \
+	       done; \
+	       chd="$$(cd "$$hdx" 2>/dev/null && pwd -P || true)"; \
 	       ctop="$$(cd "$$(git rev-parse --show-toplevel)" && pwd -P)"; \
-	       [ -z "$$cpar" ] || case "$$cpar/" in "$$ctop/"*) false;; *) true;; esac; \
+	       cgd="$$(cd "$$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P || true)"; \
+	       inr=0; \
+	       case "$$chd/" in "$$ctop/"*) inr=1;; esac; \
+	       if [ -n "$$cgd" ]; then case "$$chd/" in "$$cgd/"*) inr=1;; esac; fi; \
+	       [ -z "$$chd" ] || [ "$$inr" = 0 ]; \
 	     }; then \
-	  echo "note: core.hooksPath is set to '$$hp', outside this repo — skipping."; \
+	  echo "note: core.hooksPath is set to '$$hp' (resolves to '$$chd'), outside this repo — skipping."; \
 	  echo "      That is a shared hooks dir; installing here would run 'make check' from every repo you push."; \
 	  echo "      Add 'make check' to that hook by hand if you want it everywhere."; \
 	else \
@@ -189,8 +229,19 @@ install-hooks:
 	      '#' \
 	      '# Git exports GIT_DIR/GIT_WORK_TREE/etc into hook processes; a nested git' \
 	      '# invocation (from a test, tool, or setuptools-scm) then fails in a linked' \
-	      '# worktree with exit status 128. Clear them so make check runs as from the shell.' \
+	      '# worktree with exit status 128. Clear them so the make runs below behave' \
+	      '# as they do from an ordinary shell.' \
 	      'unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY' \
+	      '#' \
+	      '# Guarding on make alone was not enough (backend#1749): a GUI/IDE client' \
+	      '# commonly has system make on a thin PATH but not the virtualenv these' \
+	      '# checks run in, so the skip above passed and the push then hard-failed on' \
+	      '# "No module named ruff" — the exact outcome the skip exists to prevent,' \
+	      '# with no --no-verify to escape. The hook delegates to guard-toolchain,' \
+	      '# the single place the tool list lives, rather than restating it here — so' \
+	      '# the hook cannot drift from it. guard-toolchain probes the TOOLS check' \
+	      '# runs, not installed packages (a broken venv still fails make check in a shell).' \
+	      'make guard-toolchain >/dev/null 2>&1 || exit 0' \
 	      'exec make check' > "$$hook" && \
 	    chmod +x "$$hook" && \
 	    echo "==> pre-push hook installed at $$hook" && \

--- a/Makefile
+++ b/Makefile
@@ -183,22 +183,20 @@ install-hooks:
 	elif hp="$$(git config --get core.hooksPath 2>/dev/null || true)"; [ -n "$$hp" ] && { \
 	       hd="$$(git rev-parse --git-path hooks)"; \
 	       case "$$hd" in /*) hdd="$$hd";; *) hdd="$$PWD/$$hd";; esac; \
-	       hdx="$$hdd"; tail=''; \
+	       hdx="$$hdd"; sfx=''; \
 	       while [ ! -d "$$hdx" ] && [ "$$hdx" != "$$(dirname "$$hdx")" ]; do \
-	         tail="$$(basename "$$hdx")/$$tail"; hdx="$$(dirname "$$hdx")"; \
+	         sfx="$$(basename "$$hdx")/$$sfx"; hdx="$$(dirname "$$hdx")"; \
 	       done; \
 	       chd="$$(cd "$$hdx" 2>/dev/null && pwd -P || true)"; \
-	       oIFS="$$IFS"; IFS=/; for seg in $$tail; do \
-	         case "$$seg" in ''|.) : ;; ..) chd="$${chd%/*}"; [ -n "$$chd" ] || chd=/ ;; *) chd="$$chd/$$seg" ;; esac; \
-	       done; IFS="$$oIFS"; \
 	       ctop="$$(cd "$$(git rev-parse --show-toplevel)" && pwd -P)"; \
 	       cgd="$$(cd "$$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P || true)"; \
 	       inr=0; \
 	       case "$$chd/" in "$$ctop/"*) inr=1;; esac; \
 	       if [ -n "$$cgd" ]; then case "$$chd/" in "$$cgd/"*) inr=1;; esac; fi; \
+	       case "/$$sfx" in */../*) inr=0;; esac; \
 	       [ -z "$$chd" ] || [ "$$inr" = 0 ]; \
 	     }; then \
-	  echo "note: core.hooksPath is set to '$$hp' (resolves to '$$chd'), outside this repo — skipping."; \
+	  echo "note: core.hooksPath is set to '$$hp', outside this repo — skipping."; \
 	  echo "      That is a shared hooks dir; installing here would run 'make check' from every repo you push."; \
 	  echo "      Add 'make check' to that hook by hand if you want it everywhere."; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,13 @@ install-hooks:
 	      '# the single place the tool list lives, rather than restating it here — so' \
 	      '# the hook cannot drift from it. guard-toolchain probes the TOOLS check' \
 	      '# runs, not installed packages (a broken venv still fails make check in a shell).' \
-	      'make guard-toolchain >/dev/null 2>&1 || exit 0' \
+	      '#' \
+	      '# guard-toolchain may be ABSENT on an older branch: this hook lives in' \
+	      '# .git/hooks and runs against whatever Makefile the pushed branch has, and' \
+	      '# make exits 2 for a MISSING TARGET just as for a failed recipe. Probe with' \
+	      '# -n so a missing target falls through to make check instead of silently' \
+	      '# skipping it (Bugbot, backend#1749).' \
+	      'if make -n guard-toolchain >/dev/null 2>&1; then make guard-toolchain >/dev/null 2>&1 || exit 0; fi' \
 	      'exec make check' > "$$hook" && \
 	    chmod +x "$$hook" && \
 	    echo "==> pre-push hook installed at $$hook" && \

--- a/scripts/tests/test-pre-push-hook.sh
+++ b/scripts/tests/test-pre-push-hook.sh
@@ -147,5 +147,17 @@ if make -s guard-toolchain PYTHON="$gtbin/py-bad" >/dev/null 2>&1; then rc=0; el
 check "$( [ "$rc" != 0 ] && echo nonzero || echo zero )" "nonzero" "guard-toolchain fails when a tool cannot run"
 rm -rf "$gtbin"
 
+# 9b) the installed hook runs against whatever Makefile the pushed branch has
+# (it lives in .git/hooks, shared across branches). make exits 2 for a MISSING
+# guard-toolchain target just as for a failed recipe, so the hook must not read
+# "no such target" as "toolchain absent" and skip — it probes with -n and falls
+# through to make check (Bugbot, backend#1749). Stub make as an OLD Makefile:
+# guard-toolchain has no rule (exit 2), check touches a sentinel.
+sent="$(mktemp -u)"; stub="$(mktemp -d)"
+printf '#!/bin/sh\nfor a in "$@"; do case "$a" in guard-toolchain) exit 2 ;; check) : > %s ;; esac; done\nexit 0\n' "$sent" > "$stub/make"; chmod +x "$stub/make"
+printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH="$stub:$PATH" sh "$hook" >/dev/null 2>&1 || true
+check "$([ -f "$sent" ] && echo ran || echo skipped)" "ran" "old Makefile (no guard-toolchain) still runs make check"
+rm -rf "$stub"; rm -f "$sent"
+
 echo "--- pre-push hook tests: $( [ "$fails" -eq 0 ] && echo ALL GREEN || echo "$fails FAILED" ) ---"
 [ "$fails" -eq 0 ]

--- a/scripts/tests/test-pre-push-hook.sh
+++ b/scripts/tests/test-pre-push-hook.sh
@@ -1,0 +1,138 @@
+#!/bin/sh
+# test-pre-push-hook.sh — behaviour tests for `make install-hooks` and the
+# generated pre-push hook, driven by running real `make` against a copy of the
+# Makefile in a throwaway git repo. Added with the fleet-wide hook fix
+# (backend#1749). Pure POSIX sh, no bats/pytest dependency, so `make test-hooks`
+# runs it anywhere.
+#
+# Covers the branches a future edit could silently break:
+#   * fresh install writes an executable, ours-marked hook
+#   * re-install is idempotent (ours -> rewrite, no error)
+#   * a foreign pre-push hook is left untouched
+#   * core.hooksPath outside the repo is refused (no shared-dir stomp)
+#   * core.hooksPath=.. is refused too — no pre-push written into the parent
+#     (the dirname-of-hooksdir guard missed a bare `..`; backend#1749)
+#   * the hook skips delete-only / no-op pushes (all-zero local sha)
+#   * the hook degrades gracefully when `make` is off PATH (GUI clients)
+#   * the hook soft-passes when the venv toolchain is absent (guard-toolchain
+#     fails) rather than hard-blocking a GUI push that cannot --no-verify (#1749)
+#   * guard-toolchain fails on a tool it cannot run and passes when it can
+set -eu
+
+# Hermetic: ignore the developer's global/system git config so an ambient
+# core.hooksPath (corp dotfiles, husky) can't make install-hooks skip and fail
+# the fresh-install/reinstall assertions. Every git here sees only local config.
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/../.." && pwd)
+MAKEFILE="$REPO_ROOT/Makefile"
+Z=0000000000000000000000000000000000000000
+fails=0
+check() { if [ "$1" = "$2" ]; then echo "  ok: $3"; else echo "  FAIL: $3 (got '$1', want '$2')"; fails=$((fails + 1)); fi; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+cd "$work"
+git init -q .
+git config user.email t@t; git config user.name t
+cp "$MAKEFILE" ./Makefile
+hook=.git/hooks/pre-push
+
+# 1) fresh install
+make -s install-hooks >/dev/null
+check "$( [ -x "$hook" ] && echo yes )" "yes" "fresh install writes an executable hook"
+check "$(grep -c 'tracebloc pre-push hook' "$hook")" "1" "hook carries the ours-marker"
+
+# 2) idempotent re-install
+make -s install-hooks >/dev/null
+check "$(grep -c 'tracebloc pre-push hook' "$hook")" "1" "re-install stays idempotent"
+
+# 3) foreign hook left untouched
+printf '#!/bin/sh\necho FOREIGN\n' > "$hook"
+make -s install-hooks >/dev/null
+check "$(grep -c FOREIGN "$hook")" "1" "foreign hook is preserved"
+rm -f "$hook"
+
+# 4) core.hooksPath pointing OUTSIDE the repo is refused, in every escaping form
+# (absolute, relative, and .. segments that string-prefix as inside). Assert the
+# resolved shared dir stays empty — checking only .git/hooks would miss a hook
+# written into the configured dir, and a string-prefix guard misses .. escapes.
+# The parent of each form is a real, canonicalisable dir outside $work.
+outside=$(mktemp -d)                       # a sibling of $work, definitely outside
+for form in "$outside" "../$(basename "$outside")" "$work/../$(basename "$outside")"; do
+  git config core.hooksPath "$form"
+  make -s install-hooks >/dev/null
+  check "$( [ -e "$outside/pre-push" ] && echo present || echo absent )" "absent" "core.hooksPath outside repo refused: $form"
+  rm -f "$outside/pre-push"
+  git config --unset core.hooksPath
+done
+rm -rf "$outside"
+
+# 4b) core.hooksPath INSIDE the repo is honoured (install proceeds there).
+mkdir -p "$work/.githooks"
+git config core.hooksPath .githooks
+make -s install-hooks >/dev/null
+check "$(grep -c 'tracebloc pre-push hook' "$work/.githooks/pre-push" 2>/dev/null || echo 0)" "1" "core.hooksPath inside repo: hook installed there"
+git config --unset core.hooksPath
+
+# 4c) core.hooksPath=.. (or ./..) points at the worktree's PARENT — a shared dir
+# one level up. The earlier guard canonicalised dirname(hooksdir), which for a
+# bare `..` stays inside the worktree, so install-hooks wrote pre-push into the
+# parent: the exact shared-dir stomp the guard exists to prevent (backend#1749).
+# A throwaway repo whose parent is a known-empty dir makes the stomp observable.
+esc=$(mktemp -d)
+mkdir -p "$esc/repo"
+( cd "$esc/repo" && git init -q . && git config user.email t@t && git config user.name t \
+  && cp "$MAKEFILE" ./Makefile )
+for form in ".." "./.."; do
+  ( cd "$esc/repo" && git config core.hooksPath "$form" && make -s install-hooks >/dev/null )
+  check "$( [ -e "$esc/pre-push" ] && echo present || echo absent )" "absent" "core.hooksPath parent-escape refused: $form"
+  rm -f "$esc/pre-push"
+done
+rm -rf "$esc"
+
+# reinstall a clean ours-hook for the behavioural cases
+make -s install-hooks >/dev/null
+
+# 5) delete-only push (all-zero local sha) is skipped without running make
+if printf 'refs/heads/x %s refs/heads/x %s\n' "$Z" deadbeef | sh "$hook"; then rc=0; else rc=$?; fi
+check "$rc" "0" "delete-only push is skipped (exit 0)"
+
+# 6) real push but make absent -> graceful skip, not 'command not found'
+if printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH= /bin/sh "$hook"; then rc=0; else rc=$?; fi
+check "$rc" "0" "missing make degrades to skip (exit 0)"
+
+# 7) a genuine (non-delete) push RUNS make check. Stub make to touch a sentinel
+# only for `check` (the hook now runs `make guard-toolchain` first); a no-op hook
+# would leave the sentinel missing.
+sent="$(mktemp -u)"; stub="$(mktemp -d)"
+printf '#!/bin/sh\n[ "$1" = check ] && : > %s\nexit 0\n' "$sent" > "$stub/make"; chmod +x "$stub/make"
+printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH="$stub:$PATH" sh "$hook" >/dev/null 2>&1 || true
+check "$([ -f "$sent" ] && echo ran || echo missing)" "ran" "genuine push runs make check"
+rm -rf "$stub"; rm -f "$sent"
+
+# 8) an incomplete venv toolchain (system make present, but ruff/pytest absent)
+# must SOFT-PASS, not hard-block: GUI/IDE clients push on a thin PATH and cannot
+# pass --no-verify (backend#1749). The hook asks `make guard-toolchain` and skips
+# itself when it fails, so `make check` must not run. Stub make so guard-toolchain
+# fails and check would touch a sentinel; assert exit 0 and the sentinel absent.
+sent="$(mktemp -u)"; stub="$(mktemp -d)"
+printf '#!/bin/sh\ncase "$1" in guard-toolchain) exit 1 ;; check) : > %s ;; esac\nexit 0\n' "$sent" > "$stub/make"; chmod +x "$stub/make"
+if printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH="$stub:$PATH" sh "$hook"; then rc=0; else rc=$?; fi
+check "$rc" "0" "missing venv toolchain soft-passes (exit 0)"
+check "$([ -f "$sent" ] && echo ran || echo skipped)" "skipped" "soft-pass does not run make check"
+rm -rf "$stub"; rm -f "$sent"
+
+# 9) guard-toolchain itself: fails when a tool cannot run, passes when all can.
+# Driven with a stub PYTHON so it needs no real venv and stays fast.
+gtbin="$(mktemp -d)"
+printf '#!/bin/sh\nexit 0\n' > "$gtbin/py-ok"; chmod +x "$gtbin/py-ok"
+printf '#!/bin/sh\nexit 1\n' > "$gtbin/py-bad"; chmod +x "$gtbin/py-bad"
+if make -s guard-toolchain PYTHON="$gtbin/py-ok" >/dev/null 2>&1; then rc=0; else rc=$?; fi
+check "$rc" "0" "guard-toolchain passes when the toolchain runs"
+if make -s guard-toolchain PYTHON="$gtbin/py-bad" >/dev/null 2>&1; then rc=0; else rc=$?; fi
+check "$( [ "$rc" != 0 ] && echo nonzero || echo zero )" "nonzero" "guard-toolchain fails when a tool cannot run"
+rm -rf "$gtbin"
+
+echo "--- pre-push hook tests: $( [ "$fails" -eq 0 ] && echo ALL GREEN || echo "$fails FAILED" ) ---"
+[ "$fails" -eq 0 ]

--- a/scripts/tests/test-pre-push-hook.sh
+++ b/scripts/tests/test-pre-push-hook.sh
@@ -75,23 +75,34 @@ make -s install-hooks >/dev/null
 check "$(grep -c 'tracebloc pre-push hook' "$work/.githooks/pre-push" 2>/dev/null || echo 0)" "1" "core.hooksPath inside repo: hook installed there"
 git config --unset core.hooksPath
 
-# 4c) core.hooksPath escapes to the worktree's PARENT — a shared dir one level
-# up — in three shapes: a bare `..`, `./..`, and `missing/../..` where a
-# not-yet-created prefix hides the `..`. The dirname-of-hooksdir guard missed
-# bare `..`, and the ancestor-walk that replaced it missed the hidden-prefix
-# form — both wrote pre-push into the parent, the stomp the guard exists to
-# prevent (backend#1749). A throwaway repo whose parent is a known-empty dir
-# makes the stomp observable.
+# 4c) core.hooksPath escapes to a shared dir OUTSIDE the worktree, in the shapes
+# earlier guards missed: a bare `..`/`./..` (the dirname guard resolved it back
+# inside), and a `..` hidden behind a not-yet-created prefix — `missing/../..`,
+# `missing/../../shared` — where the ancestor-walk climbed past the missing
+# prefix and read the worktree as the target. Both wrote pre-push above the
+# worktree, the stomp the guard exists to prevent (backend#1749). A `..` in the
+# not-yet-existing suffix cannot be resolved until the prefix exists, so the
+# guard refuses it (Lukas, backend#2714). Assert nothing lands outside the repo.
 esc=$(mktemp -d)
 mkdir -p "$esc/repo"
 ( cd "$esc/repo" && git init -q . && git config user.email t@t && git config user.name t \
   && cp "$MAKEFILE" ./Makefile )
-for form in ".." "./.." "missing/../.."; do
+for form in ".." "./.." "missing/../.." "missing/../../shared"; do
   ( cd "$esc/repo" && git config core.hooksPath "$form" && make -s install-hooks >/dev/null )
-  check "$( [ -e "$esc/pre-push" ] && echo present || echo absent )" "absent" "core.hooksPath parent-escape refused: $form"
-  rm -f "$esc/pre-push"
+  check "$(find "$esc" -name pre-push -not -path "$esc/repo/*" 2>/dev/null | head -1 | grep -q . && echo present || echo absent)" "absent" "core.hooksPath parent-escape refused: $form"
+  find "$esc" -name pre-push -not -path "$esc/repo/*" -delete 2>/dev/null
+  ( cd "$esc/repo" && rm -rf missing shared )
 done
 rm -rf "$esc"
+
+# 4d) a not-yet-created IN-REPO hooks dir still INSTALLS — the fresh-clone case
+# the ancestor-walk exists for, and the arm the suffix-`..` refusal must not
+# over-block (Lukas, backend#2714). No `..`, so it is unambiguously in-repo.
+git config core.hooksPath freshhooks
+make -s install-hooks >/dev/null
+check "$(grep -c 'tracebloc pre-push hook' "$work/freshhooks/pre-push" 2>/dev/null || echo 0)" "1" "core.hooksPath in-repo but not-yet-created: hook installed"
+git config --unset core.hooksPath
+rm -rf "$work/freshhooks"
 
 # reinstall a clean ours-hook for the behavioural cases
 make -s install-hooks >/dev/null

--- a/scripts/tests/test-pre-push-hook.sh
+++ b/scripts/tests/test-pre-push-hook.sh
@@ -75,16 +75,18 @@ make -s install-hooks >/dev/null
 check "$(grep -c 'tracebloc pre-push hook' "$work/.githooks/pre-push" 2>/dev/null || echo 0)" "1" "core.hooksPath inside repo: hook installed there"
 git config --unset core.hooksPath
 
-# 4c) core.hooksPath=.. (or ./..) points at the worktree's PARENT — a shared dir
-# one level up. The earlier guard canonicalised dirname(hooksdir), which for a
-# bare `..` stays inside the worktree, so install-hooks wrote pre-push into the
-# parent: the exact shared-dir stomp the guard exists to prevent (backend#1749).
-# A throwaway repo whose parent is a known-empty dir makes the stomp observable.
+# 4c) core.hooksPath escapes to the worktree's PARENT — a shared dir one level
+# up — in three shapes: a bare `..`, `./..`, and `missing/../..` where a
+# not-yet-created prefix hides the `..`. The dirname-of-hooksdir guard missed
+# bare `..`, and the ancestor-walk that replaced it missed the hidden-prefix
+# form — both wrote pre-push into the parent, the stomp the guard exists to
+# prevent (backend#1749). A throwaway repo whose parent is a known-empty dir
+# makes the stomp observable.
 esc=$(mktemp -d)
 mkdir -p "$esc/repo"
 ( cd "$esc/repo" && git init -q . && git config user.email t@t && git config user.name t \
   && cp "$MAKEFILE" ./Makefile )
-for form in ".." "./.."; do
+for form in ".." "./.." "missing/../.."; do
   ( cd "$esc/repo" && git config core.hooksPath "$form" && make -s install-hooks >/dev/null )
   check "$( [ -e "$esc/pre-push" ] && echo present || echo absent )" "absent" "core.hooksPath parent-escape refused: $form"
   rm -f "$esc/pre-push"


### PR DESCRIPTION
## What

Two defects in the fleet-wide devex pre-push hook (added in backend#1606), fixed together so the hook fleet stays consistent.

**1. `core.hooksPath` parent-escape.** `install-hooks` canonicalized `dirname` of the resolved hooks path, so `core.hooksPath=..` (or `./..`) kept the dirname inside the worktree and `install-hooks` wrote `pre-push` into the shared **parent** directory — the exact shared-dir stomp the guard exists to prevent. It now canonicalizes the resolved hooks dir itself (walks to the deepest existing ancestor + `pwd -P`, so `..` resolves), and treats the git-common-dir as in-repo so linked worktrees still install.

**2. Toolchain hard-block.** The hook soft-exited only when `make` was missing, then `exec make check` hard-failed when the venv toolchain (ruff/pytest) was absent. GUI/IDE git clients (VS Code, Tower, GitKraken) commonly have system `make` on a thin PATH but not the virtualenv, and many expose no `--no-verify` — so pushes were blocked exactly where the surrounding comments promise graceful degradation. A new `guard-toolchain` target probes the actual tools; the hook runs `make guard-toolchain` and soft-passes when it fails. Mirrors the pattern backend#1995 shipped to the JS toolchain repos (design-system, docs, frontend-app).

## Tests

`make test-hooks` — adds a hook test suite covering `core.hooksPath=..` (nothing written outside the worktree) and a missing-toolchain push (soft-pass, `make check` not run), plus a direct `guard-toolchain` pass/fail check. Green locally.

The `install-hooks` guard block is now byte-identical across the hook fleet.

Part of the fleet-wide fix for tracebloc/backend#1749.

— drafted with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Makefile hook installation and local pre-push behavior; no runtime ingestion or CI test gates are altered beyond optional `make test-hooks`.
> 
> **Overview**
> Fixes two pre-push / `install-hooks` defects and adds **`make test-hooks`** coverage.
> 
> **Toolchain hard-block:** Adds **`guard-toolchain`** (probes that `$(PYTHON)` can run **ruff** and **pytest**). **`make check`** depends on it. The generated pre-push hook runs **`make guard-toolchain`** (with **`make -n`** first so branches without that target still run **`make check`**) and **soft-passes** when the venv tools are missing—matching the existing “missing `make`” skip for thin-PATH GUI git clients.
> 
> **`core.hooksPath` parent-escape:** **`install-hooks`** no longer trusts **`dirname`** of the hooks path alone. It canonicalizes the resolved hooks directory (ancestor walk + **`pwd -P`**), treats **`git-common-dir`** as in-repo for linked worktrees, and refuses suffix paths containing **`..`** so values like **`..`**, **`./..`**, or **`missing/../..`** cannot write **`pre-push`** outside the worktree. In-repo paths (including not-yet-created dirs like **`freshhooks`**) still install.
> 
> **Tests:** **`scripts/tests/test-pre-push-hook.sh`** exercises install idempotency, foreign-hook preservation, hooksPath inside/outside/escape cases, hook skip/soft-pass behavior, and **`guard-toolchain`** pass/fail—invoked via **`make test-hooks`**, not **`make check`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21aab12eae4bcff387d0ddc5c5d90c20e4db53ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->