### PR TITLE
ci(set-status): fire on `edited` so the closing-ref gate re-runs on title/body changes (backend#2756)

### DIFF
--- a/.github/workflows/set-pr-status.yml
+++ b/.github/workflows/set-pr-status.yml
@@ -2,7 +2,25 @@ name: Set PR Status
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, converted_to_draft]
+    # `edited` is load-bearing, not decoration (tracebloc/backend#2556). The
+    # `closing-ref` job decides its verdict from the PR TITLE and the PR BODY, and
+    # `edited` is the ONLY event GitHub fires when either changes. Without it the
+    # two fields the gate reads are the two fields that can change without
+    # re-running it, which is a bypass rather than a gap: open a PR titled
+    # `chore: tidy up`, the gate records NOTHING_NAMED and goes green, then
+    # retitle it to `fix(1234): …` with nothing linked -- no event fires, the
+    # green stands, and the PR merges having defeated the check.
+    #
+    # It also makes the remediation usable at all. Retitling or editing a body to
+    # SATISFY the gate did not re-run it either, so a red persisted on a PR that
+    # now complied: 20 sync PRs had to be cleared with 20 manual `gh run rerun`
+    # calls (backend#2555), because the only in-band re-trigger was closing and
+    # reopening someone else's PR.
+    #
+    # Same one-word fix, same reason, as `fr-gate-caller.yml` (backend#1945): a
+    # gate whose verdict depends on a mutable field must re-run when that field
+    # mutates.
+    types: [opened, reopened, ready_for_review, converted_to_draft, edited]
 
 jobs:
   set-status:


### PR DESCRIPTION
## What

Adds `edited` to this repo's `set-pr-status.yml` caller, syncing it to the canonical copy on `.github@main` (`set-pr-status-caller.yml`).

## Why

`.github#360` (backend#2556) taught the `closing-ref` gate to re-run when a PR's title or body changes, and updated the canonical caller. **No per-repo caller was synced — 20 of 20 lacked `edited`**, so the re-run half has been inert org-wide since it landed on 2026-08-27.

The canonical file's own comment states the consequence:

> `edited` is load-bearing, not decoration. The `closing-ref` job decides its verdict from the PR TITLE and the PR BODY, and `edited` is the ONLY event GitHub fires when either changes. Without it the two fields the gate reads are the two fields that can change without re-running it, which is a bypass rather than a gap: open a PR titled `chore: tidy up`, the gate records NOTHING_NAMED and goes green, then retitle it to `fix(1234): …` with nothing linked — no event fires, the green stands, and the PR merges having defeated the check.

## The second-order effect, observed

Because nothing re-runs the check on a push either, a `closing-ref` verdict freezes at whatever head first triggered it. A push that fixes the cause does not clear the red. That cost two reviewers' approvals on 2026-08-28 — @saqlainsyed007 on `.github#369` and @aptracebloc on `client#890` both withheld approval over a red that no longer existed on the current head. Both were reading the evidence correctly; the evidence was stale.

## Scope of the change

The canonical file and this repo's copy were **otherwise byte-identical** — the only difference is the `types:` line and the comment block explaining it. This replaces the file with the canonical copy, so the diff is exactly that.

Identical change opened against all 19 active repos.

Part of tracebloc/backend#2756

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow trigger-only change that tightens CI policy enforcement; no application runtime or data-path changes.
> 
> **Overview**
> Adds **`edited`** to the `pull_request` trigger in **`.github/workflows/set-pr-status.yml`**, matching the canonical org caller so the reusable **set PR status** workflow (including the **`closing-ref`** job) runs when a PR **title or body** changes—not only on open/reopen/ready/draft events.
> 
> A long inline comment documents why this is required: without **`edited`**, verdicts based on title/body can go **stale** (green after a retitle bypass, or red after a fix) because GitHub does not fire other events for those edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f373f25298e44f64e55465cc22950913bcffe492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->