### PR TITLE
release-train: staging -> main

### DIFF
--- a/.github/workflows/set-pr-status.yml
+++ b/.github/workflows/set-pr-status.yml
@@ -2,7 +2,25 @@ name: Set PR Status
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, converted_to_draft]
+    # `edited` is load-bearing, not decoration (tracebloc/backend#2556). The
+    # `closing-ref` job decides its verdict from the PR TITLE and the PR BODY, and
+    # `edited` is the ONLY event GitHub fires when either changes. Without it the
+    # two fields the gate reads are the two fields that can change without
+    # re-running it, which is a bypass rather than a gap: open a PR titled
+    # `chore: tidy up`, the gate records NOTHING_NAMED and goes green, then
+    # retitle it to `fix(1234): …` with nothing linked -- no event fires, the
+    # green stands, and the PR merges having defeated the check.
+    #
+    # It also makes the remediation usable at all. Retitling or editing a body to
+    # SATISFY the gate did not re-run it either, so a red persisted on a PR that
+    # now complied: 20 sync PRs had to be cleared with 20 manual `gh run rerun`
+    # calls (backend#2555), because the only in-band re-trigger was closing and
+    # reopening someone else's PR.
+    #
+    # Same one-word fix, same reason, as `fr-gate-caller.yml` (backend#1945): a
+    # gate whose verdict depends on a mutable field must re-run when that field
+    # mutates.
+    types: [opened, reopened, ready_for_review, converted_to_draft, edited]
 
 jobs:
   set-status:

--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -411,6 +411,23 @@ def test_summary_default_policy_sends_raw_labels():
     assert [s["label"] for s in sent["samples"]] == ["1", "0"]
 
 
+def test_summary_includes_record_count_when_set():
+    """backend#2770: an explicit record_count rides the payload as its own
+    field, independent of sum(labels.values()) — here labels sum to 30 while
+    the item count is 7."""
+    sent = _captured_summary_payload(_client(), record_count=7)
+    assert sent["record_count"] == 7
+    assert sum(sent["labels"].values()) == 30
+
+
+def test_summary_omits_record_count_when_unset():
+    """Default None omits the field, so a backend predating it is unaffected
+    and the payload stays byte-identical to today's (the two repos ship in
+    either order)."""
+    sent = _captured_summary_payload(_client())
+    assert "record_count" not in sent
+
+
 def test_summary_bucket_policy_buckets_labels_and_samples():
     from tracebloc_ingestor.utils.label_policy import BUCKET, apply
 

--- a/tests/test_time_series_classification.py
+++ b/tests/test_time_series_classification.py
@@ -260,6 +260,13 @@ def test_toy_csv_ingests_with_sequence_unit_counts(make_csv, monkeypatch):
     # number_of_columns still counts the CLEANED schema columns (k=2 site:
     # sequence_id + timestamp + F features; label stripped).
     assert summary_kwargs["meta_data"]["number_of_columns"] == 3
+    # backend#2770 (the TSC guard): record_count is the SAMPLE UNIT — the 3
+    # sequences, NOT the 15 stored rows. Passing inserted_records here would
+    # re-inflate total by ~mean(sequence length), the token_classification
+    # count bug (#527) one category over. This is the fixture where item count
+    # (3) and row count (15) diverge, so it pins the distinction.
+    assert summary_kwargs["record_count"] == 3
+    assert summary_kwargs["record_count"] != inserted  # 15 rows
 
 
 def test_toy_csv_requests_composite_index(make_csv):
@@ -285,8 +292,13 @@ def test_non_grouped_category_keeps_row_counts(make_csv):
     ing.database.get_label_counts.assert_called_once()
     ing.database.get_label_sequence_counts.assert_not_called()
     assert ing.database.create_table.call_args.kwargs["index_columns"] is None
-    meta = ing.api_client.send_ingest_summary.call_args.kwargs["meta_data"]
+    summary_kwargs = ing.api_client.send_ingest_summary.call_args.kwargs
+    meta = summary_kwargs["meta_data"]
     assert "number_of_sequences" not in meta
+    # backend#2770: a non-grouped category's record_count is the ROW count (15),
+    # the row unit like every non-grouped category — here it also equals
+    # sum(labels.values()), which is why the inference was ever right for them.
+    assert summary_kwargs["record_count"] == 15
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_token_classification_tag_counts.py
+++ b/tests/test_token_classification_tag_counts.py
@@ -150,6 +150,13 @@ def test_ingest_counts_distinct_tags_not_sequences():
     # Distinct TAGS (3), not distinct sequence strings (2).
     assert summary_kwargs["labels"] == {"O": 4, "B-PER": 2, "I-PER": 1}
     assert summary_kwargs["category"] == TOKEN
+    # backend#2770: the record count rides the payload EXPLICITLY and is the
+    # ROW count (2 texts) — NOT sum(labels.values()) (7 tag occurrences). This
+    # is exactly the fixture where the two diverge, which is the whole point:
+    # before this the backend inferred the count from the label sum, so #527's
+    # exploded tag counts silently inflated it by ~mean(sequence length)×.
+    assert summary_kwargs["record_count"] == 2
+    assert summary_kwargs["record_count"] != sum(summary_kwargs["labels"].values())
 
 
 def test_non_tag_category_keeps_row_counts():

--- a/tracebloc_ingestor/__init__.py
+++ b/tracebloc_ingestor/__init__.py
@@ -28,7 +28,7 @@ from .validators import (
 # Single source of truth for the package version. setup.py parses this literal
 # (see _read_version in setup.py) so the two can't drift again (#175). Bump here
 # only — setup.py picks it up automatically.
-__version__ = "0.8.14"
+__version__ = "0.8.15"
 
 __all__ = [
     "Config",

--- a/tracebloc_ingestor/api/client.py
+++ b/tracebloc_ingestor/api/client.py
@@ -223,6 +223,7 @@ class APIClient:
         meta_data: Optional[Dict[str, Any]] = None,
         physical_table: Optional[str] = None,
         label_policy: str = label_policy_module.PASSTHROUGH,
+        record_count: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Send a single ingest summary to the backend, creating the UserDataSet in one
@@ -255,6 +256,16 @@ class APIClient:
                 (tracebloc/backend#1206). ``None`` (legacy shared-table
                 ingests) omits the field entirely, keeping the payload
                 byte-identical to today's.
+            record_count: The dataset's item count, carried EXPLICITLY so the
+                backend stops inferring it from ``sum(labels.values())``
+                (backend#2770). That inference is only right when ``labels``
+                partitions the rows; token_classification's exploded per-tag
+                counts (data-ingestors#527) and any sequence-grouped
+                category's per-sequence counts both break it. The caller
+                passes the category's SAMPLE UNIT (rows, or sequences for a
+                grouped category). ``None`` omits the field, so an older
+                backend that predates it is unaffected and the payload stays
+                byte-identical to today's — the two repos ship in either order.
 
         Returns:
             ``{"dataset_id": ..., "dataset_key": ...}``
@@ -290,6 +301,16 @@ class APIClient:
             }
             if physical_table:
                 payload_fields["physical_table"] = physical_table
+            # `is not None`, not truthiness: send the count the caller computed
+            # even when it is a legitimate 0, rather than letting THIS side omit
+            # it. A 0-row run never reaches this call (the summary is skipped
+            # upstream when nothing was inserted), so the 0 is unreachable in
+            # practice — this guard does not by itself protect it end to end,
+            # because for an explicit 0 to survive the backend's fallback the
+            # reader must use the same `is not None` (not `or`); tracked with
+            # the backend half on backend#2770.
+            if record_count is not None:
+                payload_fields["record_count"] = record_count
             payload = json.dumps(payload_fields)
             logger.info(
                 f"Sending ingest summary for {table_name}: "

--- a/tracebloc_ingestor/ingestors/base.py
+++ b/tracebloc_ingestor/ingestors/base.py
@@ -1326,6 +1326,24 @@ class BaseIngestor(ABC):
                         self.physical_table_name, self.ingestor_id
                     )
 
+                    # backend#2770: carry the item count EXPLICITLY so the
+                    # backend stops inferring it from sum(labels.values()) — a
+                    # sum that equals the item count only when labels partition
+                    # the rows. It is the category's SAMPLE UNIT: a sequence-
+                    # grouped category counts sequences (already tallied into
+                    # number_of_sequences, backend#1054), every other category
+                    # counts rows. Passing rows for a grouped category would
+                    # re-inflate total by ~mean(sequence length) — the exact
+                    # shape of the token_classification bug #527 surfaced, one
+                    # category over. Mirrors the count-path branch selection
+                    # above; a future grouped-by-rows category (count_unit !=
+                    # "sequences") falls to inserted_records like every row unit.
+                    record_count = (
+                        self.file_options["number_of_sequences"]
+                        if grouping is not None and grouping.count_unit == "sequences"
+                        else stats["inserted_records"]
+                    )
+
                     self.api_client.send_ingest_summary(
                         table_name=self.table_name,
                         physical_table=(
@@ -1348,6 +1366,7 @@ class BaseIngestor(ABC):
                         # earlier, so the stored rows keep the values training
                         # needs (#486).
                         label_policy=self.label_policy,
+                        record_count=record_count,
                     )
                     dataset_registered = True
                     stats["api_sent_records"] = stats["inserted_records"]


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-main` branch (a mirror of `staging`), so it never collides with a human PR. Merged only when the fr-gate is green. <!-- release-train:base-at-cut=f65917a0fa1145c606fa05dc2e512a8df68f83c4 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how dataset totals are reported to the backend at registration time; wrong counts would affect downstream metadata until the backend half of #2770 is aligned. The workflow change is low-risk CI behavior.
> 
> **Overview**
> **Ingest summary (backend#2770)** — The ingestor now sends an optional **`record_count`** on the global-meta summary payload so the backend does not infer dataset size from **`sum(labels.values())`**. That sum is wrong for **token classification** (per-tag label counts vs row/text count) and **time series classification** (per-sequence labels vs stored rows). **`BaseIngestor`** sets the count to the category’s sample unit: **sequences** when grouping uses `count_unit == "sequences"`, otherwise **inserted row count**. **`APIClient.send_ingest_summary`** adds the field only when the caller passes a non-`None` value, keeping older backends unchanged. Package version **0.8.15**.
> 
> **CI** — **`set-pr-status.yml`** listens for **`pull_request` `edited`** so title/body changes re-run the closing-ref gate (same fix as elsewhere; avoids bypass and stuck red status after fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9f9768db2d3e1424743f2149efc3b7b1370f2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->