### PR TITLE
fix(devex): probe check in the pre-push hook (parity with the fleet)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,11 +243,15 @@ install-hooks:
 	      '# the hook cannot drift from it. guard-toolchain probes the TOOLS check' \
 	      '# runs, not installed packages (a broken venv still fails make check in a shell).' \
 	      '#' \
-	      '# guard-toolchain may be ABSENT on an older branch: this hook lives in' \
-	      '# .git/hooks and runs against whatever Makefile the pushed branch has, and' \
-	      '# make exits 2 for a MISSING TARGET just as for a failed recipe. Probe with' \
-	      '# -n so a missing target falls through to make check instead of silently' \
-	      '# skipping it (Bugbot, backend#1749).' \
+	      '# This hook lives in .git/hooks and runs against whatever Makefile the' \
+	      '# pushed branch has, so it can OUTLIVE any target it names — an older' \
+	      '# branch, staging before the train lands, or no Makefile at all. make' \
+	      '# exits 2 for a MISSING TARGET exactly as for a failed recipe, so probe' \
+	      '# every target with -n: an absent check (or Makefile) soft-passes rather' \
+	      '# than hard-blocking a push that has no --no-verify, and an absent' \
+	      '# guard-toolchain falls through to make check instead of skipping it' \
+	      '# silently (Bugbot + Lukas, backend#1749).' \
+	      'make -n check >/dev/null 2>&1 || exit 0' \
 	      'if make -n guard-toolchain >/dev/null 2>&1; then make guard-toolchain >/dev/null 2>&1 || exit 0; fi' \
 	      'exec make check' > "$$hook" && \
 	    chmod +x "$$hook" && \

--- a/scripts/tests/test-pre-push-hook.sh
+++ b/scripts/tests/test-pre-push-hook.sh
@@ -159,5 +159,17 @@ printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH="$stub:$PATH" sh "$
 check "$([ -f "$sent" ] && echo ran || echo skipped)" "ran" "old Makefile (no guard-toolchain) still runs make check"
 rm -rf "$stub"; rm -f "$sent"
 
+# 9c) an even older branch may lack `check` itself, or the Makefile entirely.
+# `make -n guard-toolchain` fails there too, so control would reach `exec make
+# check` and hard-block on "No rule to make target check" — with no --no-verify
+# in the GUI clients this family protects. The hook probes `check` too and
+# soft-passes (Lukas, backend#2714). Stub make: -n check has no rule (exit 2).
+sent="$(mktemp -u)"; stub="$(mktemp -d)"
+printf '#!/bin/sh\nfor a in "$@"; do case "$a" in check) exit 2 ;; esac; done\n: > %s\nexit 0\n' "$sent" > "$stub/make"; chmod +x "$stub/make"
+if printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH="$stub:$PATH" sh "$hook"; then rc=0; else rc=$?; fi
+check "$rc" "0" "missing check target soft-passes (exit 0, no hard-block)"
+check "$([ -f "$sent" ] && echo ran || echo skipped)" "skipped" "soft-pass does not run make check"
+rm -rf "$stub"; rm -f "$sent"
+
 echo "--- pre-push hook tests: $( [ "$fails" -eq 0 ] && echo ALL GREEN || echo "$fails FAILED" ) ---"
 [ "$fails" -eq 0 ]

--- a/scripts/tests/test-pre-push-hook.sh
+++ b/scripts/tests/test-pre-push-hook.sh
@@ -154,7 +154,7 @@ rm -rf "$gtbin"
 # through to make check (Bugbot, backend#1749). Stub make as an OLD Makefile:
 # guard-toolchain has no rule (exit 2), check touches a sentinel.
 sent="$(mktemp -u)"; stub="$(mktemp -d)"
-printf '#!/bin/sh\nfor a in "$@"; do case "$a" in guard-toolchain) exit 2 ;; check) : > %s ;; esac; done\nexit 0\n' "$sent" > "$stub/make"; chmod +x "$stub/make"
+printf '#!/bin/sh\nfor a in "$@"; do case "$a" in guard-toolchain) exit 2 ;; esac; done\n[ "$1" = check ] && : > %s\nexit 0\n' "$sent" > "$stub/make"; chmod +x "$stub/make"
 printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH="$stub:$PATH" sh "$hook" >/dev/null 2>&1 || true
 check "$([ -f "$sent" ] && echo ran || echo skipped)" "ran" "old Makefile (no guard-toolchain) still runs make check"
 rm -rf "$stub"; rm -f "$sent"


### PR DESCRIPTION
## What

Brings data-ingestors' pre-push hook to parity with the rest of the backend#1749 fleet.

data-ingestors#538 (the fleet fix) landed one review round before the hook gained a `check` existence probe. Without it, a push from a branch that lacks `check` (or the Makefile) fails `make -n guard-toolchain`, falls through to `exec make check`, and **hard-blocks** on `No rule to make target 'check'` — with no `--no-verify` in the GUI clients the hook exists to protect (found by Lukas on backend#2714).

## Fix

```sh
make -n check >/dev/null 2>&1 || exit 0
if make -n guard-toolchain >/dev/null 2>&1; then make guard-toolchain >/dev/null 2>&1 || exit 0; fi
exec make check
```

The rule: the hook lives in `.git/hooks` and runs against whatever Makefile the pushed branch has, so it probes every target it invokes — it can outlive any of them. The `install-hooks` block is now byte-identical with the fleet's other Python repos.

## Tests

`make test-hooks` — adds case 9c (missing `check` target → soft-pass, no hard-block). Green under `sh` and `dash`.

Part of the fleet-wide fix for tracebloc/backend#1749.

— drafted with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only local git hook install logic and its test script; no runtime, auth, or data-path impact.
> 
> **Overview**
> Aligns the **data-ingestors** pre-push hook with the rest of the backend#1749 fleet by probing **`make -n check`** before **`guard-toolchain`** and **`exec make check`**.
> 
> On branches (or trees) without a **`check`** target—or without a Makefile—the hook used to fall through and **hard-block** pushes with *No rule to make target 'check'*, which is especially painful in GUI git clients that often lack **`--no-verify`**. The new probe **soft-passes** (exit 0) when **`check`** is absent, matching the existing behavior for missing toolchain guards.
> 
> **`make install-hooks`** comments now state that every invoked target must be probed because the hook outlives any single Makefile revision. **`scripts/tests/test-pre-push-hook.sh`** adds case **9c** (missing **`check`** → soft-pass, **`make check`** not run) and tightens the **9b** stub **`make`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ab53dad1383c7b18f5c94a77a8317b0b7c140b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->