### PR TITLE
fix(docs): correct the PR template's closing-keyword note (backend#2188)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- 1–3 sentences. What does this PR do and why? -->
 
 ## Related
-<!-- Same repo: Closes #123 · Cross-repo: Fixes tracebloc/backend#456 (owner-qualified — a bare backend#456 closes nothing). PRs land on develop, not the default branch, so closing keywords do not fire on merge — confirm the issue actually closed. -->
+<!-- Same repo: Closes #123 · Cross-repo: Fixes tracebloc/backend#456 (owner-qualified — a bare backend#456 closes nothing). develop IS this repo's default branch, so a same-repo keyword DOES fire on merge — measured 12 for 12. A cross-repo one never does, whatever the branch: close those by hand. -->
 
 ## Type of change
 - [ ] Feature

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- 1–3 sentences. What does this PR do and why? -->
 
 ## Related
-<!-- Same repo: Closes #123 · Cross-repo: Fixes tracebloc/backend#456 (owner-qualified — a bare backend#456 closes nothing). develop IS this repo's default branch, so a same-repo keyword DOES fire on merge — measured 12 for 12. A cross-repo one never does, whatever the branch: close those by hand. -->
+<!-- Same repo: Closes #123 · Cross-repo: Fixes tracebloc/backend#456 (owner-qualified — a bare backend#456 closes nothing). develop IS this repo's default branch, so a same-repo keyword DOES fire on merge — measured 12 for 12. -->
 
 ## Type of change
 - [ ] Feature


### PR DESCRIPTION
Closes tracebloc/backend#2188

## Problem

The PR template's line-5 comment carried:

> PRs land on develop, not the default branch, so closing keywords do not fire on merge — confirm the issue actually closed.

Both halves are false: `develop` **is** this repo's default branch, so a same-repo closing keyword **does** fire on merge (measured 12/12 on recent `base:develop` merges in `backend`). A wrong doc is worse than an unhelpful one now that agents read docs first — this exact sentence manufactured a **High-severity** Bugbot finding on e2e-test-agent#165.

## Fix

Replace only the false sentence with the accurate one (as landed in e2e-test-agent#165). The load-bearing cross-repo half — a bare `repo#N` closes nothing, only an owner-qualified `tracebloc/repo#N` — is preserved, along with this repo's own example.

One of 8 repos carrying the clause (backend#2188): backend, client, averaging-service, frontend-app, tracebloc-py-package, data-ingestors, design-system, cli.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the PR template comment; no runtime, security, or deployment behavior.
> 
> **Overview**
> Updates the **Related** section comment in `.github/pull_request_template.md` so contributors aren’t misled about GitHub issue closing.
> 
> The template previously said PRs merge to `develop` instead of the default branch and that same-repo closing keywords don’t fire on merge. That guidance is **replaced** with the accurate note that **`develop` is this repo’s default branch**, so same-repo keywords like `Closes #123` **do** fire on merge (with the “12 for 12” measurement reference).
> 
> The **cross-repo** warning is unchanged: only owner-qualified references (e.g. `tracebloc/backend#456`) work; a bare `backend#456` closes nothing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b3b052c0036ee390764a1d286f80be274975f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->