### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- 1–3 sentences. What does this PR do and why? -->
 
 ## Related
-<!-- Same repo: Closes #123 · Cross-repo: Fixes tracebloc/backend#456 (owner-qualified — a bare backend#456 closes nothing). PRs land on develop, not the default branch, so closing keywords do not fire on merge — confirm the issue actually closed. -->
+<!-- Same repo: Closes #123 · Cross-repo: Fixes tracebloc/backend#456 (owner-qualified — a bare backend#456 closes nothing). develop IS this repo's default branch, so a same-repo keyword DOES fire on merge — measured 12 for 12. -->
 
 ## Type of change
 - [ ] Feature

--- a/.github/workflows/contract-consumers.yml
+++ b/.github/workflows/contract-consumers.yml
@@ -1,0 +1,218 @@
+name: contract consumers
+
+# Refuse a schema-version bump the consuming repo cannot read.
+#
+# WHY (backend#2695). On 2026-08-27 `layout.v1.json` went 2 -> 3 (#535). It
+# landed green here and turned the REQUIRED `unit` context red on every open PR
+# in `tracebloc/e2e-test-agent` -- which reads that file and accepts an explicit
+# version set -- for 68 minutes. The consumer's guard caught it at RUN time;
+# nothing caught it at MERGE time, because nothing connected the two repos.
+#
+# The comparison lives in `scripts/contract_consumers.py` and its LOGIC is
+# covered by `tests/test_contract_consumers.py`, which runs inside the REQUIRED
+# `pytest` context. That split is deliberate: this job needs a token and a second
+# checkout, so it cannot be required on a fork PR, and a check whose only
+# exercise is an unrequired job is advice rather than a gate (CLAUDE.md rule 2).
+# CI supplies the real inputs; the required suite proves the comparison works.
+#
+# THE PUBLIC/PRIVATE ASYMMETRY, AND WHY THE SKIP IS NARROW. This repo is PUBLIC
+# and the consumer is PRIVATE, so reading it needs an App token -- and GitHub
+# withholds secrets from fork PRs. Rather than fail every external contribution,
+# the job asks what the PR actually changed:
+#
+#   * no schema file touched  -> there is nothing this check could tell us, so a
+#     missing token is a NOTICE and the job passes. Not a hole: the risk it
+#     guards does not exist on such a PR.
+#   * a schema file touched, no token -> FAILS. An external contributor cannot
+#     know the private consumer's state, and a contract bump is exactly the
+#     change that needs an internal look. "Cannot tell" must not read as "fine".
+
+on:
+  pull_request:
+    paths:
+      # Only PRs that can actually break a consumer. A version cannot change in
+      # a file that is not in the diff, and running this on every PR would spend
+      # a token mint to re-answer a question nothing changed.
+      - 'tracebloc_ingestor/schema/**'
+      - 'scripts/contract_consumers.py'
+      - '.github/workflows/contract-consumers.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'tracebloc_ingestor/schema/**'
+  # A BACKSTOP, because the consumer can drift without us: it may NARROW its
+  # supported set in its own repo, which no PR here would ever notice.
+  schedule:
+    - cron: '37 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # To enumerate the PR's changed files through the API. `git diff` cannot do it
+  # here: checkout gives a depth-1 MERGE commit, so the head SHA is often not in
+  # the local repo at all -- see the scope step.
+  pull-requests: read
+
+concurrency:
+  group: contract-consumers-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  agreement:
+    name: consumers can read what we publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # PIN THE PRODUCER TO THE REF THE CONSUMER ACTUALLY READS (Bugbot, #536).
+          # A `schedule` or `workflow_dispatch` run checks out this repo's
+          # DEFAULT branch, while the consumer below is pinned at `develop` --
+          # so the nightly backstop would compare a RELEASED snapshot against the
+          # head that really reads us. A support-set narrowing on `develop` could
+          # stay green until promotion, and dropping an older released version
+          # could fail while `develop` agrees. Both are the wrong answer to the
+          # question this job asks.
+          #
+          # `github.ref` is right for the other events: the merge ref on a PR
+          # (the state after merging, which is what we are gating) and the pushed
+          # commit on a push.
+          ref: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'develop' || github.ref }}
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      # Does this run actually touch a contract? Drives whether an absent token
+      # is tolerable, so it is answered from the diff rather than assumed.
+      #
+      # ASKED OF THE API, NOT OF `git diff` (Bugbot, #536). The first cut ran
+      # `git diff "$BASE" "$HEAD"` against a default checkout -- which is a
+      # depth-1 MERGE commit, so the head SHA is frequently not in the local
+      # repo, the diff failed, `2>/dev/null` swallowed the error, and
+      # `schema-touched` stayed FALSE. That is fail-OPEN in the one place this
+      # workflow must not be: a fork schema bump would have taken the
+      # notice-and-pass branch below. "Could not tell" reading as "nothing
+      # changed" is the exact defect this whole workflow exists to prevent, and
+      # it was sitting in its own scope step.
+      #
+      # `github.token` is present on fork PRs too (read-only), so this works
+      # everywhere the check runs.
+      - name: Decide whether a contract is in play
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # A scheduled, dispatched or pushed run has no diff to consult and
+          # exists to check the CURRENT state, so the contract is always in play.
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "schema-touched=true" >> "$GITHUB_OUTPUT"
+            echo "not a pull request — treating the contract as in play"
+            exit 0
+          fi
+
+          # FAIL CLOSED ON EVERY PATH THAT CANNOT ANSWER. An unusable PR number,
+          # an API call that fails, or an empty file list all mean "this run does
+          # not know", and the safe reading of that is "a contract might have
+          # changed" -- never "none did".
+          # `case`, not `printf | grep -q`: the same SIGPIPE shape as below, and
+          # the class is worth removing entirely rather than reasoning about
+          # which instances are small enough to be safe. (This one happens to
+          # fail CLOSED under 141 -- `if !` inverts it -- which is luck, not
+          # design, and luck is not a property to leave in a fail-closed gate.)
+          case "$PR_NUMBER" in
+            ''|*[!0-9]*)
+              echo "::warning::no usable PR number; assuming a contract is in play"
+              echo "schema-touched=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+          if ! files=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
+                         --jq '.[].filename'); then
+            echo "::warning::could not enumerate this PR's files; assuming a contract is in play"
+            echo "schema-touched=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "$files" ]; then
+            echo "::warning::the API returned no files for this PR; assuming a contract is in play"
+            echo "schema-touched=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # NO PIPE INTO AN EARLY-EXITING READER (Bugbot, #536). `printf | grep -q`
+          # looks harmless and is not: `grep -q` exits on the FIRST match, `printf`
+          # then takes SIGPIPE, and under `set -o pipefail` the pipeline returns
+          # 141 -- which this `if` would read as "no match" and answer
+          # `schema-touched=false`. A large enough file list plus a schema path
+          # matching early is exactly the fork bump this branch exists to refuse.
+          # Writing the list to a file removes the pipe rather than working
+          # around it.
+          printf '%s\n' "$files" > "$RUNNER_TEMP/pr-files.txt"
+          if grep -q '^tracebloc_ingestor/schema/' "$RUNNER_TEMP/pr-files.txt"; then
+            echo "schema-touched=true" >> "$GITHUB_OUTPUT"
+            echo "this PR changes a published contract"
+          else
+            echo "schema-touched=false" >> "$GITHUB_OUTPUT"
+            echo "no published contract in this diff ($(wc -l < "$RUNNER_TEMP/pr-files.txt" | tr -d ' ') file(s) changed)"
+          fi
+
+      - name: Mint a token for the private consumer
+        id: token
+        # `continue-on-error` so an ABSENT secret (a fork PR) reaches the step
+        # below, which decides what that means. Without it the job dies here
+        # with "missing input", which reads as a broken workflow rather than as
+        # the deliberate refusal it should be on a schema PR.
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_TRAIN_APP_ID }}
+          private-key: ${{ secrets.RELEASE_TRAIN_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: e2e-test-agent
+          # LEAST PRIVILEGE, EXPLICITLY (Bugbot, #536). Without this the token
+          # inherits the App's FULL installation grant -- and `actions/checkout`
+          # stores it in `.consumer/.git`, after which this job runs the PR's own
+          # `scripts/contract_consumers.py` against that checkout. Reading two
+          # files needs `contents: read` and nothing else.
+          permission-contents: read
+
+      - name: Refuse to guess when a contract changed and the consumer is unreadable
+        if: steps.token.outcome != 'success'
+        env:
+          SCHEMA_TOUCHED: ${{ steps.scope.outputs.schema-touched }}
+        run: |
+          set -euo pipefail
+          if [ "$SCHEMA_TOUCHED" = "true" ]; then
+            echo "::error::This PR changes a published contract, but the consumer could not be read (no token — forks do not receive secrets)."
+            echo "::error::Refusing to report agreement this run could not verify: a version bump the consumer cannot read turns its REQUIRED checks red on every open PR."
+            echo "::error::A maintainer must run this from a branch in this repo, where the token is available."
+            exit 1
+          fi
+          echo "::notice::No published contract in this diff and no consumer token available — nothing this check could verify, so it is not claiming anything."
+
+      - name: Check out the consumer
+        if: steps.token.outcome == 'success'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: tracebloc/e2e-test-agent
+          # `develop` NAMED, not the repo default: that is the ref its own CI
+          # reads this repo at, so this compares the two heads that actually
+          # meet. A default-branch read here would answer a question nobody asked.
+          ref: develop
+          token: ${{ steps.token.outputs.token }}
+          path: .consumer
+          # DO NOT LEAVE THE TOKEN IN `.consumer/.git` (Bugbot, #536). The next
+          # step runs code from this PR against this checkout; a credential
+          # sitting in its git config is reachable by anything that runs there.
+          # Nothing here pushes or re-fetches, so persisting it buys nothing.
+          persist-credentials: false
+
+      - name: Every declared consumer can read every contract we publish
+        if: steps.token.outcome == 'success'
+        run: |
+          set -euo pipefail
+          python3 scripts/contract_consumers.py --producer . --consumer .consumer

--- a/Makefile
+++ b/Makefile
@@ -243,11 +243,15 @@ install-hooks:
 	      '# the hook cannot drift from it. guard-toolchain probes the TOOLS check' \
 	      '# runs, not installed packages (a broken venv still fails make check in a shell).' \
 	      '#' \
-	      '# guard-toolchain may be ABSENT on an older branch: this hook lives in' \
-	      '# .git/hooks and runs against whatever Makefile the pushed branch has, and' \
-	      '# make exits 2 for a MISSING TARGET just as for a failed recipe. Probe with' \
-	      '# -n so a missing target falls through to make check instead of silently' \
-	      '# skipping it (Bugbot, backend#1749).' \
+	      '# This hook lives in .git/hooks and runs against whatever Makefile the' \
+	      '# pushed branch has, so it can OUTLIVE any target it names — an older' \
+	      '# branch, staging before the train lands, or no Makefile at all. make' \
+	      '# exits 2 for a MISSING TARGET exactly as for a failed recipe, so probe' \
+	      '# every target with -n: an absent check (or Makefile) soft-passes rather' \
+	      '# than hard-blocking a push that has no --no-verify, and an absent' \
+	      '# guard-toolchain falls through to make check instead of skipping it' \
+	      '# silently (Bugbot + Lukas, backend#1749).' \
+	      'make -n check >/dev/null 2>&1 || exit 0' \
 	      'if make -n guard-toolchain >/dev/null 2>&1; then make guard-toolchain >/dev/null 2>&1 || exit 0; fi' \
 	      'exec make check' > "$$hook" && \
 	    chmod +x "$$hook" && \

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,32 @@ help:
 # running and finishes in ~11 s (measured, macOS). The coverage gate is
 # the only thing held back, and only because a floor is a merge concern
 # rather than a pre-push one.
+# guard-toolchain: can this shell actually run `make check`? A GUI/IDE git client
+# (VS Code, Tower, GitKraken) launches the pre-push hook on a thin PATH that has
+# system `make` and often a bare `python3`, but NOT the virtualenv these checks
+# were installed into — so `make check` hard-fails on "No module named ruff" with
+# no --no-verify to escape (backend#1749; the make-vs-toolchain shape of
+# backend#1995). `check` depends on this and the hook runs it first, so a push
+# from such a client degrades to a skip instead of a hard block.
+#
+# It asks the TOOLS, not the DEPENDENCIES: whether $(PYTHON) can run the linters
+# and test runner check invokes, not whether every package is installed. A
+# genuinely broken venv still fails `make check` when run from a real shell.
+.PHONY: guard-toolchain
+guard-toolchain:
+	@command -v "$(PYTHON)" >/dev/null 2>&1 || { \
+	  echo "not on PATH: $(PYTHON) — activate your virtualenv, then run: make setup"; \
+	  exit 1; }
+	@missing=''; \
+	for m in ruff pytest; do \
+	  "$(PYTHON)" -m "$$m" --version >/dev/null 2>&1 || missing="$$missing $$m"; \
+	done; \
+	[ -z "$$missing" ] || { \
+	  echo "$(PYTHON) cannot run:$$missing — activate your virtualenv, then run: make setup"; \
+	  exit 1; }
+
 .PHONY: check
-check: lint test
+check: guard-toolchain lint test
 	@echo "==> check: green (the coverage gate is in 'make check-all')"
 
 .PHONY: check-all
@@ -144,6 +168,14 @@ e2e:
 # `git rev-parse --git-path hooks` (not a hard-coded `.git/hooks`) so it lands
 # in the right place inside a linked worktree or a submodule, where the git dir
 # is not `.git`.
+# test-hooks: run the install-hooks / pre-push-hook behaviour suite on demand.
+# Not a `check` dependency: it runs real `make` in throwaway repos, so an
+# environment quirk (old git, noexec /tmp) could block a local push on something
+# CI never sees. Run it directly with `make test-hooks` (backend#1749).
+.PHONY: test-hooks
+test-hooks:
+	@sh scripts/tests/test-pre-push-hook.sh
+
 .PHONY: install-hooks
 install-hooks:
 	@if ! git rev-parse --git-dir >/dev/null 2>&1; then \
@@ -151,9 +183,18 @@ install-hooks:
 	elif hp="$$(git config --get core.hooksPath 2>/dev/null || true)"; [ -n "$$hp" ] && { \
 	       hd="$$(git rev-parse --git-path hooks)"; \
 	       case "$$hd" in /*) hdd="$$hd";; *) hdd="$$PWD/$$hd";; esac; \
-	       cpar="$$(cd "$$(dirname "$$hdd")" 2>/dev/null && pwd -P || true)"; \
+	       hdx="$$hdd"; sfx=''; \
+	       while [ ! -d "$$hdx" ] && [ "$$hdx" != "$$(dirname "$$hdx")" ]; do \
+	         sfx="$$(basename "$$hdx")/$$sfx"; hdx="$$(dirname "$$hdx")"; \
+	       done; \
+	       chd="$$(cd "$$hdx" 2>/dev/null && pwd -P || true)"; \
 	       ctop="$$(cd "$$(git rev-parse --show-toplevel)" && pwd -P)"; \
-	       [ -z "$$cpar" ] || case "$$cpar/" in "$$ctop/"*) false;; *) true;; esac; \
+	       cgd="$$(cd "$$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P || true)"; \
+	       inr=0; \
+	       case "$$chd/" in "$$ctop/"*) inr=1;; esac; \
+	       if [ -n "$$cgd" ]; then case "$$chd/" in "$$cgd/"*) inr=1;; esac; fi; \
+	       case "/$$sfx" in */../*) inr=0;; esac; \
+	       [ -z "$$chd" ] || [ "$$inr" = 0 ]; \
 	     }; then \
 	  echo "note: core.hooksPath is set to '$$hp', outside this repo — skipping."; \
 	  echo "      That is a shared hooks dir; installing here would run 'make check' from every repo you push."; \
@@ -189,8 +230,25 @@ install-hooks:
 	      '#' \
 	      '# Git exports GIT_DIR/GIT_WORK_TREE/etc into hook processes; a nested git' \
 	      '# invocation (from a test, tool, or setuptools-scm) then fails in a linked' \
-	      '# worktree with exit status 128. Clear them so make check runs as from the shell.' \
+	      '# worktree with exit status 128. Clear them so the make runs below behave' \
+	      '# as they do from an ordinary shell.' \
 	      'unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY' \
+	      '#' \
+	      '# Guarding on make alone was not enough (backend#1749): a GUI/IDE client' \
+	      '# commonly has system make on a thin PATH but not the virtualenv these' \
+	      '# checks run in, so the skip above passed and the push then hard-failed on' \
+	      '# "No module named ruff" — the exact outcome the skip exists to prevent,' \
+	      '# with no --no-verify to escape. The hook delegates to guard-toolchain,' \
+	      '# the single place the tool list lives, rather than restating it here — so' \
+	      '# the hook cannot drift from it. guard-toolchain probes the TOOLS check' \
+	      '# runs, not installed packages (a broken venv still fails make check in a shell).' \
+	      '#' \
+	      '# guard-toolchain may be ABSENT on an older branch: this hook lives in' \
+	      '# .git/hooks and runs against whatever Makefile the pushed branch has, and' \
+	      '# make exits 2 for a MISSING TARGET just as for a failed recipe. Probe with' \
+	      '# -n so a missing target falls through to make check instead of silently' \
+	      '# skipping it (Bugbot, backend#1749).' \
+	      'if make -n guard-toolchain >/dev/null 2>&1; then make guard-toolchain >/dev/null 2>&1 || exit 0; fi' \
 	      'exec make check' > "$$hook" && \
 	    chmod +x "$$hook" && \
 	    echo "==> pre-push hook installed at $$hook" && \

--- a/scripts/contract_consumers.py
+++ b/scripts/contract_consumers.py
@@ -1,0 +1,292 @@
+"""Refuse a schema-version bump this repo's consumers cannot read.
+
+WHY THIS EXISTS, measured rather than imagined
+----------------------------------------------
+On 2026-08-27 `layout.v1.json` went from version 2 to 3 (#535). `tracebloc/
+e2e-test-agent` reads that file and accepts an explicit set of versions, and it
+refuses an unknown one BY DESIGN -- correctly, because generating dataset
+layouts from a contract nobody has read is the misattribution its harness exists
+to prevent.
+
+The bump landed green here. Over there it turned the REQUIRED `unit` context red
+on every open PR, and the journey red with it, for 68 minutes. Nothing connected
+the two: a contract published by this repo, consumed by another, with a version
+the consumer must explicitly accept -- and no check that the two agree. The
+version guard caught it at RUN time; nothing caught it at MERGE time.
+
+This closes that. It is deliberately the smallest thing that could: it does not
+validate schemas, does not compare shapes, and has no opinion about what a
+version means. It answers one question -- can every consumer read what we are
+about to publish? -- and it answers it from both repos' real declarations.
+
+BOTH SIDES ARE DERIVED. NEITHER IS RESTATED HERE.
+------------------------------------------------
+There is no table in this file pairing a contract with a consumer, and there
+must never be one: a hand-written pairing agrees with itself while disagreeing
+with reality, which is the defect this check is for.
+
+The consumer states BOTH halves itself. Every module that reads a contract
+declares `CONTRACT_RELPATH` (which file it reads) and `SUPPORTED_VERSIONS`
+(which versions it accepts) at module level. So the pairing is discovered by
+walking the consumer for modules carrying both, and the producer side is the
+`version` field in the file that module names. Add a third contract on either
+side and this check picks it up with no edit here.
+
+READ FROM THE AST, NOT WITH A REGEX. A commented-out `SUPPORTED_VERSIONS`, or
+one built at runtime, must not count as a declaration -- a substring search would
+accept both and report agreement with a module that declares nothing.
+
+FAILS CLOSED, INCLUDING ON "I COULD NOT TELL"
+---------------------------------------------
+Zero discovered pairs is an ERROR, not a pass. Zero parsed pairs compares equal
+to zero parsed pairs, so a check that shrugged at an empty result would go green
+for ever the day the consumer's layout changed -- which is the exact shape this
+whole exercise is about. An unreadable consumer, a contract file the consumer
+names but this repo does not publish, and a contract with no `version` field are
+all findings for the same reason.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+#: Where a consumer's contract-reading modules live, relative to its repo root.
+#: A path, not a module list: the point is to find declarations we were not told
+#: about.
+CONSUMER_MODULE_DIR = "harness"
+
+#: The two names a consumer module must declare to be a contract consumer.
+RELPATH_NAME = "CONTRACT_RELPATH"
+VERSIONS_NAME = "SUPPORTED_VERSIONS"
+
+
+@dataclass(frozen=True)
+class ConsumerContract:
+    """One consumer module's declared dependency on one contract file."""
+
+    module: str  #: e.g. "harness/layout.py", for the message
+    relpath: str  #: the contract file, as the consumer names it
+    supported: frozenset  #: the versions it will accept, as strings
+
+    def describe(self) -> str:
+        return "{} reads {} and accepts {}".format(
+            self.module, self.relpath, sorted(self.supported)
+        )
+
+
+class AgreementError(RuntimeError):
+    """The check could not be performed, or was performed and failed."""
+
+
+def _path_from_expr(node: ast.AST) -> Optional[str]:
+    """`Path("a") / "b" / "c.json"` -> `"a/b/c.json"`, or None.
+
+    Handles the joined-Path idiom the consumer actually uses. Anything else --
+    a name, a call this does not recognise, an f-string -- returns None rather
+    than a guess, and the caller treats that as "not a declaration" rather than
+    inventing a path.
+    """
+    parts: List[str] = []
+
+    def walk(n: ast.AST) -> bool:
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Div):
+            return walk(n.left) and walk(n.right)
+        if isinstance(n, ast.Constant) and isinstance(n.value, str):
+            parts.append(n.value)
+            return True
+        if (
+            isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Name)
+            and n.func.id == "Path"
+        ):
+            return all(walk(a) for a in n.args)
+        return False
+
+    return "/".join(parts) if walk(node) and parts else None
+
+
+def _versions_from_expr(node: ast.AST) -> Optional[frozenset]:
+    """`{"2", "3"}` -> `{"2", "3"}`, or None if it is not a literal set of strings.
+
+    Numbers are coerced to strings so a consumer writing `{2, 3}` is still
+    understood -- the producer's `version` field is compared as a string, and a
+    type mismatch between the two repos is not the drift this check is about.
+    """
+    if not isinstance(node, ast.Set):
+        return None
+    out = set()
+    for element in node.elts:
+        if not isinstance(element, ast.Constant):
+            return None
+        if isinstance(element.value, (str, int)):
+            out.add(str(element.value))
+        else:
+            return None
+    return frozenset(out) if out else None
+
+
+def consumer_contracts(consumer_root: Path) -> List[ConsumerContract]:
+    """Every contract dependency the consumer declares, from its AST.
+
+    Raises rather than returning empty when the module directory is absent: a
+    consumer we cannot read is a finding, and an empty list here would sail
+    through the comparison below.
+    """
+    module_dir = consumer_root / CONSUMER_MODULE_DIR
+    if not module_dir.is_dir():
+        raise AgreementError(
+            "no {}/ directory under {} -- the consumer checkout is missing or "
+            "its layout changed. Refusing to report agreement with a repo this "
+            "could not read.".format(CONSUMER_MODULE_DIR, consumer_root)
+        )
+
+    found: List[ConsumerContract] = []
+    for path in sorted(module_dir.glob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError) as exc:
+            raise AgreementError(
+                "could not parse {}: {}. A consumer module that cannot be read "
+                "is a finding, not a skip.".format(path, exc)
+            )
+        relpath: Optional[str] = None
+        supported: Optional[frozenset] = None
+        for node in tree.body:  # module level only
+            # BOTH ASSIGNMENT FORMS. Only `ast.Assign` was handled, so an
+            # ANNOTATED declaration -- `SUPPORTED_VERSIONS: frozenset = {"2"}`,
+            # a shape this codebase already uses elsewhere -- was dropped as if
+            # the module declared nothing. The zero-pairs guard does not save
+            # that case: it fires only when EVERY module is missed, so one
+            # still-parseable sibling kept the check green while the module
+            # that actually gates the bumped contract was ignored (Bugbot, #536).
+            if isinstance(node, ast.Assign):
+                targets = [t for t in node.targets if isinstance(t, ast.Name)]
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                # An annotation with no value (`X: frozenset`) declares nothing.
+                targets = [node.target] if node.value is not None else []
+            else:
+                continue
+            for target in targets:
+                if target.id == RELPATH_NAME:
+                    relpath = _path_from_expr(node.value)
+                elif target.id == VERSIONS_NAME:
+                    supported = _versions_from_expr(node.value)
+        if relpath and supported:
+            found.append(
+                ConsumerContract(
+                    module="{}/{}".format(CONSUMER_MODULE_DIR, path.name),
+                    relpath=relpath,
+                    supported=supported,
+                )
+            )
+    return found
+
+
+def published_version(producer_root: Path, relpath: str) -> str:
+    """The `version` this repo publishes for `relpath`, as a string."""
+    path = producer_root / relpath
+    if not path.is_file():
+        raise AgreementError(
+            "a consumer reads {!r}, which this repo does not publish. Either the "
+            "file moved (update the consumer in the same change) or the consumer "
+            "names a path that never existed.".format(relpath)
+        )
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise AgreementError("could not read {}: {}".format(relpath, exc))
+    if "version" not in doc:
+        raise AgreementError(
+            "{} carries no `version` field, but a consumer gates on one. An "
+            "absent version is not a passing check -- the consumer would refuse "
+            "the file at run time.".format(relpath)
+        )
+    return str(doc["version"])
+
+
+def disagreements(
+    producer_root: Path, contracts: Sequence[ConsumerContract]
+) -> List[str]:
+    """Human-readable problems; empty means every consumer can read us."""
+    problems: List[str] = []
+    for contract in contracts:
+        version = published_version(producer_root, contract.relpath)
+        if version not in contract.supported:
+            problems.append(
+                "{}: this repo publishes version {!r}, but {} accepts only {}.\n"
+                "    The consumer refuses an unknown version BY DESIGN, so "
+                "merging this bump turns its required checks red on every open "
+                "PR until it is taught to read {!r}.\n"
+                "    Fix order: land the consumer change FIRST (read the diff, "
+                "then add the version to its {}), then merge this.".format(
+                    contract.relpath,
+                    version,
+                    contract.module,
+                    sorted(contract.supported),
+                    version,
+                    VERSIONS_NAME,
+                )
+            )
+    return problems
+
+
+def check(producer_root: Path, consumer_root: Path) -> List[str]:
+    """The whole check. Raises `AgreementError` when it cannot be performed."""
+    contracts = consumer_contracts(consumer_root)
+    if not contracts:
+        raise AgreementError(
+            "found no contract consumers under {}/{} -- zero parsed pairs "
+            "compares equal to zero parsed pairs, so reporting agreement here "
+            "would be a check that passes for ever. Either the consumer stopped "
+            "declaring {} / {} at module level, or its layout moved.".format(
+                consumer_root, CONSUMER_MODULE_DIR, RELPATH_NAME, VERSIONS_NAME
+            )
+        )
+    return disagreements(producer_root, contracts)
+
+
+def _main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--consumer",
+        required=True,
+        type=Path,
+        help="path to a checkout of the consuming repo",
+    )
+    parser.add_argument(
+        "--producer",
+        default=Path("."),
+        type=Path,
+        help="path to this repo (default: cwd)",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        contracts = consumer_contracts(args.consumer)
+        for contract in contracts:
+            print("  {}".format(contract.describe()))
+        # Flushed before anything reaches stderr: the two streams interleave in
+        # a terminal otherwise, and the inventory printed AFTER the failure it
+        # explains reads as though it belonged to a different run.
+        sys.stdout.flush()
+        problems = check(args.producer, args.consumer)
+    except AgreementError as exc:
+        print("contract-consumer check could not run: {}".format(exc), file=sys.stderr)
+        return 2
+    if problems:
+        print("", file=sys.stderr)
+        for problem in problems:
+            print("  {}".format(problem), file=sys.stderr)
+        return 1
+    print("every declared consumer can read every contract this repo publishes")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through CI and tests
+    raise SystemExit(_main())

--- a/scripts/tests/test-pre-push-hook.sh
+++ b/scripts/tests/test-pre-push-hook.sh
@@ -1,0 +1,163 @@
+#!/bin/sh
+# test-pre-push-hook.sh — behaviour tests for `make install-hooks` and the
+# generated pre-push hook, driven by running real `make` against a copy of the
+# Makefile in a throwaway git repo. Added with the fleet-wide hook fix
+# (backend#1749). Pure POSIX sh, no bats/pytest dependency, so `make test-hooks`
+# runs it anywhere.
+#
+# Covers the branches a future edit could silently break:
+#   * fresh install writes an executable, ours-marked hook
+#   * re-install is idempotent (ours -> rewrite, no error)
+#   * a foreign pre-push hook is left untouched
+#   * core.hooksPath outside the repo is refused (no shared-dir stomp)
+#   * core.hooksPath=.. is refused too — no pre-push written into the parent
+#     (the dirname-of-hooksdir guard missed a bare `..`; backend#1749)
+#   * the hook skips delete-only / no-op pushes (all-zero local sha)
+#   * the hook degrades gracefully when `make` is off PATH (GUI clients)
+#   * the hook soft-passes when the venv toolchain is absent (guard-toolchain
+#     fails) rather than hard-blocking a GUI push that cannot --no-verify (#1749)
+#   * guard-toolchain fails on a tool it cannot run and passes when it can
+set -eu
+
+# Hermetic: ignore the developer's global/system git config so an ambient
+# core.hooksPath (corp dotfiles, husky) can't make install-hooks skip and fail
+# the fresh-install/reinstall assertions. Every git here sees only local config.
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
+REPO_ROOT=$(unset CDPATH; cd -- "$(dirname -- "$0")/../.." && pwd)
+MAKEFILE="$REPO_ROOT/Makefile"
+Z=0000000000000000000000000000000000000000
+fails=0
+check() { if [ "$1" = "$2" ]; then echo "  ok: $3"; else echo "  FAIL: $3 (got '$1', want '$2')"; fails=$((fails + 1)); fi; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+cd "$work"
+git init -q .
+git config user.email t@t; git config user.name t
+cp "$MAKEFILE" ./Makefile
+hook=.git/hooks/pre-push
+
+# 1) fresh install
+make -s install-hooks >/dev/null
+check "$( [ -x "$hook" ] && echo yes )" "yes" "fresh install writes an executable hook"
+check "$(grep -c 'tracebloc pre-push hook' "$hook")" "1" "hook carries the ours-marker"
+
+# 2) idempotent re-install
+make -s install-hooks >/dev/null
+check "$(grep -c 'tracebloc pre-push hook' "$hook")" "1" "re-install stays idempotent"
+
+# 3) foreign hook left untouched
+printf '#!/bin/sh\necho FOREIGN\n' > "$hook"
+make -s install-hooks >/dev/null
+check "$(grep -c FOREIGN "$hook")" "1" "foreign hook is preserved"
+rm -f "$hook"
+
+# 4) core.hooksPath pointing OUTSIDE the repo is refused, in every escaping form
+# (absolute, relative, and .. segments that string-prefix as inside). Assert the
+# resolved shared dir stays empty — checking only .git/hooks would miss a hook
+# written into the configured dir, and a string-prefix guard misses .. escapes.
+# The parent of each form is a real, canonicalisable dir outside $work.
+outside=$(mktemp -d)                       # a sibling of $work, definitely outside
+for form in "$outside" "../$(basename "$outside")" "$work/../$(basename "$outside")"; do
+  git config core.hooksPath "$form"
+  make -s install-hooks >/dev/null
+  check "$( [ -e "$outside/pre-push" ] && echo present || echo absent )" "absent" "core.hooksPath outside repo refused: $form"
+  rm -f "$outside/pre-push"
+  git config --unset core.hooksPath
+done
+rm -rf "$outside"
+
+# 4b) core.hooksPath INSIDE the repo is honoured (install proceeds there).
+mkdir -p "$work/.githooks"
+git config core.hooksPath .githooks
+make -s install-hooks >/dev/null
+check "$(grep -c 'tracebloc pre-push hook' "$work/.githooks/pre-push" 2>/dev/null || echo 0)" "1" "core.hooksPath inside repo: hook installed there"
+git config --unset core.hooksPath
+
+# 4c) core.hooksPath escapes to a shared dir OUTSIDE the worktree, in the shapes
+# earlier guards missed: a bare `..`/`./..` (the dirname guard resolved it back
+# inside), and a `..` hidden behind a not-yet-created prefix — `missing/../..`,
+# `missing/../../shared` — where the ancestor-walk climbed past the missing
+# prefix and read the worktree as the target. Both wrote pre-push above the
+# worktree, the stomp the guard exists to prevent (backend#1749). A `..` in the
+# not-yet-existing suffix cannot be resolved until the prefix exists, so the
+# guard refuses it (Lukas, backend#2714). Assert nothing lands outside the repo.
+esc=$(mktemp -d)
+mkdir -p "$esc/repo"
+( cd "$esc/repo" && git init -q . && git config user.email t@t && git config user.name t \
+  && cp "$MAKEFILE" ./Makefile )
+for form in ".." "./.." "missing/../.." "missing/../../shared"; do
+  ( cd "$esc/repo" && git config core.hooksPath "$form" && make -s install-hooks >/dev/null )
+  check "$(find "$esc" -name pre-push -not -path "$esc/repo/*" 2>/dev/null | head -1 | grep -q . && echo present || echo absent)" "absent" "core.hooksPath parent-escape refused: $form"
+  find "$esc" -name pre-push -not -path "$esc/repo/*" -delete 2>/dev/null
+  ( cd "$esc/repo" && rm -rf missing shared )
+done
+rm -rf "$esc"
+
+# 4d) a not-yet-created IN-REPO hooks dir still INSTALLS — the fresh-clone case
+# the ancestor-walk exists for, and the arm the suffix-`..` refusal must not
+# over-block (Lukas, backend#2714). No `..`, so it is unambiguously in-repo.
+git config core.hooksPath freshhooks
+make -s install-hooks >/dev/null
+check "$(grep -c 'tracebloc pre-push hook' "$work/freshhooks/pre-push" 2>/dev/null || echo 0)" "1" "core.hooksPath in-repo but not-yet-created: hook installed"
+git config --unset core.hooksPath
+rm -rf "$work/freshhooks"
+
+# reinstall a clean ours-hook for the behavioural cases
+make -s install-hooks >/dev/null
+
+# 5) delete-only push (all-zero local sha) is skipped without running make
+if printf 'refs/heads/x %s refs/heads/x %s\n' "$Z" deadbeef | sh "$hook"; then rc=0; else rc=$?; fi
+check "$rc" "0" "delete-only push is skipped (exit 0)"
+
+# 6) real push but make absent -> graceful skip, not 'command not found'
+if printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH= /bin/sh "$hook"; then rc=0; else rc=$?; fi
+check "$rc" "0" "missing make degrades to skip (exit 0)"
+
+# 7) a genuine (non-delete) push RUNS make check. Stub make to touch a sentinel
+# only for `check` (the hook now runs `make guard-toolchain` first); a no-op hook
+# would leave the sentinel missing.
+sent="$(mktemp -u)"; stub="$(mktemp -d)"
+printf '#!/bin/sh\n[ "$1" = check ] && : > %s\nexit 0\n' "$sent" > "$stub/make"; chmod +x "$stub/make"
+printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH="$stub:$PATH" sh "$hook" >/dev/null 2>&1 || true
+check "$([ -f "$sent" ] && echo ran || echo missing)" "ran" "genuine push runs make check"
+rm -rf "$stub"; rm -f "$sent"
+
+# 8) an incomplete venv toolchain (system make present, but ruff/pytest absent)
+# must SOFT-PASS, not hard-block: GUI/IDE clients push on a thin PATH and cannot
+# pass --no-verify (backend#1749). The hook asks `make guard-toolchain` and skips
+# itself when it fails, so `make check` must not run. Stub make so guard-toolchain
+# fails and check would touch a sentinel; assert exit 0 and the sentinel absent.
+sent="$(mktemp -u)"; stub="$(mktemp -d)"
+printf '#!/bin/sh\ncase "$1" in guard-toolchain) exit 1 ;; check) : > %s ;; esac\nexit 0\n' "$sent" > "$stub/make"; chmod +x "$stub/make"
+if printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH="$stub:$PATH" sh "$hook"; then rc=0; else rc=$?; fi
+check "$rc" "0" "missing venv toolchain soft-passes (exit 0)"
+check "$([ -f "$sent" ] && echo ran || echo skipped)" "skipped" "soft-pass does not run make check"
+rm -rf "$stub"; rm -f "$sent"
+
+# 9) guard-toolchain itself: fails when a tool cannot run, passes when all can.
+# Driven with a stub PYTHON so it needs no real venv and stays fast.
+gtbin="$(mktemp -d)"
+printf '#!/bin/sh\nexit 0\n' > "$gtbin/py-ok"; chmod +x "$gtbin/py-ok"
+printf '#!/bin/sh\nexit 1\n' > "$gtbin/py-bad"; chmod +x "$gtbin/py-bad"
+if make -s guard-toolchain PYTHON="$gtbin/py-ok" >/dev/null 2>&1; then rc=0; else rc=$?; fi
+check "$rc" "0" "guard-toolchain passes when the toolchain runs"
+if make -s guard-toolchain PYTHON="$gtbin/py-bad" >/dev/null 2>&1; then rc=0; else rc=$?; fi
+check "$( [ "$rc" != 0 ] && echo nonzero || echo zero )" "nonzero" "guard-toolchain fails when a tool cannot run"
+rm -rf "$gtbin"
+
+# 9b) the installed hook runs against whatever Makefile the pushed branch has
+# (it lives in .git/hooks, shared across branches). make exits 2 for a MISSING
+# guard-toolchain target just as for a failed recipe, so the hook must not read
+# "no such target" as "toolchain absent" and skip — it probes with -n and falls
+# through to make check (Bugbot, backend#1749). Stub make as an OLD Makefile:
+# guard-toolchain has no rule (exit 2), check touches a sentinel.
+sent="$(mktemp -u)"; stub="$(mktemp -d)"
+printf '#!/bin/sh\nfor a in "$@"; do case "$a" in guard-toolchain) exit 2 ;; check) : > %s ;; esac; done\nexit 0\n' "$sent" > "$stub/make"; chmod +x "$stub/make"
+printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH="$stub:$PATH" sh "$hook" >/dev/null 2>&1 || true
+check "$([ -f "$sent" ] && echo ran || echo skipped)" "ran" "old Makefile (no guard-toolchain) still runs make check"
+rm -rf "$stub"; rm -f "$sent"
+
+echo "--- pre-push hook tests: $( [ "$fails" -eq 0 ] && echo ALL GREEN || echo "$fails FAILED" ) ---"
+[ "$fails" -eq 0 ]

--- a/scripts/tests/test-pre-push-hook.sh
+++ b/scripts/tests/test-pre-push-hook.sh
@@ -154,9 +154,21 @@ rm -rf "$gtbin"
 # through to make check (Bugbot, backend#1749). Stub make as an OLD Makefile:
 # guard-toolchain has no rule (exit 2), check touches a sentinel.
 sent="$(mktemp -u)"; stub="$(mktemp -d)"
-printf '#!/bin/sh\nfor a in "$@"; do case "$a" in guard-toolchain) exit 2 ;; check) : > %s ;; esac; done\nexit 0\n' "$sent" > "$stub/make"; chmod +x "$stub/make"
+printf '#!/bin/sh\nfor a in "$@"; do case "$a" in guard-toolchain) exit 2 ;; esac; done\n[ "$1" = check ] && : > %s\nexit 0\n' "$sent" > "$stub/make"; chmod +x "$stub/make"
 printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH="$stub:$PATH" sh "$hook" >/dev/null 2>&1 || true
 check "$([ -f "$sent" ] && echo ran || echo skipped)" "ran" "old Makefile (no guard-toolchain) still runs make check"
+rm -rf "$stub"; rm -f "$sent"
+
+# 9c) an even older branch may lack `check` itself, or the Makefile entirely.
+# `make -n guard-toolchain` fails there too, so control would reach `exec make
+# check` and hard-block on "No rule to make target check" — with no --no-verify
+# in the GUI clients this family protects. The hook probes `check` too and
+# soft-passes (Lukas, backend#2714). Stub make: -n check has no rule (exit 2).
+sent="$(mktemp -u)"; stub="$(mktemp -d)"
+printf '#!/bin/sh\nfor a in "$@"; do case "$a" in check) exit 2 ;; esac; done\n: > %s\nexit 0\n' "$sent" > "$stub/make"; chmod +x "$stub/make"
+if printf 'refs/heads/x deadbeef refs/heads/x 000\n' | env PATH="$stub:$PATH" sh "$hook"; then rc=0; else rc=$?; fi
+check "$rc" "0" "missing check target soft-passes (exit 0, no hard-block)"
+check "$([ -f "$sent" ] && echo ran || echo skipped)" "skipped" "soft-pass does not run make check"
 rm -rf "$stub"; rm -f "$sent"
 
 echo "--- pre-push hook tests: $( [ "$fails" -eq 0 ] && echo ALL GREEN || echo "$fails FAILED" ) ---"

--- a/tests/test_contract_consumers.py
+++ b/tests/test_contract_consumers.py
@@ -1,0 +1,465 @@
+"""The cross-repo contract check works, and can fail.
+
+`scripts/contract_consumers.py` refuses a schema-version bump the consuming repo
+cannot read. The CI job that runs it needs a token and a second checkout, so it
+cannot be a required check on a fork PR -- which means the LOGIC has to be
+covered here, in the required `pytest` context, or the comparison could rot with
+nothing able to notice.
+
+That split is the point: CI supplies the real inputs, these supply the hard ones.
+A check whose only exercise is the happy path against today's repos is a check
+that has never been shown to fail.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.contract_consumers import (  # noqa: E402
+    AgreementError,
+    check,
+    consumer_contracts,
+    disagreements,
+    published_version,
+)
+
+
+def _consumer(tmp_path: Path, **modules: str) -> Path:
+    """A fake consumer checkout: `harness/<name>.py` per keyword."""
+    harness = tmp_path / "harness"
+    harness.mkdir(parents=True, exist_ok=True)
+    for name, body in modules.items():
+        (harness / f"{name}.py").write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+def _producer(tmp_path: Path, relpath: str, doc: object) -> Path:
+    """A fake producer checkout publishing one contract file."""
+    path = tmp_path / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return tmp_path
+
+
+MODULE = """
+from pathlib import Path
+CONTRACT_RELPATH = Path("tracebloc_ingestor") / "schema" / "layout.v1.json"
+SUPPORTED_VERSIONS = {"2"}
+"""
+
+
+class TestItDiscoversTheParingRatherThanBeingToldIt:
+    def test_a_module_declaring_both_names_is_found(self, tmp_path):
+        root = _consumer(tmp_path, layout=MODULE)
+        found = consumer_contracts(root)
+        assert len(found) == 1
+        assert found[0].relpath == "tracebloc_ingestor/schema/layout.v1.json"
+        assert found[0].supported == frozenset({"2"})
+
+    def test_several_modules_each_yield_their_own_contract(self, tmp_path):
+        other = MODULE.replace("layout.v1.json", "runtime_env.v1.json").replace(
+            '{"2"}', '{"1"}'
+        )
+        root = _consumer(tmp_path, layout=MODULE, runtime_env=other)
+        assert {c.relpath for c in consumer_contracts(root)} == {
+            "tracebloc_ingestor/schema/layout.v1.json",
+            "tracebloc_ingestor/schema/runtime_env.v1.json",
+        }
+
+    def test_a_module_with_only_one_of_the_two_names_is_not_a_consumer(self, tmp_path):
+        # Half a declaration is not a dependency this check can verify, and
+        # guessing the other half is how a pairing table gets born.
+        only_path = (
+            'from pathlib import Path\nCONTRACT_RELPATH = Path("a") / "b.json"\n'
+        )
+        only_versions = 'SUPPORTED_VERSIONS = {"1"}\n'
+        root = _consumer(tmp_path, a=only_path, b=only_versions)
+        assert consumer_contracts(root) == []
+
+    def test_an_ANNOTATED_declaration_is_found_too(self, tmp_path):
+        # Only `ast.Assign` was handled, so `SUPPORTED_VERSIONS: frozenset = {...}`
+        # -- a shape this codebase uses elsewhere -- was dropped as if the module
+        # declared nothing. The zero-pairs guard does NOT cover that: it fires
+        # only when every module is missed, so one still-parseable sibling kept
+        # the check green while the module gating the bumped contract was
+        # ignored (Bugbot, #536).
+        annotated = (
+            "from pathlib import Path\n"
+            "from typing import FrozenSet\n"
+            'CONTRACT_RELPATH: Path = Path("tracebloc_ingestor") / "schema" / "layout.v1.json"\n'
+            'SUPPORTED_VERSIONS: FrozenSet[str] = {"2"}\n'
+        )
+        root = _consumer(tmp_path, annotated=annotated)
+        found = consumer_contracts(root)
+        assert len(found) == 1
+        assert found[0].supported == frozenset({"2"})
+
+    def test_a_module_missed_while_a_SIBLING_parses_is_still_caught(self, tmp_path):
+        # The precise hole: zero-pairs cannot see a PARTIAL miss. With one plain
+        # and one annotated module, dropping the annotated one leaves a non-empty
+        # result -- green, while the contract it gates goes unchecked.
+        plain = MODULE.replace("layout.v1.json", "runtime_env.v1.json")
+        annotated = (
+            "from pathlib import Path\n"
+            'CONTRACT_RELPATH: Path = Path("tracebloc_ingestor") / "schema" / "layout.v1.json"\n'
+            'SUPPORTED_VERSIONS: frozenset = {"2"}\n'
+        )
+        root = _consumer(tmp_path, runtime_env=plain, layout=annotated)
+        paths = {c.relpath for c in consumer_contracts(root)}
+        assert paths == {
+            "tracebloc_ingestor/schema/layout.v1.json",
+            "tracebloc_ingestor/schema/runtime_env.v1.json",
+        }, f"an annotated module was dropped while its sibling kept the walk non-empty: {paths}"
+
+    def test_a_bare_annotation_with_no_value_declares_nothing(self, tmp_path):
+        # `SUPPORTED_VERSIONS: set` states a type, not a value. Treating it as a
+        # declaration would invent a supported set nobody wrote.
+        root = _consumer(
+            tmp_path,
+            layout=(
+                "from pathlib import Path\n"
+                "CONTRACT_RELPATH: Path\n"
+                "SUPPORTED_VERSIONS: set\n"
+            ),
+        )
+        assert consumer_contracts(root) == []
+
+    def test_a_commented_out_declaration_does_not_count(self, tmp_path):
+        # THE REASON THIS READS THE AST. A substring search would accept this
+        # module and report agreement with something that declares nothing.
+        root = _consumer(
+            tmp_path,
+            layout=(
+                "from pathlib import Path\n"
+                'CONTRACT_RELPATH = Path("tracebloc_ingestor") / "schema" / "layout.v1.json"\n'
+                '# SUPPORTED_VERSIONS = {"2"}\n'
+            ),
+        )
+        assert consumer_contracts(root) == []
+
+    def test_a_runtime_built_version_set_does_not_count(self, tmp_path):
+        # Not a literal, so this check cannot know what it will hold. Reporting
+        # a guess would be worse than reporting nothing -- and reporting nothing
+        # is itself caught, by the zero-pairs rule below.
+        root = _consumer(
+            tmp_path,
+            layout=(
+                "from pathlib import Path\n"
+                'CONTRACT_RELPATH = Path("a") / "b.json"\n'
+                "SUPPORTED_VERSIONS = set(_load_versions())\n"
+            ),
+        )
+        assert consumer_contracts(root) == []
+
+
+class TestItFailsClosed:
+    def test_a_missing_consumer_directory_raises_rather_than_returning_empty(
+        self, tmp_path
+    ):
+        with pytest.raises(AgreementError) as caught:
+            consumer_contracts(tmp_path / "nowhere")
+        assert "missing" in str(caught.value)
+
+    def test_zero_discovered_pairs_is_an_error_not_a_pass(self, tmp_path):
+        # THE HEADLINE RULE. Zero parsed pairs compares equal to zero parsed
+        # pairs, so a check that shrugged here would go green for ever the day
+        # the consumer's layout moved -- which is the exact defect class this
+        # whole thing exists for.
+        consumer = _consumer(tmp_path / "c", empty="x = 1\n")
+        producer = _producer(tmp_path / "p", "a/b.json", {"version": 1})
+        with pytest.raises(AgreementError) as caught:
+            check(producer, consumer)
+        assert "zero parsed pairs" in str(caught.value)
+
+    def test_an_unparseable_consumer_module_is_a_finding(self, tmp_path):
+        root = _consumer(tmp_path, broken="def (:\n")
+        with pytest.raises(AgreementError):
+            consumer_contracts(root)
+
+    def test_a_contract_the_consumer_names_but_we_do_not_publish_is_a_finding(
+        self, tmp_path
+    ):
+        producer = _producer(tmp_path / "p", "other.json", {"version": 1})
+        with pytest.raises(AgreementError) as caught:
+            published_version(producer, "tracebloc_ingestor/schema/layout.v1.json")
+        assert "does not publish" in str(caught.value)
+
+    def test_a_contract_with_no_version_field_is_a_finding(self, tmp_path):
+        # An absent version is not a passing check: the consumer gates on one
+        # and would refuse the file at run time.
+        producer = _producer(tmp_path / "p", "a/b.json", {"tasks": {}})
+        with pytest.raises(AgreementError) as caught:
+            published_version(producer, "a/b.json")
+        assert "no `version` field" in str(caught.value)
+
+
+class TestTheComparison:
+    def test_a_version_the_consumer_accepts_is_no_problem(self, tmp_path):
+        consumer = _consumer(tmp_path / "c", layout=MODULE)
+        producer = _producer(
+            tmp_path / "p", "tracebloc_ingestor/schema/layout.v1.json", {"version": 2}
+        )
+        assert check(producer, consumer) == []
+
+    def test_a_version_the_consumer_refuses_is_reported_with_the_fix_order(
+        self, tmp_path
+    ):
+        consumer = _consumer(tmp_path / "c", layout=MODULE)
+        producer = _producer(
+            tmp_path / "p", "tracebloc_ingestor/schema/layout.v1.json", {"version": 3}
+        )
+        problems = check(producer, consumer)
+        assert len(problems) == 1
+        # The message has to say what to do, not just that something is wrong:
+        # the fix is ordered (consumer first) and a reader who does not know
+        # that will merge these in the order that causes the outage.
+        assert "land the consumer change FIRST" in problems[0]
+        assert "harness/layout.py" in problems[0]
+
+    def test_the_version_is_compared_as_a_string_either_way_round(self, tmp_path):
+        # The producer writes `3` as JSON number; a consumer may write "3" or 3.
+        # A type mismatch between two repos is not the drift this check is for,
+        # and letting it fail here would produce a confusing red for a real pair.
+        numeric = MODULE.replace('{"2"}', "{2, 3}")
+        consumer = _consumer(tmp_path / "c", layout=numeric)
+        producer = _producer(
+            tmp_path / "p", "tracebloc_ingestor/schema/layout.v1.json", {"version": 3}
+        )
+        assert check(producer, consumer) == []
+
+    def test_one_bad_pair_among_several_is_still_reported(self, tmp_path):
+        # BOTH must disagree for this to test what it claims. The first cut
+        # published `2` for the second contract -- which its consumer accepts --
+        # so the assertion failed for a reason unrelated to the behaviour under
+        # test. A fixture that quietly agrees is the fixture bug that makes a
+        # "we report all of them" claim untested.
+        other = MODULE.replace("layout.v1.json", "runtime_env.v1.json")
+        consumer = _consumer(tmp_path / "c", layout=MODULE, runtime_env=other)
+        producer = tmp_path / "p"
+        _producer(producer, "tracebloc_ingestor/schema/layout.v1.json", {"version": 9})
+        _producer(
+            producer, "tracebloc_ingestor/schema/runtime_env.v1.json", {"version": 5}
+        )
+        problems = check(producer, consumer)
+        assert len(problems) == 2, "each disagreeing pair should be named"
+        assert any("layout.v1.json" in p for p in problems)
+        assert any("runtime_env.v1.json" in p for p in problems)
+
+
+class TestItWouldHaveCaughtTheIncidentItWasWrittenFor:
+    """The mutation that matters: replay 2026-08-27 and watch it go red.
+
+    `layout.v1.json` went to version 3 while the consumer accepted only `{"2"}`.
+    That turned a REQUIRED context red on every open PR in the consuming repo for
+    68 minutes. A check written after an incident that would not have caught the
+    incident is decoration.
+    """
+
+    def test_the_real_pairing_reddens_on_the_real_bump(self, tmp_path):
+        consumer = _consumer(tmp_path / "c", layout=MODULE)  # accepts {"2"}
+        producer = _producer(
+            tmp_path / "p", "tracebloc_ingestor/schema/layout.v1.json", {"version": 3}
+        )  # what #535 published
+        problems = check(producer, consumer)
+        assert problems, "the check would NOT have caught the outage it exists for"
+        assert "'3'" in problems[0] and "'2'" in problems[0]
+
+    def test_and_goes_green_once_the_consumer_is_taught_to_read_it(self, tmp_path):
+        # The other direction, so the test above is not passing for a reason
+        # unrelated to the version -- #290 is what made this true in reality.
+        fixed = MODULE.replace('{"2"}', '{"2", "3"}')
+        consumer = _consumer(tmp_path / "c", layout=fixed)
+        producer = _producer(
+            tmp_path / "p", "tracebloc_ingestor/schema/layout.v1.json", {"version": 3}
+        )
+        assert check(producer, consumer) == []
+
+
+class TestTheRealReposAgreeToday:
+    """Run against the actual files in this repo, not a fixture.
+
+    The fixtures above prove the logic; this proves the logic is pointed at
+    something real. It skips only when no consumer checkout is present -- CI
+    provides one, and a developer without it is not blocked.
+    """
+
+    def test_every_contract_this_repo_publishes_parses_and_carries_a_version(self):
+        root = Path(__file__).resolve().parents[1]
+        schemas = sorted((root / "tracebloc_ingestor" / "schema").glob("*.json"))
+        assert schemas, "no schema files found — the layout moved"
+        for path in schemas:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+            assert isinstance(doc, dict), f"{path.name} is not an object"
+
+    def test_the_checked_out_consumer_can_read_us(self):
+        root = Path(__file__).resolve().parents[1]
+        consumer = Path(__file__).resolve().parents[2] / "e2e-test-agent"
+        if not (consumer / "harness").is_dir():
+            pytest.skip("no e2e-test-agent checkout beside this repo")
+        assert disagreements(root, consumer_contracts(consumer)) == []
+
+
+class TestTheWorkflowScopeStepFailsClosed:
+    """The scope step decides whether a missing token is tolerable.
+
+    Every path that cannot answer must choose "a contract might have changed".
+    The first cut chose the opposite by accident -- it ran `git diff` against a
+    depth-1 merge checkout, the diff failed, `2>/dev/null` ate the error and the
+    output defaulted to `false`, so a fork schema bump would have passed with a
+    notice (Bugbot, #536). That is the exact defect this workflow exists to
+    prevent, which is why it is pinned here rather than left to review.
+    """
+
+    @staticmethod
+    def _scope_step() -> str:
+        text = (
+            Path(__file__).resolve().parents[1]
+            / ".github/workflows/contract-consumers.yml"
+        ).read_text()
+        start = text.index("- name: Decide whether a contract is in play")
+        end = text.index("- name: Mint a token for the private consumer")
+        return text[start:end]
+
+    def test_it_does_not_infer_the_diff_from_git(self):
+        # `git diff` cannot answer here: checkout gives a depth-1 MERGE commit,
+        # so the head SHA is frequently absent from the local repo.
+        step = self._scope_step()
+        code = "\n".join(
+            line for line in step.splitlines() if not line.strip().startswith("#")
+        )
+        assert "git diff" not in code, (
+            "the scope step infers the diff from git again; a depth-1 merge "
+            "checkout cannot answer this and the failure is silent"
+        )
+
+    def test_every_cannot_tell_branch_chooses_in_play(self):
+        # Derived from the step itself: every `schema-touched=` it writes must be
+        # `true` except exactly one -- the branch that positively established no
+        # contract changed. A second `false` is a new way to fail open.
+        step = self._scope_step()
+        writes = [
+            line.strip()
+            for line in step.splitlines()
+            if "schema-touched=" in line and "echo" in line
+        ]
+        assert writes, "the scope step writes no output at all"
+        false_writes = [w for w in writes if "schema-touched=false" in w]
+        assert len(false_writes) == 1, (
+            f"expected exactly one `false` path (the positive 'no contract "
+            f"changed' answer); found {len(false_writes)}: {false_writes}"
+        )
+
+    def test_the_refusal_branch_still_exists_and_is_fatal(self):
+        # The other half: having decided a contract IS in play, an unreadable
+        # consumer must end the run rather than warn.
+        text = (
+            Path(__file__).resolve().parents[1]
+            / ".github/workflows/contract-consumers.yml"
+        ).read_text()
+        start = text.index("- name: Refuse to guess when a contract changed")
+        end = text.index("- name: Check out the consumer")
+        refusal = text[start:end]
+        assert 'SCHEMA_TOUCHED" = "true"' in refusal
+        assert "exit 1" in refusal, "the refusal branch does not fail the run"
+
+
+class TestTheWorkflowDoesNotReintroduceTheClassesBugbotFound:
+    """Four findings on #536, each turned into something that can fail again.
+
+    All four were fail-open or over-privilege on a path no test could see, in a
+    workflow whose entire purpose is to fail closed. They are pinned as CLASSES
+    rather than as the reported lines: a sweep of the file after the first fix
+    found a fourth `printf | grep -q` that the review had not flagged, which is
+    the argument for checking the class rather than the instance.
+    """
+
+    @staticmethod
+    def _workflow():
+        return (
+            Path(__file__).resolve().parents[1]
+            / ".github/workflows/contract-consumers.yml"
+        )
+
+    @staticmethod
+    def _parsed():
+        import yaml
+
+        return yaml.safe_load(
+            (
+                Path(__file__).resolve().parents[1]
+                / ".github/workflows/contract-consumers.yml"
+            ).read_text()
+        )
+
+    def test_nothing_pipes_into_an_early_exiting_reader(self):
+        # `printf | grep -q` under `set -o pipefail`: grep exits on the first
+        # match, printf takes SIGPIPE, the pipeline returns 141, and an `if`
+        # reads that as "no match". In this workflow that answers
+        # `schema-touched=false` -- the fail-open branch it exists to close.
+        import re
+
+        code = [
+            line
+            for line in self._workflow().read_text().splitlines()
+            if not line.strip().startswith("#")
+        ]
+        offenders = [
+            line.strip()
+            for line in code
+            if re.search(r"\|\s*(grep\s+-[A-Za-z]*q|head\b)", line)
+        ]
+        assert not offenders, (
+            "a pipe into an early-exiting reader is back; under pipefail it "
+            f"returns 141 and reads as 'no match': {offenders}"
+        )
+
+    def test_the_app_token_is_scoped_rather_than_inheriting_the_installation(self):
+        # Unscoped, it inherits the App's full grant -- and checkout stores it in
+        # the consumer's .git, after which this job runs the PR's own script
+        # against that checkout.
+        for step in self._parsed()["jobs"]["agreement"]["steps"]:
+            if "create-github-app-token" in step.get("uses", ""):
+                perms = {
+                    k: v
+                    for k, v in (step.get("with") or {}).items()
+                    if k.startswith("permission-")
+                }
+                assert perms == {
+                    "permission-contents": "read"
+                }, f"the token mint is not scoped to contents:read: {perms}"
+                return
+        raise AssertionError("no token mint found — the step was renamed or removed")
+
+    def test_the_consumer_checkout_does_not_persist_the_token(self):
+        for step in self._parsed()["jobs"]["agreement"]["steps"]:
+            with_ = step.get("with") or {}
+            if with_.get("repository", "").endswith("e2e-test-agent"):
+                assert with_.get("persist-credentials") is False, (
+                    "the consumer checkout leaves the token in .consumer/.git, "
+                    "which the PR's own script then runs against"
+                )
+                return
+        raise AssertionError("no consumer checkout found")
+
+    def test_the_producer_is_pinned_to_the_ref_the_consumer_reads(self):
+        # A scheduled run checks out the DEFAULT branch unless told otherwise,
+        # while the consumer is pinned at `develop` — so the nightly would
+        # compare a released snapshot against the head that actually reads us.
+        steps = self._parsed()["jobs"]["agreement"]["steps"]
+        producer = next(
+            s
+            for s in steps
+            if "checkout" in s.get("uses", "")
+            and not (s.get("with") or {}).get("repository")
+        )
+        ref = (producer.get("with") or {}).get("ref", "")
+        assert "schedule" in ref and "develop" in ref, (
+            "the producer checkout does not pin `develop` on scheduled runs: "
+            f"ref={ref!r}"
+        )


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green. <!-- release-train:base-at-cut=9bc8548a6361ea9881912f155f61f7a8c4a3ddc0 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces CI and pre-push behavior that can block merges or pushes when schemas change or tooling is misconfigured; logic is heavily tested and mostly degrades gracefully outside schema-bump paths.
> 
> **Overview**
> Adds a **merge-time gate** so published schema version bumps cannot land while `tracebloc/e2e-test-agent` still declares a narrower `SUPPORTED_VERSIONS` set. **`scripts/contract_consumers.py`** discovers pairings from the consumer’s `harness/*.py` AST (`CONTRACT_RELPATH` + literal `SUPPORTED_VERSIONS`) and compares them to each JSON schema’s `version`; **`tests/test_contract_consumers.py`** exercises failures in the required pytest job, while **`.github/workflows/contract-consumers.yml`** runs the real cross-repo check (scoped token, `develop` pin, API-based “schema touched” detection, fail-closed when a fork PR changes schemas without a token).
> 
> **Makefile / git hooks** gain **`guard-toolchain`** ahead of `make check`, **`make test-hooks`**, tighter **`core.hooksPath`** refusal (parent/`..` escapes), and pre-push logic that soft-passes missing make/toolchain/old Makefile targets instead of hard-blocking GUI pushes. The PR template comment is corrected: **`develop` is the default branch**, so same-repo closing keywords apply on merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91ccbb8a0e0560a203c41cdeea7e2856a3f2fc5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->