### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/workflows/set-pr-status.yml
+++ b/.github/workflows/set-pr-status.yml
@@ -2,7 +2,25 @@ name: Set PR Status
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, converted_to_draft]
+    # `edited` is load-bearing, not decoration (tracebloc/backend#2556). The
+    # `closing-ref` job decides its verdict from the PR TITLE and the PR BODY, and
+    # `edited` is the ONLY event GitHub fires when either changes. Without it the
+    # two fields the gate reads are the two fields that can change without
+    # re-running it, which is a bypass rather than a gap: open a PR titled
+    # `chore: tidy up`, the gate records NOTHING_NAMED and goes green, then
+    # retitle it to `fix(1234): …` with nothing linked -- no event fires, the
+    # green stands, and the PR merges having defeated the check.
+    #
+    # It also makes the remediation usable at all. Retitling or editing a body to
+    # SATISFY the gate did not re-run it either, so a red persisted on a PR that
+    # now complied: 20 sync PRs had to be cleared with 20 manual `gh run rerun`
+    # calls (backend#2555), because the only in-band re-trigger was closing and
+    # reopening someone else's PR.
+    #
+    # Same one-word fix, same reason, as `fr-gate-caller.yml` (backend#1945): a
+    # gate whose verdict depends on a mutable field must re-run when that field
+    # mutates.
+    types: [opened, reopened, ready_for_review, converted_to_draft, edited]
 
 jobs:
   set-status:


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green. <!-- release-train:base-at-cut=200f190f11c60f4ad8162fce66835c3721a4bb78 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change that tightens enforcement by re-running checks when PR metadata changes; no application or secrets logic is modified.
> 
> **Overview**
> The **Set PR Status** workflow now listens for the `pull_request` **`edited`** event, in addition to open/reopen/ready-for-review/draft transitions.
> 
> That re-run is required because downstream status logic (including **`closing-ref`**) derives its result from the **PR title and body**, which can change without any of the previously subscribed events. Without **`edited`**, a green check could stay after a retitle that should fail the gate, and fixing a red PR by updating title/body would not refresh status without manual workflow reruns.
> 
> Inline comments document the bypass/remediation rationale and note alignment with the same change in **`fr-gate-caller.yml`** (backend#1945).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36b8087dbd4f255be0d7bdc9af945e41e074a384. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->